### PR TITLE
Add optional callback "getSpellCallback()" to class config spell loadouts

### DIFF
--- a/utils/rgmercs_utils.lua
+++ b/utils/rgmercs_utils.lua
@@ -2646,6 +2646,12 @@ function Utils.SetLoadOut(caller, spellGemList, itemSets, abilitySets)
     local spellLoadOut = {}
     local resolvedActionMap = {}
     local spellsToLoad = {}
+    
+    -- Allow a callback fn for generating spell loadouts rather than a static list
+    -- Can be used by bards to prioritize loadouts based on user choices
+    if spellGemList.getSpellCallback ~= nil and type(spellGemList.getSpellCallback) == "function" then
+        spellGemList = spellGemList.getSpellCallback()
+    end
 
     Utils.UseGem = mq.TLO.Me.NumGems()
 


### PR DESCRIPTION
Allows for complex loadout organization taking into account user-selected UI options.  Intended primarily for bards.

To use, set `_ClassConfig['Spells'] = { getSpellCallback = <callback fn> }` in place of the concrete list.  

If getSpellCallback does not exist, we use prior default behavior.

