### PR TITLE
Fix Utils.SongMemed to use TLO Spell.RankName() in addition to plain Name()

### DIFF
--- a/utils/rgmercs_utils.lua
+++ b/utils/rgmercs_utils.lua
@@ -1797,8 +1797,8 @@ end
 function Utils.SongMemed(songSpell)
     if not songSpell or not songSpell() then return false end
     local me = mq.TLO.Me
-
-    return me.Gem(songSpell.Name())() ~= nil
+    -- Rk. II and III songs fail this check without RankName()
+    return me.Gem(songSpell.RankName() or songSpell.Name())() ~= nil
 end
 
 ---@param songSpell MQSpell


### PR DESCRIPTION
Name() alone fails on 125 at least, probably earlier than that, too.