### PR TITLE
Berserker looks to inventory rather than bank for reagents

### DIFF
--- a/class_configs/ber_class_config.lua
+++ b/class_configs/ber_class_config.lua
@@ -375,6 +375,28 @@ return {
                 end,
             },
             {
+                name = "SummonBluntAxes",
+                type = "CustomFunc",
+                custom_func = function(self)
+                    if not RGMercUtils.GetSetting('SummonAxes2') then return false end
+					
+					if not mq.TLO.Me.CombatAbilityReady('Blunt Axe')() then return false end
+--                    if not RGMercUtils.PCDiscReady('Blunt Axe') then return false end
+
+                    if mq.TLO.FindItemCount('Blunt Axe')() > RGMercUtils.GetSetting('AutoAxe2Count') then return false end
+                    if RGMercUtils.GetSetting('AutoAxe2Count') == 0 then return false end
+--                    local spell = mq.TLO.Spell('Blunt Axe')
+--                    if not spell or not spell() then return false end
+--                    if mq.TLO.FindItemBankCount(59933)() == 0 then return false end
+                    if mq.TLO.FindItemCount('Basic Axe Components')() == 0 then return false end
+
+					RGMercUtils.DoCmd("/squelch /doability Blunt Axe")
+                    local ret = true
+                    RGMercUtils.DoCmd("/autoinv")
+                    return ret
+                end,
+            },
+            {
                 name = "SummonDichoAxe",
                 type = "CustomFunc",
                 custom_func = function(self)
@@ -552,6 +574,13 @@ return {
                 cond = function(self, aaName)
                     return RGMercUtils.GetSetting('DoBattleLeap') and not RGMercUtils.SongActiveByName("Battle Leap Warcry") and
                         not RGMercUtils.SongActiveByName("Group Bestial Alignment")
+                end,
+            },
+            {
+                name = "Leg Strke",
+                type = "Ability",
+                cond = function(self, discSpell)
+                    return mq.TLO.Me.CombatAbilityReady("Leg Strike")()
                 end,
             },
             {

--- a/class_configs/ber_class_config.lua
+++ b/class_configs/ber_class_config.lua
@@ -350,7 +350,7 @@ return {
                     if RGMercUtils.GetSetting('AutoAxeCount') == 0 then return false end
                     local spell = mq.TLO.Spell(self.ResolvedActionMap['AutoAxe1'].Name())
                     if not spell or not spell() then return false end
-                    if mq.TLO.FindItemBankCount(spell.ReagentID(1)())() == 0 then return false end
+                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() == 0 then return false end
 
                     local ret = RGMercUtils.UseDisc(self.ResolvedActionMap['AutoAxe1'], mq.TLO.Me.ID())
                     RGMercUtils.DoCmd("/autoinv")
@@ -367,7 +367,7 @@ return {
                     if RGMercUtils.GetSetting('AutoAxe2Count') == 0 then return false end
                     local spell = mq.TLO.Spell(self.ResolvedActionMap['AutoAxe2'].Name())
                     if not spell or not spell() then return false end
-                    if mq.TLO.FindItemBankCount(spell.ReagentID(1)())() == 0 then return false end
+                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() == 0 then return false end
 
                     local ret = RGMercUtils.UseDisc(self.ResolvedActionMap['AutoAxe2'], mq.TLO.Me.ID())
                     RGMercUtils.DoCmd("/autoinv")
@@ -384,7 +384,7 @@ return {
                     if RGMercUtils.GetSetting('DichoAxeCount') == 0 then return false end
                     local spell = mq.TLO.Spell(self.ResolvedActionMap['DichoAxe'].Name())
                     if not spell or not spell() then return false end
-                    if mq.TLO.FindItemBankCount(spell.ReagentID(1)())() == 0 then return false end
+                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() == 0 then return false end
 
                     local ret = RGMercUtils.UseDisc(self.ResolvedActionMap['DichoAxe'], mq.TLO.Me.ID())
                     RGMercUtils.DoCmd("/autoinv")

--- a/class_configs/enc_class_config.lua
+++ b/class_configs/enc_class_config.lua
@@ -1363,7 +1363,8 @@ local _ClassConfig = {
         {
             gem = 5,
             spells = {
-                { name = "NdtBuff", },
+--                { name = "NdtBuff", },
+                { name = "NdtBuff", cond = function(self) return RGMercUtils.GetSetting('DoNDTBuff') end, },
             },
         },
         {

--- a/class_configs/mag_class_config.lua
+++ b/class_configs/mag_class_config.lua
@@ -1484,17 +1484,17 @@ _ClassConfig      = {
                 end,
             },
             {
+                name = "FireBoltNuke",
+                type = "Spell",
+                cond = function(self) return mq.TLO.Me.Level() < 70 or RGMercUtils.IsModeActive("PetTank") end,
+            },
+            {
                 name = "FireNuke1",
                 type = "Spell",
                 cond = function(self) return mq.TLO.Me.Level() < 70 or RGMercUtils.IsModeActive("PetTank") end,
             },
             {
                 name = "FireNuke2",
-                type = "Spell",
-                cond = function(self) return mq.TLO.Me.Level() < 70 or RGMercUtils.IsModeActive("PetTank") end,
-            },
-            {
-                name = "FireBoltNuke",
                 type = "Spell",
                 cond = function(self) return mq.TLO.Me.Level() < 70 or RGMercUtils.IsModeActive("PetTank") end,
             },

--- a/class_configs/mag_class_config.lua
+++ b/class_configs/mag_class_config.lua
@@ -1821,21 +1821,21 @@ _ClassConfig      = {
             gem = 8,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "PetHealSpell", },
+                { name = "DichoSpell", },
             },
         },
         {
             gem = 9,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "DichoSpell", },
+                { name = "TwinCast", },
             },
         },
         {
             gem = 10,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "TwinCast", },
+                { name = "GatherMana", },
             },
         },
         {
@@ -1849,7 +1849,7 @@ _ClassConfig      = {
             gem = 12,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "GatherMana", },
+                { name = "PetHealSpell", },
             },
         },
     },

--- a/class_configs/rng_class_config.lua
+++ b/class_configs/rng_class_config.lua
@@ -1696,7 +1696,8 @@ local _ClassConfig = {
             end
 
             if not RGMercUtils.GetSetting('NavCircle') and (RGMercUtils.GetTargetDistance() >= 75 or forceMove) then
-                RGMercUtils.DoCmd("/squelch /nav id %d facing=backward distance=%d", RGMercConfig.Globals.AutoTargetID, RGMercUtils.GetSetting('NavCircleDist'))
+--                RGMercUtils.DoCmd("/squelch /nav id %d facing=backward distance=%d", RGMercConfig.Globals.AutoTargetID, RGMercUtils.GetSetting('NavCircleDist'))
+                RGMercUtils.DoCmd("/squelch /nav id %d distance=%d", RGMercConfig.Globals.AutoTargetID, RGMercUtils.GetSetting('NavCircleDist'))
             end
         end,
     },

--- a/class_configs/rng_class_config.lua
+++ b/class_configs/rng_class_config.lua
@@ -1456,6 +1456,16 @@ local _ClassConfig = {
                     return not mq.TLO.Me.ActiveDisc.ID() and not RGMercUtils.SongActiveByName(discSpell.RankName.Name() or "") and mq.TLO.Me.PctEndurance() < 30
                 end,
             },
+            {
+                name = "Disarm",
+                type = "Ability",
+                tooltip = Tooltips.Taunt,
+                cond = function(self, abilityName)
+                    return mq.TLO.Me.AbilityReady(abilityName)() and
+                        mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and RGMercUtils.GetTargetID() > 0 and
+                        RGMercUtils.GetTargetDistance() < 30
+                end,
+            },
         },
         ['DPS Buffs'] = {
             {


### PR DESCRIPTION
Fixes the axe summoning logic to look to inventory for axe summon reagents rather than looking to the bank. Without this fix, the Berserker doesn't summon axes.