### PR TITLE
Update nec_class_config.lua

### DIFF
--- a/class_configs/nec_class_config.lua
+++ b/class_configs/nec_class_config.lua
@@ -661,10 +661,11 @@ local _ClassConfig = {
             "Incite Ally",
             "Infuse Ally",
             "Imbue Ally",
-            "Sanction Ally",
-            "Empower Ally",
-            "Energize Ally",
-            "Necrotize Ally",
+            --The below spells deal PBAE damage on fade and should not be casually used (later spells drop this effect)
+            --"Sanction Ally",
+            --"Empower Ally",
+            --"Energize Ally",
+            --"Necrotize Ally",
         },
         ['PetHaste'] = {
             ---Pet Haste Spell * Var Name:, string outer


### PR DESCRIPTION
The level 80-100 Pet Buffs (Necrotize, Energize, Empower, Sanction Ally) have an explosion effect tied to their removal/wearing which causes unsuspected necromancers to randomly die when idling near NPCs. Commented these out with a disclaimer.