### PR TITLE
fix: import not honoring spells removed from sets.

### DIFF
--- a/utils/rgmercs_classloader.lua
+++ b/utils/rgmercs_classloader.lua
@@ -22,18 +22,8 @@ function ClassLoader.load(class)
             customConfigLoaded = true
         end
     end
-    local classConfig
-    if overrideClassConfig['FullConfig'] ~= nil then
-        if overrideClassConfig['FullConfig'] then
-            RGMercsLogger.log_info("\agFull Replacement Config Loaded")
-            classConfig = {}
-            classConfig = overrideClassConfig
-            classConfig.IsCustom = customConfigLoaded
-            return classConfig
-        end
-    else
-        classConfig = ClassLoader.mergeTables(baseClassConfig, overrideClassConfig)
-    end
+
+    local classConfig = ClassLoader.mergeTables(baseClassConfig, overrideClassConfig)
     classConfig.IsCustom = customConfigLoaded
     return classConfig
 end
@@ -42,7 +32,7 @@ function ClassLoader.mergeTables(tblA, tblB)
     for k, v in pairs(tblB) do
         if type(v) == "table" then
             if type(tblA[k] or false) == "table" then
-                ClassLoader.mergeTables(tblA[k] or {}, tblB[k] or {})
+                ClassLoader.mergeTables({}, tblB[k] or {})
             else
                 tblA[k] = v
             end

--- a/utils/rgmercs_classloader.lua
+++ b/utils/rgmercs_classloader.lua
@@ -30,17 +30,30 @@ end
 
 function ClassLoader.mergeTables(tblA, tblB)
     for k, v in pairs(tblB) do
-        if type(v) == "table" then
-            if type(tblA[k] or false) == "table" then
-                ClassLoader.mergeTables({}, tblB[k] or {})
+        if v == nil then
+            -- Remove key from tblA if value in tblB is nil
+            tblA[k] = nil
+        elseif type(v) == "table" then
+            if type(tblA[k]) == "table" then
+                if #v > 0 or next(v) == nil then
+                    -- Directly assign the list from tblB to tblA
+                    tblA[k] = v
+                else
+                    -- Recursive call to merge nested tables
+                    tblA[k] = ClassLoader.mergeTables(tblA[k], v)
+                end
             else
+                -- If tblA[k] is not a table, directly assign tblB[k]
                 tblA[k] = v
             end
         else
+            -- Directly assign the value if it's not a table
             tblA[k] = v
         end
     end
     return tblA
 end
+
+
 
 return ClassLoader

--- a/utils/rgmercs_classloader.lua
+++ b/utils/rgmercs_classloader.lua
@@ -22,8 +22,18 @@ function ClassLoader.load(class)
             customConfigLoaded = true
         end
     end
-
-    local classConfig = ClassLoader.mergeTables(baseClassConfig, overrideClassConfig)
+    local classConfig
+    if overrideClassConfig['FullConfig'] ~= nil then
+        if overrideClassConfig['FullConfig'] then
+            RGMercsLogger.log_info("\agFull Replacement Config Loaded")
+            classConfig = {}
+            classConfig = overrideClassConfig
+            classConfig.IsCustom = customConfigLoaded
+            return classConfig
+        end
+    else
+        classConfig = ClassLoader.mergeTables(baseClassConfig, overrideClassConfig)
+    end
     classConfig.IsCustom = customConfigLoaded
     return classConfig
 end

--- a/utils/rgmercs_classloader.lua
+++ b/utils/rgmercs_classloader.lua
@@ -30,30 +30,17 @@ end
 
 function ClassLoader.mergeTables(tblA, tblB)
     for k, v in pairs(tblB) do
-        if v == nil then
-            -- Remove key from tblA if value in tblB is nil
-            tblA[k] = nil
-        elseif type(v) == "table" then
-            if type(tblA[k]) == "table" then
-                if #v > 0 or next(v) == nil then
-                    -- Directly assign the list from tblB to tblA
-                    tblA[k] = v
-                else
-                    -- Recursive call to merge nested tables
-                    tblA[k] = ClassLoader.mergeTables(tblA[k], v)
-                end
+        if type(v) == "table" then
+            if type(tblA[k] or false) == "table" then
+                ClassLoader.mergeTables({}, tblB[k] or {})
             else
-                -- If tblA[k] is not a table, directly assign tblB[k]
                 tblA[k] = v
             end
         else
-            -- Directly assign the value if it's not a table
             tblA[k] = v
         end
     end
     return tblA
 end
-
-
 
 return ClassLoader

--- a/utils/rgmercs_classloader.lua
+++ b/utils/rgmercs_classloader.lua
@@ -22,8 +22,18 @@ function ClassLoader.load(class)
             customConfigLoaded = true
         end
     end
-
-    local classConfig = ClassLoader.mergeTables(baseClassConfig, overrideClassConfig)
+    local classConfig
+    if overrideClassConfig['FullConfig'] ~= nil then
+        if overrideClassConfig['FullConfig'] then
+            RGMercsLogger.log_info("\agFull Replacement Config Loaded")
+            classConfig = {}
+            classConfig = overrideClassConfig
+            classConfig.IsCustom = customConfigLoaded
+            return classConfig
+        end
+    else
+        classConfig = ClassLoader.mergeTables(baseClassConfig, overrideClassConfig)
+    end
     classConfig.IsCustom = customConfigLoaded
     return classConfig
 end
@@ -32,7 +42,7 @@ function ClassLoader.mergeTables(tblA, tblB)
     for k, v in pairs(tblB) do
         if type(v) == "table" then
             if type(tblA[k] or false) == "table" then
-                ClassLoader.mergeTables({}, tblB[k] or {})
+                ClassLoader.mergeTables(tblA[k] or {}, tblB[k] or {})
             else
                 tblA[k] = v
             end


### PR DESCRIPTION
if you comment out sections and try to import the config as a custom one, the commented out sections get ignored.

Added a flag to the config FullConfig = true/false if the flag is present and true then replace the default config with the custom one. otherwise use the mergeTables function.

example:
local _ClassConfig = {
    _version          = "1.0 Beta",
    _author           = "Derple",
    ['FullConfig'] = true,