### PR TITLE
groupwatch wasn't resuming at the correct percentage

### DIFF
--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -839,11 +839,11 @@ end
 
 ---comment
 ---@param classes table|nil # mq.Set type
----@param resourceStartPct number -- resume pulls at this pct
----@param resourceStopPct number -- stop pulls at this pct
+---@param resourceResumePct number -- Resume pulls at this pct
+---@param resourcePausePct number -- Hold pulls at this pct
 ---@param campData table
 ---@return boolean, string
-function Module:CheckGroupForPull(classes, resourceStartPct, resourceStopPct, campData)
+function Module:CheckGroupForPull(classes, resourceResumePct, resourcePausePct, campData)
     local groupCount = mq.TLO.Group.Members()
 
     if not groupCount or groupCount == 0 then return true, "" end
@@ -854,20 +854,20 @@ function Module:CheckGroupForPull(classes, resourceStartPct, resourceStopPct, ca
 
         if member and member.ID() > 0 then
             if not classes or classes:contains(member.Class.ShortName()) then
-                local resourcePct = self.TempSettings.PullState == PullStates.PULL_GROUPWATCH_WAIT and resourceStartPct or resourceStopPct
+                local resourcePct = self.TempSettings.PullState == PullStates.PULL_GROUPWATCH_WAIT and resourceResumePct or resourcePausePct
                 if member.PctHPs() < resourcePct then
                     RGMercUtils.PrintGroupMessage("%s is low on hp - Holding pulls!", member.CleanName())
-                    RGMercsLogger.log_verbose("\arMember is low on hp - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
+                    RGMercsLogger.log_verbose("\arMember is low on Health - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%d \aoStopPct: \at%d \ayStartPct: \at%d \aoPullState: \at%d",resourcePct,resourcePausePct,resourceResumePct, self.TempSettings.PullState)
                     return false, string.format("%s Low HP", member.CleanName())
                 end
                 if member.Class.CanCast() and member.Class.ShortName() ~= "BRD" and member.PctMana() < resourcePct  then
                     RGMercUtils.PrintGroupMessage("%s is low on mana - Holding pulls!", member.CleanName())
-                    RGMercsLogger.log_verbose("\arMember is low on mana - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
+                    RGMercsLogger.log_verbose("\arMember is low on Mana - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%d \aoStopPct: \at%d \ayStartPct: \at%d \aoPullState: \at%d",resourcePct,resourcePausePct,resourceResumePct, self.TempSettings.PullState)
                     return false, string.format("%s Low Mana", member.CleanName())
                 end
                 if member.Class.ShortName() ~= "BRD" and member.PctEndurance() < resourcePct  then
                     RGMercUtils.PrintGroupMessage("%s is low on endurance - Holding pulls!", member.CleanName())
-                    RGMercsLogger.log_verbose("\arMember is low on endurance - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
+                    RGMercsLogger.log_verbose("\arMember is low on Endurance - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%d \aoStopPct: \at%d \ayStartPct: \at%d \aoPullState: \at%d",resourcePct,resourcePausePct,resourceResumePct, self.TempSettings.PullState)
                     return false, string.format("%s Low End", member.CleanName())
                 end
 

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -857,17 +857,17 @@ function Module:CheckGroupForPull(classes, resourceStartPct, resourceStopPct, ca
                 local resourcePct = self.TempSettings.PullState == PullStates.PULL_GROUPWATCH_WAIT and resourceStartPct or resourceStopPct
                 if member.PctHPs() < resourcePct then
                     RGMercUtils.PrintGroupMessage("%s is low on hp - Holding pulls!", member.CleanName())
-                    RGMercsLogger.log_warn("\arMember is low on hp - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
+                    RGMercsLogger.log_verbose("\arMember is low on hp - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
                     return false, string.format("%s Low HP", member.CleanName())
                 end
                 if member.Class.CanCast() and member.Class.ShortName() ~= "BRD" and member.PctMana() < resourcePct  then
                     RGMercUtils.PrintGroupMessage("%s is low on mana - Holding pulls!", member.CleanName())
-                    RGMercsLogger.log_warn("\arMember is low on mana - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
+                    RGMercsLogger.log_verbose("\arMember is low on mana - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
                     return false, string.format("%s Low Mana", member.CleanName())
                 end
                 if member.Class.ShortName() ~= "BRD" and member.PctEndurance() < resourcePct  then
                     RGMercUtils.PrintGroupMessage("%s is low on endurance - Holding pulls!", member.CleanName())
-                    RGMercsLogger.log_warn("\arMember is low on endurance - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
+                    RGMercsLogger.log_verbose("\arMember is low on endurance - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
                     return false, string.format("%s Low End", member.CleanName())
                 end
 

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -839,8 +839,8 @@ end
 
 ---comment
 ---@param classes table|nil # mq.Set type
----@param resourceStartPct number
----@param resourceStopPct number
+---@param resourceStartPct number -- resume pulls at this pct
+---@param resourceStopPct number -- stop pulls at this pct
 ---@param campData table
 ---@return boolean, string
 function Module:CheckGroupForPull(classes, resourceStartPct, resourceStopPct, campData)
@@ -854,17 +854,20 @@ function Module:CheckGroupForPull(classes, resourceStartPct, resourceStopPct, ca
 
         if member and member.ID() > 0 then
             if not classes or classes:contains(member.Class.ShortName()) then
-                local resourcePct = self.TempSettings.PullState == PullStates.PULL_GROUPWATCH_WAIT and resourceStopPct or resourceStartPct
+                local resourcePct = self.TempSettings.PullState == PullStates.PULL_GROUPWATCH_WAIT and resourceStartPct or resourceStopPct
                 if member.PctHPs() < resourcePct then
                     RGMercUtils.PrintGroupMessage("%s is low on hp - Holding pulls!", member.CleanName())
+                    RGMercsLogger.log_warn("\arMember is low on hp - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
                     return false, string.format("%s Low HP", member.CleanName())
                 end
-                if member.Class.CanCast() and member.Class.ShortName() ~= "BRD" and member.PctMana() < resourcePct then
+                if member.Class.CanCast() and member.Class.ShortName() ~= "BRD" and member.PctMana() < resourcePct  then
                     RGMercUtils.PrintGroupMessage("%s is low on mana - Holding pulls!", member.CleanName())
+                    RGMercsLogger.log_warn("\arMember is low on mana - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
                     return false, string.format("%s Low Mana", member.CleanName())
                 end
-                if member.Class.ShortName() ~= "BRD" and member.PctEndurance() < resourcePct then
+                if member.Class.ShortName() ~= "BRD" and member.PctEndurance() < resourcePct  then
                     RGMercUtils.PrintGroupMessage("%s is low on endurance - Holding pulls!", member.CleanName())
+                    RGMercsLogger.log_warn("\arMember is low on endurance - \ayHolding pulls!\ax\ag ResourcePCT:\ax \at%s \aoStopPct: \at%s \ayStartPct: \at%s \aoPullState: \at%s",resourcePct,resourceStopPct,resourceStartPct, self.TempSettings.PullState)
                     return false, string.format("%s Low End", member.CleanName())
                 end
 


### PR DESCRIPTION
the assignment was backward when checking the state. instead of assigning the resourceStartPct  (aka the resume value) it was assigning the resourceSopPct (aka the pause pulls value)

could have either flipped the assignments or just switched from == to ~=

also added in a WARN debug message.