### PR TITLE
BST and ENC fixes and updates

### DIFF
--- a/class_configs/bst_class_config.lua
+++ b/class_configs/bst_class_config.lua
@@ -669,21 +669,21 @@ return {
             end,
         },
         {
-            name = 'Paragon',
-            targetId = function(self)
-                return { RGMercUtils.FindWorstHurtManaGroupMember(RGMercUtils.GetSetting('ParagonPct')),
-                    RGMercUtils.FindWorstHurtManaXT(RGMercUtils.GetSetting('ParagonPct')), }
-            end,
-            cond = function(self, combat_state)
-                return combat_state ~= "Downtime" and RGMercUtils.GetSetting('DoParagon')
-            end,
-        },
-        {
             name = 'Downtime Pet',
             targetId = function(self) return { mq.TLO.Me.Pet.ID(), } end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and
                     RGMercUtils.DoBuffCheck() and mq.TLO.Me.Pet.ID() > 0 and RGMercConfig:GetTimeSinceLastMove() > RGMercUtils.GetSetting('BuffWaitMoveTimer')
+            end,
+        },
+        {
+            name = 'FocusedParagon',
+            targetId = function(self)
+                return { RGMercUtils.FindWorstHurtManaGroupMember(RGMercUtils.GetSetting('ParagonPct')),
+                    RGMercUtils.FindWorstHurtManaXT(RGMercUtils.GetSetting('ParagonPct')), }
+            end,
+            cond = function(self, combat_state)
+                return combat_state ~= "Downtime" and RGMercUtils.GetSetting('DoParagon') and not RGMercUtils.BuffActive(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
             end,
         },
         {
@@ -872,18 +872,10 @@ return {
         },
         ['Paragon'] = {
             {
-                name = "Paragon of Spirit",
-                type = "AA",
-                cond = function(self, aaName)
-                    return RGMercUtils.AAReady(aaName)
-                end,
-            },
-            {
                 name = "Focused Paragon of Spirits",
                 type = "AA",
                 cond = function(self, aaName)
-                    return RGMercUtils.AAReady(aaName) and not
-					    RGMercUtils.BuffActive(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
+                    return RGMercUtils.AAReady(aaName)
                 end,
             },
         },
@@ -893,6 +885,13 @@ return {
                 type = "Spell",
                 cond = function(self, spell)
                     return mq.TLO.Me.Pet.ID() == 0
+                end,
+            },
+            {
+                name = "Paragon of Spirit",
+                type = "AA",
+                cond = function(self, aaName)
+                    return RGMercUtils.AAReady(aaName) and RGMercUtils.GetSetting('DoParagon') and (mq.TLO.Group.LowMana(RGMercUtils.GetSetting('ParagonPct'))() or -1) > 0
                 end,
             },
             {

--- a/class_configs/bst_class_config.lua
+++ b/class_configs/bst_class_config.lua
@@ -683,7 +683,8 @@ return {
                     RGMercUtils.FindWorstHurtManaXT(RGMercUtils.GetSetting('ParagonPct')), }
             end,
             cond = function(self, combat_state)
-                return combat_state ~= "Downtime" and RGMercUtils.GetSetting('DoParagon') and not RGMercUtils.BuffActive(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
+                return combat_state == "Combat" and RGMercUtils.GetSetting('DoParagon') and not RGMercUtils.BuffActive(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
+                    and not RGMercUtils.Feigning()
             end,
         },
         {

--- a/class_configs/bst_class_config.lua
+++ b/class_configs/bst_class_config.lua
@@ -683,8 +683,7 @@ return {
                     RGMercUtils.FindWorstHurtManaXT(RGMercUtils.GetSetting('ParagonPct')), }
             end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and RGMercUtils.GetSetting('DoParagon') and not RGMercUtils.BuffActive(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
-                    and not RGMercUtils.Feigning()
+                return combat_state == "Combat" and RGMercUtils.GetSetting('DoParagon') and not RGMercUtils.BuffActive(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell) and not RGMercUtils.Feigning()
             end,
         },
         {

--- a/class_configs/bst_class_config.lua
+++ b/class_configs/bst_class_config.lua
@@ -872,17 +872,18 @@ return {
         },
         ['Paragon'] = {
             {
-                name = "Focused Paragon of Spirit",
+                name = "Paragon of Spirit",
                 type = "AA",
                 cond = function(self, aaName)
                     return RGMercUtils.AAReady(aaName)
                 end,
             },
             {
-                name = "Paragon of Spirit",
+                name = "Focused Paragon of Spirits",
                 type = "AA",
                 cond = function(self, aaName)
-                    return RGMercUtils.AAReady(aaName)
+                    return RGMercUtils.AAReady(aaName) and not
+					    RGMercUtils.BuffActive(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
                 end,
             },
         },

--- a/utils/rgmercs_utils.lua
+++ b/utils/rgmercs_utils.lua
@@ -2938,8 +2938,8 @@ end
 
 function RGMercUtils.FindWorstHurtManaGroupMember(minMana)
     local groupSize = mq.TLO.Group.Members()
-    local worstId = mq.TLO.Me.ID()
-    local worstPct = mq.TLO.Me.PctMana() < minMana and mq.TLO.Me.PctMana() or minMana
+    local worstId = mq.TLO.Me.ID() --initializes with the BST's ID/Mana because it isn't checked below
+    local worstPct = mq.TLO.Me.PctMana()
 
     RGMercsLogger.log_verbose("\ayChecking for worst HurtMana Group Members. Group Count: %d", groupSize)
 
@@ -2947,7 +2947,7 @@ function RGMercUtils.FindWorstHurtManaGroupMember(minMana)
         local healTarget = mq.TLO.Group.Member(i)
 
         if healTarget and healTarget() and not healTarget.OtherZone() and not healTarget.Offline() then
-            if RGMercConfig.Constants.RGCasters:contains(healTarget.Class.ShortName() or "none") then -- berzerkers have special handing
+            if RGMercConfig.Constants.RGCasters:contains(healTarget.Class.ShortName()) then
                 if not healTarget.Dead() and healTarget.PctMana() < worstPct then
                     RGMercsLogger.log_verbose("\aySo far %s is the worst off.", healTarget.DisplayName())
                     worstPct = healTarget.PctMana()
@@ -2957,7 +2957,8 @@ function RGMercUtils.FindWorstHurtManaGroupMember(minMana)
         end
     end
 
-    if worstId > 0 then
+    --Still possibly carrying the BST ID, but only reports BST if under 100%, which is when they will self-Paragon
+    if worstId > 0 and worstPct < 100 then
         RGMercsLogger.log_verbose("\agWorst HurtMana group member id is %d", worstId)
     else
         RGMercsLogger.log_verbose("\agNo one is HurtMana!")


### PR DESCRIPTION
[BST] Corrected typo in Focused Paragon
[Utils] Slightly modified the underlying function behind the Paragon rotation so Paragon and Focused Paragon weren't used if the BST had 100% mana.
[BST] Adjusted rotations so that (group) Paragon of Spirit would properly fire only when a group member was under the ParagonPct threshold.
[BST] Added condition to Focused paragon rotation to avoid spamming when group Paragon was active

Current behavior:
Group Paragon will be used when any group member's mana is below the class config setting "ParagonPct".
Focused Paragon will be used on the BST unless another target meets the criteria above and Group Paragon is on cooldown.

[ENC] Adjusted rotations so that low -level haste spells that were intended to be used on a pet before pet-specific buffs were available don't continually spam the Enchanter (tested with Speed of Vallon).
[ENC] Updated Downtime rotations to support BuffWaitMoveTimer
[ENC] Added support for NDT to be cast on the group (once group versions are available) regardless of the presence of melee party members (tested (single) Night's Darkest Terror, NDT group buff currently not available).