### PR TITLE
Correction to bst_class_config.lua

### DIFF
--- a/class_configs/bst_class_config.lua
+++ b/class_configs/bst_class_config.lua
@@ -870,7 +870,7 @@ return {
                 end,
             },
         },
-        ['Paragon'] = {
+        ['FocusedParagon'] = {
             {
                 name = "Focused Paragon of Spirits",
                 type = "AA",


### PR DESCRIPTION
Corrected new rotation name for Focused Paragon of Spirits, oversight from yesterday's push.