### PR TITLE
PAL and SHD Tooltips/Shield Flash

### DIFF
--- a/class_configs/enc_class_config.lua
+++ b/class_configs/enc_class_config.lua
@@ -596,18 +596,19 @@ local _ClassConfig = {
             "Mental Appropriation",
             "Cognitive Appropriation",
         },
-        ['ChromaNuke'] = {
+        --Unused table, temporarily removed - was causing conflicts while resolving NukeSpell1 action maps (will revisit nukes later)
+        -- ['ChromaNuke'] = {
             --- Chromatic Lowest Nuke - Normal -- >=LVL73
-            "Polycascading Assault",
-            "Polyfluorescent Assault",
-            "Polyrefractive Assault",
-            "Phantasmal Assault",
-            "Arcane Assault",
-            "Spectral Assault",
-            "Polychaotic Assault",
-            "Multichromatic Assault",
-            "Polychromatic Assault",
-        },
+            -- "Polycascading Assault",
+            -- "Polyfluorescent Assault",
+            -- "Polyrefractive Assault",
+            -- "Phantasmal Assault",
+            -- "Arcane Assault",
+            -- "Spectral Assault",
+            -- "Polychaotic Assault",
+            -- "Multichromatic Assault",
+            -- "Polychromatic Assault",
+        -- },
         ['CripSlowSpell'] = {
             --- Slow Cripple Combo Spell - Beginning @ Level 88
             "Constraining Coil",
@@ -866,7 +867,7 @@ local _ClassConfig = {
                 name = "PetSpell",
                 type = "Spell",
                 active_cond = function(self, _) return mq.TLO.Me.Pet.ID() > 0 end,
-                cond = function(self, spell) return mq.TLO.Me.Pet.ID() == 0 end,
+                cond = function(self, spell) return mq.TLO.Me.Pet.ID() == 0 and RGMercUtils.ReagentCheck(spell) end,
             },
             {
                 name = "SelfHPBuff",
@@ -964,9 +965,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target, uiCheck)
                     if not target or not target() then return false end
 
-                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() < 0 then return false end
-
-                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck)
+                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {
@@ -976,9 +975,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target, uiCheck)
                     if not target or not target() then return false end
 
-                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() < 0 then return false end
-
-                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck)
+                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {
@@ -1016,9 +1013,8 @@ local _ClassConfig = {
                     if not target or not target() then return false end
 
                     if not RGMercConfig.Constants.RGTank:contains(target.Class.ShortName()) then return false end
-                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() < 0 then return false end
 
-                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck)
+                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {
@@ -1030,9 +1026,8 @@ local _ClassConfig = {
                     if not target or not target() then return false end
 
                     if not RGMercConfig.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
-                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() < 0 then return false end
 
-                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck)
+                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {

--- a/class_configs/pal_class_config.lua
+++ b/class_configs/pal_class_config.lua
@@ -1394,9 +1394,9 @@ return {
     ['DefaultConfig']     = {
         ['Mode']         = { DisplayName = "Mode", Category = "Combat", Tooltip = "Select the Combat Mode for this Toon", Type = "Custom", RequiresLoadoutChange = true, Default = 1, Min = 1, Max = 2, },
         ['DoNuke']       = { DisplayName = "Cast Spells", Category = "Spells and Abilities", Tooltip = "Use Spells", Default = true, },
-        ['FlashHP']      = { DisplayName = "Flash HP", Category = "Combat", Tooltip = "TODO: No Idea", Default = 35, Min = 1, Max = 100, },
-        ['TotHealPoint'] = { DisplayName = "Flash HP", Category = "Combat", Tooltip = "TODO: No Idea", Default = 30, Min = 1, Max = 100, },
-        ['LayHandsPct']  = { DisplayName = "Flash HP", Category = "Combat", Tooltip = "TODO: No Idea", Default = 35, Min = 1, Max = 100, },
+        ['FlashHP']      = { DisplayName = "Use Shield Flash", Category = "Combat", Tooltip = "Your HP % before we use Shield Flash.", Default = 35, Min = 1, Max = 100, },
+        ['TotHealPoint'] = { DisplayName = "ToT HealPoint", Category = "Combat", Tooltip = "HP % before we use Target of Target heals.", Default = 30, Min = 1, Max = 100, },
+        ['LayHandsPct']  = { DisplayName = "Use Lay on Hands", Category = "Combat", Tooltip = "HP % before we use Lay on Hands.", Default = 35, Min = 1, Max = 100, },
         ['DoChestClick'] = { DisplayName = "Do Chest Click", Category = "Utilities", Tooltip = "Click your chest item", Default = true, },
         ['DoReverseDS']  = { DisplayName = "Do Reverse DS", Category = "Utilities", Tooltip = "Cast Reverse DS", Default = true, },
         ['SummonArrows'] = { DisplayName = "Summon Arrows", Category = "Utilities", Tooltip = "Enable Summon Arrows", Default = true, },

--- a/class_configs/shd_class_config.lua
+++ b/class_configs/shd_class_config.lua
@@ -920,7 +920,13 @@ local _ClassConfig = {
                     return true
                 end,
             },
-
+            {
+                name = "Shield Flash",
+                type = "AA",
+                cond = function(self, aaName)
+                    return RGMercUtils.AAReady(aaName) and mq.TLO.Me.PctHPs() < RGMercUtils.GetSetting('FlashHP')
+                end,
+            },
             {
                 name = mq.TLO.Me.Inventory("Charm").Name(),
                 type = "Item",
@@ -1379,7 +1385,7 @@ local _ClassConfig = {
         ['AeTauntCnt']      = { DisplayName = "AE Taunt Count", Category = "Spells and Abilities", Tooltip = "Minimum number of haters before using AE Taunt.", Default = 2, Min = 1, Max = 10, },
         ['HPStopDOT']       = { DisplayName = "HP Stop DOTs", Category = "Spells and Abilities", Tooltip = "Stop casting DOTs when the mob hits [x] HP %.", Default = 30, Min = 1, Max = 100, },
         ['UseVoT']          = { DisplayName = "Use Voice of Thule", Category = "Spells and Abilities", Tooltip = "Cast Voice of Thule", Default = true, },
-        ['FlashHP']         = { DisplayName = "Flash HP", Category = "Combat", Tooltip = "TODO: No Idea", Default = 35, Min = 1, Max = 100, },
+        ['FlashHP']         = { DisplayName = "Use Shield Flash", Category = "Combat", Tooltip = "Your HP % before we use Shield Flash.", Default = 35, Min = 1, Max = 100, },
         ['DoChestClick']    = { DisplayName = "Do Chest Click", Category = "Equipment", Tooltip = "Click your chest item", Default = true, },
         ['DoCharmClick']    = { DisplayName = "Do Charm Click", Category = "Equipment", Tooltip = "Click your charm item", Default = true, },
         ['StartBigTap']     = { DisplayName = "Use Big Taps", Category = "Spells and Abilities", Tooltip = "Your HP % before we use Big Taps.", Default = 80, Min = 1, Max = 100, },


### PR DESCRIPTION
[PAL] Corrected Tooltips in the Combat options.
[SHD] Added Shield Flash and updated the Tooltip to match PAL.

Shield Flash may have been an accidental deletion, as there is an empty space in the SHD file in the same location it is listed in the PAL file.

If its removal was intended, we can simply delete the FlashHP setting from SHD.