### PR TITLE
[ENC] Aura Fix

### DIFF
--- a/class_configs/clr_class_config.lua
+++ b/class_configs/clr_class_config.lua
@@ -15,7 +15,7 @@ local _ClassConfig = {
     },
     ['Cures']             = {
         CureNow = function(self, type, targetId)
-            if RGMercUtils.CanUseAA("Radiant Cure") then
+            if RGMercUtils.AAReady("Radiant Cure") then
                 return RGMercUtils.UseAA("Radiant Cure", targetId)
             end
 

--- a/class_configs/dru_class_config.lua
+++ b/class_configs/dru_class_config.lua
@@ -15,6 +15,9 @@ local _ClassConfig = {
     },
     ['Cures']             = {
         CureNow = function(self, type, targetId)
+            if RGMercUtils.AAReady("Radiant Cure") then
+                return RGMercUtils.UseAA("Radiant Cure", targetId)
+            end
             local cureSpell = RGMercUtils.GetResolvedActionMapItem('SingleTgtCure')
             if not cureSpell or not cureSpell() then return false end
             return RGMercUtils.UseSpell(cureSpell.RankName.Name(), targetId, true)

--- a/class_configs/enc_class_config.lua
+++ b/class_configs/enc_class_config.lua
@@ -916,21 +916,24 @@ local _ClassConfig = {
                 name = "AuraBuff1",
                 type = "Spell",
                 active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) end,
-                cond = function(self, spell) return not RGMercUtils.AuraActiveByName(spell.Name()) and RGMercUtils.PCSpellReady(spell) end,
+                cond = function(self, spell)
+				    if RGMercUtils.GetSetting('DoLearners') and not RGMercUtils.CanUseAA('Auroria Mastery') then return false end
+				    return RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name()) end,
             },
             {
                 name = "AuraBuff2",
                 type = "Spell",
                 active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) end,
-                cond = function(self, spell) return RGMercUtils.CanUseAA('Auroria Mastery') and not RGMercUtils.GetSetting('DoLearners') and not RGMercUtils.AuraActiveByName(spell.Name()) and RGMercUtils.PCSpellReady(spell) end,
+                cond = function(self, spell)
+                    return RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name()) and not RGMercUtils.GetSetting('DoLearners') end,
             },
             {
                 name = "AuraBuff3",
                 type = "Spell",
                 active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) end,
-                cond = function(self, spell) return RGMercUtils.CanUseAA('Auroria Mastery') and RGMercUtils.GetSetting('DoLearners') and not RGMercUtils.AuraActiveByName(spell.Name()) and RGMercUtils.PCSpellReady(spell) end,
+                cond = function(self, spell)
+                    return RGMercUtils.GetSetting('DoLearners') and RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name()) end,
             },
-
         },
         ['GroupBuff'] = {
             -- TODO : Macro group buff rotation never was hooked up ask Mori about this later.

--- a/class_configs/shm_class_config.lua
+++ b/class_configs/shm_class_config.lua
@@ -15,6 +15,9 @@ local _ClassConfig = {
     },
     ['Cures']             = {
         CureNow = function(self, type, targetId)
+            if RGMercUtils.AAReady("Radiant Cure") then
+                return RGMercUtils.UseAA("Radiant Cure", targetId)
+            end
             local cureSpell = RGMercUtils.GetResolvedActionMapItem('CureSpell')
             if cureSpell and cureSpell() then
                 return RGMercUtils.UseSpell(cureSpell.RankName.Name(), targetId, true)


### PR DESCRIPTION
[ENC] Updated aura entries so that the proper auras should be selected in all likely use cases: 
-Under Level 85, with or without Learner's selected (Twincast isn't available). 
-Level 85+, with or without Learner's selected, and with or without Auroria Mastery (second aura) AA.

Note: Auroria Mastery is available at level 81, but the code as written will not use a second aura until level 85 when Twincast is available.

Radiant Cure support
[SHM, DRU] Added Radiant Cure
[CLR] Improved handling with Radiant Cure

Using AAReady will simply return false if the PC doesn't have the AA and will not return when RC is on cooldown like CanUseAA.