### PR TITLE
Fix for Cleric Aego/Symbol swap and Cleric/Ench Aura 

### DIFF
--- a/class_configs/clr_class_config.lua
+++ b/class_configs/clr_class_config.lua
@@ -1205,7 +1205,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target, uiCheck)
                     -- force the target for StacksTarget to work.
                     if not uiCheck then RGMercUtils.SetTarget(target.ID() or 0) end
-                    return RGMercUtils.GetSetting('DoDruid') and RGMercUtils.SpellStacksOnTarget(spell)
+                    return RGMercUtils.GetSetting('DoDruid') and RGMercUtils.SpellStacksOnTarget(spell) and not RGMercUtils.BuffActive(spell)
                 end,
             },
         },

--- a/class_configs/clr_class_config.lua
+++ b/class_configs/clr_class_config.lua
@@ -1150,7 +1150,7 @@ local _ClassConfig = {
                 name = "aurabuff1",
                 type = "Spell",
                 cond = function(self, spell)
-                    return RGMercUtils.CanUseAA('Spirit Mastery') and not RGMercUtils.AuraActiveByName("Reverent Aura") and RGMercUtils.SpellStacksOnMe(spell)
+                    return RGMercUtils.CanUseAA('Spirit Mastery') and not RGMercUtils.AuraActiveByName(spell.BaseName()) and not RGMercUtils.AuraActiveByName("Reverent Aura") and RGMercUtils.SpellStacksOnMe(spell)
                 end,
             },
             {

--- a/class_configs/clr_class_config.lua
+++ b/class_configs/clr_class_config.lua
@@ -383,7 +383,7 @@ local _ClassConfig = {
             "Unified Hand of Assurance",
             "Unified Hand of Righteousness",
             "Unified Hand of Persistence",
-            "Unified Hand of Helmsbane",
+            "Unified Hand of Infallibility",
         },
         ['TankBuff'] = {
             --Tank Buff Traditionally Shining Series of Buffs
@@ -453,7 +453,7 @@ local _ClassConfig = {
             "Unified Hand of Jorlleag",
             "Unified Hand of Assurance",
             "Unified Hand of the Diabo",
-            "Unified Hand of Infallibility",
+            "Unified Hand of Helmsbane",
         },
         ['HPBuff'] = {
             ----Single Target HP Buffs

--- a/class_configs/enc_class_config.lua
+++ b/class_configs/enc_class_config.lua
@@ -923,9 +923,9 @@ local _ClassConfig = {
             {
                 name = "AuraBuff2",
                 type = "Spell",
-                active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) end,
+                active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) and not RGMercUtils.AuraActiveByName("Mana Ripple") end,
                 cond = function(self, spell)
-                    return RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name()) and not RGMercUtils.GetSetting('DoLearners') end,
+                    return RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name()) and not RGMercUtils.AuraActiveByName("Mana Ripple") and not RGMercUtils.GetSetting('DoLearners') end,
             },
             {
                 name = "AuraBuff3",


### PR DESCRIPTION
Swapped last entry for Cleric Aego and Symbol which was wrong

Fix for Cleric and Enchanter Aura that didnt got recognized as they have 1 Aura each that does not match with the Spell name.

And trying this Pull Request thing for the first time hoping I do it right.