### PR TITLE
[PAL] Rez/Cures, [ENC] Spell Gem update

### DIFF
--- a/class_configs/enc_class_config.lua
+++ b/class_configs/enc_class_config.lua
@@ -988,9 +988,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target, uiCheck)
                     if not target or not target() then return false end
 
-                    if mq.TLO.FindItemCount(spell.ReagentID(1)())() < 0 then return false end
-
-                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck)
+                    return RGMercUtils.CheckPCNeedsBuff(spell, target.ID(), target.CleanName(), uiCheck) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {
@@ -1025,7 +1023,7 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target, uiCheck)
-                    if not self.DoGroupAbsorb then return false end
+                    if not RGMercUtils.GetSetting('DoGroupAbsorb') then return false end
                     if not target or not target() then return false end
 
                     if not RGMercConfig.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
@@ -1180,6 +1178,13 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell)
                     return RGMercUtils.GetSetting('DoDot') and RGMercUtils.DetSpellCheck(spell) and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                end,
+            },
+            {
+                name = "ManaDot",
+                type = "Spell",
+                cond = function(self, spell)
+                    return RGMercUtils.IsNamed(mq.TLO.Target) and RGMercUtils.DetSpellCheck(spell) and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
                 end,
             },
             {
@@ -1414,14 +1419,14 @@ local _ClassConfig = {
             gem = 10,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "RuneNuke", cond = function(self) return true end, },
+                { name = "SingleRune", cond = function(self) return true end, },
             },
         },
         {
             gem = 11,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "DebuffDot", cond = function(self) return true end, },
+                { name = "GroupSpellShield", cond = function(self) return true end, },
             },
         },
         {

--- a/class_configs/pal_class_config.lua
+++ b/class_configs/pal_class_config.lua
@@ -7,10 +7,34 @@ return {
     ['ModeChecks']        = {
         IsTanking = function() return RGMercUtils.IsModeActive("Tank") end,
         IsHealing = function() return true end,
+        IsCuring = function() return RGMercUtils.GetSetting('DoCures') end,
+        IsRezing = function() return (RGMercUtils.GetSetting('DoBattleRez') and not RGMercUtils.IsTanking()) or RGMercUtils.GetXTHaterCount() == 0 end,
+            --Disabling tank battle rez is not optional to prevent settings in different areas and to avoid causing more potential deaths
     },
     ['Modes']             = {
         'Tank',
         'DPS',
+    },
+    ['Cures']             = {
+        CureNow = function(self, type, targetId)
+            if RGMercUtils.AAReady("Radiant Cure") then
+                return RGMercUtils.UseAA("Radiant Cure", targetId)
+            end
+            -- TODO: Consider the impact of memorizing cures outside of combat or increasing number of options in settings
+            -- local cureSpell = RGMercUtils.GetResolvedActionMapItem('Puritycure')
+
+            -- if type:lower() == "poison" then
+                -- cureSpell = RGMercUtils.GetResolvedActionMapItem('Puritycure')
+            -- elseif type:lower() == "curse" then
+                -- cureSpell = RGMercUtils.GetResolvedActionMapItem('Puritycure')
+            --TODO: Add Corruption AbilitySets
+            -- elseif type:lower() == "corruption" then
+                -- cureSpell = RGMercUtils.GetResolvedActionMapItem('')
+            -- end
+
+            -- if not cureSpell or not cureSpell() then return false end
+            -- return RGMercUtils.UseSpell(cureSpell.RankName.Name(), targetId, true)
+        end,
     },
     ['ItemSets']          = {
         ['Epic'] = {
@@ -627,6 +651,25 @@ return {
             local DPULevel = mq.TLO.Spell(mq.TLO.Me.AltAbility("Divine Protector's Unity").Spell.Trigger(1).BaseName()).Level() or 0
 
             return furyProcLevel <= DPULevel
+        end,
+       --Did not include Staff of Forbidden Rites, GoR refresh is very fast and rez is 96%
+		DoRez = function(self, corpseId)
+
+            if RGMercUtils.GetSetting('DoBattleRez') or RGMercUtils.DoBuffCheck() then
+                RGMercUtils.SetTarget(corpseId)
+
+                local target = mq.TLO.Target
+
+                if not target or not target() then return false end
+
+                if mq.TLO.Target.Distance() > 25 then
+                    RGMercUtils.DoCmd("/corpse")
+                end
+
+                if RGMercUtils.AAReady("Gift of Resurrection") then
+                    return RGMercUtils.UseAA("Gift of Resurrection", corpseId)
+                end
+            end
         end,
     },
     ['HealRotationOrder'] = {


### PR DESCRIPTION
[PAL] Added barebones support for curing, currently only Radiant Cure is supported.

[PAL] Added barebones support for resurrection. Gift of Resurrection is the only source at this time, no items are included. Currently, Battle Rez is disabled in the Tank Mode regardless of the general setting "DoBattleRez".

Further implementation for both features is possible, but I feel more discussion or feedback is warranted.

[ENC] Swapped spell gems of unused spells to reduce remems during buff cycles.

[ENC] Added ManaDoT to dps rotation.

Further optimization likely needed, I am concentrating on small issues which give immediate returns.