### PR TITLE
Chestclick only if mana is under harvets %?

### DIFF
--- a/class_configs/wiz_class_config.lua
+++ b/class_configs/wiz_class_config.lua
@@ -1099,7 +1099,7 @@ return {
                 end,
                 cond = function(self)
                     local item = mq.TLO.Me.Inventory("Chest")
-                    return RGMercUtils.GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                    return RGMercUtils.GetSetting('DoChestClick') and mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HavestManaPct') and item() and item.Spell.Stacks() and item.TimerReady() == 0
                 end,
             },
             {


### PR DESCRIPTION
This actually only applies to higher lvls, but how should it be handled not to clicked even when full mana?

chestclick only if mana is under harvest mana %