### PR TITLE
Combat Rez Fix, Spell Scribe Fix

### DIFF
--- a/utils/rgmercs_events.lua
+++ b/utils/rgmercs_events.lua
@@ -160,10 +160,18 @@ end)
 -- [ END MEM SPELL HANDLERS ] --
 
 -- [ SCRIBE SPELL HANDLERS ] --
+mq.event('Begin Scribe', "Beginning to scribe #1#...", function(spell)
+    RGMercUtils.Memorizing = true
+end)
 
 mq.event('End Scribe', "You have finished scribing #1#.", function(spell)
+	RGMercUtils.Memorizing = false
     -- Rescan spell list
     RGMercModules:ExecModule("Class", "RescanLoadout")
+end)
+
+mq.event('Abort Scribe', "Aborting scribing of spell.", function()
+    RGMercUtils.Memorizing = false
 end)
 
 -- [ END SCRIBE SPELL HANDLERS ] --

--- a/utils/rgmercs_utils.lua
+++ b/utils/rgmercs_utils.lua
@@ -195,9 +195,9 @@ function RGMercUtils.HandleDeath()
         end
     end
 
-    mq.delay("2m", function() return (mq.TLO.Zone.ID() ~= RGMercConfig.Globals.CurZoneId) end)
+    mq.delay("2m", function() return not mq.TLO.Me.Hovering() or (mq.TLO.Zone.ID() ~= RGMercConfig.Globals.CurZoneId) end)
 
-    RGMercsLogger.log_debug("Done zoning post death.")
+    RGMercsLogger.log_debug("Fishfood no more! Accepted rez or finished zoning post death.")
 
     -- if we want do do fellowship but we arent in the fellowship zone (rezed)
     if RGMercUtils.GetSetting('DoFellow') and not RGMercModules:ExecModule("Movement", "InCampZone") then


### PR DESCRIPTION
[utils] Automation will now immediately resume after receiving a rez.

[events] Spell scribing should now function when automation is active and "Stand When Done Medding" is checked. Some classes may still need to pause before scribing due to frequent autoinventory commands (Magician). The "Reload Spell Loadout" button in the Loadout section of your Class tab can be used to refresh your gems in this case.