### PR TITLE
DRU - Removed Nature's Boon from downtime rotation

### DIFF
--- a/class_configs/dru_class_config.lua
+++ b/class_configs/dru_class_config.lua
@@ -1301,18 +1301,6 @@ local _ClassConfig = {
         },
         ['Downtime'] = {
             {
-                name = "Nature's Boon",
-                type = "AA",
-                active_cond = function(self, aaName)
-                    return RGMercUtils.BuffActiveByID(mq.TLO.Me.AltAbility(aaName)
-                        .Spell.ID())
-                end,
-                cond = function(self, aaName)
-                    return RGMercUtils.GetSetting('WardsPlease') and
-                        not RGMercUtils.BuffActiveByID(mq.TLO.Me.AltAbility(aaName).Spell.ID())
-                end,
-            },
-            {
                 name = "SelfShield",
                 type = "Spell",
                 active_cond = function(self, spell) return RGMercUtils.BuffActiveByID(spell.ID()) end,


### PR DESCRIPTION
Removed the AA Nature's Boon from downtime. Looks weird that it casts it when you start the Lua, even if everyone is full health and/or standing in safe places. 20min reuse. Its already in the Burn section.