### PR TITLE
fix selecting a path not letting you edit

### DIFF
--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -569,6 +569,7 @@ function Module:Render()
                         local mpy, mpx, mpz = data.loc:match("([^,]+),%s*([^,]+),%s*([^,]+)")
                         self.settings.FarmWayPoints[mq.TLO.Zone.ShortName()][step] = { x = tonumber(mpx), y = tonumber(mpy), z = tonumber(mpz), }
                     end
+                    self.TempSettings.SelectedPath = "None"
                 end
             else
                 Module.TempSettings.MyPaths = 'None'


### PR DESCRIPTION
now resets after populating the table with the path you selected so you can modify it needed without reloading rgmercs.