### PR TITLE
removed announce to group

### DIFF
--- a/utils/rgmercs_config.lua
+++ b/utils/rgmercs_config.lua
@@ -261,9 +261,9 @@ Config.DefaultConfig = {
     -- [ ANNOUNCEMENTS ] --
     ['AnnounceTarget']       = { DisplayName = "Announce Target", Category = "Announcements", Tooltip = "Announces Target over DanNet in kissassist format, incase you are running a mixed set on your group.Config", Default = false, ConfigType = "Advanced", },
     ['MezAnnounce']          = { DisplayName = "Mez Announce", Category = "Announcements", Default = false, Tooltip = "Set to announce mez casts.", ConfigType = "Normal", },
-    ['MezAnnounceGroup']     = { DisplayName = "Mez Announce to Group", Category = "Announcements", Default = false, Tooltip = "Set to announce mez casts In group.", ConfigType = "Normal", },
+    --['MezAnnounceGroup']     = { DisplayName = "Mez Announce to Group", Category = "Announcements", Default = false, Tooltip = "Set to announce mez casts In group.", ConfigType = "Normal", },
     ['CharmAnnounce']          = { DisplayName = "Charm Announce", Category = "Announcements", Default = false, Tooltip = "Set to announce Charm casts.", ConfigType = "Advanced", },
-    ['CharmAnnounceGroup']     = { DisplayName = "Charm Announce to Group", Category = "Announcements", Default = false, Tooltip = "Set to announce Charm casts In group.", ConfigType = "Advanced", },
+    --['CharmAnnounceGroup']     = { DisplayName = "Charm Announce to Group", Category = "Announcements", Default = false, Tooltip = "Set to announce Charm casts In group.", ConfigType = "Advanced", },
 
 }
 

--- a/utils/rgmercs_utils.lua
+++ b/utils/rgmercs_utils.lua
@@ -3075,14 +3075,7 @@ end
 
 -- cleaned up message handlers for announcements
 function RGMercUtils.HandleMezAnnounce(msg)
-    if RGMercUtils.GetSetting('MezAnnounceGroup') and RGMercUtils.GetSetting('MezAnnounce') then
-        local cleanMsg = msg:gsub("\a.", "")
-        RGMercUtils.DoCmd("/gsay %s", cleanMsg)
-        RGMercUtils.PrintGroupMessage(msg)
-    elseif RGMercUtils.GetSetting('MezAnnounceGroup') then
-        local cleanMsg = msg:gsub("\a.", "")
-        RGMercUtils.DoCmd("/gsay %s", cleanMsg)
-    elseif RGMercUtils.GetSetting('MezAnnounce') then
+    if RGMercUtils.GetSetting('MezAnnounce') then
         RGMercUtils.PrintGroupMessage(msg)
     else
         RGMercsLogger.log_debug(msg)
@@ -3090,14 +3083,7 @@ function RGMercUtils.HandleMezAnnounce(msg)
 end
 
 function RGMercUtils.HandleCharmAnnounce(msg)
-    if RGMercUtils.GetSetting('CharmAnnounceGroup') and RGMercUtils.GetSetting('CharmAnnounce') then
-        local cleanMsg = msg:gsub("\a.", "")
-        RGMercUtils.DoCmd("/gsay %s", cleanMsg)
-        RGMercUtils.PrintGroupMessage(msg)
-    elseif RGMercUtils.GetSetting('CharmAnnounceGroup') then
-        local cleanMsg = msg:gsub("\a.", "")
-        RGMercUtils.DoCmd("/gsay %s", cleanMsg)
-    elseif RGMercUtils.GetSetting('CharmAnnounce') then
+    if RGMercUtils.GetSetting('CharmAnnounce') then
         RGMercUtils.PrintGroupMessage(msg)
     else
         RGMercsLogger.log_debug(msg)


### PR DESCRIPTION
probably shouldn't be sending EQ group chat Spawn  and spell ID#'s and failure messages like CAST_INTERRUPTED

Maybe if we want to announces a charm or mez we could create a separate handler for the group message that's cleaner