### PR TITLE
Bandaid fix for recourses and f2p players with Rk. II spells

### DIFF
--- a/class_configs/mag_class_config.lua
+++ b/class_configs/mag_class_config.lua
@@ -1738,8 +1738,8 @@ _ClassConfig      = {
                 name = "PetManaConv",
                 type = "Spell",
                 cond = function(self, spell)
-                    return spell and spell() and not RGMercUtils.BuffActive(mq.TLO.Spell(spell.RankName.AutoCast() or 0)) and
-                    not RGMercUtils.BuffActiveByName(mq.TLO.Spell(spell.RankName.AutoCast() or 0).Name() .. " Recourse") and mq.TLO.Me.Pet.ID() > 0
+                    if not spell or not spell() then return false end
+                    return not mq.TLO.Me.Buff(spell.Name() .. " Recourse")() and mq.TLO.Me.Pet.ID() > 0
                 end,
             },
             {

--- a/class_configs/shd_class_config.lua
+++ b/class_configs/shd_class_config.lua
@@ -1520,7 +1520,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.BuffTap,
                 cond = function(self, spell, target)
                     if not RGMercUtils.GetSetting('DoBuffTap') then return false end
-                    return not mq.TLO.Me.Buff(spell.Trigger())() and RGMercUtils.SpellStacksOnMe(spell.Trigger)() and RGMercUtils.NPCSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Trigger())() and RGMercUtils.SpellStacksOnMe(spell.Trigger) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
         },

--- a/class_configs/shd_class_config.lua
+++ b/class_configs/shd_class_config.lua
@@ -1511,7 +1511,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Torrent,
                 cond = function(self, spell, target)
                     if not RGMercUtils.GetSetting('DoTorrent') or not spell or not spell() then return false end
-                    return not RGMercUtils.BuffActiveByName((spell.Name() or "N/A") .. " Recourse") and RGMercUtils.NPCSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Name() .. " Recourse")() and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1520,8 +1520,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.BuffTap,
                 cond = function(self, spell, target)
                     if not RGMercUtils.GetSetting('DoBuffTap') then return false end
-                    return not RGMercUtils.BuffActive(spell.RankName.Name.Trigger(1)()) and RGMercUtils.SpellStacksOnMe(spell.RankName.Name.Trigger(1)()) and
-                        RGMercUtils.NPCSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Trigger())() and RGMercUtils.SpellStacksOnMe(spell.Trigger)() and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
         },


### PR DESCRIPTION
This will work for now. More may be necessary as they rear their head. 
Both tested with 120 mage/shd. Check recourse names and they seem to be consistent in these instances.