### PR TITLE
[WIZ] Minor fixes for chest click

### DIFF
--- a/class_configs/wiz_class_config.lua
+++ b/class_configs/wiz_class_config.lua
@@ -1102,12 +1102,12 @@ return {
                 type = "Item",
                 active_cond = function(self)
                     local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and mq.TLO.Me.Song(item.Spell.RankName.Name())() ~= nil
+                    return RGMercUtils.BuffActive(item.Spell)
                 end,
                 cond = function(self)
                     local item = mq.TLO.Me.Inventory("Chest")
-                    return RGMercUtils.GetSetting('DoChestClick') and mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and item() and item.Spell.Stacks() and
-                        item.TimerReady() == 0
+                    if not RGMercUtils.GetSetting('DoChestClick') or not item or not item() then return false end
+                    return mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and item.TimerReady() == 0 and RGMercUtils.SelfBuffCheck(item.Spell)
                 end,
             },
             {


### PR DESCRIPTION
Fixed active condition, adjusted condition to stop attempt spam in a niche case. (SelfBuffCheck has a .Stacks check so long as it isn't passed a string).

This can likely become the default for chest clicks that go to buff window, but some clicks may go to song window so I will need to check one by one.

on the active condition, buffactive will return false if passed nil, no need to check for item