### PR TITLE
[ENC] Update, new mode added

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "mq-defs.etag": "W/\"84544c5652386665b2e53f0b19459992843f4f45316093d0f9a4ea9ab1bfa7e8\""
+    "mq-defs.etag": "W/\"bdb0b0df2f885c265c1dec6eed58eb3c8c6101336f9705772f5fd9250ab4a622\""
 }

--- a/class_configs/brd_class_config.lua
+++ b/class_configs/brd_class_config.lua
@@ -1316,6 +1316,10 @@ local _ClassConfig = {
             {
                 name = "BardDPSAura",
                 type = "Song",
+                pre_activate = function(self, songSpell) --remove the old aura if we leveled up (or the other aura if we just changed options), otherwise we will be spammed because of no focus.
+                    ---@diagnostic disable-next-line: undefined-field
+                    if not RGMercUtils.AuraActiveByName(songSpell.BaseName()) then mq.TLO.Me.Aura(1).Remove() end
+                end,
                 cond = function(self, songSpell)
                     return not RGMercUtils.AuraActiveByName(songSpell.BaseName()) and RGMercUtils.GetSetting('UseAura') == 1
                 end,
@@ -1323,6 +1327,10 @@ local _ClassConfig = {
             {
                 name = "BardRegenAura",
                 type = "Song",
+                pre_activate = function(self, songSpell) --remove the old aura if we leveled up (or the other aura if we just changed options), otherwise we will be spammed because of no focus.
+                    ---@diagnostic disable-next-line: undefined-field
+                    if not RGMercUtils.AuraActiveByName(songSpell.BaseName()) then mq.TLO.Me.Aura(1).Remove() end
+                end,
                 cond = function(self, songSpell)
                     return not RGMercUtils.AuraActiveByName(songSpell.BaseName()) and RGMercUtils.GetSetting('UseAura') == 2
                 end,

--- a/class_configs/enc_class_config.lua
+++ b/class_configs/enc_class_config.lua
@@ -2,29 +2,29 @@ local mq           = require('mq')
 local RGMercUtils  = require("utils.rgmercs_utils")
 
 local _ClassConfig = {
-    _version          = "1.1 Beta",
-    _author           = "Derple, Grimmier",
-    ['ModeChecks']    = {
+    _version            = "1.2",
+    _author             = "Derple, Grimmier, Algar",
+    ['ModeChecks']      = {
         CanMez     = function() return true end,
         CanCharm   = function() return true end,
         IsCharming = function() return RGMercUtils.GetSetting('CharmOn') end,
         IsMezzing  = function() return true end,
-        -- IsCharming = function() return RGMercUtils.IsModeActive("Charm") end,
     },
-    ['Modes']         = {
-        'Mez',
+    ['Modes']           = {
+        'Default',
+        'ModernEra', --Different DPS rotation, meant for ~90+ (and may not come fully online until 105ish)
     },
-    ['ItemSets']      = {
+    ['ItemSets']        = {
         ['Epic'] = {
             "Staff of Eternal Eloquence",
             "Oculus of Persuasion",
         },
     },
-    ['AbilitySets']   = {
-        ['AuraBuff1'] = {
+    ['AbilitySets']     = {
+        ['TwincastAura'] = {
             "Twincast Aura",
         },
-        ['AuraBuff2'] = {
+        ['SpellProcAura'] = {
             "Mana Ripple Aura",
             "Mana Radix Aura",
             "Mana Replication Aura",
@@ -40,7 +40,7 @@ local _ClassConfig = {
             "Illusionist's Aura",
             "Beguiler's Aura",
         },
-        ['AuraBuff3'] = {
+        ['LearnersAura'] = {
             "Learner's Aura",
         },
         ['HasteBuff'] = {
@@ -289,8 +289,8 @@ local _ClassConfig = {
             "Umbral Auspice",
         },
         ['SelfGuardShield'] = {
+            "Shield of Inevitability",
             "Shield of Inescapability",
-            "Shield of Shadow",
             "Shield of Destiny",
             "Shield of Order",
             "Shield of Consequence",
@@ -302,13 +302,25 @@ local _ClassConfig = {
             "Transfixer's Auspice",
             "Enticer's Auspice",
         },
+        ['SpellProcBuff'] = {
+            "Mana Reproduction",
+            "Mana Rebirth",
+            "Mana Replication",
+            "Mana Repetition",
+            "Mana Reciprocation",
+            "Mana Reverberation",
+            "Mana Repercussion",
+            "Mana Reiteration",
+            "Mana Reiterate",
+            "Mana Resurgence",
+        },
         ['AllianceSpell'] = {
             "Chromatic Conjunction",
             "Chromatic Coalition",
             "Chromatic Covenant",
             "Chromatic Alliance",
         },
-        ['TwinCast'] = {
+        ['TwinCastMez'] = {
             "Chaotic Deception",
             "Chaotic Delusion",
             "Chaotic Bewildering",
@@ -790,22 +802,29 @@ local _ClassConfig = {
             "Root",
         },
     },
-    ['RotationOrder'] = {
+    ['RotationOrder']   = {
         {
-            name = 'SelfBuff',
+            name = 'Downtime',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and
-                    RGMercUtils.DoBuffCheck()
+                return combat_state == "Downtime" and RGMercUtils.DoBuffCheck()
             end,
-
         },
-        {
-            name = 'PetBuff',
-            targetId = function(self) return { mq.TLO.Me.Pet.ID(), } end,
+        { --Summon pet even when buffs are off on emu
+            name = 'Pet Management',
+            state = 1,
+            steps = 1,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and
-                    RGMercUtils.DoBuffCheck() and mq.TLO.Me.Pet.ID() > 0
+                return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() == 0 and not RGMercUtils.IsCharming()
+            end,
+        },
+        { --Pet Buffs if we have one, timer because we don't need to constantly check this
+            name = 'Pet Downtime',
+            timer = 60,
+            targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
+            cond = function(self, combat_state)
+                return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and RGMercUtils.DoBuffCheck()
             end,
         },
         {
@@ -826,13 +845,26 @@ local _ClassConfig = {
                 return combat_state == "Downtime" and RGMercUtils.DoBuffCheck()
             end,
         },
-        {
-            name = 'Debuff',
+        { --Slow and Tash separated so we use both before we start DPS
+            name = 'Tash',
             state = 1,
             steps = 1,
             targetId = function(self) return mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and { RGMercConfig.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not RGMercUtils.Feigning()
+                if not RGMercUtils.GetSetting('DoTash') then return false end
+                return combat_state == "Combat" and RGMercUtils.DebuffConCheck() and not RGMercUtils.Feigning() and
+                    mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToDebuff')
+            end,
+        },
+        { --Slow and Tash separated so we use both before we start DPS
+            name = 'CripSlow',
+            state = 1,
+            steps = 1,
+            targetId = function(self) return mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and { RGMercConfig.Globals.AutoTargetID, } or {} end,
+            cond = function(self, combat_state)
+                if not RGMercUtils.GetSetting('DoSlow') or not RGMercUtils.GetSetting('DoCripple') then return false end
+                return combat_state == "Combat" and RGMercUtils.DebuffConCheck() and not RGMercUtils.Feigning() and
+                    mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToDebuff')
             end,
         },
         {
@@ -844,8 +876,8 @@ local _ClassConfig = {
                 return combat_state == "Combat" and RGMercUtils.BurnCheck() and not RGMercUtils.Feigning()
             end,
         },
-        {
-            name = 'DPS',
+        { --AA Stuns, Runes, etc, moved from previous home in DPS
+            name = 'CombatSupport',
             state = 1,
             steps = 1,
             targetId = function(self) return mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and { RGMercConfig.Globals.AutoTargetID, } or {} end,
@@ -853,23 +885,60 @@ local _ClassConfig = {
                 return combat_state == "Combat" and not RGMercUtils.Feigning()
             end,
         },
-
-    },
-    ['Rotations']     = {
-        ['PetBuff'] = {
-            {
-                name = "PetBuffSpell",
-                type = "Spell",
-                active_cond = function(self, spell) return mq.TLO.Me.PetBuff(spell.ID()).ID() end,
-                cond = function(self, spell) return RGMercUtils.SelfBuffPetCheck(spell) end,
-            },
+        {
+            name = 'DPS',
+            state = 1,
+            steps = 1,
+            targetId = function(self) return mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and { RGMercConfig.Globals.AutoTargetID, } or {} end,
+            cond = function(self, combat_state)
+                if not RGMercUtils.IsModeActive("Default") then return false end
+                return combat_state == "Combat" and not RGMercUtils.Feigning()
+            end,
         },
-        ['SelfBuff'] = {
+        {
+            name = 'ModernEraDPS',
+            state = 1,
+            steps = 1,
+            targetId = function(self) return mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and { RGMercConfig.Globals.AutoTargetID, } or {} end,
+            cond = function(self, combat_state)
+                if not RGMercUtils.IsModeActive("ModernEra") then return false end
+                return combat_state == "Combat" and not RGMercUtils.Feigning()
+            end,
+        },
+    },
+    ['HelperFunctions'] = { --used to autoinventory our azure crystal after summon
+        StashCrystal = function()
+            mq.delay("2s", function() return mq.TLO.Cursor() and mq.TLO.Cursor.ID() == mq.TLO.Spell("Azure Mind Crystal").Base(1)() end)
+
+            if not mq.TLO.Cursor() then
+                RGMercsLogger.log_debug("No valid item found on cursor, item handling aborted.")
+                return false
+            end
+
+            RGMercsLogger.log_info("Sending the %s to our bags.", mq.TLO.Cursor())
+            mq.delay(150)
+            RGMercUtils.DoCmd("/autoinventory")
+        end,
+    },
+    ['Rotations']       = {
+        ['Downtime'] = {
             {
-                name = "PetSpell",
+                name = "Orator's Unity",
+                type = "AA",
+                active_cond = function(self, aaName) return RGMercUtils.BuffActiveByName(aaName) end,
+                cond = function(self, aaName) return RGMercUtils.SelfBuffAACheck(aaName) and RGMercUtils.AAReady(aaName) end,
+            },
+            {
+                name = "SelfGuardShield",
                 type = "Spell",
-                active_cond = function(self, _) return mq.TLO.Me.Pet.ID() > 0 end,
-                cond = function(self, spell) return mq.TLO.Me.Pet.ID() == 0 and RGMercUtils.ReagentCheck(spell) end,
+                active_cond = function(self, spell) return RGMercUtils.BuffActiveByID(spell.RankName.ID()) end,
+                cond = function(self, spell) return RGMercUtils.SelfBuffCheck(spell) end,
+            },
+            {
+                name = "SelfRune1",
+                type = "Spell",
+                active_cond = function(self, spell) return RGMercUtils.BuffActiveByID(spell.ID()) end,
+                cond = function(self, spell) return RGMercUtils.SelfBuffCheck(spell) end,
             },
             {
                 name = "SelfHPBuff",
@@ -884,12 +953,6 @@ local _ClassConfig = {
                 cond = function(self, spell) return RGMercUtils.SelfBuffCheck(spell) end,
             },
             {
-                name = "SelfRune1",
-                type = "Spell",
-                active_cond = function(self, spell) return RGMercUtils.BuffActiveByID(spell.ID()) end,
-                cond = function(self, spell) return RGMercUtils.SelfBuffCheck(spell) end,
-            },
-            {
                 name = "SelfRune2",
                 type = "Spell",
                 active_cond = function(self, spell) return RGMercUtils.BuffActiveByID(spell.ID()) end,
@@ -899,23 +962,36 @@ local _ClassConfig = {
                 name = "Veil of Mindshadow",
                 type = "AA",
                 active_cond = function(self, aaName) return RGMercUtils.BuffActiveByName(aaName) end,
-                cond = function(self, aaName) return RGMercUtils.SelfBuffAACheck(aaName) end,
+                cond = function(self, aaName) return RGMercUtils.SelfBuffAACheck(aaName) and RGMercUtils.AAReady(aaName) end,
             },
 
             {
                 name = "Azure Mind Crystal",
                 type = "AA",
                 active_cond = function(self, aaName) return mq.TLO.FindItem(aaName)() ~= nil end,
-                cond = function(self, aaName) return mq.TLO.Me.PctMana() > 90 and not mq.TLO.FindItem(aaName)() end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() > 90 and not mq.TLO.FindItem(aaName)() and RGMercUtils.AAReady(aaName) end,
+                post_activate = function(self, aaName, success)
+                    if success then
+                        RGMercUtils.SafeCallFunc("Autoinventory", self.ClassConfig.HelperFunctions.StashCrystal)
+                    end
+                end,
             },
             {
                 name = "Gather Mana",
                 type = "AA",
                 active_cond = function(self, aaName) return RGMercUtils.AAReady(aaName) end,
-                cond = function(self, aaName) return mq.TLO.Me.PctMana() < 60 end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() < 60 and RGMercUtils.AAReady(aaName) end,
             },
             {
-                name = "AuraBuff1",
+                name = "LearnersAura",
+                type = "Spell",
+                active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) end,
+                cond = function(self, spell)
+                    return RGMercUtils.GetSetting('DoLearners') and RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name())
+                end,
+            },
+            {
+                name = "TwincastAura",
                 type = "Spell",
                 active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) end,
                 cond = function(self, spell)
@@ -924,34 +1000,48 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "AuraBuff2",
+                name = "SpellProcAura",
                 type = "Spell",
-                active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) and not RGMercUtils.AuraActiveByName("Mana Ripple") end,
-                cond = function(self, spell)
-                    return RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name()) and not RGMercUtils.AuraActiveByName("Mana Ripple") and
-                        not RGMercUtils.GetSetting('DoLearners')
+                active_cond = function(self, spell)
+                    local aura = string.sub(spell.Name(), 1, 8)
+                    return RGMercUtils.AuraActiveByName(aura)
                 end,
-            },
-            {
-                name = "AuraBuff3",
-                type = "Spell",
-                active_cond = function(self, spell) return RGMercUtils.AuraActiveByName(spell.Name()) end,
+                pre_activate = function(self, spell)               --remove the old aura if we leveled up, otherwise we will be spammed because of no focus.
+                    local aura = string.sub(spell.Name(), 1, 8)
+                    if not RGMercUtils.AuraActiveByName(aura) then ----This is complex because the aura could be in slot 1 or 2 depending on level and aa status
+                        local rmv = RGMercUtils.CanUseAA('Auroria Mastery') and 2 or 1
+                        mq.TLO.Me.Aura(rmv).Remove()               --I have to remove by slot because I can't map the "old" aura to remove it by name
+                    end
+                end,
                 cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoLearners') and RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(spell.Name())
+                    local aura = string.sub(spell.Name(), 1, 8)
+                    return RGMercUtils.PCSpellReady(spell) and not RGMercUtils.AuraActiveByName(aura) and not RGMercUtils.GetSetting('DoLearners')
                 end,
             },
         },
+        ['Pet Management'] = {
+            {
+                name = "PetSpell",
+                type = "Spell",
+                active_cond = function(self, _) return mq.TLO.Me.Pet.ID() > 0 end,
+                cond = function(self, spell) return RGMercUtils.ReagentCheck(spell) end,
+            },
+        },
+        ['Pet Downtime'] = {
+            {
+                name = "PetBuffSpell",
+                type = "Spell",
+                active_cond = function(self, spell) return mq.TLO.Me.PetBuff(spell.ID()).ID() end,
+                cond = function(self, spell) return RGMercUtils.SelfBuffPetCheck(spell) end,
+            },
+        },
         ['GroupBuff'] = {
-            -- TODO : Macro group buff rotation never was hooked up ask Mori about this later.
             {
                 name = "ManaRegen",
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not target or not target() then return false end
-
                     if not RGMercConfig.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
-
                     return RGMercUtils.GroupBuffCheck(spell, target)
                 end,
             },
@@ -960,11 +1050,7 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not target or not target() then return false end
-
-                    if not RGMercConfig.Constants.RGMelee:contains(target.Class.ShortName()) then return false end
-
-                    return RGMercUtils.GroupBuffCheck(spell, target)
+                    return RGMercConfig.Constants.RGMelee:contains(target.Class.ShortName()) and RGMercUtils.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -972,9 +1058,7 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not target or not target() then return false end
-
-                    return RGMercUtils.GroupBuffCheck(spell, target)
+                    return RGMercUtils.GroupBuffCheck(spell, target) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {
@@ -982,9 +1066,8 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not target or not target() then return false end
-
-                    return RGMercUtils.GroupBuffCheck(spell, target)
+                    if not RGMercUtils.GetSetting('DoGroupDotShield') then return false end
+                    return RGMercUtils.GroupBuffCheck(spell, target) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {
@@ -992,9 +1075,7 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not target or not target() then return false end
-
-                    return RGMercUtils.GroupBuffCheck(spell, target)
+                    return RGMercUtils.GroupBuffCheck(spell, target) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
             {
@@ -1002,8 +1083,6 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not target or not target() then return false end
-
                     --NDT will not be cast or memorized if it isn't already on the bar due to a very long refresh time
                     if not RGMercUtils.GetSetting('DoNDTBuff') or not RGMercUtils.CastReady(spell.RankName) then return false end
                     --Single target versions of the spell will only be used on Melee, group versions will be cast if they are missing from any groupmember
@@ -1016,15 +1095,12 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "SingleRune",
+                name = "SpellProcBuff",
                 type = "Spell",
-                active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
+                active_cond = function(self, spell) return RGMercUtils.BuffActiveByID(spell.ID()) end,
                 cond = function(self, spell, target)
-                    if not target or not target() then return false end
-
-                    if not RGMercConfig.Constants.RGTank:contains(target.Class.ShortName()) then return false end
-
-                    return RGMercUtils.GroupBuffCheck(spell, target) and RGMercUtils.ReagentCheck(spell)
+                    if not RGMercConfig.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
+                    return RGMercUtils.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1032,11 +1108,7 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not RGMercUtils.GetSetting('DoGroupAbsorb') then return false end
-                    if not target or not target() then return false end
-
-                    if not RGMercConfig.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
-
+                    if not RGMercUtils.GetSetting('DoGroupAbsorb') or not RGMercConfig.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
                     return RGMercUtils.GroupBuffCheck(spell, target) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
@@ -1045,23 +1117,27 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not RGMercUtils.GetSetting('DoAggroRune') then return false end
-                    if not target or not target() then return false end
-
-                    if not RGMercConfig.Constants.RGTank:contains(target.Class.ShortName()) then return false end
-
-                    return RGMercUtils.GroupBuffCheck(spell, target.CleanName())
+                    if not RGMercUtils.GetSetting('DoAggroRune') or not RGMercConfig.Constants.RGTank:contains(target.Class.ShortName()) then return false end
+                    return RGMercUtils.GroupBuffCheck(spell, target)
+                end,
+            },
+            {
+                name = "SingleRune",
+                type = "Spell",
+                active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
+                cond = function(self, spell, target)
+                    if RGMercUtils.GetSetting('DoGroupAbsorb') then return false end
+                    return RGMercUtils.GroupBuffCheck(spell, target) and RGMercUtils.ReagentCheck(spell)
                 end,
             },
         },
-        ['DPS'] = {
+        ['CombatSupport'] = {
             {
                 name = "Glyph Spray",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
                     return (RGMercUtils.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        RGMercUtils.GetMainAssistPctHPs() < 45 and RGMercUtils.GetMainAssistPctHPs() > 5
+                        RGMercUtils.GetMainAssistPctHPs() < 45 and RGMercUtils.GetMainAssistPctHPs() > 5 and RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1069,9 +1145,8 @@ local _ClassConfig = {
                 name = "Reactive Rune",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
                     return (RGMercUtils.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        RGMercUtils.GetMainAssistPctHPs() < 45 and RGMercUtils.GetMainAssistPctHPs() > 5
+                        RGMercUtils.GetMainAssistPctHPs() < 45 and RGMercUtils.GetMainAssistPctHPs() > 5 and RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1079,8 +1154,8 @@ local _ClassConfig = {
                 name = "Self Stasis",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30
+                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30 and
+                        RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1088,8 +1163,8 @@ local _ClassConfig = {
                 name = "Dimensional Instability",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30
+                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30 and
+                        RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1097,8 +1172,8 @@ local _ClassConfig = {
                 name = "Beguiler's Directed Banishment",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 40
+                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 40 and
+                        RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1106,9 +1181,8 @@ local _ClassConfig = {
                 name = "Beguiler's Banishment",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
                     return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 50 and
-                        mq.TLO.SpawnCount("npc radius 20")() > 2
+                        mq.TLO.SpawnCount("npc radius 20")() > 2 and RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1116,8 +1190,8 @@ local _ClassConfig = {
                 name = "Doppelganger",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 60
+                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 60 and
+                        RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1125,8 +1199,8 @@ local _ClassConfig = {
                 name = "Phantasmal Opponent",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 60
+                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 60 and
+                        RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1134,8 +1208,8 @@ local _ClassConfig = {
                 name = "Dimensional Shield",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 80
+                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == RGMercConfig.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 80 and
+                        RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1143,8 +1217,7 @@ local _ClassConfig = {
                 name = "Arcane Whisper",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.PctAggro() >= 90
+                    return mq.TLO.Me.PctAggro() >= 90 and RGMercUtils.AAReady(aaName)
                 end,
 
             },
@@ -1152,27 +1225,9 @@ local _ClassConfig = {
                 name = "Silent Casting",
                 type = "AA",
                 cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return mq.TLO.Me.PctAggro() >= 90
+                    return mq.TLO.Me.PctAggro() >= 90 and RGMercUtils.AAReady(aaName)
                 end,
 
-            },
-            {
-                name = "Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return true
-                end,
-
-            },
-            {
-                name = "Bite of Tashani",
-                type = "AA",
-                cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return RGMercUtils.GetSetting('DoTash') and RGMercUtils.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and not mq.TLO.Target.Tashed()
-                end,
             },
             {
                 name = "UseAzureMindCrystal",
@@ -1180,62 +1235,141 @@ local _ClassConfig = {
                 cond = function(self)
                     if not RGMercUtils.CanUseAA("Azure Mind Crystal") then return false end
                     local crystal = mq.TLO.FindItem("Azure Mind Crystal")
-                    ---@diagnostic disable-next-line: param-type-mismatch
-                    return crystal and crystal() and mq.TLO.FindItem(crystal).TimerReady() == 0 and mq.TLO.Me.PctMana() <= RGMercUtils.GetSetting('ModRodManaPct')
+                    if not crystal or crystal() then return false end
+                    return crystal.TimerReady() == 0 and mq.TLO.Me.PctMana() <= RGMercUtils.GetSetting('ModRodManaPct')
                 end,
                 custom_func = function(self)
                     local crystal = mq.TLO.FindItem("Azure Mind Crystal")
                     return RGMercUtils.UseItem(crystal.Name(), mq.TLO.Me.ID())
                 end,
             },
+        },
+        ['DPS'] = {
+            {
+                name = "StripBuffSpell",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoStripBuff') then return false end
+                    return mq.TLO.Target.Beneficial() and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+            {
+                name = "Focus of Arcanum",
+                type = "AA",
+                cond = function(self, aaName)
+                    return RGMercUtils.AAReady(aaName)
+                end,
+            },
             {
                 name = "TwinCast",
                 type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoTwincastDPS') and not RGMercUtils.BuffActiveByID(spell.ID()) and not RGMercUtils.BuffActiveByName("Improved Twincast") and
-                        not RGMercModules:ExecModule("Mez", "IsMezImmune", mq.TLO.Target.ID())
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoTwincastDPS') or RGMercModules:ExecModule("Mez", "IsMezImmune", mq.TLO.Target.ID()) then return false end
+                    return not RGMercUtils.BuffActiveByID(spell.ID()) and not RGMercUtils.BuffActiveByName("Improved Twincast") and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "DoTSpell1",
                 type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoDot') and RGMercUtils.DetSpellCheck(spell) and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoDot') then return false end
+                    return RGMercUtils.DotSpellCheck(spell) and (RGMercUtils.DotManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "ManaDot",
                 type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.IsNamed(mq.TLO.Target) and RGMercUtils.DetSpellCheck(spell) and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoDot') and RGMercUtils.IsNamed(mq.TLO.Target) then return false end
+                    return RGMercUtils.DotSpellCheck(spell) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "DichoSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoDicho') and RGMercUtils.DetSpellCheck(spell) and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoDicho') then return false end
+                    return (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "NukeSpell1",
                 type = "Spell",
-                cond = function(self, spell)
-                    return mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                cond = function(self, spell, target)
+                    return (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "NukeSpell2",
                 type = "Spell",
-                cond = function(self, spell)
-                    return mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                cond = function(self, spell, target)
+                    return (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "ManaDrainSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return (mq.TLO.Target.CurrentMana() or 0) > 10 and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                cond = function(self, spell, target)
+                    return (mq.TLO.Target.CurrentMana() or 0) > 10 and (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+        },
+        ['ModernEraDPS'] = {
+            {
+                name = "StripBuffSpell",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoStripBuff') then return false end
+                    return mq.TLO.Target.Beneficial() and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+            {
+                name = "Focus of Arcanum",
+                type = "AA",
+                cond = function(self, aaName)
+                    return RGMercUtils.AAReady(aaName)
+                end,
+            },
+            {
+                name = "DichoSpell",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return RGMercUtils.DetSpellCheck(spell) and (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+            {
+                name = "ManaDot",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return RGMercUtils.DotSpellCheck(spell) and (RGMercUtils.DotManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+            {
+                name = "NukeSpell1",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+            { --Mana check used instead of dot mana check because this is spammed like a nuke
+                name = "DoTSpell1",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+            { --this is not an error, we want the spell twice in a row as part of the rotation.
+                name = "DoTSpell1",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return (RGMercUtils.ManaCheck() or RGMercUtils.BurnCheck()) and RGMercUtils.NPCSpellReady(spell, target.ID())
+                end,
+            },
+            { --used when the chanter or group members are low mana
+                name = "ManaNuke",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return (mq.TLO.Group.LowMana(80)() or -1) > 1 or not RGMercUtils.ManaCheck() and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
         },
@@ -1243,142 +1377,119 @@ local _ClassConfig = {
             {
                 name = "Illusions of Grandeur",
                 type = "AA",
-                cond = function(self, aaName) return true end,
-
-            },
-            {
-                name = "Spire of Enchantment",
-                type = "AA",
-                cond = function(self, aaName) return true end,
-
+                cond = function(self, aaName) return RGMercUtils.AAReady(aaName) end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName) return true end,
-
+                cond = function(self, aaName) return RGMercUtils.AAReady(aaName) end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName) return true end,
-
+                cond = function(self, aaName) return RGMercUtils.AAReady(aaName) end,
             },
             {
                 name = "Calculated Insanity",
                 type = "AA",
-                cond = function(self, aaName) return true end,
-
+                cond = function(self, aaName) return RGMercUtils.AAReady(aaName) end,
             },
             {
                 name = "Mental Contortion",
                 type = "AA",
-                cond = function(self, aaName) return RGMercUtils.IsNamed(mq.TLO.Target) end,
-
+                cond = function(self, aaName) return RGMercUtils.AAReady(aaName) and RGMercUtils.IsNamed(mq.TLO.Target) end,
             },
             {
                 name = "Chromatic Haze",
                 type = "AA",
-                cond = function(self, aaName) return true end,
-
+                cond = function(self, aaName) return RGMercUtils.AAReady(aaName) end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
                 type = "Item",
                 active_cond = function(self)
                     local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and mq.TLO.Me.Song(item.Spell.RankName.Name())() ~= nil
+                    return RGMercUtils.SongActive(item.Spell)
                 end,
                 cond = function(self)
                     local item = mq.TLO.Me.Inventory("Chest")
-                    return RGMercUtils.GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                    if not RGMercUtils.GetSetting('DoChestClick') or not item or not item() then return false end
+                    return not RGMercUtils.SongActive(item.Spell) and RGMercUtils.SpellStacksOnMe(item.Spell) and item.TimerReady() == 0
                 end,
             },
+            {
+                name = "Spire of Enchantment",
+                type = "AA",
+                cond = function(self, aaName) return not RGMercUtils.SongActiveByName("Illusions of Grandeur") and RGMercUtils.AAReady(aaName) end,
+            },
         },
-        ['Debuff'] = {
+        ['Tash'] = {
             {
                 name = "TashSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoTash') and RGMercUtils.DetSpellCheck(spell) and not mq.TLO.Target.Tashed() and
-                        mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToDebuff')
+                    return RGMercUtils.GetSetting('DoTash') and RGMercUtils.DetSpellCheck(spell) and not mq.TLO.Target.Tashed()
+                        and RGMercUtils.NPCSpellReady(spell)
                 end,
             },
             {
                 name = "Bite of Tashani",
                 type = "AA",
-                cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return RGMercUtils.GetSetting('DoTash') and RGMercUtils.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and not mq.TLO.Target.Tashed()
-                end,
-
-            },
-            {
-                name = "StripBuffSpell",
-                type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoStripBuff') and mq.TLO.Target.Beneficial() and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToDebuff')
+                cond = function(self, aaName, target)
+                    return RGMercUtils.GetSetting('DoTash') and RGMercUtils.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and not mq.TLO.Target.Tashed() and
+                        RGMercUtils.GetXTHaterCount() > 1 and RGMercUtils.NPCAAReady(aaName, target.ID())
                 end,
             },
+        },
+        ['CripSlow'] = {
             {
                 name = "Enveloping Helix",
                 type = "AA",
-                cond = function(self, aaName)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-                    return RGMercUtils.GetSetting('DoSlow') and RGMercUtils.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and
-                        RGMercUtils.GetXTHaterCount() >= RGMercUtils.GetSetting('SlowCount') and
-                        mq.TLO.Target.Slowed() == nil
+                cond = function(self, aaName, target)
+                    if RGMercUtils.GetXTHaterCount() < RGMercUtils.GetSetting('AESlowCount') then return false end
+                    return RGMercUtils.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and RGMercUtils.NPCAAReady(aaName, target.ID())
                 end,
             },
             {
                 name = "Slowing Helix",
                 type = "AA",
-                cond = function(self, aaName, _)
-                    if mq.TLO.Target.ID() <= 0 then return false end
-
-                    local detAACheck = RGMercUtils.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
-                    local slowedCheck = mq.TLO.Target.Slowed() == nil or RGMercUtils.GetTargetSlowedPct() < 50
-
-                    RGMercsLogger.log_verbose("Enc: Slowing Helix: detAA(%s), slowed(%s), slowedPct(%d)", RGMercUtils.BoolToColorString(detAACheck),
-                        RGMercUtils.BoolToColorString(slowedCheck), RGMercUtils.GetTargetSlowedPct())
-                    return RGMercUtils.GetSetting('DoSlow') and detAACheck and slowedCheck
+                cond = function(self, aaName, target)
+                    return not RGMercUtils.TargetHasBuffByName(aaName) and (mq.TLO.Me.AltAbility(aaName).Spell.SlowPct() or 0) > (RGMercUtils.GetTargetSlowedPct()) and
+                        RGMercUtils.NPCAAReady(aaName, target.ID())
                 end,
             },
             {
                 name = "CripSlowSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return (RGMercUtils.GetSetting('DoSlow') or RGMercUtils.GetSetting('DoCripple')) and RGMercUtils.DetSpellCheck(spell) and
-                        mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToDebuff')
+                cond = function(self, spell, target)
+                    if RGMercUtils.CanUseAA("Enveloping Helix") then return false end
+                    return RGMercUtils.DetSpellCheck(spell) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "SlowSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoSlow') and RGMercUtils.DetSpellCheck(spell) and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToDebuff')
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoSlow') then return false end
+                    return not RGMercUtils.TargetHasBuffByName(spell) and (mq.TLO.Me.AltAbility(spell).Spell.SlowPct() or 0) > (RGMercUtils.GetTargetSlowedPct()) and
+                        RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "CrippleSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.GetSetting('DoSlow') and RGMercUtils.DetSpellCheck(spell) and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToDebuff')
-                end,
-            },
-            {
-                name = "ManaDrainSpell",
-                type = "Spell",
-                cond = function(self, spell)
-                    return RGMercUtils.DetSpellCheck(spell) and mq.TLO.Target.CurrentMana() > 10 and mq.TLO.Me.PctMana() >= RGMercUtils.GetSetting('ManaToNuke')
+                cond = function(self, spell, target)
+                    if not RGMercUtils.GetSetting('DoCripple') or RGMercUtils.CanUseAA("Enveloping Helix") then return false end
+                    return RGMercUtils.DetSpellCheck(spell) and RGMercUtils.NPCSpellReady(spell, target.ID())
                 end,
             },
         },
     },
-    ['Spells']        = {
+    ['Spells']          = {
         {
             gem = 1,
             spells = {
+                { name = "TwinCastMez", cond = function(self) return RGMercUtils.IsModeActive("ModernEra") and RGMercUtils.GetSetting('DoTwincastMez') end, },
                 { name = "MezSpell", },
             },
         },
@@ -1391,12 +1502,15 @@ local _ClassConfig = {
         {
             gem = 3,
             spells = {
+                { name = "CharmSpell",     cond = function(self) return RGMercUtils.GetSetting('CharmOn') and RGMercUtils.IsModeActive("ModernEra") end, },
+                { name = "StripBuffSpell", cond = function(self) return RGMercUtils.GetSetting('DoStripBuff') and RGMercUtils.IsModeActive("ModernEra") end, },
                 { name = "TashSpell", },
             },
         },
         {
             gem = 4,
             spells = {
+                { name = "DichoSpell",     cond = function(self) return RGMercUtils.IsModeActive("ModernEra") end, },
                 { name = "SlowSpell",      cond = function(self) return not RGMercUtils.CanUseAA("Slowing Helix") and mq.TLO.Me.Level() < 88 end, },
                 { name = "CripSlowSpell",  cond = function(self) return not RGMercUtils.CanUseAA("Slowing Helix") and mq.TLO.Me.Level() >= 88 end, },
                 { name = "ManaDrainSpell", cond = function(self) return true end, },
@@ -1405,6 +1519,7 @@ local _ClassConfig = {
         {
             gem = 5,
             spells = {
+                { name = "ManaDot",    cond = function(self) return RGMercUtils.IsModeActive("ModernEra") end, },
                 { name = "CharmSpell", cond = function(self) return RGMercUtils.GetSetting('CharmOn') end, },
                 { name = "NdtBuff", },
             },
@@ -1424,6 +1539,7 @@ local _ClassConfig = {
         {
             gem = 8,
             spells = {
+                { name = "ManaNuke",       cond = function(self) return RGMercUtils.IsModeActive("ModernEra") end, },
                 { name = "CrippleSpell",   cond = function(self) return RGMercUtils.GetSetting('DoCripple') and mq.TLO.Me.Level() < 88 end, },
                 { name = "StripBuffSpell", cond = function(self) return RGMercUtils.GetSetting('DoStripBuff') end, },
                 { name = "NukeSpell2",     cond = function(self) return true end, },
@@ -1433,6 +1549,7 @@ local _ClassConfig = {
             gem = 9,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
+                { name = "NdtBuff", cond = function(self) return RGMercUtils.IsModeActive("ModernEra") end, },
                 { name = "ManaDot", cond = function(self) return true end, },
             },
         },
@@ -1454,33 +1571,63 @@ local _ClassConfig = {
             gem = 12,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "DichoSpell", cond = function(self) return true end, },
+                { name = "SpellProcBuff", cond = function(self) return RGMercUtils.IsModeActive("ModernEra") end, },
+                { name = "DichoSpell",    cond = function(self) return true end, },
             },
         },
         {
             gem = 13,
             cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
             spells = {
-                { name = "AllianceSpell",  cond = function(self) return RGMercUtils.GetSetting('DoAlliance') end, },
-                { name = "ManaDrainSpell", cond = function(self) return true end, },
+                { name = "AllianceSpell",    cond = function(self) return RGMercUtils.GetSetting('DoAlliance') end, },
+                { name = "GroupAuspiceBuff", cond = function(self) return RGMercUtils.IsModeActive("ModernEra") end, },
+                { name = "ManaDrainSpell",   cond = function(self) return RGMercUtils.IsModeActive("Default") end, },
             },
         },
     },
-    ['DefaultConfig'] = {
-        ['Mode']          = { DisplayName = "Mode", Category = "Combat", Tooltip = "Select the Combat Mode for this Toon", Type = "Custom", RequiresLoadoutChange = true, Default = 1, Min = 1, Max = 1, },
-        ['DoLearners']    = { DisplayName = "Do Learners", Category = "Spells & Abilities", Tooltip = "Set to use the Learner's Aura instead of the Mana Regen Aura.", Default = false, },
-        ['SlowCount']     = { DisplayName = "Slow Count", Category = "Spells & Abilities", Tooltip = "Number of XT Haters before we start slowing", Min = 1, Default = 3, Max = 10, },
-        ['DoTash']        = { DisplayName = "Do Tash", Category = "Spells & Abilities", Tooltip = "Cast Tash Spells", Default = true, },
-        ['DoTwincastDPS'] = { DisplayName = "Do Twincast DPS", Category = "Spells & Abilities", Tooltip = "Cast Twincast during DPS rotation", Default = true, },
-        ['DoDot']         = { DisplayName = "Cast DOTs", Category = "Spells and Abilities", Tooltip = "Enable casting Damage Over Time spells.", Default = true, },
-        ['DoSlow']        = { DisplayName = "Cast Slow", Category = "Spells and Abilities", Tooltip = "Enable casting Slow spells.", Default = true, },
-        ['DoCripple']     = { DisplayName = "Cast Cripple", Category = "Spells and Abilities", Tooltip = "Enable casting Cripple spells.", Default = true, },
-        ['DoDicho']       = { DisplayName = "Cast Dicho", Category = "Spells and Abilities", Tooltip = "Enable casting Dicho spells.", Default = true, },
-        ['DoNDTBuff']     = { DisplayName = "Cast NDT", Category = "Spells and Abilities", Tooltip = "Enable casting use Melee Proc Buff (Night's Dark Terror Line).", Default = true, },
-        ['DoGroupAbsorb'] = { DisplayName = "Do Group Absorb", Category = "Spells and Abilities", Tooltip = "Enable casting the Group Absorb line with -Hate Proc.", Default = true, },
-        ['DoAggroRune']   = { DisplayName = "Do Aggro Rune", Category = "Spells and Abilities", Tooltip = "Enable casting the Tank Aggro Rune", Default = true, },
-        ['DoStripBuff']   = { DisplayName = "Do Strip Buffs", Category = "Spells and Abilities", Tooltip = "Enable casting buff canceler spells.", Default = true, },
-        ['DoChestClick']  = { DisplayName = "Do Chest Click", Category = "Utilities", Tooltip = "Click your chest item", Default = true, },
+    ['PullAbilities']   = {
+        {
+            id = 'TashSpell',
+            Type = "Spell",
+            DisplayName = function() return RGMercUtils.GetResolvedActionMapItem('TashSpell').RankName.Name() or "" end,
+            AbilityName = function() return RGMercUtils.GetResolvedActionMapItem('TashSpell').RankName.Name() or "" end,
+            AbilityRange = 200,
+            cond = function(self)
+                local resolvedSpell = RGMercUtils.GetResolvedActionMapItem('TashSpell')
+                if not resolvedSpell then return false end
+                return mq.TLO.Me.Gem(resolvedSpell.RankName.Name() or "")() ~= nil
+            end,
+        },
+        {
+            id = 'StripBuffSpell',
+            Type = "Spell",
+            DisplayName = function() return RGMercUtils.GetResolvedActionMapItem('StripBuffSpell').RankName.Name() or "" end,
+            AbilityName = function() return RGMercUtils.GetResolvedActionMapItem('StripBuffSpell').RankName.Name() or "" end,
+            AbilityRange = 200,
+            cond = function(self)
+                local resolvedSpell = RGMercUtils.GetResolvedActionMapItem('StripBuffSpell')
+                if not resolvedSpell then return false end
+                return mq.TLO.Me.Gem(resolvedSpell.RankName.Name() or "")() ~= nil
+            end,
+        },
+    },
+    ['DefaultConfig']   = {
+        ['Mode']             = { DisplayName = "Mode", Category = "Combat", Tooltip = "Select the Combat Mode for this PC. Default: The original RGMercs Config. ModernEra: DPS rotation and spellset aimed at modern live play (~90+)", Type = "Custom", RequiresLoadoutChange = true, Default = 1, Min = 1, Max = 2, },
+        ['DoLearners']       = { DisplayName = "Do Learners", Category = "Buffs", Tooltip = "Set to use the Learner's Aura instead of the Mana Regen Aura.", Default = false, },
+        ['AESlowCount']      = { DisplayName = "Slow Count", Category = "Debuffs", Tooltip = "Number of XT Haters before we start AE slowing", Min = 1, Default = 2, Max = 10, },
+        ['DoTash']           = { DisplayName = "Do Tash", Category = "Debuffs", Tooltip = "Cast Tash Spells", Default = true, },
+        ['DoTwincastDPS']    = { DisplayName = "Do Twincast DPS", Category = "Combat", Tooltip = "(Default Mode Only) Cast TwinCast Mez during DPS rotation", Default = true, },
+        ['DoTwincastMez']    = { DisplayName = "Use Twincast Mez", Category = "Debuffs", Tooltip = "(ModernEra Mode Only) Use TwinCast Mez as your main ST Mez", Default = true, },
+        ['DoDot']            = { DisplayName = "Cast DOTs", Category = "Combat", Tooltip = "Enable casting Damage Over Time spells. (Dots always used for ModernEra Mode)", Default = true, },
+        ['DoSlow']           = { DisplayName = "Cast Slow", Category = "Debuffs", Tooltip = "Enable casting Slow spells.", Default = true, },
+        ['DoCripple']        = { DisplayName = "Cast Cripple", Category = "Debuffs", Tooltip = "Enable casting Cripple spells.", Default = true, },
+        ['DoDicho']          = { DisplayName = "Cast Dicho", Category = "Combat", Tooltip = "Enable casting Dicho spells.(Dicho always used for ModernEra Mode)", Default = true, },
+        ['DoNDTBuff']        = { DisplayName = "Cast NDT", Category = "Buffs", Tooltip = "Enable casting use Melee Proc Buff (Night's Dark Terror Line).", Default = true, },
+        ['DoGroupAbsorb']    = { DisplayName = "Do Group Absorb", Category = "Buffs", Tooltip = "Enable casting the Group Absorb line with -Hate Proc. If disabled, single target runes will be used.", Default = true, },
+        ['DoGroupDotShield'] = { DisplayName = "Do Group DoT Shield", Category = "Buffs", Tooltip = "Enable casting the Group DoT Shield Line.", Default = true, },
+        ['DoAggroRune']      = { DisplayName = "Do Aggro Rune", Category = "Buffs", Tooltip = "Enable casting the Tank Aggro Rune", Default = true, },
+        ['DoStripBuff']      = { DisplayName = "Do Strip Buffs", Category = "Debuffs", Tooltip = "Enable removing beneficial enemy effects.", Default = true, },
+        ['DoChestClick']     = { DisplayName = "Do Chest Click", Category = "Combat", Tooltip = "Click your equipped chest item during burns.", Default = true, },
     },
 }
 

--- a/modules/mez.lua
+++ b/modules/mez.lua
@@ -204,7 +204,9 @@ function Module:GetMezSpell()
     if RGMercUtils.MyClassIs("BRD") then
         return RGMercModules:ExecModule("Class", "GetResolvedActionMapItem", "MezSong")
     end
-
+    if RGMercUtils.MyClassIs("ENC") and RGMercUtils.GetSetting('UseTwinCastMez') then
+        return RGMercModules:ExecModule("Class", "GetResolvedActionMapItem", "TwinCastMez")
+    end
     return RGMercModules:ExecModule("Class", "GetResolvedActionMapItem", "MezSpell")
 end
 


### PR DESCRIPTION
[ENC]
* Added a new mode ("ModernEra"), which updates the enchanter DPS rotation for modern live. Likely usable around level 90, and should come fully into it's own by 105ish.

* Moved emergency abilities (Stun AA, etc.) from DPS to their own rotation.

* Added Spell Proc Buff (for ModernEra)

* Separated Tash and (Crip)Slow into two rotations to improve the chances of them both being applied before we start DPS.

* Moved pet summon to its own rotation (and set it to not summon if we have enabled charm).

* Added autoinventory command after an Azure Crystal is summoned.

* Updated and retrofitted recent settings, functions and conditions

* Added Pull abilities

* Added a couple of options. Please note that ModernEra Mode has less options than typical and will ignore some configuration options (Do DoT, Do Dicho). This is annotated in each applicable tooltip.

[BRD] Aura entries will now cancel the previous aura if necessary to prevent spam after you learn a new aura.

[mez] Added the option for a ModernEra ENC to use the TwinCastMez as the primary mez.