### PR TITLE
feat: setitem and setglobalitem tweaks

### DIFF
--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -218,13 +218,22 @@ end
 function Module:SetItem(params)
 	if LootnScoot ~= nil then
 		LootnScoot.commandHandler(params)
-		RGMercUtils.DoCmd("/autoinv")
+		if params == "destroy" then
+			RGMercUtils.DoCmd("/destroy")
+		else
+			RGMercUtils.DoCmd("/autoinv")
+		end
 	end
 end
 
 function Module:SetGlobalItem(params)
 	if LootnScoot ~= nil then
 		LootnScoot.commandHandler(params)
+		if params == "destroy" then
+			RGMercUtils.DoCmd("/destroy")
+		else
+			RGMercUtils.DoCmd("/autoinv")
+		end
 	end
 end
 


### PR DESCRIPTION
issuing either `/rgl setitem [action]` or `/rgl setglobalitem [action]` will auto inventory

If the action is destroy, we will /destroy the item instead of putting it back into inventory