### PR TITLE
[utils] UseSong/Spell/AA Updates

### DIFF
--- a/utils/rgmercs_config.lua
+++ b/utils/rgmercs_config.lua
@@ -201,6 +201,7 @@ Config.DefaultConfig = {
     ['WaitOnGlobalCooldown'] = { DisplayName = "Wait on Global Cooldown", Category = "Combat", Tooltip = "Wait on Global Cooldown before trying to cast more spells (Should NOT be used by classes that have Weave rotations!)", Default = false, ConfigType = "Advanced", },
     ['FaceTarget']           = { DisplayName = "Face Target in Combat", Category = "Combat", Tooltip = "Periodically /face your target while in combat.", Default = true, ConfigType = "Advanced", },
     ['CastReadyDelayFact']   = { DisplayName = "Cast Ready Delay Factor", Category = "Combat", Tooltip = "Wait Ping * [n] ms before saying we are ready to cast.", Default = 0, Min = 0, Max = 10, ConfigType = "Advanced", },
+    ['SongClipDelayFact']    = { DisplayName = "Song Clip Delay Factor", Category = "Combat", Tooltip = "Wait Ping * [n] ms to allow songs to take effect before singing the next.", Default = 2, Min = 1, Max = 10, ConfigType = "Advanced", },
 
     -- [ Debuffs] --
     ['DebuffMinCon']         = { DisplayName = "Debuff Min Con", Category = "Debuffs", Tooltip = "Min Con to use debuffs on", Default = 4, Min = 1, Max = #Config.Constants.ConColors, Type = "Combo", ComboOptions = Config.Constants.ConColors, },


### PR DESCRIPTION
* UseSong now has the adjustments to song clipping intended to release alongside the bard revamp. Expect 200-300ms improvement per song.

* Fix for UseSpell and UseAA relying on imprecise data for cast times, AA's with cast times should no longer clip early (further tuning may be needed on the value).