### PR TITLE
removed autoloot setting

### DIFF
--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -274,18 +274,21 @@ function loot.writeSettings()
     for option, value in pairs(loot.Settings) do
         local valueType = type(value)
         if saveOptionTypes[valueType] then
+            mq.cmdf('/ini "%s" "%s" "%s" "%s"', SettingsFile, 'Settings', option, value)
             loot.Settings[option] = value
         end
     end
     for option, value in pairs(loot.BuyItems) do
         local valueType = type(value)
         if saveOptionTypes[valueType] then
+            mq.cmdf('/ini "%s" "%s" "%s" "%s"', SettingsFile, 'BuyItems', option, value)
             loot.BuyItems[option] = value
         end
     end
     for option, value in pairs(loot.GlobalItems) do
         local valueType = type(value)
         if saveOptionTypes[valueType] then
+            mq.cmdf('/ini "%s" "%s" "%s" "%s"', loot.Settings.LootFile, 'GlobalItems', option, value)
             loot.GlobalItems[option] = value
         end
     end
@@ -365,6 +368,7 @@ function loot.addRule(itemName, section, rule)
     if section == 'GlobalItems' then
         loot.GlobalItems[itemName] = rule
     end
+    mq.cmdf('/ini "%s" "%s" "%s" "%s"', loot.Settings.LootFile, section, itemName, rule)
     RGMercModules:ExecModule("Loot", "ModifyLootSettings")
 end
 
@@ -504,6 +508,12 @@ end
 -- BINDS
 function loot.setBuyItem(item, qty)
     loot.BuyItems[item] = qty
+    mq.cmdf('/ini "%s" "BuyItems" "%s" "%s"', SettingsFile, item, qty)
+end
+
+function loot.setGlobalItem(item, val)
+    loot.GlobalItems[item] = val
+    mq.cmdf('/ini "%s" "GlobalItems" "%s" "%s"', loot.Settings.LootFile, item, val)
 end
 
 function loot.commandHandler(...)
@@ -556,9 +566,11 @@ function loot.commandHandler(...)
             RGMercsLogger.log_info("Setting \ay%s\ax to \ayQuest|%s\ax", mq.TLO.Cursor(), args[2])
         elseif args[1] == 'buy' and mq.TLO.Cursor() then
             loot.BuyItems[mq.TLO.Cursor()] = args[2]
+            mq.cmdf('/ini "%s" "BuyItems" "%s" "%s"', SettingsFile, mq.TLO.Cursor(), args[2])
             RGMercsLogger.log_info("Setting \ay%s\ax to \ayBuy|%s\ax", mq.TLO.Cursor(), args[2])
         elseif args[1] == 'globalitem' and validActions[args[2]] and mq.TLO.Cursor() then
             loot.GlobalItems[mq.TLO.Cursor()] = validActions[args[2]]
+            loot.addRule(mq.TLO.Cursor(), 'GlobalItems', validActions[args[2]])
             RGMercsLogger.log_info("Setting \ay%s\ax to \agGlobal Item \ay%s\ax", mq.TLO.Cursor(), validActions[args[2]])
         elseif validActions[args[1]] and args[2] ~= 'NULL' then
             loot.addRule(args[2], args[2]:sub(1, 1), validActions[args[1]])
@@ -573,6 +585,7 @@ function loot.commandHandler(...)
             RGMercsLogger.log_info("Setting \ay%s\ax to \agGlobal Item \ay%s\ax", args[3], validActions[args[2]])
         elseif args[1] == 'buy' then
             loot.BuyItems[args[2]] = args[3]
+            mq.cmdf('/ini "%s" "BuyItems" "%s" "%s"', SettingsFile, args[2], args[3])
             RGMercsLogger.log_info("Setting \ay%s\ax to \ayBuy|%s\ax", args[2], args[3])
         elseif validActions[args[1]] and args[2] ~= 'NULL' then
             loot.addRule(args[2], args[2]:sub(1, 1), validActions[args[1]] .. '|' .. args[3])
@@ -822,8 +835,10 @@ function loot.eventSell(_, itemName)
     if loot.Settings.AddNewSales then
         RGMercsLogger.log_info(string.format('Setting %s to Sell', itemName))
         if not lootData[firstLetter] then lootData[firstLetter] = {} end
+        mq.cmdf('/ini "%s" "%s" "%s" "%s"', loot.Settings.LootFile, firstLetter, itemName, 'Sell')
         lootData[firstLetter][itemName] = 'Sell'
         loot.NormalItems[itemName] = 'Sell'
+        RGMercModules:ExecModule("Loot", "ModifyLootSettings")
     end
 end
 
@@ -919,8 +934,10 @@ function loot.eventTribute(line, itemName)
     if loot.Settings.AddNewTributes then
         RGMercsLogger.log_info(string.format('Setting %s to Tribute', itemName))
         if not lootData[firstLetter] then lootData[firstLetter] = {} end
+        mq.cmdf('/ini "%s" "%s" "%s" "%s"', loot.Settings.LootFile, firstLetter, itemName, 'Tribute')
         lootData[firstLetter][itemName] = 'Tribute'
         loot.NormalItems[itemName] = 'Tribute'
+        RGMercModules:ExecModule("Loot", "ModifyLootSettings")
     end
 end
 
@@ -966,7 +983,9 @@ function loot.markTradeSkillAsBank()
             if bagSlot.ID() then
                 if bagSlot.Tradeskills() then
                     local itemToMark = bagSlot.Name()
+                    loot.NormalItems[itemToMark] = 'Bank'
                     loot.addRule(itemToMark, itemToMark:sub(1, 1), 'Bank')
+                    RGMercModules:ExecModule("Loot", "ModifyLootSettings")
                 end
             end
         end
@@ -980,7 +999,9 @@ function loot.markTradeSkillAsBank()
                 local item = bagSlot.Item(j)
                 if item.ID() and item.Tradeskills() then
                     local itemToMark = bagSlot.Item(j).Name()
+                    loot.NormalItems[itemToMark] = 'Bank'
                     loot.addRule(itemToMark, itemToMark:sub(1, 1), 'Bank')
+                    RGMercModules:ExecModule("Loot", "ModifyLootSettings")
                 end
             end
         end

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -21,7 +21,6 @@ Module.NormalItemsTable  = {}
 
 Module.DefaultConfig     = {
 	['DoLoot']          = { DisplayName = "DoLoot", Category = "Loot N Scoot", Tooltip = "Enables Loot Settings for Looting", Default = true, },
-	['AutoLoot']        = { DisplayName = "Auto Loot", Category = "Loot N Scoot", Tooltip = "Auto Loot During Downtime.", Default = true, },
 
 	--- Looted Settings
 	['LootFile']        = { DisplayName = 'Loot File', Category = 'Loot Settings', Tooltip = "Where your loot.ini file lives", Default = LootnScoot.Settings.LootFile, },
@@ -450,28 +449,30 @@ function Module:Render()
 				ImGui.SeparatorText("Add New Item##GlobalItems")
 				if ImGui.BeginTable("AddItem##GlobalItems", 3, ImGuiTableFlags.Borders) then
 					ImGui.TableSetupColumn("Item")
-					ImGui.TableSetupColumn("Qty")
+					ImGui.TableSetupColumn("Value")
 					ImGui.TableSetupColumn("Add")
 					ImGui.TableHeadersRow()
 					ImGui.TableNextColumn()
 
 					ImGui.SetNextItemWidth(150)
-					self.TempSettings.NewGlobalItem = ImGui.InputText("New Item##BuyItems", self.TempSettings.NewGlobalItem) or nil
+					self.TempSettings.NewGlobalItem = ImGui.InputText("New Item##GlobalItems", self.TempSettings.NewGlobalItem) or nil
 
 					ImGui.TableNextColumn()
 					ImGui.SetNextItemWidth(120)
 
-					self.TempSettings.NewGlobalQty = ImGui.InputInt("New Qty##BuyItems", self.TempSettings.NewGlobalQty, 1, 10) or nil
-					if self.TempSettings.NewGlobalQty > 1000 then self.TempSettings.NewGlobalQty = 1000 end
+					self.TempSettings.NewGlobalValue = ImGui.InputTextWithHint("New Value##GlobalItems", "Quest, Keep, Sell, Tribute, Bank, Ignore, Destroy",
+						self.TempSettings.NewGlobalValue) or nil
 
 					ImGui.TableNextColumn()
 
-					if ImGui.Button("Add Item##BuyItems") then
-						self.BuyItemsTable[self.TempSettings.NewGlobalItem] = self.TempSettings.NewGlobalQty
-						LootnScoot.setBuyItem(self.TempSettings.NewBuyItem, self.TempSettings.NewGlobalQty)
-						self.TempSettings.NeedSave = true
-						self.TempSettings.NewGlobalItem = ""
-						self.TempSettings.NewGlobalQty = 1
+					if ImGui.Button("Add Item##GlobalItems") then
+						if self.TempSettings.NewGlobalValue ~= "" and self.TempSettings.NewGlobalValue ~= "" then
+							self.GlobalItemsTable[self.TempSettings.NewGlobalItem] = self.TempSettings.NewGlobalValue
+							LootnScoot.setGlobalItem(self.TempSettings.NewBuyItem, self.TempSettings.NewGlobalValue)
+							self.TempSettings.NeedSave = true
+							self.TempSettings.NewGlobalItem = ""
+							self.TempSettings.NewGlobalValue = ""
+						end
 					end
 					ImGui.EndTable()
 				end
@@ -685,12 +686,11 @@ function Module:GiveTime(combat_state)
 	if self.TempSettings.NeedSave then
 		self:SaveSettings(false)
 		self.TempSettings.NeedSave = false
-		LootnScoot.writeSettings()
 		self:SortItemTables()
 	end
 	-- Main Module logic goes here.
 	if self.CombatState ~= combat_state and combat_state == "Downtime" then
-		if LootnScoot ~= nil and self.settings.DoLoot and self.settings.AutoLoot then
+		if LootnScoot ~= nil and self.settings.DoLoot and self.settings.DoLoot then
 			LootnScoot.lootMobs()
 		end
 	end


### PR DESCRIPTION
cleaned up some ini stuff
added back in the save to ini functions. for when looting new items or auto sell/tribute also writes to the ini if we add items to global or buy

Does not write to the file when we modify or delete an item. that stays in our local rgmers settings we  use. this way we do not pollute the loot.ini