### PR TITLE
removed autoloot setting

### DIFF
--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -453,28 +453,30 @@ function Module:Render()
 				ImGui.SeparatorText("Add New Item##GlobalItems")
 				if ImGui.BeginTable("AddItem##GlobalItems", 3, ImGuiTableFlags.Borders) then
 					ImGui.TableSetupColumn("Item")
-					ImGui.TableSetupColumn("Qty")
+					ImGui.TableSetupColumn("Value")
 					ImGui.TableSetupColumn("Add")
 					ImGui.TableHeadersRow()
 					ImGui.TableNextColumn()
 
 					ImGui.SetNextItemWidth(150)
-					self.TempSettings.NewGlobalItem = ImGui.InputText("New Item##BuyItems", self.TempSettings.NewGlobalItem) or nil
+					self.TempSettings.NewGlobalItem = ImGui.InputText("New Item##GlobalItems", self.TempSettings.NewGlobalItem) or nil
 
 					ImGui.TableNextColumn()
 					ImGui.SetNextItemWidth(120)
 
-					self.TempSettings.NewGlobalQty = ImGui.InputInt("New Qty##BuyItems", self.TempSettings.NewGlobalQty, 1, 10) or nil
-					if self.TempSettings.NewGlobalQty > 1000 then self.TempSettings.NewGlobalQty = 1000 end
+					self.TempSettings.NewGlobalValue = ImGui.InputTextWithHint("New Value##GlobalItems", "Quest, Keep, Sell, Tribute, Bank, Ignore, Destroy",
+						self.TempSettings.NewGlobalValue) or nil
 
 					ImGui.TableNextColumn()
 
-					if ImGui.Button("Add Item##BuyItems") then
-						self.BuyItemsTable[self.TempSettings.NewGlobalItem] = self.TempSettings.NewGlobalQty
-						LootnScoot.setBuyItem(self.TempSettings.NewBuyItem, self.TempSettings.NewGlobalQty)
-						self.TempSettings.NeedSave = true
-						self.TempSettings.NewGlobalItem = ""
-						self.TempSettings.NewGlobalQty = 1
+					if ImGui.Button("Add Item##GlobalItems") then
+						if self.TempSettings.NewGlobalValue ~= "" and self.TempSettings.NewGlobalValue ~= "" then
+							self.GlobalItemsTable[self.TempSettings.NewGlobalItem] = self.TempSettings.NewGlobalValue
+							LootnScoot.setGlobalItem(self.TempSettings.NewBuyItem, self.TempSettings.NewGlobalValue)
+							self.TempSettings.NeedSave = true
+							self.TempSettings.NewGlobalItem = ""
+							self.TempSettings.NewGlobalValue = ""
+						end
 					end
 					ImGui.EndTable()
 				end
@@ -688,7 +690,6 @@ function Module:GiveTime(combat_state)
 	if self.TempSettings.NeedSave then
 		self:SaveSettings(false)
 		self.TempSettings.NeedSave = false
-		LootnScoot.writeSettings()
 		self:SortItemTables()
 	end
 	-- Main Module logic goes here.


### PR DESCRIPTION
cleaned up some ini stuff
added back in the save to ini functions. for when looting new items or auto sell/tribute also writes to the ini if we add items to global or buy

Does not write to the file when we modify or delete an item. that stays in our local rgmers settings we  use. this way we do not pollute the loot.ini