### PR TITLE
Loot tables to SQL DB

### DIFF
--- a/lib/lootnscoot/loot_hist.lua
+++ b/lib/lootnscoot/loot_hist.lua
@@ -855,7 +855,7 @@ local function getNextID(table)
 end
 
 function guiLoot.RegisterActor()
-	guiLoot.actor = RGMercUtils.Actor.register('looted', function(message)
+	guiLoot.actor = RGMercUtils.Actors.register('looted', function(message)
 		local lootEntry = message()
 		for _, item in ipairs(lootEntry.Items) do
 			local link = item.Link

--- a/lib/lootnscoot/loot_hist.lua
+++ b/lib/lootnscoot/loot_hist.lua
@@ -65,26 +65,26 @@
 	end
 
 ]]
-local mq = require('mq')
-local imgui = require('ImGui')
-local actor = require('actors')
-local Icons = require('mq.ICONS')
-local theme, settings = {}, {}
-local script = 'Looted'
+local mq                                                     = require('mq')
+local imgui                                                  = require('ImGui')
+local RGMercUtils                                            = require("utils.rgmercs_utils")
+local Icons                                                  = require('mq.ICONS')
+local theme, settings                                        = {}, {}
+local script                                                 = 'Looted'
 local ColorCount, ColorCountConf, StyleCount, StyleCountConf = 0, 0, 0, 0
-local ColorCountRep, StyleCountRep = 0, 0
-local openConfigGUI, locked, zoom = false, false, false
-local themeFile = mq.configDir .. '/MyThemeZ.lua'
-local configFile = mq.configDir .. '/MyUI_Configs.lua'
-local ZoomLvl = 1.0
-local showReport = false
-local ThemeName = 'None'
-local gIcon = Icons.MD_SETTINGS
-local globalNewIcon = Icons.FA_GLOBE
-local globeIcon = Icons.FA_GLOBE
-local changed = false
-local txtBuffer = {}
-local defaults = {
+local ColorCountRep, StyleCountRep                           = 0, 0
+local openConfigGUI, locked, zoom                            = false, false, false
+local themeFile                                              = mq.configDir .. '/MyThemeZ.lua'
+local configFile                                             = mq.configDir .. '/MyUI_Configs.lua'
+local ZoomLvl                                                = 1.0
+local showReport                                             = false
+local ThemeName                                              = 'None'
+local gIcon                                                  = Icons.MD_SETTINGS
+local globalNewIcon                                          = Icons.FA_GLOBE
+local globeIcon                                              = Icons.FA_GLOBE
+local changed                                                = false
+local txtBuffer                                              = {}
+local defaults                                               = {
 	LoadTheme = 'None',
 	Scale = 1.0,
 	Zoom = false,
@@ -93,7 +93,7 @@ local defaults = {
 	lastScrollPos = 0,
 }
 
-local guiLoot = {
+local guiLoot                                                = {
 	SHOW = false,
 	openGUI = false,
 	shouldDrawGUI = false,
@@ -112,7 +112,7 @@ local guiLoot = {
 	winFlags = bit32.bor(ImGuiWindowFlags.MenuBar),
 }
 
-local lootTable = {}
+local lootTable                                              = {}
 
 ---@param names boolean
 ---@param links boolean
@@ -149,34 +149,17 @@ function guiLoot.ReportLoot()
 	if guiLoot.recordData then
 		showReport = true
 		guiLoot.console:AppendText("\ay[Looted]\at[Loot Report]")
-		-- for looter, lootData in pairs(lootTable) do
-		-- guiLoot.console:AppendText("\at[%s] \ax: ", looter)
 		for item, data in pairs(lootTable) do
 			local itemName = item
 			local looter = data['Who']
 			local itemLink = data["Link"]
 			local itemCount = data["Count"]
-			-- guiLoot.console:AppendText("\at[%s] \ax: ", looter)
 			guiLoot.console:AppendText("\ao%s \ax: \ax(%d)", itemLink, itemCount)
 			guiLoot.console:AppendText("\at\t[%s] \ax: ", looter)
 		end
-		-- end
 	else
 		guiLoot.recordData = true
 		guiLoot.console:AppendText("\ay[Looted]\ag[Recording Data Enabled]\ax Check back later for Data.")
-	end
-end
-
----comment Check to see if the file we want to work on exists.
----@param name string -- Full Path to file
----@return boolean -- returns true if the file exists and false otherwise
-local function File_Exists(name)
-	local f = io.open(name, "r")
-	if f ~= nil then
-		io.close(f)
-		return true
-	else
-		return false
 	end
 end
 
@@ -189,16 +172,8 @@ local function getSortedKeys(t)
 	return keys
 end
 
----comment Writes settings from the settings table passed to the setting file (full path required)
--- Uses mq.pickle to serialize the table and write to file
----@param file string -- File Name and path
----@param settings table -- Table of settings to write
-local function writeSettings(file, settings)
-	mq.pickle(file, settings)
-end
-
 local function loadTheme()
-	if File_Exists(themeFile) then
+	if RGMercUtils.file_exists(themeFile) then
 		theme = dofile(themeFile)
 	else
 		theme = require('lib.lootnscoot.themes')
@@ -208,7 +183,7 @@ end
 
 local function loadSettings()
 	local temp = {}
-	if not File_Exists(configFile) then
+	if not RGMercUtils.file_exists(configFile) then
 		mq.pickle(configFile, defaults)
 		loadSettings()
 	else
@@ -256,7 +231,7 @@ local function loadSettings()
 	ZoomLvl = settings[script].Scale
 	ThemeName = settings[script].LoadTheme
 
-	writeSettings(configFile, settings)
+	mq.pickle(configFile, settings)
 
 	temp = settings[script]
 end
@@ -293,11 +268,11 @@ end
 
 function guiLoot.GUI()
 	if guiLoot.openGUI then
-		local windowName = 'Looted Items##' .. mq.TLO.Me.DisplayName()
+		local windowName = 'Looted Items##' .. RGMercConfig.Globals.CurLoadedChar
 		ImGui.SetNextWindowSize(260, 300, ImGuiCond.FirstUseEver)
 		--imgui.PushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(1, 0));
 		ColorCount, StyleCount = DrawTheme(ThemeName)
-		if guiLoot.imported then windowName = 'Looted Items Local##Imported_' .. mq.TLO.Me.DisplayName() end
+		if guiLoot.imported then windowName = 'Looted Items Local##Imported_' .. RGMercConfig.Globals.CurLoadedChar end
 		local openGui, show = ImGui.Begin(windowName, true, guiLoot.winFlags)
 		if not openGui then
 			guiLoot.openGUI = false
@@ -841,7 +816,7 @@ function guiLoot.lootedConf_GUI()
 			settings[script].Scale = ZoomLvl
 			settings[script].LoadTheme = ThemeName
 
-			writeSettings(configFile, settings)
+			mq.pickle(configFile, settings)
 		end
 	end
 
@@ -880,7 +855,7 @@ local function getNextID(table)
 end
 
 function guiLoot.RegisterActor()
-	guiLoot.actor = actor.register('looted', function(message)
+	guiLoot.actor = RGMercUtils.Actor.register('looted', function(message)
 		local lootEntry = message()
 		for _, item in ipairs(lootEntry.Items) do
 			local link = item.Link
@@ -888,7 +863,7 @@ function guiLoot.RegisterActor()
 			local eval = item.Eval
 			local who = lootEntry.LootedBy
 			if guiLoot.hideNames then
-				if who ~= mq.TLO.Me() then who = mq.TLO.Spawn(string.format("%s", who)).Class.ShortName() else who = mq.TLO.Me.Class.ShortName() end
+				if who ~= mq.TLO.Me() then who = mq.TLO.Spawn(string.format("%s", who)).Class.ShortName() else who = RGMercConfig.Globals.CurLoadedClass end
 			end
 			if guiLoot.recordData and item.Action == 'Looted' then
 				addRule(who, what, link, eval)
@@ -942,7 +917,7 @@ function guiLoot.EventLoot(line, who, what)
 			link = mq.TLO.LinkDB(string.format("=%s", what))() or link
 		end
 		if guiLoot.hideNames then
-			if who ~= 'You' then who = mq.TLO.Spawn(string.format("%s", who)).Class.ShortName() else who = mq.TLO.Me.Class.ShortName() end
+			if who ~= 'You' then who = mq.TLO.Spawn(string.format("%s", who)).Class.ShortName() else who = RGMercConfig.Globals.CurLoadedClass end
 		end
 		local text = string.format('\ao[%s] \at%s \axLooted %s', mq.TLO.Time(), who, link)
 		guiLoot.console:AppendText(text)
@@ -971,11 +946,11 @@ function guiLoot.EventLoot(line, who, what)
 	end
 end
 
-function guiLoot.init(actors, imported, caller)
+function guiLoot.init(use_actors, imported, caller)
 	guiLoot.imported = imported
-	guiLoot.UseActors = actors
+	guiLoot.UseActors = use_actors
 	guiLoot.caller = caller
-	if not actors then
+	if not use_actors then
 		guiLoot.linkdb = mq.TLO.Plugin('mq2linkdb').IsLoaded()
 	else
 		guiLoot.linkdb = false

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -596,7 +596,7 @@ end
 
 -- EVENTS
 
-local lootActor = actors.register('lootnscoot', function(message) end)
+local lootActor = RGMercUtils.Actors.register('lootnscoot', function(message) end)
 
 local itemNoValue = nil
 function loot.eventNovalue(line, item)

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -404,8 +404,6 @@ function loot.navToID(spawnID)
 end
 
 function loot.modifyItem(item, action, tableName)
-    printf("Item: %s Action: %s Table: %s", item, action, tableName)
-
     local db = sqlite3.open(ItemsDB)
     if not db then
         printf("Failed to open database.")
@@ -601,7 +599,6 @@ end
 
 function loot.setGlobalItem(item, val)
     loot.GlobalItems[item] = val ~= 'delete' or nil
-    printf("Passing Item: %s Action: %s", item, val)
     loot.modifyItem(item, val, 'Global_Rules')
 end
 

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -295,18 +295,12 @@ function loot.UpdateDB()
     local db = sqlite3.open(ItemsDB)
     for k, v in pairs(loot.NormalItems) do
         local stmt, err = db:prepare("INSERT INTO Normal_Rules (item_name, item_rule) VALUES (?, ?)")
-        if not stmt then
-            RGMercsLogger.log_warn("Item Exists Skipping: %s", err)
-        end
         stmt:bind_values(k, v)
         stmt:step()
         stmt:finalize()
     end
     for k, v in pairs(loot.GlobalItems) do
         local stmt, err = db:prepare("INSERT INTO Global_Rules (item_name, item_rule) VALUES (?, ?)")
-        if not stmt then
-            RGMercsLogger.log_warn("Item Exists Skipping: %s", err)
-        end
         stmt:bind_values(k, v)
         stmt:step()
         stmt:finalize()

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -294,22 +294,18 @@ function loot.UpdateDB()
 
     local db = sqlite3.open(ItemsDB)
     for k, v in pairs(loot.NormalItems) do
-        local stmt, err = db:prepare("INSERT OR REPLACE INTO Normal_Rules (item_name, item_rule) VALUES (?, ?)")
+        local stmt, err = db:prepare("INSERT INTO Normal_Rules (item_name, item_rule) VALUES (?, ?)")
         if not stmt then
-            RGMercsLogger.log_warn("Failed to prepare statement: %s", err)
-            db:close()
-            break
+            RGMercsLogger.log_warn("Item Exists Skipping: %s", err)
         end
         stmt:bind_values(k, v)
         stmt:step()
         stmt:finalize()
     end
     for k, v in pairs(loot.GlobalItems) do
-        local stmt, err = db:prepare("INSERT OR REPLACE INTO Global_Rules (item_name, item_rule) VALUES (?, ?)")
+        local stmt, err = db:prepare("INSERT INTO Global_Rules (item_name, item_rule) VALUES (?, ?)")
         if not stmt then
-            RGMercsLogger.log_warn("Failed to prepare statement: %s", err)
-            db:close()
-            break
+            RGMercsLogger.log_warn("Item Exists Skipping: %s", err)
         end
         stmt:bind_values(k, v)
         stmt:step()

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -557,8 +557,8 @@ function loot.getRule(item)
         -- set Tribute flag if tribute value is greater than minTributeValue and the sell price is less than min sell price or has no value
         if tributeValue >= loot.Settings.MinTributeValue and (sellPrice < loot.Settings.MinSellPrice or sellPrice == 0) then lootDecision = 'Tribute' end
         loot.addRule(itemName, firstLetter, lootDecision)
-        if loot.Settings.AutoTag and lootDecision == 'Keep' then                              -- Do we want to automatically tag items 'Sell'
-            if not stackable and sellPrice > loot.MinSellPrice then lootDecision = 'Sell' end -- added stackable check otherwise it would stay set to Ignore when checking Stackable items in next steps.
+        if loot.Settings.AutoTag and lootDecision == 'Keep' then                                       -- Do we want to automatically tag items 'Sell'
+            if not stackable and sellPrice > loot.Settings.MinSellPrice then lootDecision = 'Sell' end -- added stackable check otherwise it would stay set to Ignore when checking Stackable items in next steps.
             if (stackable and loot.Settings.StackPlatValue > 0) and (sellPrice * stackSize >= loot.Settings.StackPlatValue) then lootDecision = 'Sell' end
             loot.addRule(itemName, firstLetter, lootDecision)
         end

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -319,6 +319,8 @@ function loot.UpdateDB()
 end
 
 function loot.loadSettings()
+    loot.NormalItems = {}
+    loot.GlobalItems = {}
     -- SQL setup
     if not RGMercUtils.file_exists(ItemsDB) then
         -- Create the database and its table if it doesn't exist
@@ -669,7 +671,7 @@ function loot.commandHandler(...)
             loot.guiLoot.hideNames = not loot.guiLoot.hideNames
         elseif args[1] == 'config' then
             local confReport = string.format("\ayLoot N Scoot Settings\ax")
-            for key, value in pairs(loot) do
+            for key, value in pairs(loot.Settings) do
                 if type(value) ~= "function" and type(value) ~= "table" then
                     confReport = confReport .. string.format("\n\at%s\ax = \ag%s\ax", key, tostring(value))
                 end

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -365,7 +365,7 @@ function loot.loadSettings()
     end
     shouldLootActions.Destroy = loot.Settings.DoDestroy
     shouldLootActions.Tribute = loot.Settings.TributeKeep
-    loot.BuyItems = loot.load(loot.Settings.SettingsFile, 'BuyItems')
+    loot.BuyItems = loot.load(SettingsFile, 'BuyItems')
 
     return needSave
 end

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -290,18 +290,18 @@ end
 
 function loot.loadSettings()
     -- SQL setup
+    printf(tostring(RGMercUtils.file_exists(ItemsDB)))
     if not RGMercUtils.file_exists(ItemsDB) then
         -- Create the database and its table if it doesn't exist
         RGMercsLogger.log_warn("Loot Rules Database not found, creating it now.")
         local db = sqlite3.open(ItemsDB)
         db:exec([[
-            CREATE TABLE IF NOT EXISTS "Global_Rules" (
+                CREATE TABLE IF NOT EXISTS Global_Rules (
                 "item_name" TEXT NOT NULL UNIQUE,
                 "item_rule" TEXT NOT NULL,
                 "id" INTEGER PRIMARY KEY AUTOINCREMENT
             );
-
-            CREATE TABLE IF NOT EXISTS "Normal_Rules" (
+                CREATE TABLE IF NOT EXISTS Normal_Rules (
                 "item_name" TEXT NOT NULL UNIQUE,
                 "item_rule" TEXT NOT NULL,
                 "id" INTEGER PRIMARY KEY AUTOINCREMENT
@@ -318,7 +318,7 @@ function loot.loadSettings()
             if not stmt then
                 printf("Failed to prepare statement: %s", err)
                 db:close()
-                return
+                break
             end
             stmt:bind_values(k, v)
             stmt:step()
@@ -329,7 +329,7 @@ function loot.loadSettings()
             if not stmt then
                 printf("Failed to prepare statement: %s", err)
                 db:close()
-                return
+                break
             end
             stmt:bind_values(k, v)
             stmt:step()

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -330,11 +330,13 @@ function loot.loadSettings()
                 CREATE TABLE IF NOT EXISTS Global_Rules (
                 "item_name" TEXT NOT NULL UNIQUE,
                 "item_rule" TEXT NOT NULL,
+                "item_classes" TEXT,
                 "id" INTEGER PRIMARY KEY AUTOINCREMENT
             );
                 CREATE TABLE IF NOT EXISTS Normal_Rules (
                 "item_name" TEXT NOT NULL UNIQUE,
                 "item_rule" TEXT NOT NULL,
+                "item_classes" TEXT,
                 "id" INTEGER PRIMARY KEY AUTOINCREMENT
             );
         ]])

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -137,6 +137,13 @@ Module.CommandHandlers   = {
 			self:LootReload()
 		end,
 	},
+	lootupdate = {
+		usage = "/rgl lootupdate",
+		about = "Updates LootRules DB from INI. Incase you were running in standalone mode prior to running RGMercs Lua.",
+		handler = function(self, _)
+			self:LootUpdate()
+		end,
+	},
 }
 
 Module.DefaultCategories = Set.new({})
@@ -689,6 +696,13 @@ end
 function Module:LootReload()
 	if LootnScoot ~= nil then
 		LootnScoot.commandHandler('reload')
+		self:LoadSettings()
+	end
+end
+
+function Module:LootUpdate()
+	if LootnScoot ~= nil then
+		LootnScoot.commandHandler('update')
 		self:LoadSettings()
 	end
 end

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -325,7 +325,7 @@ function Module:Render()
 				end
 				ImGui.Text("Delete the Item Name to remove it from the table")
 
-				if ImGui.Button("Save Changes##BuyItems") then
+				if ImGui.SmallButton("Save Changes##BuyItems") then
 					for k, v in pairs(self.TempSettings.UpdatedBuyItems) do
 						if k ~= "" then
 							self.BuyItemsTable[k] = v
@@ -341,6 +341,30 @@ function Module:Render()
 
 					self.TempSettings.NeedSave = true
 				end
+
+				ImGui.SameLine()
+
+				if ImGui.SmallButton("Reload Loot") then
+					self:LootReload()
+				end
+				if ImGui.IsItemHovered() then
+					ImGui.BeginTooltip()
+					ImGui.Text("Reloads working Tables from the Database.")
+					ImGui.EndTooltip()
+				end
+				ImGui.SameLine()
+
+				if ImGui.SmallButton("Update Loot") then
+					self:LootUpdate()
+				end
+				if ImGui.IsItemHovered() then
+					ImGui.BeginTooltip()
+					ImGui.Text("Imports the ini file into the table.")
+					ImGui.TextColored(ImVec4(0.8, 0.1, 0.1, 1), "ONLY Run on ONE Character")
+					ImGui.Text("Use Reload on the Other Characters After.")
+					ImGui.EndTooltip()
+				end
+
 				self.TempSettings.SearchBuyItems = ImGui.InputText("Search Items##NormalItems", self.TempSettings.SearchBuyItems) or nil
 				ImGui.SeparatorText("Add New Item")
 				if ImGui.BeginTable("AddItem", 3, ImGuiTableFlags.Borders) then
@@ -433,7 +457,7 @@ function Module:Render()
 				end
 				ImGui.Text("Delete the Item Name to remove it from the table")
 
-				if ImGui.Button("Save Changes##GlobalItems") then
+				if ImGui.SmallButton("Save Changes##GlobalItems") then
 					for k, v in pairs(self.TempSettings.UpdatedGlobalItems) do
 						if k ~= "" then
 							self.GlobalItemsTable[k] = v
@@ -450,6 +474,30 @@ function Module:Render()
 
 					self:SortItemTables()
 				end
+
+				ImGui.SameLine()
+
+				if ImGui.SmallButton("Reload Loot") then
+					self:LootReload()
+				end
+				if ImGui.IsItemHovered() then
+					ImGui.BeginTooltip()
+					ImGui.Text("Reloads working Tables from the Database.")
+					ImGui.EndTooltip()
+				end
+				ImGui.SameLine()
+
+				if ImGui.SmallButton("Update Loot") then
+					self:LootUpdate()
+				end
+				if ImGui.IsItemHovered() then
+					ImGui.BeginTooltip()
+					ImGui.Text("Imports the ini file into the table.")
+					ImGui.TextColored(ImVec4(0.8, 0.1, 0.1, 1), "ONLY Run on ONE Character")
+					ImGui.Text("Use Reload on the Other Characters After.")
+					ImGui.EndTooltip()
+				end
+
 				self.TempSettings.SearchGlobalItems = ImGui.InputText("Search Items##NormalItems", self.TempSettings.SearchGlobalItems) or nil
 				ImGui.SeparatorText("Add New Item##GlobalItems")
 				if ImGui.BeginTable("AddItem##GlobalItems", 3, ImGuiTableFlags.Borders) then
@@ -545,7 +593,7 @@ function Module:Render()
 				end
 				ImGui.Text("Delete the Item Name to remove it from the table")
 
-				if ImGui.Button("Save Changes##NormalItems") then
+				if ImGui.SmallButton("Save Changes##NormalItems") then
 					for k, v in pairs(self.TempSettings.UpdatedNormalItems) do
 						self.NormalItemsTable[k] = v
 						LootnScoot.setNormalItem(k, v)
@@ -558,6 +606,29 @@ function Module:Render()
 					end
 					self.TempSettings.DeletedNormalKeys = {}
 					self:SortItemTables()
+				end
+
+				ImGui.SameLine()
+
+				if ImGui.SmallButton("Reload Loot") then
+					self:LootReload()
+				end
+				if ImGui.IsItemHovered() then
+					ImGui.BeginTooltip()
+					ImGui.Text("Reloads working Tables from the Database.")
+					ImGui.EndTooltip()
+				end
+				ImGui.SameLine()
+
+				if ImGui.SmallButton("Update Loot") then
+					self:LootUpdate()
+				end
+				if ImGui.IsItemHovered() then
+					ImGui.BeginTooltip()
+					ImGui.Text("Imports the ini file into the table.")
+					ImGui.TextColored(ImVec4(0.8, 0.1, 0.1, 1), "ONLY Run on ONE Character")
+					ImGui.Text("Use Reload on the Other Characters After.")
+					ImGui.EndTooltip()
 				end
 
 				self.TempSettings.SearchItems = ImGui.InputText("Search Items##NormalItems", self.TempSettings.SearchItems) or nil


### PR DESCRIPTION
Migrated the loot tables to an SQL DB with tables for (Global_Items,  Normal_Items)

This allows the data to be shared by all of the characters without to many conflicts.

If you edit or add anything on the driver and save the settings you can issue /rgl lootreload on all characters to reload from the DB. 

## IMPORTANT !!

The **FIRST TIME** you run this after this update, **ONLY** Load RGMercs Lua On **ONE Character** to build the DB. 

This Could take a couple seconds to create and populate the database. (_especially if your loot.ini is large_)

After you have the database created you can load as many toons as you would like. 

## Loading Order of Operation.

* Check for loot DB (saved by server name cause emu servers can have different loot)
  * If the DB is missing we create it and the 2 tables.
  * If we created a new Database
    * then load working tables from  loot.ini file and write their contents to the database tables.
  * If we already have the DB then load our working tables from that.
  * Pass the Working tables back to the Loot Module

## Notes:

Any item changes and new additions are written to the ini file for non mercs users, and to the Database. Buy items are per character so we will keep those in our own tables since we do not need to share them.