### PR TITLE
Loot fixes and changes

### DIFF
--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -313,10 +313,14 @@ function loot.loadSettings()
     loot.GlobalItems = {}
     -- SQL setup
     if not RGMercUtils.file_exists(ItemsDB) then
-        -- Create the database and its table if it doesn't exist
-        RGMercsLogger.log_warn("Loot Rules Database not found, creating it now.")
-        local db = sqlite3.open(ItemsDB)
-        db:exec([[
+        RGMercsLogger.log_warn("\ayLoot Rules Database \arNOT found\ax, \atCreating it now\ax. Please run \at/rgl lootimport\ax to Import your \atloot.ini \axfile.")
+        RGMercsLogger.log_warn("\arOnly run this one One Character\ax. use \at/rgl lootreload\ax to update the data on the other characters.")
+    else
+        RGMercsLogger.log_info("Loot Rules Database found, loading it now.")
+    end
+    -- Create the database and its table if it doesn't exist
+    local db = sqlite3.open(ItemsDB)
+    db:exec([[
                 CREATE TABLE IF NOT EXISTS Global_Rules (
                 "item_name" TEXT NOT NULL UNIQUE,
                 "item_rule" TEXT NOT NULL,
@@ -330,24 +334,20 @@ function loot.loadSettings()
                 "id" INTEGER PRIMARY KEY AUTOINCREMENT
             );
         ]])
-        db:close()
+    db:close()
 
-        loot.UpdateDB()
-    else
-        RGMercsLogger.log_info("Loot Rules Database found, loading it now.")
-        local db = sqlite3.open(ItemsDB)
-        local stmt = db:prepare("SELECT * FROM Global_Rules")
-        for row in stmt:nrows() do
-            loot.GlobalItems[row.item_name] = row.item_rule
-        end
-        stmt:finalize()
-        stmt = db:prepare("SELECT * FROM Normal_Rules")
-        for row in stmt:nrows() do
-            loot.NormalItems[row.item_name] = row.item_rule
-        end
-        stmt:finalize()
-        db:close()
+    local db = sqlite3.open(ItemsDB)
+    local stmt = db:prepare("SELECT * FROM Global_Rules")
+    for row in stmt:nrows() do
+        loot.GlobalItems[row.item_name] = row.item_rule
     end
+    stmt:finalize()
+    stmt = db:prepare("SELECT * FROM Normal_Rules")
+    for row in stmt:nrows() do
+        loot.NormalItems[row.item_name] = row.item_rule
+    end
+    stmt:finalize()
+    db:close()
 
     local tmpSettings = loot.load(SettingsFile, 'Settings')
     local needSave = false

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -177,6 +177,8 @@ function Module:SaveSettings(doBroadcast)
 	if doBroadcast == true then
 		RGMercUtils.BroadcastUpdate(self._name, "LoadSettings")
 	end
+	LootnScoot.BuyItems = {}
+	LootnScoot.Settings = {}
 	LootnScoot.Settings = self.settings
 	LootnScoot.BuyItems = self.BuyItemsTable
 end
@@ -245,6 +247,8 @@ function Module:LoadSettings()
 	end
 
 	--pass settings to lootnscoot lib
+	LootnScoot.Settings = {}
+	LootnScoot.BuyItems = {}
 	LootnScoot.Settings = self.settings
 	LootnScoot.BuyItems = self.BuyItemsTable
 
@@ -375,12 +379,12 @@ function Module:Render()
 					ImGui.TableNextColumn()
 
 					ImGui.SetNextItemWidth(150)
-					self.TempSettings.NewBuyItem = ImGui.InputText("New Item##BuyItems", self.TempSettings.NewBuyItem) or nil
+					self.TempSettings.NewBuyItem = ImGui.InputText("New Item##BuyItems", self.TempSettings.NewBuyItem)
 
 					ImGui.TableNextColumn()
 					ImGui.SetNextItemWidth(120)
 
-					self.TempSettings.NewBuyQty = ImGui.InputInt("New Qty##BuyItems", self.TempSettings.NewBuyQty, 1, 10) or nil
+					self.TempSettings.NewBuyQty = ImGui.InputInt("New Qty##BuyItems", (self.TempSettings.NewBuyQty or 1), 1, 50)
 					if self.TempSettings.NewBuyQty > 1000 then self.TempSettings.NewBuyQty = 1000 end
 
 					ImGui.TableNextColumn()

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -137,9 +137,10 @@ Module.CommandHandlers   = {
 			self:LootReload()
 		end,
 	},
-	lootupdate = {
-		usage = "/rgl lootupdate",
-		about = "Updates LootRules DB from INI. Incase you were running in standalone mode prior to running RGMercs Lua.",
+	lootimport = {
+		usage = "/rgl lootimport",
+		about =
+		"Imports from INI to LootRules DB. Incase you were running in standalone mode prior to running RGMercs Lua. This may cause a some lag. Only Run on ONE Character to populate / update the DB.",
 		handler = function(self, _)
 			self:LootUpdate()
 		end,
@@ -318,6 +319,15 @@ function Module:Render()
 		self:SaveSettings(false)
 	end
 	if ImGui.CollapsingHeader("Items Tables") then
+		if ImGui.Button("Reload Loot") then
+			self:LootReload()
+		end
+		if ImGui.IsItemHovered() then
+			ImGui.BeginTooltip()
+			ImGui.Text("Reloads working Tables from the Database.")
+			ImGui.EndTooltip()
+		end
+
 		if ImGui.BeginTabBar("Items") then
 			local col = math.max(2, math.floor(ImGui.GetContentRegionAvail() / 150))
 			col = col + (col % 2)
@@ -344,29 +354,6 @@ function Module:Render()
 					self.TempSettings.DeletedBuyKeys = {}
 
 					self.TempSettings.NeedSave = true
-				end
-
-				ImGui.SameLine()
-
-				if ImGui.SmallButton("Reload Loot") then
-					self:LootReload()
-				end
-				if ImGui.IsItemHovered() then
-					ImGui.BeginTooltip()
-					ImGui.Text("Reloads working Tables from the Database.")
-					ImGui.EndTooltip()
-				end
-				ImGui.SameLine()
-
-				if ImGui.SmallButton("Update Loot") then
-					self:LootUpdate()
-				end
-				if ImGui.IsItemHovered() then
-					ImGui.BeginTooltip()
-					ImGui.Text("Imports the ini file into the table.")
-					ImGui.TextColored(ImVec4(0.8, 0.1, 0.1, 1), "ONLY Run on ONE Character")
-					ImGui.Text("Use Reload on the Other Characters After.")
-					ImGui.EndTooltip()
 				end
 
 				self.TempSettings.SearchBuyItems = ImGui.InputText("Search Items##NormalItems", self.TempSettings.SearchBuyItems) or nil
@@ -479,29 +466,6 @@ function Module:Render()
 					self:SortItemTables()
 				end
 
-				ImGui.SameLine()
-
-				if ImGui.SmallButton("Reload Loot") then
-					self:LootReload()
-				end
-				if ImGui.IsItemHovered() then
-					ImGui.BeginTooltip()
-					ImGui.Text("Reloads working Tables from the Database.")
-					ImGui.EndTooltip()
-				end
-				ImGui.SameLine()
-
-				if ImGui.SmallButton("Update Loot") then
-					self:LootUpdate()
-				end
-				if ImGui.IsItemHovered() then
-					ImGui.BeginTooltip()
-					ImGui.Text("Imports the ini file into the table.")
-					ImGui.TextColored(ImVec4(0.8, 0.1, 0.1, 1), "ONLY Run on ONE Character")
-					ImGui.Text("Use Reload on the Other Characters After.")
-					ImGui.EndTooltip()
-				end
-
 				self.TempSettings.SearchGlobalItems = ImGui.InputText("Search Items##NormalItems", self.TempSettings.SearchGlobalItems) or nil
 				ImGui.SeparatorText("Add New Item##GlobalItems")
 				if ImGui.BeginTable("AddItem##GlobalItems", 3, ImGuiTableFlags.Borders) then
@@ -610,29 +574,6 @@ function Module:Render()
 					end
 					self.TempSettings.DeletedNormalKeys = {}
 					self:SortItemTables()
-				end
-
-				ImGui.SameLine()
-
-				if ImGui.SmallButton("Reload Loot") then
-					self:LootReload()
-				end
-				if ImGui.IsItemHovered() then
-					ImGui.BeginTooltip()
-					ImGui.Text("Reloads working Tables from the Database.")
-					ImGui.EndTooltip()
-				end
-				ImGui.SameLine()
-
-				if ImGui.SmallButton("Update Loot") then
-					self:LootUpdate()
-				end
-				if ImGui.IsItemHovered() then
-					ImGui.BeginTooltip()
-					ImGui.Text("Imports the ini file into the table.")
-					ImGui.TextColored(ImVec4(0.8, 0.1, 0.1, 1), "ONLY Run on ONE Character")
-					ImGui.Text("Use Reload on the Other Characters After.")
-					ImGui.EndTooltip()
 				end
 
 				self.TempSettings.SearchItems = ImGui.InputText("Search Items##NormalItems", self.TempSettings.SearchItems) or nil


### PR DESCRIPTION
Lets not auto import the ini on the initial load if the database doesn't exist. 

Instead we will create the tables if they do not exist but to import you must issue

`/rgl lootupdate` or `/rgl lootimport`

Added a warn message about this if you do not already have a database created.

fix destroy and tribute settings updating.
fix reporting showing all items as global.