### PR TITLE
loot check when tributing stackable items

### DIFF
--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -846,10 +846,7 @@ function loot.lootCorpse(corpseID)
         mq.delay(1000, function() return mq.TLO.Window('LootWnd').Open() end)
         if mq.TLO.Window('LootWnd').Open() then break end
     end
-    if areFull then
-        mq.TLO.Window('LootWnd').DoClose()
-        return
-    end
+
     mq.doevents('CantLoot')
     mq.delay(3000, function() return cantLootID > 0 or mq.TLO.Window('LootWnd').Open() end)
     if not mq.TLO.Window('LootWnd').Open() then
@@ -1059,9 +1056,7 @@ end
 
 function loot.RestockItems()
     local rowNum = 0
-    printf("Restock")
     for itemName, qty in pairs(loot.BuyItems) do
-        printf(itemName)
         rowNum = mq.TLO.Window("MerchantWnd/MW_ItemList").List(itemName, 2)() or 0
         mq.delay(20)
         local tmpQty = qty - mq.TLO.FindItemCount(itemName)()
@@ -1128,9 +1123,13 @@ function loot.TributeToVendor(itemToTrib, bag, slot)
                 mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled()
         end)
 
-        mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').LeftMouseUp()
+        mq.TLO.Window('TributeMasterWnd/TMW_DonateButton').LeftMouseUp()
         mq.delay(1)
-        mq.delay(5000, function() return not mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled() end)
+        mq.delay(5000, function() return not mq.TLO.Window('TributeMasterWnd/TMW_DonateButton').Enabled() end)
+        if mq.TLO.Window("QuantityWnd").Open() then
+            mq.TLO.Window("QuantityWnd/QTYW_Accept_Button").LeftMouseUp()
+            mq.delay(5000, function() return not mq.TLO.Window("QuantityWnd").Open() end)
+        end
         mq.delay(1000) -- This delay is necessary because there is seemingly a delay between donating and selecting the next item.
     end
 end

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -378,7 +378,8 @@ function Module:Render()
 					ImGui.EndTable()
 				end
 				ImGui.SeparatorText("Buy Items Table")
-				if ImGui.BeginTable("Buy Items", col, ImGuiTableFlags.Borders) then
+				if ImGui.BeginTable("Buy Items", col, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
+					ImGui.TableSetupScrollFreeze(col, 1)
 					for i = 1, col / 2 do
 						ImGui.TableSetupColumn("Item")
 						ImGui.TableSetupColumn("Qty")
@@ -502,7 +503,8 @@ function Module:Render()
 					ImGui.EndTable()
 				end
 				ImGui.SeparatorText("Global Items Table")
-				if ImGui.BeginTable("GlobalItems", col, ImGuiTableFlags.Borders) then
+				if ImGui.BeginTable("GlobalItems", col, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
+					ImGui.TableSetupScrollFreeze(col, 1)
 					for i = 1, col / 2 do
 						ImGui.TableSetupColumn("Item")
 						ImGui.TableSetupColumn("Setting")
@@ -587,7 +589,8 @@ function Module:Render()
 
 				self.TempSettings.SearchItems = ImGui.InputText("Search Items##NormalItems", self.TempSettings.SearchItems) or nil
 
-				if ImGui.BeginTable("NormalItems", col, ImGuiTableFlags.Borders) then
+				if ImGui.BeginTable("NormalItems", col, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
+					ImGui.TableSetupScrollFreeze(col, 1)
 					for i = 1, col / 2 do
 						ImGui.TableSetupColumn("Item")
 						ImGui.TableSetupColumn("Setting")

--- a/modules/movement.lua
+++ b/modules/movement.lua
@@ -150,7 +150,17 @@ function Module:LoadSettings()
 
     -- Setup Defaults
     self.settings, settingsChanged = RGMercUtils.ResolveDefaults(self.DefaultConfig, self.settings)
-
+    if RGMercConfig.Globals.BuildType == 'Emu' then
+        self.DefaultConfig['DoMercenary'] = { DisplayName = "Use Mercenary", Category = "Mercenary", Tooltip = "Use Merc during combat.", Default = false, ConfigType = "Normal", }
+        self.DefaultConfig['DoFellow'] = {
+            DisplayName = "Enable Fellowship Insignia",
+            Category = "Fellowship",
+            Tooltip = "Use fellowship insignia automatically.",
+            Default = false,
+            ConfigType =
+            "Advanced",
+        }
+    end
     if settingsChanged then
         self:SaveSettings(false)
     end

--- a/utils/rgmercs_config.lua
+++ b/utils/rgmercs_config.lua
@@ -291,17 +291,6 @@ function Config:LoadSettings()
     self.Globals.CurLoadedChar  = mq.TLO.Me.DisplayName()
     self.Globals.CurLoadedClass = mq.TLO.Me.Class.ShortName()
     self.Globals.CurServer      = mq.TLO.EverQuest.Server():gsub(" ", "")
-    if self.Globals.BuildType == 'Emu' then
-        self.DefaultConfig['DoMercenary'] = { DisplayName = "Use Mercenary", Category = "Mercenary", Tooltip = "Use Merc during combat.", Default = false, ConfigType = "Normal", }
-        self.DefaultConfig['DoFellow'] = {
-            DisplayName = "Enable Fellowship Insignia",
-            Category = "Fellowship",
-            Tooltip = "Use fellowship insignia automatically.",
-            Default = false,
-            ConfigType =
-            "Advanced",
-        }
-    end
     RGMercsLogger.log_info(
         "\ayLoading Main Settings for %s!",
         self.Globals.CurLoadedChar)


### PR DESCRIPTION
* also fixed the bags full check so you will still loot stackable items if you have a stack started and space for more.  (i broke that a lone time ago and no one noticed except Derple)

* Limited the table sizes on the loot tables and made the table itself scrollable instead of the whole window.

* fix warning message about DoMercenary being in 2 locations when on emu.