### PR TITLE
importing loot.ini to db is no batched

### DIFF
--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -304,14 +304,14 @@ function loot.UpdateDB()
 
         count = count + 1
         if count % batchSize == 0 then
-            print("Inserted " .. count .. " NormalItems so far...")
+            RGMercsLogger.log_debug("Inserted " .. count .. " NormalItems so far...")
             db:exec("COMMIT")
             db:exec("BEGIN TRANSACTION")
         end
     end
 
     db:exec("COMMIT")
-    print("Inserted all " .. count .. " NormalItems.")
+    RGMercsLogger.log_debug("Inserted all " .. count .. " NormalItems.")
 
     -- Reset counter for GlobalItems
     count = 0
@@ -327,14 +327,14 @@ function loot.UpdateDB()
 
         count = count + 1
         if count % batchSize == 0 then
-            print("Inserted " .. count .. " GlobalItems so far...")
+            RGMercsLogger.log_debug("Inserted " .. count .. " GlobalItems so far...")
             db:exec("COMMIT")
             db:exec("BEGIN TRANSACTION")
         end
     end
 
     db:exec("COMMIT")
-    print("Inserted all " .. count .. " GlobalItems.")
+    RGMercsLogger.log_debug("Inserted all " .. count .. " GlobalItems.")
     db:close()
 end
 

--- a/lib/lootnscoot/loot_lib.lua
+++ b/lib/lootnscoot/loot_lib.lua
@@ -290,18 +290,51 @@ function loot.UpdateDB()
     loot.GlobalItems = loot.load(LootFile, 'GlobalItems')
 
     local db = SQLite3.open(ItemsDB)
+    local batchSize = 500
+    local count = 0
+
+    db:exec("BEGIN TRANSACTION") -- Start transaction for NormalItems
+
+    -- Insert NormalItems in batches
     for k, v in pairs(loot.NormalItems) do
         local stmt, err = db:prepare("INSERT INTO Normal_Rules (item_name, item_rule) VALUES (?, ?)")
         stmt:bind_values(k, v)
         stmt:step()
         stmt:finalize()
+
+        count = count + 1
+        if count % batchSize == 0 then
+            print("Inserted " .. count .. " NormalItems so far...")
+            db:exec("COMMIT")
+            db:exec("BEGIN TRANSACTION")
+        end
     end
+
+    db:exec("COMMIT")
+    print("Inserted all " .. count .. " NormalItems.")
+
+    -- Reset counter for GlobalItems
+    count = 0
+
+    db:exec("BEGIN TRANSACTION")
+
+    -- Insert GlobalItems in batches
     for k, v in pairs(loot.GlobalItems) do
         local stmt, err = db:prepare("INSERT INTO Global_Rules (item_name, item_rule) VALUES (?, ?)")
         stmt:bind_values(k, v)
         stmt:step()
         stmt:finalize()
+
+        count = count + 1
+        if count % batchSize == 0 then
+            print("Inserted " .. count .. " GlobalItems so far...")
+            db:exec("COMMIT")
+            db:exec("BEGIN TRANSACTION")
+        end
     end
+
+    db:exec("COMMIT")
+    print("Inserted all " .. count .. " GlobalItems.")
     db:close()
 end
 


### PR DESCRIPTION
this should prevent the lockup when importing a large loot.ini