### PR TITLE
Revert the additions to the PAL Aego spell list

### DIFF
--- a/class_configs/pal_class_config.lua
+++ b/class_configs/pal_class_config.lua
@@ -230,10 +230,6 @@ return {
         },
         ["Aego"] = {
             --- Pally Aegolism
-            "Courage",                       -- Level 8
-            "Center",                        -- Level 20
-            "Daring",                        -- Level 37
-            "Valor",                         -- Level 47
             "Austerity",                     -- Level 55
             "Blessing of Austerity",         -- Level 58 - Group
             "Guidance",                      -- Level 65


### PR DESCRIPTION
Revert the addition of Courage, Center, Daring, and Valor to the Aego list as they compete with low level DRU group buffs