### PR TITLE
Update pal_class_config.lua

### DIFF
--- a/class_configs/pal_class_config.lua
+++ b/class_configs/pal_class_config.lua
@@ -147,6 +147,7 @@ return {
         },
         ["FuryProc"] = {
             --- Fury Proc Strike
+            "Instrument of Nife",   -- Level 26 (undead-only)
             "Divine Might",   -- Level 45
             "Pious Might",    -- Level 63
             "Holy Order",     -- Level 65


### PR DESCRIPTION
Hear me out. While "Instrument of Nife" is an undead-only weapon proc, it's the first one that PALs get, it lasts an hour, and it's extra DPS until Divine Might at 45.