### PR TITLE
Class Updates

### DIFF
--- a/class_configs/pal_class_config.lua
+++ b/class_configs/pal_class_config.lua
@@ -147,11 +147,11 @@ return {
         },
         ["FuryProc"] = {
             --- Fury Proc Strike
-            "Divine Might",   -- Level 45
-            "Pious Might",    -- Level 63
-            "Holy Order",     -- Level 65
-            "Pious Fury",     -- Level 68
-            "Righteous Fury", -- Level 80
+            "Divine Might",   -- Level 45, 65pt
+            "Pious Might",    -- Level 63, 150pt
+            "Holy Order",     -- Level 65, 180pt
+            "Pious Fury",     -- Level 68, 190pt
+            "Righteous Fury", -- Level 80, 268pt --For simplicity of coding and conflict prevention, once fury is rolled into DPU at 80, we will no longer use the undead proc.
             "Devout Fury",    -- Level 85
             "Earnest Fury",   -- Level 90
             "Zealous Fury",   -- Level 95
@@ -161,6 +161,12 @@ return {
             "Sincere Fury",   -- Level 115
             "Wrathful Fury",  -- Level 120
             "Avowed Fury",    -- Level 125
+        },
+        ["UndeadProc"] = {
+            --- Undead Proc Strike : does not stack with Fury Proc, will be used until Fury is available even if setting not enabled.
+            "Instrument of Nife", -- Level 26, 243pt
+            "Ward of Nife",       -- Level 62, 300pt
+            "Silvered Fury",      -- Level 67, 390pt
         },
         ["Aurora"] = {
             "Aurora of Dawning",
@@ -1283,6 +1289,14 @@ return {
                 end,
             },
             {
+                name = "UndeadProc",
+                type = "Spell",
+                cond = function(self, spell) --use this always until we have a Fury proc, and optionally after that, up until the point that Fury is rolled into DPU
+                    if (mq.TLO.Me.AltAbility("Divine Protector's Unity").Rank() or 0) > 1 or (self:GetResolvedActionMapItem("FuryProc") and not RGMercUtils.GetSetting('DoUndeadProc')) then return false end
+                    return RGMercUtils.PCSpellReady(spell) and RGMercUtils.SelfBuffCheck(spell)
+                end,
+            },
+            {
                 name = "Remorse",
                 type = "Spell",
                 cond = function(self, spell)
@@ -1529,6 +1543,15 @@ return {
             Default = true,
             FAQ = "Why am I not curing?",
             Answer = "Make sure you have the [DoCures] setting enabled.",
+        },
+        ['DoUndeadProc'] = {
+            DisplayName = "Use Undead Proc",
+            Category = "Spells and Abilities",
+            Tooltip = "Use Undead proc over Fury proc until Fury is rolled into Divine Protector's Unity (Level 80).",
+            Default = false,
+            FAQ = "I was using an undead proc buff and it recently switched to the Fury line proc, how do I get it back?",
+            Answer = "By default, we will use the undead proc from levels 26-44 as it is the only proc available.\n" ..
+                "If you would like to continue to use the Undead proc after that, please enable it in the Spells and Abilities tab.",
         },
         ['FlashHP']      = {
             DisplayName = "Use Shield Flash",

--- a/class_configs/shd_class_config.lua
+++ b/class_configs/shd_class_config.lua
@@ -652,8 +652,10 @@ local _ClassConfig = {
         --function to determine if we should AE taunt and optionally, if it is safe to do so
         AETauntCheck = function(printDebug)
             local mobs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-            if mobs < RGMercUtils.GetSetting('AETauntCnt') then return false end
             local xtCount = mq.TLO.Me.XTarget() or 0
+
+            if (mobs or xtCount) < RGMercUtils.GetSetting('AETauntCnt') then return false end
+
             local tauntme = {}
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)

--- a/class_configs/wiz_class_config.lua
+++ b/class_configs/wiz_class_config.lua
@@ -767,7 +767,7 @@ return {
                 name = "HarvestSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and mq.TLO.Me.SpellReady(spell.RankName())
+                    return mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
                 end,
             },
         },
@@ -847,7 +847,7 @@ return {
                 name = "HarvestSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and mq.TLO.Me.SpellReady(spell.RankName())
+                    return mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
                 end,
             },
         },
@@ -1120,7 +1120,7 @@ return {
                 name = "HarvestSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and mq.TLO.Me.SpellReady(spell.RankName())
+                    return mq.TLO.Me.PctMana() < RGMercUtils.GetSetting('HarvestManaPct') and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
                 end,
             },
             {

--- a/utils/rgmercs_utils.lua
+++ b/utils/rgmercs_utils.lua
@@ -315,11 +315,8 @@ function RGMercUtils.WelcomeMsg()
     RGMercsLogger.log_info("\aw\awBy \ag%s", RGMercConfig._author)
     RGMercsLogger.log_info("\aw****************************")
     RGMercsLogger.log_info("\aw use \ag /rg \aw for a list of commands")
-    RGMercsLogger.log_info("\ay*** PLEASE NOTE ***")
-    RGMercsLogger.log_info("\awOur humblest apologies...")
-    RGMercsLogger.log_info(
-        "\awThe setting to run movement while paused has been moved from the \ag\"RGMercsMain\" \awtab to the \ag\"Movement\" \awtab and must be re-selected to use it.")
-    RGMercsLogger.log_info("\ay*** END NOTE ***")
+    --RGMercsLogger.log_info("\ay*** PLEASE NOTE ***")
+    --RGMercsLogger.log_info("\ay*** END NOTE ***")
 end
 
 --- Checks if a given Alternate Advancement (AA) ability can be used.


### PR DESCRIPTION
[SHD]
* AE Taunts will no longer activate on a single target unless they are configured to do so (setting AE Taunt Count to "1" should use them when aggro is lost/not yet established).

[WIZ]
* Loosened overly stringent conditions on Harvest Spell usage.

[PAL]
* Added support for the Undead Proc spells:
* * Under Level 45 (when the first all-target ("Fury") proc is available), these spells will always be used.
* * Once we have a Fury proc, we will prefer it unless the option "Use Undead Proc" is selected.
* * Once our Unity buff includes Fury, we will cease to use the Undead Proc entirely, regardless of the above option.