### PR TITLE
Update pal_class_config.lua

### DIFF
--- a/class_configs/pal_class_config.lua
+++ b/class_configs/pal_class_config.lua
@@ -1424,6 +1424,7 @@ return {
                 { name = "BurstHeal",    cond = function(self) return RGMercUtils.IsModeActive('DPS') end, },
                 { name = "TotLightHeal", },
                 { name = "Preservation", },
+                { name = "LightHeal",	 },
             },
         },
         {


### PR DESCRIPTION
Here's one to consider. Add the LightHeal set to Gem 7 so that low level PALs have a heal spell ready to use. In the 30s none of the heal spells get loaded despite open Gem slots.