### PR TITLE
New command: /rgl usemap (manually cast/use by rotation entry name).

### DIFF
--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -752,6 +752,23 @@ local _ClassConfig = {
             "Jonthan's Provocation",
             "Jonthan's Whistling Warsong",
         },
+        ['CalmSong'] = {
+            -- CalmSong - Level Range 8+ --Included for manual use with /rgl usemap
+            "Kelin's Lugubrious Lament", -- Level 8 (Max Mob Level of 60)
+            "Silent Song of Quellious",  -- Level 61
+            "Luvwen's Aria of Serenity", -- Level 66
+            "Whispersong of Veshma",     -- Level 71
+            "Elddar's Dawnsong",         -- Level 76
+            "Silence of the Void",       -- Level 81
+            "Silence of the Dreamer",    -- Level 86
+            "Silence of the Windsong",   -- Level 91
+            "Silence of the Forsaken",   -- Level 96
+            "Silence of the Silisia",    -- Level 101
+            "Silence of Jembel",         -- Level 106
+            "Silence of Zburator",       -- Level 111
+            "Silence of Quietus",        -- Level 116
+            "Silence of the Forgotten",  -- Level 121
+        },
     },
     ['HelperFunctions'] = {
         SwapInst = function(type)

--- a/utils/rgmercs_binds.lua
+++ b/utils/rgmercs_binds.lua
@@ -158,6 +158,34 @@ Bind.Handlers     = {
             RGMercUtils.UseAA(spell, targetId)
         end,
     },
+    ['usemap'] = {
+        usage = "/rgl usemap \"<maptype>\" \"<mapname>\" <targetId?>",
+        about = "RGMercs will use the mapped spell, song, AA, disc, or item (using smart targeting, or, if provided, on the specified <targetID>).",
+        handler = function(mapType, mapName, targetId)
+            local action = RGMercModules:ExecModule("Class", "GetResolvedActionMapItem", mapName)
+            if not action or not action() then
+                RGMercsLogger.log_debug("\arUseMap: \"\ay%s\ar\" does not appear to be a valid mapped action! \awPlease note this value is case-sensitive.", mapName)
+                return false
+            end
+            targetId = targetId and tonumber(targetId)
+            targetId = targetId or (mq.TLO.Target.ID() > 0 and mq.TLO.Target.ID() or mq.TLO.Me.ID())
+
+            local actionHandlers = {
+                spell = function() return RGMercUtils.UseSpell(action.RankName, targetId, true) end,
+                song = function() return RGMercUtils.UseSong(action.RankName, targetId, true) end,
+                aa = function() return RGMercUtils.UseAA(action, targetId) end, --AFAIK we don't have any AA mapped, but, future proof.
+                item = function() return RGMercUtils.UseItem(action, targetId) end,
+                disc = function() return RGMercUtils.UseDisc(action, targetId) end,
+            }
+
+            local handlerFunc = actionHandlers[mapType:lower()]
+            if handlerFunc then
+                handlerFunc()
+            else
+                RGMercsLogger.log_debug("\arUseMap: \"\ay%s\ar\" is an invalid maptype. \awValid maptypes are : \agspell \aw| \agsong \aw| \agAA \aw| \agdisc \aw| \agitem", mapType)
+            end
+        end,
+    },
     ['setlogfilter'] = {
         usage = "/rgl setlogfilter <filter|filter|filter|...>",
         about = "Set a Lua regex filter to match log lines against before printing (does not effect file logging)",


### PR DESCRIPTION
* Usage: /rgl usemap maptype mapname targetID
* * Maptype: spell, song, aa, item, disc
* * Mapname: Entry name as shown in rotation window (e.g, FireSpell3, MezSpell)
* * TargetID: Optional, will use the current target and fallback to targeting yourself if you don't have one.

This may be handy to hotbutton abilities that are often used manually but updated constantly as you level.

* Examples
* * (SK) /rgl usemap disc Mantle : uses your current Mantle Disc
* * (SHM)/dg shm /rgl usemap spell GroupRenewalHoT $\{Me.ID} : Tell your shaman to cast his group HoT on himself

Smart use of hotbuttons could have your driver telling your bard to calm the driver's target, your enchanter to mez the same,  having "preburn" buttons just before a big pull, etc.