### PR TITLE
Temporarily disabled custom config creation via UI button.

### DIFF
--- a/modules/class.lua
+++ b/modules/class.lua
@@ -180,7 +180,8 @@ function Module:LoadSettings()
 end
 
 function Module:WriteCustomConfig()
-    ClassLoader.writeCustomConfig(Config.Globals.CurLoadedClass)
+    Logger.log_info("Automated custom config creation via this button is temporarily disabled. Please copy manually.")
+    --ClassLoader.writeCustomConfig(Config.Globals.CurLoadedClass)
 end
 
 function Module:GetSettings()


### PR DESCRIPTION
* Disabled while we examine an error in the underlying function. Manual copying is unimpeded.