### PR TITLE
Healer Updates

### DIFF
--- a/class_configs/Live - Experimental/clr_class_config.lua
+++ b/class_configs/Live - Experimental/clr_class_config.lua
@@ -51,6 +51,9 @@ local _ClassConfig = {
             "Harmony of the Soul",
             "Aegis of Superior Divinity",
         },
+        ['VP2Hammer'] = {
+            "Apothic Dragon Spine Hammer",
+        },
     },
     ['AbilitySets']       = {
         ['WardBuff'] = {
@@ -582,6 +585,7 @@ local _ClassConfig = {
                 name = "Divine Arbitration",
                 type = "AA",
                 cond = function(self, aaName, target)
+                    if not Targeting.GroupedWithTarget(target) then return false end
                     return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId
                 end,
             },
@@ -613,13 +617,13 @@ local _ClassConfig = {
                     return Casting.AAReady(aaName)
                 end,
             },
-            -- {
-            --     name = "VP2Hammer",
-            --     type = "Item",
-            --     cond = function(self, itemName)
-            --         return mq.TLO.FindItem(itemName).TimerReady() == 0
-            --     end,
-            -- },
+            {
+                name = "VP2Hammer",
+                type = "Item",
+                cond = function(self, itemName)
+                    return mq.TLO.FindItem(itemName).TimerReady() == 0
+                end,
+            },
             { --if we hit this we need spells back ASAP
                 name = "Forceful Rejuvenation",
                 type = "AA",
@@ -657,13 +661,13 @@ local _ClassConfig = {
                     return Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
-            -- {
-            --     name = "VP2Hammer",
-            --     type = "Item",
-            --     cond = function(self, itemName)
-            --         return mq.TLO.FindItem(itemName).TimerReady() == 0
-            --     end,
-            -- },
+            {
+                name = "VP2Hammer",
+                type = "Item",
+                cond = function(self, itemName)
+                    return mq.TLO.FindItem(itemName).TimerReady() == 0
+                end,
+            },
         },
     },
     ['RotationOrder']     = {

--- a/class_configs/Live - Experimental/dru_class_config.lua
+++ b/class_configs/Live - Experimental/dru_class_config.lua
@@ -754,6 +754,7 @@ local _ClassConfig = {
                 name = "QuickGroupHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
+                    if not Targeting.GroupedWithTarget(target) then return false end
                     return Casting.SpellReady(spell) and (target.ID() or 0) == Core.GetMainAssistId()
                 end,
             },

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -780,7 +780,7 @@ local _ClassConfig = {
                 name = "GroupRenewalHoT",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoHealOverTime') then return false end
+                    if not Config:GetSetting('DoHealOverTime') or not Targeting.GroupedWithTarget(target) then return false end
                     return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true)
                         and Casting.GroupBuffCheck(spell, target)
                 end,
@@ -853,6 +853,7 @@ local _ClassConfig = {
                 name = "InterventionHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
+                    if not Targeting.GroupedWithTarget(target) then return false end
                     return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
@@ -860,6 +861,7 @@ local _ClassConfig = {
                 name = "Soothsayer's Intervention",
                 type = "AA",
                 cond = function(self, aaName, target)
+                    if not Targeting.GroupedWithTarget(target) then return false end
                     return Casting.TargetedAAReady(aaName, target.ID(), true)
                 end,
             },
@@ -897,6 +899,7 @@ local _ClassConfig = {
                 name = "RecourseHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
+                    if not Targeting.GroupedWithTarget(target) then return false end
                     return Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -777,7 +777,7 @@ local _ClassConfig = {
                 name = "GroupRenewalHoT",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoHealOverTime') then return false end
+                    if not Config:GetSetting('DoHealOverTime') or not Targeting.GroupedWithTarget(target) then return false end
                     return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true)
                         and Casting.GroupBuffCheck(spell, target)
                 end,

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -427,4 +427,10 @@ function Targeting.ClearSafeTargetCache()
     Targeting.SafeTargetCache = {}
 end
 
+--- Checks if the target is in the same group.
+function Targeting.GroupedWithTarget(target)
+    local targetName = target.CleanName() or "None"
+    return mq.TLO.Group.Member(targetName)()
+end
+
 return Targeting


### PR DESCRIPTION
* Added check to ensure we are grouped with the target before using group heals for a single target in the main healing rotations (e.g, Shaman Recourse).
* * Improves X-Target/OAL healing.
* * This affects SHM Live/Laz, CLR/DRU Live Experimental.

* [CLR] Added RoS VP Hammer support to Live - Exp config.