### PR TITLE
Changed BuffRezables behavior

### DIFF
--- a/class_configs/Live - Experimental/pal_class_config.lua
+++ b/class_configs/Live - Experimental/pal_class_config.lua
@@ -696,6 +696,9 @@ local _ClassConfig = {
         ["Spellblock"] = {
             "Sanctification Discipline",
         },
+        ['Deflection'] = {
+            'Deflection Discipline',
+        },
         ["ReflexStrike"] = {
             --- Reflexive Strike Heal
             "Reflexive Resolution",

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1457,7 +1457,10 @@ function Casting.GetBuffableGroupIDs()
     local count = mq.TLO.Group.Members()
     for i = 1, count do
         local rezSearch = string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Group.Member(i).DisplayName())
-        if Config:GetSetting('BuffRezables') or mq.TLO.SpawnCount(rezSearch)() == 0 then
+        if mq.TLO.SpawnCount(rezSearch)() > 0 and not Config:GetSetting('BuffRezables') then
+            groupIds = {}
+            break
+        else
             table.insert(groupIds, mq.TLO.Group.Member(i).ID())
         end
     end

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -464,7 +464,7 @@ function Casting.ReagentCheck(spell)
         if spell.NoExpendReagentID(1)() > 0 and mq.TLO.FindItemCount(spell.NoExpendReagentID(1)())() == 0 then
             Logger.log_verbose("Missing NoExpendReagent: (%d)", spell.NoExpendReagentID(1)())
             Comms.HandleAnnounce(
-                string.format('I want to cast %s, but I am missing a non-expended reagent(%d)!', spell(), spell.ReagentID(1)()),
+                string.format('I want to cast %s, but I am missing a non-expended reagent(%d)!', spell(), spell.NoExpendReagentID(1)()),
                 Config:GetSetting('ReagentAnnounceGroup'),
                 Config:GetSetting('ReagentAnnounce'))
             return false
@@ -1459,6 +1459,7 @@ function Casting.GetBuffableGroupIDs()
         local rezSearch = string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Group.Member(i).DisplayName())
         if mq.TLO.SpawnCount(rezSearch)() > 0 and not Config:GetSetting('BuffRezables') then
             groupIds = {}
+            Logger.log_debug("Groupmember corpse detected (%s), aborting group buff rotation.", mq.TLO.Group.Member(i).DisplayName())
             break
         else
             table.insert(groupIds, mq.TLO.Group.Member(i).ID())


### PR DESCRIPTION
Adjusted BuffRezables to stop all group buff use if not enabled and there is a corpse of *any* group member in range.

Current behavior is one PC will be rezzed, and while the rez is on cooldown, we will often buff them. The rez will come back up, but we are still busy buffing rezzed dude, and we don't rez dead dude. Then we rez dead dude, and do the entire thing again, because now HE needs buffs too. Etc. Better than before, but still has room for improvement.

This behavior should be fixed with this change, and we should save time and mana.