### PR TITLE
Changed default for [StandWhenDone] (aka, force stand) to false

### DIFF
--- a/utils/config.lua
+++ b/utils/config.lua
@@ -402,7 +402,7 @@ Config.DefaultConfig = {
         Category = "Med/Mana",
         Index = 8,
         Tooltip = "Force a stand when medding thresholds are reached.",
-        Default = true,
+        Default = false,
         FAQ = "I don't want to stand up after medding, I prefer to stay seated until combat starts or I take another action, how do I change this?",
         Answer = "You can set the [StandWhenDone] option to false to stay seated until something else requires you to stand.",
     },


### PR DESCRIPTION
Users will not have to fight automation or pause to med/sit/camp unless they elect to do so.