### PR TITLE
Minor UI Overhaul

### DIFF
--- a/modules/charm.lua
+++ b/modules/charm.lua
@@ -147,11 +147,12 @@ Module.DefaultConfig             = {
 	},
 	[string.format("%s_Popped", Module._name)] = {
 		DisplayName = Module._name .. " Popped",
-		Category = "Monitoring",
+		Category = "Custom",
 		Tooltip = Module._name .. " Pop Out Into Window",
 		Default = false,
 		FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-		Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+		Answer =
+		"You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
 	},
 }
 
@@ -281,28 +282,22 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-	if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-		self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-		self:SaveSettings(false)
+	if not self.settings[self._name .. "_Popped"] then
+		if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+			self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+			self:SaveSettings(false)
+		end
+		Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+		ImGui.NewLine()
 	end
-	ImGui.SameLine()
-	ImGui.Text("Charm Module")
 
 	---@type boolean|nil
 	local pressed = false
 
 	if self.ModuleLoaded then
-		if ImGui.CollapsingHeader("Config Options") then
-			self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,
-				self.DefaultCategories)
-			if pressed then
-				self:SaveSettings(false)
-			end
-		end
-
-		ImGui.Separator()
 		-- CCEd targets
 		if ImGui.CollapsingHeader("Charm Target List") then
+			ImGui.Indent()
 			if ImGui.BeginTable("CharmedList", 4, bit32.bor(ImGuiTableFlags.None, ImGuiTableFlags.Borders, ImGuiTableFlags.Reorderable, ImGuiTableFlags.Resizable, ImGuiTableFlags.Hideable)) then
 				ImGui.PushStyleColor(ImGuiCol.Text, 1.0, 0.0, 1.0, 1)
 				ImGui.TableSetupColumn('Id', (ImGuiTableColumnFlags.WidthFixed), 70.0)
@@ -323,11 +318,13 @@ function Module:Render()
 				end
 				ImGui.EndTable()
 			end
+			ImGui.Unindent()
 		end
 
 		ImGui.Separator()
 		-- Immune targets
 		if ImGui.CollapsingHeader("Invalid Charm Targets") then
+			ImGui.Indent()
 			if ImGui.BeginTable("Immune", 5, bit32.bor(ImGuiTableFlags.None, ImGuiTableFlags.Borders, ImGuiTableFlags.Reorderable, ImGuiTableFlags.Resizable, ImGuiTableFlags.Hideable)) then
 				ImGui.PushStyleColor(ImGuiCol.Text, 1.0, 0.0, 1.0, 1)
 				ImGui.TableSetupColumn('Id', (ImGuiTableColumnFlags.WidthFixed), 70.0)
@@ -373,9 +370,18 @@ function Module:Render()
 				end
 				ImGui.EndTable()
 			end
+			ImGui.Unindent()
 		end
 
 		ImGui.Separator()
+
+		if ImGui.CollapsingHeader("Config Options") then
+			self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,
+				self.DefaultCategories)
+			if pressed then
+				self:SaveSettings(false)
+			end
+		end
 	end
 end
 

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -272,15 +272,17 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-    ImGui.Text("Core Class Modules")
+    ImGui.Text("Combat State: %s", self.CombatState)
+    ImGui.Text("Current Rotation: %s [%d]", self.CurrentRotation.name, self.CurrentRotation.state)
 
     ---@type boolean|nil
     local pressed = false
     local loadoutChange = false
 
     if self.ClassConfig and self.ModuleLoaded then
-        ImGui.Text("Mode: ")
+        ImGui.Text("Active Mode:")
         ImGui.SameLine()
+        ImGui.SetNextItemWidth(200)
         Ui.Tooltip(self.ClassConfig.DefaultConfig.Mode.Tooltip)
         self.settings.Mode, pressed = ImGui.Combo("##_select_ai_mode", self.settings.Mode, self.ClassConfig.Modes,
             #self.ClassConfig.Modes)
@@ -289,14 +291,7 @@ function Module:Render()
             self:RescanLoadout()
         end
 
-        if ImGui.CollapsingHeader("Config Options") then
-            self.settings, pressed, loadoutChange = Ui.RenderSettings(self.settings,
-                self.ClassConfig.DefaultConfig, self.DefaultCategories)
-            if pressed then
-                self:SaveSettings(false)
-                self.TempSettings.NewCombatMode = self.TempSettings.NewCombatMode or loadoutChange
-            end
-        end
+        Ui.RenderConfigSelector()
 
         ImGui.Separator()
 
@@ -333,6 +328,8 @@ function Module:Render()
         if not self.TempSettings.ReloadingLoadouts then
             if ImGui.CollapsingHeader("Rotations") then
                 ImGui.Indent()
+                ImGui.Text("Combat State: %s", self.CombatState)
+                ImGui.Text("Current Rotation: %s [%d]", self.CurrentRotation.name, self.CurrentRotation.state)
                 Ui.RenderRotationTableKey()
 
                 for _, r in ipairs(self.TempSettings.RotationStates) do
@@ -368,8 +365,16 @@ function Module:Render()
             end
         end
 
-        ImGui.Text("Combat State: %s", self.CombatState)
-        ImGui.Text("Current Rotation: %s [%d]", self.CurrentRotation.name, self.CurrentRotation.state)
+        ImGui.Separator()
+
+        if ImGui.CollapsingHeader("Config Options") then
+            self.settings, pressed, loadoutChange = Ui.RenderSettings(self.settings,
+                self.ClassConfig.DefaultConfig, self.DefaultCategories)
+            if pressed then
+                self:SaveSettings(false)
+                self.TempSettings.NewCombatMode = self.TempSettings.NewCombatMode or loadoutChange
+            end
+        end
     end
 end
 

--- a/modules/drag.lua
+++ b/modules/drag.lua
@@ -55,11 +55,12 @@ Module.DefaultConfig     = {
     },
     [string.format("%s_Popped", Module._name)] = {
         DisplayName = Module._name .. " Popped",
-        Category = "UI",
+        Category = "Custom",
         Tooltip = Module._name .. " Pop Out Into Window",
         Default = false,
         FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-        Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
 }
 Module.DefaultCategories = {}
@@ -141,18 +142,23 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-    if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-        self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-        self:SaveSettings(false)
+    if not self.settings[self._name .. "_Popped"] then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+            self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+            self:SaveSettings(false)
+        end
+        Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+        ImGui.NewLine()
     end
-    ImGui.SameLine()
-    ImGui.Text("Drag Module")
+
     local pressed
     if self.ModuleLoaded then
         if ImGui.Button(Config:GetSetting('DoDrag') and "Stop Dragging" or "Start Dragging", ImGui.GetWindowWidth() * .3, 25) then
             self.settings.DoDrag = not self.settings.DoDrag
             self:SaveSettings(false)
         end
+
+        ImGui.Separator()
 
         if ImGui.CollapsingHeader("Config Options") then
             self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,

--- a/modules/experience.lua
+++ b/modules/experience.lua
@@ -255,6 +255,8 @@ function Module:Render()
         ImPlot.EndPlot()
     end
 
+    ImGui.Separator()
+
     if ImGui.CollapsingHeader("Config Options") then
         self.settings.ExpSecondsToStore, pressed = ImGui.SliderInt(self.DefaultConfig.ExpSecondsToStore.DisplayName,
             self.settings.ExpSecondsToStore, self.DefaultConfig.ExpSecondsToStore.Min,

--- a/modules/faq.lua
+++ b/modules/faq.lua
@@ -1,6 +1,7 @@
 -- Sample FAQ Class Module
 local mq                 = require('mq')
 local Config             = require('utils.config')
+local Ui                 = require("utils.ui")
 local Comms              = require("utils.comms")
 local Logger             = require("utils.logger")
 local Binds              = require("utils.binds")
@@ -21,11 +22,12 @@ Module.DefaultCategories = Set.new({})
 Module.DefaultConfig     = {
 	[string.format("%s_Popped", Module._name)] = {
 		DisplayName = Module._name .. " Popped",
-		Category = "FAQ",
+		Category = "Custom",
 		Tooltip = Module._name .. " Pop Out Into Window",
 		Default = false,
 		FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-		Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+		Answer =
+		"You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
 	},
 }
 
@@ -292,12 +294,15 @@ function Module:FaqFind(question)
 end
 
 function Module:Render()
-	if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-		self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-		self:SaveSettings(false)
+	if not self.settings[self._name .. "_Popped"] then
+		if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+			self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+			self:SaveSettings(false)
+		end
+		Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+		ImGui.NewLine()
 	end
-	ImGui.SameLine()
-	ImGui.Text("FAQ Module")
+
 	ImGui.Spacing()
 	ImGui.PushStyleColor(ImGuiCol.Text, ImVec4(1, 1, 0, 1))
 	ImGui.Text("Local FAQ Browser Link")

--- a/modules/mez.lua
+++ b/modules/mez.lua
@@ -148,11 +148,12 @@ Module.DefaultConfig               = {
     },
     [string.format("%s_Popped", Module._name)] = {
         DisplayName = Module._name .. " Popped",
-        Category = "Monitoring",
+        Category = "Custom",
         Tooltip = Module._name .. " Pop Out Into Window",
         Default = false,
         FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-        Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
 }
 
@@ -238,28 +239,22 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-    if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-        self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-        self:SaveSettings(false)
+    if not self.settings[self._name .. "_Popped"] then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+            self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+            self:SaveSettings(false)
+        end
+        Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+        ImGui.NewLine()
     end
-    ImGui.SameLine()
-    ImGui.Text("Mez Module")
 
     ---@type boolean|nil
     local pressed = false
 
     if self.ModuleLoaded then
-        if ImGui.CollapsingHeader("Config Options") then
-            self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,
-                self.DefaultCategories)
-            if pressed then
-                self:SaveSettings(false)
-            end
-        end
-
-        ImGui.Separator()
         -- CCEd targets
         if ImGui.CollapsingHeader("CC Target List") then
+            ImGui.Indent()
             if ImGui.BeginTable("MezzedList", 4, bit32.bor(ImGuiTableFlags.Resizable, ImGuiTableFlags.Borders)) then
                 ImGui.PushStyleColor(ImGuiCol.Text, 1.0, 0.0, 1.0, 1)
                 ImGui.TableSetupColumn('Id', (ImGuiTableColumnFlags.WidthFixed), 70.0)
@@ -288,11 +283,13 @@ function Module:Render()
                 end
                 ImGui.EndTable()
             end
+            ImGui.Unindent()
         end
 
         ImGui.Separator()
         -- Immune targets
         if ImGui.CollapsingHeader("Immune Target List") then
+            ImGui.Indent()
             if ImGui.BeginTable("Immune", 2, bit32.bor(ImGuiTableFlags.None, ImGuiTableFlags.Borders)) then
                 ImGui.PushStyleColor(ImGuiCol.Text, 1.0, 0.0, 1.0, 1)
                 ImGui.TableSetupColumn('Id', (ImGuiTableColumnFlags.WidthFixed), 70.0)
@@ -307,9 +304,18 @@ function Module:Render()
                 end
                 ImGui.EndTable()
             end
+            ImGui.Unindent()
         end
 
         ImGui.Separator()
+
+        if ImGui.CollapsingHeader("Config Options") then
+            self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,
+                self.DefaultCategories)
+            if pressed then
+                self:SaveSettings(false)
+            end
+        end
     end
 end
 

--- a/modules/movement.lua
+++ b/modules/movement.lua
@@ -190,11 +190,12 @@ Module.DefaultConfig     = {
     },
     [string.format("%s_Popped", Module._name)] = {
         DisplayName = Module._name .. " Popped",
-        Category = "Monitoring",
+        Category = "Custom",
         Tooltip = Module._name .. " Pop Out Into Window",
         Default = false,
         FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-        Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
 }
 
@@ -486,17 +487,20 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-    if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-        self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-        self:SaveSettings(false)
+    if not self.settings[self._name .. "_Popped"] then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+            self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+            self:SaveSettings(false)
+        end
+        Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+        ImGui.NewLine()
     end
-    ImGui.SameLine()
-    ImGui.Text("Movement Module")
 
     if self.settings and self.ModuleLoaded and Config.Globals.SubmodulesLoaded then
         ImGui.Text("Chase Distance: %d", self.settings.ChaseDistance)
         ImGui.Text("Chase Stop Distance: %d", self.settings.ChaseStopDistance)
         ImGui.Text("Chase LOS Required: %s", self.settings.RequireLoS == true and "On" or "Off")
+        ImGui.Text("Last Movement Command: %s", self.TempSettings.LastCmd)
 
         local pressed
         local chaseSpawn = mq.TLO.Spawn("pc =" .. self:GetChaseTarget())
@@ -592,10 +596,6 @@ function Module:Render()
                 self:SaveSettings(false)
             end
         end
-
-        ImGui.Separator()
-
-        ImGui.Text("Last Movement Command: %s", self.TempSettings.LastCmd)
     end
 end
 

--- a/modules/named.lua
+++ b/modules/named.lua
@@ -43,11 +43,12 @@ Module.DefaultConfig     = {
     },
     [string.format("%s_Popped", Module._name)] = {
         DisplayName = Module._name .. " Popped",
-        Category = "Named Table",
+        Category = "Custom",
         Tooltip = Module._name .. " Pop Out Into Window",
         Default = false,
         FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-        Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
 }
 
@@ -139,12 +140,16 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-    if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-        self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-        self:SaveSettings(false)
+    if not self.settings[self._name .. "_Popped"] then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+            self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+            self:SaveSettings(false)
+        end
+        Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+        ImGui.NewLine()
     end
-    ImGui.SameLine()
-    ImGui.Text("Named Spawns")
+
+    Ui.RenderZoneNamed()
 
     ---@type boolean|nil
     local pressed
@@ -167,9 +172,6 @@ function Module:Render()
         end
         self:RefreshNamedTable()
     end
-
-    ImGui.Separator()
-    Ui.RenderZoneNamed()
 end
 
 ---comment

--- a/modules/performance.lua
+++ b/modules/performance.lua
@@ -57,11 +57,12 @@ Module.DefaultConfig      = {
     },
     [string.format("%s_Popped", Module._name)] = {
         DisplayName = Module._name .. " Popped",
-        Category = "Monitoring",
+        Category = "Custom",
         Tooltip = Module._name .. " Pop Out Into Window",
         Default = false,
         FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-        Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
 }
 
@@ -142,12 +143,15 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-    if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-        self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-        self:SaveSettings(false)
+    if not self.settings[self._name .. "_Popped"] then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+            self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+            self:SaveSettings(false)
+        end
+        Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+        ImGui.NewLine()
     end
-    ImGui.SameLine()
-    ImGui.Text("Performance Monitor Modules")
+
     local pressed
     if not self.SettingsLoaded then return end
 
@@ -190,6 +194,8 @@ function Module:Render()
 
         ImPlot.EndPlot()
     end
+
+    ImGui.Separator()
 
     if ImGui.CollapsingHeader("Config Options") then
         self.settings.SecondsToStore, pressed = ImGui.SliderInt(self.DefaultConfig.SecondsToStore.DisplayName,

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -498,11 +498,12 @@ Module.DefaultConfig                   = {
     },
     [string.format("%s_Popped", Module._name)] = {
         DisplayName = Module._name .. " Popped",
-        Category = "UI",
+        Category = "Custom",
         Tooltip = Module._name .. " Pop Out Into Window",
         Default = false,
         FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-        Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
 }
 
@@ -748,12 +749,14 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
-    if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-        self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-        self:SaveSettings(false)
+    if not self.settings[self._name .. "_Popped"] then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+            self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+            self:SaveSettings(false)
+        end
+        Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+        ImGui.NewLine()
     end
-    ImGui.SameLine()
-    ImGui.Text("Pull")
 
     local pressed
 
@@ -979,6 +982,8 @@ function Module:Render()
             end
         end
     end
+
+    ImGui.Separator()
 
     if ImGui.CollapsingHeader("Config Options") then
         if self.ModuleLoaded then

--- a/modules/travel.lua
+++ b/modules/travel.lua
@@ -53,11 +53,12 @@ travelColors["Single"]["b"]        = 180
 Module.DefaultConfig               = {
     [string.format("%s_Popped", Module._name)] = {
         DisplayName = Module._name .. " Popped",
-        Category = "FAQ",
+        Category = "Custom",
         Tooltip = Module._name .. " Pop Out Into Window",
         Default = false,
         FAQ = "Can I pop out the " .. Module._name .. " module into its own window?",
-        Answer = "You can pop out the " .. Module._name .. " module into its own window by toggeling " .. Module._name .. "_Popped",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
 }
 
@@ -234,15 +235,19 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
+    if not self.settings[self._name .. "_Popped"] then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
+            self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
+            self:SaveSettings(false)
+        end
+        Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
+        ImGui.NewLine()
+    end
+
     local width = ImGui.GetWindowWidth()
     local buttonsPerRow = math.max(1, math.floor(width / self.ButtonWidth))
     local changed
-    if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
-        self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-        self:SaveSettings(false)
-    end
-    ImGui.SameLine()
-    ImGui.Text("Travel")
+
     if #self.TempSettings.PorterList > 0 then
         self.TempSettings.SelectedPorter, changed = ImGui.Combo("Select Character", self.TempSettings.SelectedPorter, self.TempSettings.PorterList)
         if changed then

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -79,10 +79,7 @@ Binds.Handlers    = {
         usage = "/rgl burnnow <id?>",
         about = "Will force the target <id> or your current target to trigger all burn checks - resets when combat ends.",
         handler = function(targetId)
-            Targeting.ForceBurnTargetID = tonumber(targetId) or mq.TLO.Target.ID()
-            local burnNowSpawn = mq.TLO.Spawn(Targeting.ForceBurnTargetID)
-            Logger.log_info("\aoForcing Burn Now: \at%s \aw(\am%d\aw)", burnNowSpawn and (burnNowSpawn() and burnNowSpawn.CleanName() or "None") or "None",
-                Targeting.ForceBurnTargetID)
+            Targeting.SetForceBurn(targetId)
         end,
     },
     ['addoa'] = {

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1262,21 +1262,23 @@ Config.DefaultConfig = {
     },
     ['PopOutForceTarget']    = {
         DisplayName = "Pop Out Force Target",
-        Category = "UI",
+        Category = "Custom",
         Tooltip = "Pop out the Force Target into it's own Window",
         Default = false,
         ConfigType = "Advanced",
         FAQ = "How do I pop out the Force Target?",
-        Answer = "You can set the [PopOutForceTarget] option to true to pop out the Force Target into it's own Window.",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
     ['PopOutConsole']        = {
         DisplayName = "Pop Out Console",
-        Category = "UI",
+        Category = "Custom",
         Tooltip = "Pop out the Console into it's own Window",
         Default = false,
         ConfigType = "Advanced",
         FAQ = "How do I pop out the Console?",
-        Answer = "You can set the [PopOutConsole] option to true to pop out the Debug Console into it's own Window.",
+        Answer =
+        "You can set the click the popout button at the top of a tab or heading to pop it into its own window.\n Simply close the window and it will snap back to the main window.",
     },
     ['MainWindowLocked']     = {
         DisplayName = "Main Window Locked",

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -433,4 +433,11 @@ function Targeting.GroupedWithTarget(target)
     return mq.TLO.Group.Member(targetName)()
 end
 
+function Targeting.SetForceBurn(targetId)
+    Targeting.ForceBurnTargetID = tonumber(targetId) or mq.TLO.Target.ID()
+    local burnNowSpawn = mq.TLO.Spawn(Targeting.ForceBurnTargetID)
+    Logger.log_info("\aoForcing Burn Now: \at%s \aw(\am%d\aw)", burnNowSpawn and (burnNowSpawn() and burnNowSpawn.CleanName() or "None") or "None",
+        Targeting.ForceBurnTargetID)
+end
+
 return Targeting

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -93,11 +93,52 @@ function Ui.RenderOAList()
     end
 end
 
+function Ui.GetClassConfigIDFromName(name)
+    for idx, curName in ipairs(Config.Globals.ClassConfigDirs or {}) do
+        if curName == name then return idx end
+    end
+
+    return 1
+end
+
+function Ui.RenderConfigSelector()
+    if Config.Globals.ClassConfigDirs ~= nil then
+        ImGui.Text("Config Type:")
+        Ui.Tooltip(
+            "Select your current server/environment.\nLive: Official EQ Servers (Live, Test, TLP).\nBeta: Configs in testing (see forums).\nExpirimental: Configs restricted to specific modes or levels (see forums, often preferred over the base if available!).\nProject Lazurus: Laz-specific (Live may be better suited for other emu servers).\nCustom: Copies of the above configs that you have edited yourself.")
+        ImGui.SameLine()
+        ImGui.SetNextItemWidth(200)
+        local newConfigDir, changed = ImGui.Combo("##config_type", Ui.GetClassConfigIDFromName(Config:GetSetting('ClassConfigDir')), Config.Globals.ClassConfigDirs,
+            #Config.Globals.ClassConfigDirs)
+        if changed then
+            Config:SetSetting('ClassConfigDir', Config.Globals.ClassConfigDirs[newConfigDir])
+            Config:SaveSettings()
+            Config:LoadSettings()
+            Modules:ExecAll("LoadSettings")
+        end
+
+        ImGui.SameLine()
+        if ImGui.SmallButton(Icons.FA_REFRESH) then
+            Core.ScanConfigDirs()
+        end
+        Ui.Tooltip("Refreshes the class config directory list.")
+
+        ImGui.SameLine()
+        if ImGui.SmallButton('Create Custom Config') then
+            Modules:ExecModule("Class", "WriteCustomConfig")
+        end
+        Ui.Tooltip("Places a copy of the currently loaded class config in the MQ config directory for customization.\nWill back up the existing custom configuration.")
+        ImGui.NewLine()
+    end
+end
+
 function Ui.RenderForceTargetList(showPopout)
     if showPopout then
-        if ImGui.Button(Icons.MD_OPEN_IN_NEW, 0, 18) then
+        if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
             Config:SetSetting('PopOutForceTarget', true)
         end
+        Ui.Tooltip("Pop the Force Target list out into its own window.")
+        ImGui.NewLine()
     end
 
     if ImGui.Button("Clear Forced Target", ImGui.GetWindowWidth() * .3, 18) then
@@ -632,6 +673,7 @@ end
 --- @return boolean: any_pressed was anythign pressed?
 --- @return boolean: requires_new_loadout do we require a new loadout?
 function Ui.RenderSettings(settings, defaults, categories, hideControls, showMainOptions)
+    ImGui.Indent()
     local any_pressed = false
     local new_loadout = false
 
@@ -712,6 +754,8 @@ function Ui.RenderSettings(settings, defaults, categories, hideControls, showMai
         end
         ImGui.EndTabBar()
     end
+
+    ImGui.Unindent()
 
     return settings, any_pressed, new_loadout
 end


### PR DESCRIPTION
* Reorganized and sorted elements and features that have been "tacked on" over time.
* Improved pop-out function and aesthetics.
* Added ease-of-use button for /rgl burnnow.
* Hid the console behind a collapsing header.
* Organized all config windows to be at the bottom of their respective windows.
* Moved pertinent information closer to the top of each window.
* Moved the class config selection to the class module tab.
* Added indents under some collapsing headers for uniformity.
* Added tooltips to some UI elements (WIP, intend to add more).