### PR TITLE
Improved Resurrection Handling

### DIFF
--- a/class_configs/Live - Experimental/dru_class_config.lua
+++ b/class_configs/Live - Experimental/dru_class_config.lua
@@ -1361,42 +1361,28 @@ local _ClassConfig = {
     },
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
-            if not Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) and
-                not mq.TLO.FindItem("Staff of Forbidden Rites")() and
-                not Casting.AAReady("Rejuvenation of Spirit") and
-                not Casting.AAReady("Call of the Wild") then
-                return false
+            local rezAction = false
+
+            if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
+                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
+                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                elseif Casting.AAReady("Call of the Wild") then
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                end
+            elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
+                if Casting.AAReady("Rejuvenation of Spirit") then
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
+                    rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
+                end
             end
-            -- local target = mq.TLO.Target
 
-            -- if not target or not target() then return false end
-
-            if mq.TLO.Target.Distance() > 25 then
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
                 Targeting.SetTarget(corpseId)
                 Core.DoCmd("/corpse")
             end
 
-            --local targetClass = target.Class.ShortName()
-
-            if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then --(targetClass == "dru" or targetClass == "clr" or Config:GetSetting('DoBattleRez')) then
-                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("=Staff of Forbidden Rites")() then
-                    return Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                end
-
-                if Casting.AAReady("Call of the Wild") then
-                    return Casting.UseAA("Call of the Wild", corpseId)
-                end
-            elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
-                if Casting.AAReady("Rejuvenation of Spirit") then
-                    return Casting.UseAA("Rejuvenation of Spirit", corpseId)
-                end
-
-                if Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
-                    return Casting.UseSpell("Incarnate Anew", corpseId, true, true)
-                end
-            end
-
-            return false
+            return rezAction
         end,
     },
     --TODO: These are nearly all in need of Display and Tooltip updates.

--- a/class_configs/Live - Experimental/pal_class_config.lua
+++ b/class_configs/Live - Experimental/pal_class_config.lua
@@ -706,25 +706,33 @@ local _ClassConfig = {
             "Reflexive Righteousness",
             "Reflexive Reverence",
         },
+        ['RezSpell'] = {
+            'Resurrection',
+            'Restoration',
+            'Renewal',
+            'Revive',
+            'Reparation',
+            'Reconstitution',
+            'Reanimation',
+        },
     },
     ['HelperFunctions']   = {
-        --Did not include Staff of Forbidden Rites, GoR refresh is very fast and rez is 96%
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.DoBuffCheck() then
-                Targeting.SetTarget(corpseId)
+            local rezAction = false
+            local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
 
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
-                if Casting.AAReady("Gift of Resurrection") then
-                    return Casting.UseAA("Gift of Resurrection", corpseId)
-                end
+            if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
+                rezAction = Casting.UseAA("Gift of Resurrection", corpseId)
+            elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell) then
+                rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
             end
+
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
+                Core.DoCmd("/corpse")
+            end
+
+            return rezAction
         end,
         --determine whether we should overwrite DPU buffs with better single buffs
         SingleBuffCheck = function(self)

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -749,29 +749,31 @@ local _ClassConfig = {
     }, -- end AbilitySets
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.DoBuffCheck() then
-                Targeting.SetTarget(corpseId, true)
+            local rezAction = false
+            local rezSpell = self.ResolvedActionMap['RezSpell']
 
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
+            if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    return Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
+                    rezAction = Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
-
-                if mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
-                    Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
-                end
-
-                if Casting.SpellReady(self.ResolvedActionMap['RezSpell']) and Targeting.GetXTHaterCount() == 0 and not Casting.CanUseAA("Blessing of Resurrection") then
-                    Casting.UseSpell(self.ResolvedActionMap['RezSpell'], corpseId, true, true)
+            elseif mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence")) and mq.TLO.Me.CombatState():lower() == "active" or mq.TLO.Me.CombatState():lower() == "resting" then
+                rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
+            else
+                if Casting.AAReady("Blessing of Resurrection") then
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell) then
+                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end
+
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
+                Core.DoCmd("/corpse")
+            end
+
+            return rezAction
         end,
     },
     -- These are handled differently from normal rotations in that we try to make some intelligent desicions about which spells to use instead

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1668,44 +1668,28 @@ local _ClassConfig = {
     },
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
-            if not Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) and
-                not mq.TLO.FindItem("Staff of Forbidden Rites")() and
-                not Casting.CanUseAA("Rejuvenation of Spirit") and
-                not Casting.CanUseAA("Call of the Wild") then
-                return false
+            local rezAction = false
+
+            if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
+                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
+                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                elseif Casting.AAReady("Call of the Wild") then
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                end
+            elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
+                if Casting.AAReady("Rejuvenation of Spirit") then
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
+                    rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
+                end
             end
 
-            Targeting.SetTarget(corpseId)
-
-            local target = mq.TLO.Target
-
-            if not target or not target() then return false end
-
-            if mq.TLO.Target.Distance() > 25 then
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
                 Core.DoCmd("/corpse")
             end
 
-            local targetClass = target.Class.ShortName()
-
-            if mq.TLO.Me.CombatState():lower() == "combat" and (targetClass == "dru" or targetClass == "clr" or Config:GetSetting('DoBattleRez')) then
-                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("=Staff of Forbidden Rites")() then
-                    return Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                end
-
-                if Casting.AAReady("Call of the Wild") then
-                    return Casting.UseAA("Call of the Wild", corpseId)
-                end
-            else
-                if Casting.CanUseAA("Rejuvenation of Spirit") then
-                    return Casting.UseAA("Rejuvenation of Spirit", corpseId)
-                end
-
-                if Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
-                    return Casting.UseSpell("Incarnate Anew", corpseId, true, true)
-                end
-            end
-
-            return false
+            return rezAction
         end,
     },
     --TODO: These are nearly all in need of Display and Tooltip updates.

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -703,6 +703,15 @@ return {
             "Reflexive Righteousness",
             "Reflexive Reverence",
         },
+        ['RezSpell'] = {
+            'Resurrection',
+            'Restoration',
+            'Renewal',
+            'Revive',
+            'Reparation',
+            'Reconstitution',
+            'Reanimation',
+        },
     },
     ['HelperFunctions']   = {
         -- helper function for advanced logic to see if we want to use Divine Protector's Unity
@@ -715,21 +724,21 @@ return {
         end,
         --Did not include Staff of Forbidden Rites, GoR refresh is very fast and rez is 96%
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.DoBuffCheck() then
-                Targeting.SetTarget(corpseId)
+            local rezAction = false
+            local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
 
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
-                if Casting.AAReady("Gift of Resurrection") then
-                    return Casting.UseAA("Gift of Resurrection", corpseId)
-                end
+            if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
+                rezAction = Casting.UseAA("Gift of Resurrection", corpseId)
+            elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell) then
+                rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
             end
+
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
+                Core.DoCmd("/corpse")
+            end
+
+            return rezAction
         end,
     },
     ['HealRotationOrder'] = {

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -739,29 +739,31 @@ local _ClassConfig = {
     }, -- end AbilitySets
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.DoBuffCheck() then
-                Targeting.SetTarget(corpseId, true)
+            local rezAction = false
+            local rezSpell = self.ResolvedActionMap['RezSpell']
 
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
+            if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    return Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
+                    rezAction = Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
-
-                if mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
-                    Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
-                end
-
-                if Casting.SpellReady(self.ResolvedActionMap['RezSpell']) and Targeting.GetXTHaterCount() == 0 and not Casting.CanUseAA("Blessing of Resurrection") then
-                    Casting.UseSpell(self.ResolvedActionMap['RezSpell'], corpseId, true, true)
+            elseif mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence")) and mq.TLO.Me.CombatState():lower() == "active" or mq.TLO.Me.CombatState():lower() == "resting" then
+                rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
+            else
+                if Casting.AAReady("Blessing of Resurrection") then
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell) then
+                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end
+
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
+                Core.DoCmd("/corpse")
+            end
+
+            return rezAction
         end,
     },
     -- These are handled differently from normal rotations in that we try to make some intelligent desicions about which spells to use instead

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -857,6 +857,12 @@ local _ClassConfig = {
             "Nightspire Bulwark",
             "Bramblespike Bulwark",
         },
+        ['RezSpell'] = {
+            'Incarnate Anew', -- Level 59
+            'Resuscitate',    --emu only
+            'Revive',         --emu only
+            'Reanimation',    --emu only
+        },
     },
     ['HealRotationOrder'] = {
         {
@@ -1709,44 +1715,29 @@ local _ClassConfig = {
     },
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
-            if not Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) and
-                not mq.TLO.FindItem("Staff of Forbidden Rites")() and
-                not Casting.CanUseAA("Rejuvenation of Spirit") and
-                not Casting.CanUseAA("Call of the Wild") then
-                return false
+            local rezAction = false
+            local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
+
+            if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
+                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
+                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                elseif Casting.AAReady("Call of the Wild") then
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                end
+            elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
+                if Casting.AAReady("Rejuvenation of Spirit") then
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(rezSpell) then
+                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
+                end
             end
 
-            Targeting.SetTarget(corpseId)
-
-            local target = mq.TLO.Target
-
-            if not target or not target() then return false end
-
-            if mq.TLO.Target.Distance() > 25 then
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
                 Core.DoCmd("/corpse")
             end
 
-            local targetClass = target.Class.ShortName()
-
-            if mq.TLO.Me.CombatState():lower() == "combat" and (targetClass == "dru" or targetClass == "clr" or Config:GetSetting('DoBattleRez')) then
-                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("=Staff of Forbidden Rites")() then
-                    return Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                end
-
-                if Casting.AAReady("Call of the Wild") then
-                    return Casting.UseAA("Call of the Wild", corpseId)
-                end
-            else
-                if Casting.CanUseAA("Rejuvenation of Spirit") then
-                    return Casting.UseAA("Rejuvenation of Spirit", corpseId)
-                end
-
-                if Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
-                    return Casting.UseSpell("Incarnate Anew", corpseId, true, true)
-                end
-            end
-
-            return false
+            return rezAction
         end,
     },
     --TODO: These are nearly all in need of Display and Tooltip updates.

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -697,6 +697,15 @@ return {
             "Reflexive Righteousness",
             "Reflexive Reverence",
         },
+        ['RezSpell'] = {
+            'Resurrection',
+            'Restoration',
+            'Renewal',
+            'Revive',
+            'Reparation',
+            'Reconstitution',
+            'Reanimation',
+        },
     },
     ['HelperFunctions']   = {
         -- helper function for advanced logic to see if we want to use Divine Protector's Unity
@@ -709,21 +718,21 @@ return {
         end,
         --Did not include Staff of Forbidden Rites, GoR refresh is very fast and rez is 96%
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.DoBuffCheck() then
-                Targeting.SetTarget(corpseId)
+            local rezAction = false
+            local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
 
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
-                if Casting.AAReady("Gift of Resurrection") then
-                    return Casting.UseAA("Gift of Resurrection", corpseId)
-                end
+            if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
+                rezAction = Casting.UseAA("Gift of Resurrection", corpseId)
+            elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell) then
+                rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
             end
+
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
+                Core.DoCmd("/corpse")
+            end
+
+            return rezAction
         end,
     },
     ['HealRotationOrder'] = {

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -676,54 +676,29 @@ local _ClassConfig = {
     },
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
-            Logger.log_debug("DoRez(): Checking for a valid rez ability.")
+            local rezAction = false
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
-            if (not Casting.SpellReady(rezSpell)) and
-                not mq.TLO.FindItem("Staff of Forbidden Rites")() and
-                not Casting.CanUseAA("Rejuvenation of Spirit") and
-                not Casting.CanUseAA("Call of the Wild") then
-                return false
+
+            if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
+                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
+                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                elseif Casting.AAReady("Call of the Wild") then
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                end
+            elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
+                if Casting.AAReady("Rejuvenation of Spirit") then
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(rezSpell) then
+                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
+                end
             end
 
-            Logger.log_debug("DoRez(): Found for a valid rez ability.")
-
-            Targeting.SetTarget(corpseId)
-
-            local target = mq.TLO.Target
-
-            if not target or not target() then return false end
-
-            if mq.TLO.Target.Distance() > 25 then
+            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
+                Targeting.SetTarget(corpseId)
                 Core.DoCmd("/corpse")
             end
 
-            local targetClass = target.Class.ShortName()
-
-            if Targeting.GetXTHaterCount() > 0 and (targetClass == "dru" or targetClass == "clr" or Config:GetSetting('DoBattleRez')) then
-                Logger.log_debug("DoRez(): Doing Battle Rez!")
-                if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("=Staff of Forbidden Rites")() then
-                    return Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                end
-
-                if Casting.AAReady("Call of the Wild") then
-                    return Casting.UseAA("Call of the Wild", corpseId)
-                end
-            elseif Targeting.GetXTHaterCount() == 0 then
-                Logger.log_debug("DoRez(): Doing out of combat Rez!")
-                if Casting.CanUseAA("Rejuvenation of Spirit") then
-                    Logger.log_debug("DoRez(): Using AA Rez!")
-                    return Casting.UseAA("Rejuvenation of Spirit", corpseId)
-                end
-
-                if Casting.SpellReady(rezSpell) then
-                    Logger.log_debug("DoRez(): Using Spell Res: %s", rezSpell.RankName.Name())
-                    return Casting.UseSpell(rezSpell.RankName.Name(), corpseId, true, true)
-                end
-
-                Logger.log_debug("DoRez(): Failed out of combat Rez!")
-            end
-
-            return false
+            return rezAction
         end,
     },
     -- These are handled differently from normal rotations in that we try to make some intelligent desicions about which spells to use instead


### PR DESCRIPTION
* Tightened conditions for Rez functions:
* * We should no longer target a corpse until a rez action is ready
* * Corpse summoning should no longer occur unless a rez action is ready
* Added PAL rez spells to all PAL configs.
* Added DRU rez spells to Laz config.
* CLR will now use Larger Reviviscence (6 person rez) if three or more group/OAL corpses are present.

Numerous PCs were harmed during the making of these changes.