### PR TITLE
BRD, Mez updates

### DIFF
--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -895,6 +895,15 @@ local _ClassConfig = {
             name = 'Combat',
             state = 1,
             steps = 1,
+            targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and not Casting.IAmFeigning()
+            end,
+        },
+        {
+            name = 'CombatSongs',
+            state = 1,
+            steps = 1,
             doFullRotation = true,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
@@ -902,7 +911,6 @@ local _ClassConfig = {
             end,
         },
     },
-    --TODO: Triple-check usage of PCAAReady and TargetedAAReady, etc, depending on ability
     ['Rotations']       = {
         ['Burn'] = {
             {
@@ -915,8 +923,8 @@ local _ClassConfig = {
             {
                 name = "Funeral Dirge",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) -- and Config:GetSetting('UseFuneralDirge') --see note in config settings
+                cond = function(self, aaName, target)
+                    return Casting.TargetedAAReady(aaName, target.ID()) -- and Config:GetSetting('UseFuneralDirge') --see note in config settings
                 end,
             },
             {
@@ -936,8 +944,8 @@ local _ClassConfig = {
             {
                 name = "Song of Stone",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
+                cond = function(self, aaName, target)
+                    return Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
             {
@@ -983,8 +991,8 @@ local _ClassConfig = {
             {
                 name = "Frenzied Kicks",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                cond = function(self, aaName)
+                    return Casting.AAReady(aaName)
                 end,
             },
             {
@@ -997,14 +1005,14 @@ local _ClassConfig = {
             },
         },
         ['Debuff'] = {
-            {
-                name = "MezAESong",
-                type = "Song",
-                cond = function(self, songSpell)
-                    if not (Config:GetSetting('MezOn') and Config:GetSetting('UseAEAAMez') and Casting.SongMemed(songSpell)) then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting("MezAECount") and (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0
-                end,
-            },
+            -- {
+            --     name = "MezAESong",
+            --     type = "Song",
+            --     cond = function(self, songSpell)
+            --         if not (Config:GetSetting('MezOn') and Config:GetSetting('UseAEAAMez') and Casting.SongMemed(songSpell)) then return false end
+            --        return Targeting.GetXTHaterCount() >= Config:GetSetting("MezAECount") and (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0
+            --     end,
+            -- },
             {
                 name = "AESlowSong",
                 type = "Song",
@@ -1026,8 +1034,6 @@ local _ClassConfig = {
                     return Config:GetSetting('DoDispel') and mq.TLO.Target.Beneficial()
                 end,
             },
-        },
-        ['Heal'] = {
         },
         ['Combat'] = {
             -- Kludge that addresses bards not attempting to start attacking until after a song completes
@@ -1087,6 +1093,16 @@ local _ClassConfig = {
                         Casting.DetSpellCheck(mq.TLO.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
+            {
+                name = "Intimidation",
+                type = "Ability",
+                cond = function(self, abilityName)
+                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
+                    return mq.TLO.Me.AbilityReady(abilityName)()
+                end,
+            },
+        },
+        ['CombatSongs'] = {
             {
                 name = "DichoSong",
                 type = "Song",

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -881,6 +881,15 @@ local _ClassConfig = {
             name = 'Combat',
             state = 1,
             steps = 1,
+            targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and not Casting.IAmFeigning()
+            end,
+        },
+        {
+            name = 'CombatSongs',
+            state = 1,
+            steps = 1,
             doFullRotation = true,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
@@ -888,7 +897,6 @@ local _ClassConfig = {
             end,
         },
     },
-    --TODO: Triple-check usage of PCAAReady and TargetedAAReady, etc, depending on ability
     ['Rotations']       = {
         ['Burn'] = {
             {
@@ -901,8 +909,8 @@ local _ClassConfig = {
             {
                 name = "Funeral Dirge",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) -- and Config:GetSetting('UseFuneralDirge') --see note in config settings
+                cond = function(self, aaName, target)
+                    return Casting.TargetedAAReady(aaName, target.ID()) -- and Config:GetSetting('UseFuneralDirge') --see note in config settings
                 end,
             },
             {
@@ -922,8 +930,8 @@ local _ClassConfig = {
             {
                 name = "Song of Stone",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
+                cond = function(self, aaName, target)
+                    return Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
             {
@@ -969,8 +977,8 @@ local _ClassConfig = {
             {
                 name = "Frenzied Kicks",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                cond = function(self, aaName)
+                    return Casting.AAReady(aaName)
                 end,
             },
             {
@@ -983,14 +991,14 @@ local _ClassConfig = {
             },
         },
         ['Debuff'] = {
-            {
-                name = "MezAESong",
-                type = "Song",
-                cond = function(self, songSpell)
-                    if not (Config:GetSetting('MezOn') and Config:GetSetting('UseAEAAMez') and Casting.SongMemed(songSpell)) then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting("MezAECount") and (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0
-                end,
-            },
+            -- {
+            --     name = "MezAESong",
+            --     type = "Song",
+            --     cond = function(self, songSpell)
+            --         if not (Config:GetSetting('MezOn') and Config:GetSetting('UseAEAAMez') and Casting.SongMemed(songSpell)) then return false end
+            --         return Targeting.GetXTHaterCount() >= Config:GetSetting("MezAECount") and (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0
+            --     end,
+            -- },
             {
                 name = "AESlowSong",
                 type = "Song",
@@ -1012,8 +1020,6 @@ local _ClassConfig = {
                     return Config:GetSetting('DoDispel') and mq.TLO.Target.Beneficial()
                 end,
             },
-        },
-        ['Heal'] = {
         },
         ['Combat'] = {
             -- Kludge that addresses bards not attempting to start attacking until after a song completes
@@ -1073,6 +1079,16 @@ local _ClassConfig = {
                         Casting.DetSpellCheck(mq.TLO.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
+            {
+                name = "Intimidation",
+                type = "Ability",
+                cond = function(self, abilityName)
+                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
+                    return mq.TLO.Me.AbilityReady(abilityName)()
+                end,
+            },
+        },
+        ['CombatSongs'] = {
             {
                 name = "DichoSong",
                 type = "Song",

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -134,7 +134,7 @@ Binds.Handlers    = {
             end
             Core.DoCmd("/squelch /dggaexecute /mqtarget id %d", Targeting.GetTargetID())
             mq.delay(5)
-            Core.DoCmd("/squelch /dggaexecute /docommand /timed $\\{Math.Rand[1,40]} /say %s", text)
+            Core.DoCmd("/squelch /dggaexecute /docommand /timed $\\{Math.Rand[1,60]} /say %s", text)
         end,
     },
     ['cast'] = {

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1323,7 +1323,7 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, overrideWa
 
         Casting.ActionPrep()
 
-        retryCount = retryCount or 5
+        retryCount = retryCount or 3
 
         if targetId > 0 then
             Targeting.SetTarget(targetId, true)


### PR DESCRIPTION
[BRD]
* Added Intimidation (we will not use this until the second rank of the AA).
* Split "Combat" rotation into "Combat" and "Combat Songs" for better flow.
* Returned control of AE Mez to the mez module.

[Mez]
* Added "AE Mez Safety Check" which defaults to false (previous behavior was hardcode to true).
* Slightly refactored to allow for bard AE mez processing

[casting]
* Changed default retry count to 3.

[binds]
* Lengthened the random window of time for /rgl qsay.