### PR TITLE
AA with cast times now treated the same as spells during cast.

### DIFF
--- a/class_configs/Live - Experimental/clr_class_config.lua
+++ b/class_configs/Live - Experimental/clr_class_config.lua
@@ -437,7 +437,7 @@ local _ClassConfig = {
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
                     rezAction = Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
@@ -445,7 +445,7 @@ local _ClassConfig = {
                 rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
             else
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell) then
                     rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
@@ -881,6 +881,7 @@ local _ClassConfig = {
             {
                 name = "Yaulp",
                 type = "AA",
+                allowDead = true,
                 cond = function(self, aaName)
                     return Casting.SelfBuffAACheck(aaName)
                 end,
@@ -888,6 +889,7 @@ local _ClassConfig = {
             {
                 name = "GroupElixir",
                 type = "Spell",
+                allowDead = true,
                 cond = function(self, spell)
                     return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
                 end,

--- a/class_configs/Live - Experimental/dru_class_config.lua
+++ b/class_configs/Live - Experimental/dru_class_config.lua
@@ -1097,7 +1097,7 @@ local _ClassConfig = {
                 end,
                 cond = function(self, aaName, target)
                     local bookSpell = self:GetResolvedActionMapItem('MoveSpells')
-                    local aaSpell = mq.TLO.AltAbility(aaName).Spell.Trigger(1)
+                    local aaSpell = mq.TLO.AltAbility(aaName).Spell
                     if not Config:GetSetting('DoMoveBuffs') or (bookSpell and bookSpell.Level() or 999) > (aaSpell.Level() or 0) then return false end
 
                     return Casting.GroupBuffCheck(aaSpell, target)
@@ -1367,11 +1367,11 @@ local _ClassConfig = {
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
                     rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
                 end

--- a/class_configs/Live - Experimental/nec_class_config.lua
+++ b/class_configs/Live - Experimental/nec_class_config.lua
@@ -1208,7 +1208,7 @@ local _ClassConfig = {
                 end
 
                 if Casting.AAReady("Convergence") and mq.TLO.FindItemCount(mq.TLO.AltAbility("Convergence").Spell.ReagentID(1)())() > 0 then
-                    return Casting.UseAA("Convergence", corpseId)
+                    return Casting.UseAA("Convergence", corpseId, true, 1)
                 end
             end
         end,

--- a/class_configs/Live - Experimental/pal_class_config.lua
+++ b/class_configs/Live - Experimental/pal_class_config.lua
@@ -722,7 +722,7 @@ local _ClassConfig = {
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
 
             if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
-                rezAction = Casting.UseAA("Gift of Resurrection", corpseId)
+                rezAction = Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
             elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell) then
                 rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
             end

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -754,7 +754,7 @@ local _ClassConfig = {
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
                     rezAction = Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
@@ -762,7 +762,7 @@ local _ClassConfig = {
                 rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
             else
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell) then
                     rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1334,7 +1334,7 @@ local _ClassConfig = {
                 end,
                 cond = function(self, aaName, target)
                     local bookSpell = self:GetResolvedActionMapItem('MoveSpells')
-                    local aaSpell = mq.TLO.AltAbility(aaName).Spell.Trigger(1)
+                    local aaSpell = mq.TLO.AltAbility(aaName).Spell
                     if not Config:GetSetting('DoRunSpeed') or (bookSpell and bookSpell.Level() or 999) > (aaSpell.Level() or 0) then return false end
 
                     return Casting.GroupBuffCheck(aaSpell, target)
@@ -1674,11 +1674,11 @@ local _ClassConfig = {
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
                     rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
                 end

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -1231,7 +1231,7 @@ local _ClassConfig = {
                 end
 
                 if Casting.AAReady("Convergence") and mq.TLO.FindItemCount(mq.TLO.AltAbility("Convergence").Spell.ReagentID(1)())() > 0 then
-                    return Casting.UseAA("Convergence", corpseId)
+                    return Casting.UseAA("Convergence", corpseId, true, 1)
                 end
             end
         end,

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -728,7 +728,7 @@ return {
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
 
             if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
-                rezAction = Casting.UseAA("Gift of Resurrection", corpseId)
+                rezAction = Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
             elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell) then
                 rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
             end

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -685,11 +685,11 @@ local _ClassConfig = {
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew")) then
                     rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
                 end
@@ -1252,6 +1252,7 @@ local _ClassConfig = {
             {
                 name = "Cannibalization",
                 type = "AA",
+                allowDead = true,
                 cond = function(self, aaName)
                     if not (Config:GetSetting('DoAACanni') and Config:GetSetting('DoCombatCanni')) then return false end
                     return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and
@@ -1261,6 +1262,7 @@ local _ClassConfig = {
             {
                 name = "CanniSpell",
                 type = "Spell",
+                allowDead = true,
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
                     return Casting.CastReady(spell.RankName()) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
@@ -1270,6 +1272,7 @@ local _ClassConfig = {
             {
                 name = "GroupRenewalHoT",
                 type = "Spell",
+                allowDead = true,
                 cond = function(self, spell)
                     if not Casting.CanUseAA("Luminary's Synergy") and Config:GetSetting('DoHealOverTime') then return false end
                     return not Casting.DotSpellCheck(spell) and Casting.SpellStacksOnMe(spell.RankName)
@@ -1424,7 +1427,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.AAReady(aaName)
+                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1515,7 +1518,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target) --check ranks because this won't use Tala'Tak between 74 and 90
                     if not Config:GetSetting('DoRunSpeed') or (mq.TLO.Me.AltAbility(aaName).Rank() or 0) < 4 then return false end
 
-                    local speedSpell = mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1)
+                    local speedSpell = mq.TLO.Me.AltAbility(aaName).Spell
                     if not speedSpell or not speedSpell() then return false end
 
                     return Casting.GroupBuffCheck(speedSpell, target)

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -744,7 +744,7 @@ local _ClassConfig = {
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
                     rezAction = Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
@@ -752,7 +752,7 @@ local _ClassConfig = {
                 rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
             else
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId)
+                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell) then
                     rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -1722,11 +1722,11 @@ local _ClassConfig = {
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(rezSpell) then
                     rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -1227,7 +1227,7 @@ local _ClassConfig = {
                 end
 
                 if Casting.AAReady("Convergence") and mq.TLO.FindItemCount(mq.TLO.AltAbility("Convergence").Spell.ReagentID(1)())() > 0 then
-                    return Casting.UseAA("Convergence", corpseId)
+                    return Casting.UseAA("Convergence", corpseId, true, 1)
                 end
             end
         end,

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -722,7 +722,7 @@ return {
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
 
             if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
-                rezAction = Casting.UseAA("Gift of Resurrection", corpseId)
+                rezAction = Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
             elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell) then
                 rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
             end

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -683,11 +683,11 @@ local _ClassConfig = {
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId)
+                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId)
+                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(rezSpell) then
                     rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
@@ -1238,6 +1238,7 @@ local _ClassConfig = {
             {
                 name = "Cannibalization",
                 type = "AA",
+                allowDead = true,
                 cond = function(self, aaName)
                     if not (Config:GetSetting('DoAACanni') and Config:GetSetting('DoCombatCanni')) then return false end
                     return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and
@@ -1247,6 +1248,7 @@ local _ClassConfig = {
             {
                 name = "CanniSpell",
                 type = "Spell",
+                allowDead = true,
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
                     return Casting.CastReady(spell.RankName()) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
@@ -1256,6 +1258,7 @@ local _ClassConfig = {
             {
                 name = "GroupRenewalHoT",
                 type = "Spell",
+                allowDead = true,
                 cond = function(self, spell)
                     if not Casting.CanUseAA("Luminary's Synergy") and Config:GetSetting('DoHealOverTime') then return false end
                     return not Casting.DotSpellCheck(spell) and Casting.SpellStacksOnMe(spell.RankName)
@@ -1415,7 +1418,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.AAReady(aaName)
+                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1506,7 +1509,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target) --check ranks because this won't use Tala'Tak between 74 and 90
                     if not Config:GetSetting('DoRunSpeed') or (mq.TLO.Me.AltAbility(aaName).Rank() or 0) < 4 then return false end
 
-                    local speedSpell = mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1)
+                    local speedSpell = mq.TLO.Me.AltAbility(aaName).Spell
                     if not speedSpell or not speedSpell() then return false end
 
                     return Casting.GroupBuffCheck(speedSpell, target)

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -162,7 +162,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
     if entry.type:lower() == "aa" then
         if Casting.AAReady(entry.name) then
-            Casting.UseAA(entry.name, targetId)
+            Casting.UseAA(entry.name, targetId, entry.allowDead, entry.retries)
             ret = true
         else
             ret = false


### PR DESCRIPTION
Custom Config Users (Rez Classes): Action Required (see forum post).

* AA Spells with cast times now have the same early cancel conditions that normal spells do (e.g, cancel on target death, cancel when target moves too far out of range).
* * Certain rez actions will not work for custom config users until the AA entry has been edited (see forum post).

* Minor Shaman updates