### PR TITLE
Minor "under the hood" adjustments

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -589,7 +589,7 @@ local function RGInit(...)
     if mainAssist:len() > 0 then
         Config.Globals.MainAssist = mainAssist
         Comms.PopUp("Targeting %s for Main Assist", Config.Globals.MainAssist)
-        Targeting.SetTarget(Core.GetMainAssistId())
+        Targeting.SetTarget(Core.GetMainAssistId(), true)
         Logger.log_info("\aw Assisting \ay >> \ag %s \ay << \aw at \ag %d%%", Config.Globals.MainAssist,
             Config:GetSetting('AutoAssistAt'))
     end

--- a/modules/charm.lua
+++ b/modules/charm.lua
@@ -700,7 +700,7 @@ function Module:ProcessCharmList()
 						table.insert(removeList, id)
 					else
 						Logger.log_debug("\ayProcessCharmList(%d) :: Mob needs charmed.", id)
-						if mq.TLO.Me.Combat() or mq.TLO.Me.Casting.ID() then
+						if mq.TLO.Me.Combat() or mq.TLO.Me.Casting() then
 							Logger.log_debug(
 								" \awNOTICE:\ax Stopping Melee/Singing -- must retarget to start charm.")
 							Core.DoCmd("/attack off")

--- a/modules/mez.lua
+++ b/modules/mez.lua
@@ -541,7 +541,7 @@ function Module:AEMezCheck()
     end
     -- Checking to see if we are auto attacking, or if we are actively casting a spell (Algar comment: we turn attack off, why do we care about auto-attacking enchanters here?)
     -- purpose for this is to catch auto attacking enchanters and bards who never are not casting.
-    if mq.TLO.Me.Combat() or mq.TLO.Me.Casting.ID() ~= nil then
+    if mq.TLO.Me.Combat() or mq.TLO.Me.Casting() then
         Logger.log_debug("\awNOTICE:\ax Stopping cast or song so I can cast AE mez.")
         Core.DoCmd("/stopcast")
         Core.DoCmd("/stopsong")
@@ -726,7 +726,7 @@ function Module:ProcessMezList()
                         table.insert(removeList, id)
                     else
                         Logger.log_debug("\ayProcessMezList(%d) :: Mob needs mezed.", id)
-                        if mq.TLO.Me.Combat() or mq.TLO.Me.Casting.ID() then
+                        if mq.TLO.Me.Combat() or mq.TLO.Me.Casting() then
                             Logger.log_debug(
                                 " \awNOTICE:\ax Stopping Melee/Singing -- must retarget to start mez.")
                             Core.DoCmd("/attack off")

--- a/modules/movement.lua
+++ b/modules/movement.lua
@@ -662,7 +662,7 @@ function Module:ShouldFollow()
     local assistSpawn = Core.GetMainAssistSpawn()
 
     return not mq.TLO.MoveTo.Moving() and
-        (not me.Casting.ID() or Core.MyClassIs("brd")) and
+        (not me.Casting() or Core.MyClassIs("brd")) and
         (Targeting.GetXTHaterCount() == 0 or (assistSpawn() and (assistSpawn.Distance() or 0) > self.settings.ChaseDistance))
 end
 

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -539,7 +539,7 @@ function Casting.SpellReady(spell)
 
     if me.Stunned() then return false end
 
-    return me.CurrentMana() > spell.Mana() and (me.Casting.ID() or 0) == 0 and me.Book(spell.RankName.Name())() ~= nil and
+    return me.CurrentMana() > spell.Mana() and not me.Casting() and me.Book(spell.RankName.Name())() ~= nil and
         not (me.Moving() and (spell.MyCastTime() or -1) > 0)
 end
 
@@ -589,7 +589,7 @@ function Casting.TargetedSpellReady(spellName, targetId, healingSpell)
     if not target or not target() then return false end
 
     if me.SpellReady(spell.RankName.Name())() and me.CurrentMana() >= spell.Mana() then
-        if not (me.Moving() and (spell.MyCastTime() or -1) > 0) and not me.Casting.ID() and not Targeting.TargetIsType("corpse", target) then
+        if not (me.Moving() and (spell.MyCastTime() or -1) > 0) and not me.Casting() and not Targeting.TargetIsType("corpse", target) then
             if target.LineOfSight() then
                 return true
             elseif healingSpell then
@@ -630,7 +630,7 @@ function Casting.TargetedAAReady(aaName, targetId, healingSpell)
     end
 
     if Casting.AAReady(aaName) and me.CurrentMana() >= ability.Spell.Mana() and me.CurrentEndurance() >= ability.Spell.EnduranceCost() then
-        if Core.MyClassIs("brd") or (not me.Moving() and not me.Casting.ID()) then
+        if Core.MyClassIs("brd") or (not me.Moving() and not me.Casting()) then
             Logger.log_verbose("TargetedAAReady(%s) - Check LOS", aaName)
             if target.LineOfSight() then
                 Logger.log_verbose("TargetedAAReady(%s) - Success", aaName)
@@ -861,7 +861,7 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
         return false
     end
 
-    if mq.TLO.Window("CastingWindow").Open() or me.Casting.ID() then
+    if mq.TLO.Window("CastingWindow").Open() or me.Casting() then
         if Core.MyClassIs("brd") then
             mq.delay("3s", function() return (not mq.TLO.Window("CastingWindow").Open()) end)
             mq.delay(10)
@@ -940,7 +940,7 @@ end
 function Casting.UseItem(itemName, targetId)
     local me = mq.TLO.Me
 
-    if mq.TLO.Window("CastingWindow").Open() or me.Casting.ID() then
+    if mq.TLO.Window("CastingWindow").Open() or me.Casting() then
         if Core.MyClassIs("brd") then
             mq.delay("3s", function() return not mq.TLO.Window("CastingWindow").Open() end)
             mq.delay(10)
@@ -1014,16 +1014,16 @@ function Casting.UseItem(itemName, targetId)
         mq.delay(4)
     else
         local maxWait = 1000
-        while maxWait > 0 and not me.Casting.ID() do
+        while maxWait > 0 and not me.Casting() do
             Logger.log_verbose("Waiting for item to start casting...")
             mq.delay(100)
             mq.doevents()
             maxWait = maxWait - 100
         end
-        mq.delay(item.CastTime(), function() return not me.Casting.ID() end)
+        mq.delay(item.CastTime(), function() return not me.Casting() end)
 
         -- pick up any additonal server lag.
-        while me.Casting.ID() do
+        while me.Casting() do
             mq.delay(5)
             mq.doevents()
         end
@@ -1062,7 +1062,7 @@ function Casting.UseDisc(discSpell, targetId)
 
     if not discSpell or not discSpell() then return false end
 
-    if mq.TLO.Window("CastingWindow").Open() or me.Casting.ID() then
+    if mq.TLO.Window("CastingWindow").Open() or me.Casting() then
         Logger.log_debug("CANT USE Disc - Casting Window Open")
         return false
     else
@@ -1085,7 +1085,7 @@ function Casting.UseDisc(discSpell, targetId)
             Core.DoCmd("/squelch /doability \"%s\"", discSpell.RankName.Name())
 
             mq.delay(discSpell.MyCastTime() or 1000,
-                function() return (not me.CombatAbilityReady(discSpell.RankName.Name())() and not me.Casting.ID()) end)
+                function() return (not me.CombatAbilityReady(discSpell.RankName.Name())() and not me.Casting()) end)
 
             -- Is this even needed?
             if Casting.IsActiveDisc(discSpell.RankName.Name()) then

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -438,7 +438,7 @@ function Combat.FindBestAutoTarget(validateFn)
 
     if Config.Globals.AutoTargetID > 0 and mq.TLO.Target.ID() ~= Config.Globals.AutoTargetID then
         if not validateFn or validateFn(Config.Globals.AutoTargetID) then
-            Targeting.SetTarget(Config.Globals.AutoTargetID, true)
+            Targeting.SetTarget(Config.Globals.AutoTargetID)
         end
     end
 end
@@ -645,7 +645,7 @@ end
 function Combat.AutoCampCheck(tempConfig)
     if not Config:GetSetting('ReturnToCamp') then return end
 
-    if mq.TLO.Me.Casting.ID() and not Core.MyClassIs("brd") then return end
+    if mq.TLO.Me.Casting() and not Core.MyClassIs("brd") then return end
 
     -- chasing a toon dont use camnp.
     if Config:GetSetting('ChaseOn') then return end
@@ -705,7 +705,7 @@ end
 function Combat.CombatCampCheck(tempConfig)
     if not Config:GetSetting('ReturnToCamp') then return end
 
-    if mq.TLO.Me.Casting.ID() and not Core.MyClassIs("brd") then return end
+    if mq.TLO.Me.Casting() and not Core.MyClassIs("brd") then return end
 
     -- chasing a toon dont use camnp.
     if Config:GetSetting('ChaseOn') then return end

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -45,7 +45,9 @@ function Ui.RenderOAList()
             ImGui.TableNextColumn()
             local _, clicked = ImGui.Selectable(name, false)
             if clicked then
-                Targeting.SetTarget(spawn.ID() or 0, false)
+                if spawn and spawn() then
+                    mq.TLO.Spawn(spawn.ID()).DoTarget()
+                end
             end
             ImGui.TableNextColumn()
             if spawn() and spawn.ID() > 0 then


### PR DESCRIPTION
* Corrected implementation SetTarget() variables in our assist functions, we should now wait for buffs to populate before checking whether a target is OkayToEngage().
* * Speculative fix for PC's sometimes acting as if a target is Mezzed when the mez has already been broken, causing repeated target clears.

* Changed several instances of checking for an .ID() while casting to simply checking for .Casting() (I believe this is a macro holdover).