### PR TITLE
Group Buff Check Update

### DIFF
--- a/class_configs/Live - Experimental/clr_class_config.lua
+++ b/class_configs/Live - Experimental/clr_class_config.lua
@@ -243,10 +243,10 @@ local _ClassConfig = {
             "Daring",
             "Bravery",
             "Valor",
-            -- [] = "Resolution",
+            --"Resolution",
             "Temperance",
-            "]Blessing of Temperance",
-            -- [] = "Heroic Bond",
+            "Blessing of Temperance",
+            "Heroic Bond",
             "Blessing of Aegolism",
             "Hand of Virtue",
             "Hand of Conviction",
@@ -955,7 +955,8 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Config:GetSetting('AegoSymbol') ~= 1 then return false end
-                    return Casting.GroupBuffCheck(spell, target)
+                    ---@diagnostic disable-next-line: undefined-field
+                    return Casting.GroupBuffCheck(spell, target, mq.TLO.Me.Spell(spell).ID())
                 end,
             },
             {

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -376,7 +376,7 @@ local _ClassConfig = {
             -- [] = "Resolution",
             "Temperance",
             "Blessing of Temperance",
-            -- [] = "Heroic Bond",
+            "Heroic Bond",
             "Blessing of Aegolism",
             "Hand of Virtue",
             "Hand of Conviction",
@@ -1216,9 +1216,8 @@ local _ClassConfig = {
                 name = "AegoBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    -- force the target for StacksTarget to work.
-                    Targeting.SetTarget(target.ID() or 0)
-                    return Config:GetSetting('DoDruid') and Casting.SpellStacksOnTarget(spell) and not Casting.BuffActive(spell)
+                    ---@diagnostic disable-next-line: undefined-field
+                    return Config:GetSetting('DoDruid') and Casting.GroupBuffCheck(spell, target, mq.TLO.Me.Spell(spell).ID())
                 end,
             },
         },

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -372,7 +372,7 @@ local _ClassConfig = {
             -- [] = "Resolution",
             "Temperance",
             "Blessing of Temperance",
-            -- [] = "Heroic Bond",
+            "Heroic Bond",
             "Blessing of Aegolism",
             "Hand of Virtue",
             "Hand of Conviction",
@@ -1216,9 +1216,8 @@ local _ClassConfig = {
                 name = "AegoBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    -- force the target for StacksTarget to work.
-                    Targeting.SetTarget(target.ID() or 0)
-                    return Config:GetSetting('DoDruid') and Casting.SpellStacksOnTarget(spell) and not Casting.BuffActive(spell)
+                    ---@diagnostic disable-next-line: undefined-field
+                    return Config:GetSetting('DoDruid') and Casting.GroupBuffCheck(spell, target, mq.TLO.Me.Spell(spell).ID())
                 end,
             },
         },

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -227,27 +227,26 @@ end
 --- @param spell MQSpell The name of the spell to check.
 --- @param target MQSpawn The name of the target to receive the buff.
 --- @return boolean Returns true if the buff can be cast, false otherwise.
-function Casting.GroupBuffCheck(spell, target)
+function Casting.GroupBuffCheck(spell, target, spellID)
     if not spell or not spell() then return false end
     if not target or not target() then return false end
+    if not spellID then spellID = spell.RankName.ID() end
 
     local targetName = target.CleanName() or "None"
 
     if mq.TLO.DanNet(targetName)() ~= nil then
         local spellName = spell.RankName.Name()
-        local spellID = spell.RankName.ID()
         local spellResult = DanNet.query(targetName, string.format("Me.FindBuff[id %d]", spellID), 1000)
         Logger.log_verbose("\ayGroupBuffCheck() Querying via DanNet for %s(ID:%d) on %s", spellName, spellID, targetName)
-        --Logger.log_verbose("AlgarInclude.GroupBuffCheckNeedsBuff() DanNet result for %s: %s", spellName, spellResult)
         if spellResult == spellName then
             Logger.log_verbose("\atGroupBuffCheck() DanNet detects that %s(ID:%d) is already present on %s, ending.", spellName, spellID, targetName)
             return false
         elseif spellResult == "NULL" then
             Logger.log_verbose("\atGroupBuffCheck() DanNet detects %s(ID:%d) is missing on %s, let's check for triggers.", spellName, spellID, targetName)
-            local numEffects = spell.NumEffects()
+            local numEffects = mq.TLO.Spell(spellID).NumEffects()
             local triggerCt = 0
             for i = 1, numEffects do
-                local triggerSpell = spell.RankName.Trigger(i)
+                local triggerSpell = mq.TLO.Spell(spellID).RankName.Trigger(i)
                 if triggerSpell and triggerSpell() then
                     local triggerRankResult = DanNet.query(targetName, string.format("Me.FindBuff[id %d]", triggerSpell.ID()), 1000)
                     --Logger.log_verbose("GroupBuffCheck() DanNet result for trigger %d of %d (%s, %s): %s", i, numEffects, triggerSpell.Name(), triggerSpell.ID(), triggerRankResult)


### PR DESCRIPTION
* Added support to pass a spell ID to check against in GroupBuffCheck()
* * ID is optional and should be the third variable (See AegoBuff entry in any Cleric config for example).
* * This was added to handle situations where the EQ spell list contained two or more spells with the same name, and should only be required on a case-by-case basis.

* While there is a strong case to move to the sole use of ID's in the function, this fix is completely compatible with existing custom configs.