### PR TITLE
Various Updates

### DIFF
--- a/class_configs/Live - Experimental/dru_class_config.lua
+++ b/class_configs/Live - Experimental/dru_class_config.lua
@@ -1069,7 +1069,7 @@ local _ClassConfig = {
                 name = "Season's Wrath",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Live - Experimental/wiz_class_config.lua
+++ b/class_configs/Live - Experimental/wiz_class_config.lua
@@ -767,7 +767,7 @@ return {
                 name = "Lower Element",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.DetAACheck(mq.TLO.AltAbility(aaName).ID()) and Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
             {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -936,7 +936,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetAACheck(aaSpell.ID()) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
+                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
                         Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1024,7 +1024,7 @@ local _ClassConfig = {
                 name = "Season's Wrath",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsModeActive("Mana") and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and
+                    return Core.IsModeActive("Mana") and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and
                         Targeting.GetTargetPctHPs() > 75
                 end,
             },
@@ -1141,7 +1141,7 @@ local _ClassConfig = {
                 name = "Nature's Frost",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsModeActive("Mana") and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and
+                    return Core.IsModeActive("Mana") and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and
                         mq.TLO.Me.PctMana() > 50 and
                         (not Core.IsModeActive("Heal") or (Core.IsModeActive("Heal") and not Config:GetSetting('DoFire') and (Casting.HaveManaToNuke() or Casting.BurnCheck())))
                 end,
@@ -1150,7 +1150,7 @@ local _ClassConfig = {
                 name = "Nature's Fire",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and mq.TLO.Me.PctMana() > 50 and
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and mq.TLO.Me.PctMana() > 50 and
                         Config:GetSetting('DoNuke') and
                         (not Core.IsModeActive("Heal") or (Core.IsModeActive("Heal") and Config:GetSetting('DoFire') and (Casting.HaveManaToNuke() or Casting.BurnCheck())))
                 end,
@@ -1159,7 +1159,7 @@ local _ClassConfig = {
                 name = "Nature's Bolt",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsModeActive("Mana") and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and
+                    return Core.IsModeActive("Mana") and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and
                         mq.TLO.Me.PctMana() > 50
                 end,
             },
@@ -1291,8 +1291,8 @@ local _ClassConfig = {
                 name = "Entrap",
                 tooltip = "AA: Snare",
                 type = "AA",
-                cond = function(self)
-                    return Config:GetSetting('DoSnare') and Casting.DetAACheck(219)
+                cond = function(self, aaName)
+                    return Config:GetSetting('DoSnare') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1306,7 +1306,7 @@ local _ClassConfig = {
                 name = "Season's Wrath",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -1448,7 +1448,7 @@ local _ClassConfig = {
                 name = "Bite of Tashani",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Config:GetSetting('DoTash') and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and not mq.TLO.Target.Tashed() and
+                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and not mq.TLO.Target.Tashed() and
                         Targeting.GetXTHaterCount() > 1 and Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
@@ -1459,7 +1459,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if Targeting.GetXTHaterCount() < Config:GetSetting('AESlowCount') then return false end
-                    return Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
             {
@@ -1468,7 +1468,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSlow') then return false end
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetAACheck(aaSpell.ID()) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
+                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
                         Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -1647,7 +1647,7 @@ _ClassConfig      = {
                 name = "Malaise",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(aaName)
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1663,7 +1663,7 @@ _ClassConfig      = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(aaName)
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -1332,7 +1332,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.EncroachingDarkness,
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -1112,7 +1112,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEMalo') then return false end
                     return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1129,7 +1129,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1148,7 +1148,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAESlow') then return false end
                     return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1165,7 +1165,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTSlow') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -891,7 +891,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSnare') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -923,7 +923,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetAACheck(aaSpell.ID()) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
+                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
                         Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -1085,7 +1085,7 @@ local _ClassConfig = {
                 name = "Season's Wrath",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsModeActive("Mana") and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and
+                    return Core.IsModeActive("Mana") and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and
                         Targeting.GetTargetPctHPs() > 75
                 end,
             },
@@ -1202,7 +1202,7 @@ local _ClassConfig = {
                 name = "Nature's Frost",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsModeActive("Mana") and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and
+                    return Core.IsModeActive("Mana") and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and
                         mq.TLO.Me.PctMana() > 50 and
                         (not Core.IsModeActive("Heal") or (Core.IsModeActive("Heal") and not Config:GetSetting('DoFire') and (Casting.HaveManaToNuke() or Casting.BurnCheck())))
                 end,
@@ -1211,7 +1211,7 @@ local _ClassConfig = {
                 name = "Nature's Fire",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and mq.TLO.Me.PctMana() > 50 and
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and mq.TLO.Me.PctMana() > 50 and
                         Config:GetSetting('DoNuke') and
                         (not Core.IsModeActive("Heal") or (Core.IsModeActive("Heal") and Config:GetSetting('DoFire') and (Casting.HaveManaToNuke() or Casting.BurnCheck())))
                 end,
@@ -1220,7 +1220,7 @@ local _ClassConfig = {
                 name = "Nature's Bolt",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsModeActive("Mana") and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and
+                    return Core.IsModeActive("Mana") and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and
                         mq.TLO.Me.PctMana() > 50
                 end,
             },
@@ -1352,8 +1352,8 @@ local _ClassConfig = {
                 name = "Entrap",
                 tooltip = "AA: Snare",
                 type = "AA",
-                cond = function(self)
-                    return Config:GetSetting('DoSnare') and Casting.DetAACheck(219)
+                cond = function(self, aaName)
+                    return Config:GetSetting('DoSnare') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1367,7 +1367,7 @@ local _ClassConfig = {
                 name = "Season's Wrath",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -775,6 +775,9 @@ local _ClassConfig = {
             "Instill",
             "Root",
         },
+        ['HasteManaCombo'] = {
+            "Unified Alacrity",
+        },
     },
     ['RotationOrder']   = {
         {
@@ -1036,11 +1039,19 @@ local _ClassConfig = {
         },
         ['GroupBuff'] = {
             {
+                name = "HasteManaCombo",
+                type = "Spell",
+                active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
+                cond = function(self, spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
+                end,
+            },
+            {
                 name = "ManaRegen",
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not Config.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
+                    if self:GetResolvedActionMapItem('HasteManaCombo') or not Config.Constants.RGCasters:contains(target.Class.ShortName()) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -1049,7 +1060,8 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    return Config.Constants.RGMelee:contains(target.Class.ShortName()) and Casting.GroupBuffCheck(spell, target)
+                    if self:GetResolvedActionMapItem('HasteManaCombo') or not Config.Constants.RGMelee:contains(target.Class.ShortName()) then return false end
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1443,7 +1455,7 @@ local _ClassConfig = {
                 name = "Bite of Tashani",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Config:GetSetting('DoTash') and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and not mq.TLO.Target.Tashed() and
+                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and not mq.TLO.Target.Tashed() and
                         Targeting.GetXTHaterCount() > 1 and Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
@@ -1454,7 +1466,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if Targeting.GetXTHaterCount() < Config:GetSetting('AESlowCount') then return false end
-                    return Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID()) and Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },
             {
@@ -1462,7 +1474,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetAACheck(aaSpell.ID()) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
+                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and
                         Casting.TargetedAAReady(aaName, target.ID())
                 end,
             },

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1657,7 +1657,7 @@ _ClassConfig      = {
                 name = "Malosinete",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(aaName)
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1673,7 +1673,7 @@ _ClassConfig      = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(aaName)
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -1321,7 +1321,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.EncroachingDarkness,
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -1098,7 +1098,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEMalo') then return false end
                     return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1115,7 +1115,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1134,7 +1134,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAESlow') then return false end
                     return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1151,7 +1151,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTSlow') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -905,7 +905,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSnare') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetAACheck(mq.TLO.Me.AltAbility(aaName).ID())
+                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -754,7 +754,7 @@ function Module:DoCombatClickies()
     if not Config:GetSetting('UseCombatClickies') then return end
 
     -- make sure we are safe to use clickies
-    if mq.TLO.Me.Sitting() or Casting.IAmFeigning() or not Core.OkayToNotHeal() or mq.TLO.Me.PctHPs() < (Config:GetSetting('EmergencyStart') and Config:GetSetting('EmergencyStart') or 45) then return end
+    if mq.TLO.Me.Sitting() or Casting.IAmFeigning() or not Core.OkayToNotHeal() or mq.TLO.Me.PctHPs() < (Config:GetSetting('EmergencyStart', true) and Config:GetSetting('EmergencyStart') or 45) then return end
 
     -- Control the frequency of checks to prioritize rotations
     self.TempSettings.CombatClickiesTimer = self.TempSettings.CombatClickiesTimer or 0

--- a/utils/item_manager.lua
+++ b/utils/item_manager.lua
@@ -88,7 +88,7 @@ function ItemManager.SwapItemToSlot(slot, item)
     Core.DoCmd("/itemnotify \"%s\" leftmouseup", item)
     mq.delay(100, function() return mq.TLO.Cursor() and mq.TLO.Cursor.Name() == item end)
     Core.DoCmd("/itemnotify %s leftmouseup", slot)
-    mq.delay(100, function() return not mq.TLO.Cursor() or mq.TLO.Cursor.Name() ~= item end)
+    mq.delay(100, function() return mq.TLO.Cursor() and mq.TLO.Cursor.Name() ~= item end)
 
     while mq.TLO.Cursor.ID() do
         mq.delay(1)


### PR DESCRIPTION
Known Issue: Enabling "Do Destroy" in the loot module when using the bard instrument swap feature may cause a rare condition in which an item is deleted. Please don't use them together. Fix is in work to lock them out from each other.

* [ENC] (Laz): Added Unified Alacrity (Thanks Robban!)

* Under the hood change for AA debuff checks.

* Fixed missing setting reporting error in combat clicky use.

* Slightly adjusted bard item swap code.