### PR TITLE
Rez Fixes (Thanks scvone!)

### DIFF
--- a/class_configs/Live - Experimental/dru_class_config.lua
+++ b/class_configs/Live - Experimental/dru_class_config.lua
@@ -1366,7 +1366,7 @@ local _ClassConfig = {
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                elseif Casting.AAReady("Call of the Wild") then
+                elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
                     rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1673,7 +1673,7 @@ local _ClassConfig = {
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                elseif Casting.AAReady("Call of the Wild") then
+                elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
                     rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -684,7 +684,7 @@ local _ClassConfig = {
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                elseif Casting.AAReady("Call of the Wild") then
+                elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
                     rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
@@ -946,7 +946,7 @@ local _ClassConfig = {
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and
-                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.DoBuffCheck()
+                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.DoBuffCheck() and Casting.AmIBuffable()
             end,
         },
         { --Spells that should be checked on group members

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -1721,7 +1721,7 @@ local _ClassConfig = {
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                elseif Casting.AAReady("Call of the Wild") then
+                elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
                     rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -682,7 +682,7 @@ local _ClassConfig = {
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
                     rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
-                elseif Casting.AAReady("Call of the Wild") then
+                elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
                     rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
@@ -932,7 +932,7 @@ local _ClassConfig = {
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and
-                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.DoBuffCheck()
+                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.DoBuffCheck() and Casting.AmIBuffable()
             end,
         },
         { --Spells that should be checked on group members

--- a/utils/movement.lua
+++ b/utils/movement.lua
@@ -10,9 +10,9 @@ Movement.LastDoStick = 0
 --- Sticks the player to the specified target.
 --- @param targetId number The ID of the target to stick to.
 function Movement.DoStick(targetId)
-    if os.clock() - Movement.LastDoStick < 4 then
+    if os.clock() - Movement.LastDoStick < 1.5 then
         Logger.log_debug(
-            "\ayIgnoring DoStick because we just stuck less than 4 seconds ago - let's give it some time.")
+            "\ayIgnoring DoStick because we just stuck a second ago - let's give it some time.")
         return
     end
 


### PR DESCRIPTION
* Rezzers will no longer respect certain meditation settings if a group/OA corpse is present.
* Added corpse check to the Shaman "Slow Downtime" rotation.
* Fixed a condition in which the Group Buff rotation would still process when the caster's corpse was the only one present.

Other minor adjustments:
* Reduced the delay between stick adjustments. Further adjustment may be warranted after more testing and feedback.
* Updated Call of the Wild usage to make sure it is never used on the caster's corpse.