### PR TITLE
SHD Updates

### DIFF
--- a/class_configs/Beta/mnk_class_config.lua
+++ b/class_configs/Beta/mnk_class_config.lua
@@ -228,14 +228,15 @@ local _ClassConfig = {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage
         AETargetCheck = function(printDebug)
-            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 50 zradius 50")()
-            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 50 zradius 50")()
-            if (haters + haterPets) < Config:GetSetting('AETargetCnt') then return false end
+            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()
+            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 80 zradius 50")()
+            local totalHaters = haters + haterPets
+            if totalHaters < Config:GetSetting('AETargetCnt') or totalHaters > Config:GetSetting('MaxAETargetCnt') then return false end
 
             if Config:GetSetting('SafeAEDamage') then
-                local npcs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-                local npcPets = mq.TLO.SpawnCount("NPCpet radius 50 zradius 50")()
-                if (haters + haterPets) < (npcs + npcPets) then
+                local npcs = mq.TLO.SpawnCount("NPC radius 80 zradius 50")()
+                local npcPets = mq.TLO.SpawnCount("NPCpet radius 80 zradius 50")()
+                if totalHaters < (npcs + npcPets) then
                     if printDebug then
                         Logger.log_verbose("AETargetCheck(): %d mobs in range but only %d xtarget haters, blocking AE damage actions.", npcs + npcPets, haters + haterPets)
                     end
@@ -752,10 +753,23 @@ local _ClassConfig = {
             Answer =
             "You can adjust the AE Target Count to control when you will use actions with AE damage attached.",
         },
+        ['MaxAETargetCnt'] = {
+            DisplayName = "Max AE Targets",
+            Category = "Damage Spells",
+            Index = 3,
+            Tooltip =
+            "Maximum number of valid targets before using AE Spells, Disciplines or AA.\nUseful for setting up AE Mez at a higher threshold on another character in case you are overwhelmed.",
+            Default = 5,
+            Min = 2,
+            Max = 30,
+            FAQ = "How do I take advantage of the Max AE Targets setting?",
+            Answer =
+            "Use this setting to set a value just under your mezzer's AE mez count, if desired.",
+        },
         ['SafeAEDamage']   = {
             DisplayName = "AE Proximity Check",
             Category = "Abilities",
-            Index = 3,
+            Index = 5,
             Tooltip = "Check to ensure there aren't neutral mobs in range we could aggro if AE damage is used. May result in non-use due to false positives.",
             Default = false,
             FAQ = "Can you better explain the AE Proximity Check?",
@@ -766,7 +780,7 @@ local _ClassConfig = {
         ['AggroFeign']     = {
             DisplayName = "Emergency Feign",
             Category = "Abilities",
-            Index = 8,
+            Index = 9,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a RGMercsNamed/SpawnMaster mob.",
             Default = true,
             FAQ = "How do I use my Feign Death?",
@@ -776,7 +790,7 @@ local _ClassConfig = {
         ['EmergencyStart'] = {
             DisplayName = "Emergency HP%",
             Category = "Abilities",
-            Index = 9,
+            Index = 10,
             Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
             Default = 50,
             Min = 1,
@@ -788,7 +802,7 @@ local _ClassConfig = {
         ['DoChestClick']   = {
             DisplayName = "Do Chest Click",
             Category = "Abilities",
-            Index = 7,
+            Index = 8,
             Tooltip = "Click your chest item during burns.",
             Default = true,
             ConfigType = "Advanced",
@@ -799,7 +813,7 @@ local _ClassConfig = {
         ['DoCoating']      = {
             DisplayName = "Use Coating",
             Category = "Equipment",
-            Index = 5,
+            Index = 6,
             Tooltip = "Click your Blood/Spirit Drinker's Coating in an emergency.",
             Default = false,
             FAQ = "What is a Coating?",

--- a/class_configs/Beta/rog_class_config.lua
+++ b/class_configs/Beta/rog_class_config.lua
@@ -685,14 +685,15 @@ return {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage
         AETargetCheck = function(printDebug)
-            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 50 zradius 50")()
-            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 50 zradius 50")()
-            if (haters + haterPets) < Config:GetSetting('AETargetCnt') then return false end
+            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()
+            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 80 zradius 50")()
+            local totalHaters = haters + haterPets
+            if totalHaters < Config:GetSetting('AETargetCnt') or totalHaters > Config:GetSetting('MaxAETargetCnt') then return false end
 
             if Config:GetSetting('SafeAEDamage') then
-                local npcs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-                local npcPets = mq.TLO.SpawnCount("NPCpet radius 50 zradius 50")()
-                if (haters + haterPets) < (npcs + npcPets) then
+                local npcs = mq.TLO.SpawnCount("NPC radius 80 zradius 50")()
+                local npcPets = mq.TLO.SpawnCount("NPCpet radius 80 zradius 50")()
+                if totalHaters < (npcs + npcPets) then
                     if printDebug then
                         Logger.log_verbose("AETargetCheck(): %d mobs in range but only %d xtarget haters, blocking AE damage actions.", npcs + npcPets, haters + haterPets)
                     end
@@ -792,10 +793,23 @@ return {
             Answer =
             "You can adjust the AE Target Count to control when you will use actions with AE damage attached.",
         },
+        ['MaxAETargetCnt']  = {
+            DisplayName = "Max AE Targets",
+            Category = "Damage Spells",
+            Index = 5,
+            Tooltip =
+            "Maximum number of valid targets before using AE Spells, Disciplines or AA.\nUseful for setting up AE Mez at a higher threshold on another character in case you are overwhelmed.",
+            Default = 5,
+            Min = 2,
+            Max = 30,
+            FAQ = "How do I take advantage of the Max AE Targets setting?",
+            Answer =
+            "Use this setting to set a value just under your mezzer's AE mez count, if desired.",
+        },
         ['SafeAEDamage']    = {
             DisplayName = "AE Proximity Check",
             Category = "Abilities",
-            Index = 5,
+            Index = 6,
             Tooltip = "Check to ensure there aren't neutral mobs in range we could aggro if AE damage is used. May result in non-use due to false positives.",
             Default = false,
             FAQ = "Can you better explain the AE Proximity Check?",
@@ -806,7 +820,7 @@ return {
         ['EmergencyStart']  = {
             DisplayName = "Emergency HP%",
             Category = "Abilities",
-            Index = 6,
+            Index = 7,
             Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
             Default = 50,
             Min = 1,
@@ -818,7 +832,7 @@ return {
         ['DoVetAA']         = {
             DisplayName = "Use Vet AA",
             Category = "Abilities",
-            Index = 7,
+            Index = 8,
             Tooltip = "Use Veteran AA's in emergencies or during Burn. (See FAQ)",
             Default = true,
             FAQ = "What Vet AA's does MNK use?",

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -792,14 +792,15 @@ return {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage or non-taunt AE hate abilities
         AETargetCheck = function(printDebug)
-            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 50 zradius 50")()
-            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 50 zradius 50")()
-            if (haters + haterPets) < Config:GetSetting('AETargetCnt') then return false end
+            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()
+            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 80 zradius 50")()
+            local totalHaters = haters + haterPets
+            if totalHaters < Config:GetSetting('AETargetCnt') or totalHaters > Config:GetSetting('MaxAETargetCnt') then return false end
 
             if Config:GetSetting('SafeAEDamage') then
-                local npcs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-                local npcPets = mq.TLO.SpawnCount("NPCpet radius 50 zradius 50")()
-                if (haters + haterPets) < (npcs + npcPets) then
+                local npcs = mq.TLO.SpawnCount("NPC radius 80 zradius 50")()
+                local npcPets = mq.TLO.SpawnCount("NPCpet radius 80 zradius 50")()
+                if totalHaters < (npcs + npcPets) then
                     if printDebug then
                         Logger.log_verbose("AETargetCheck(): %d mobs in range but only %d xtarget haters, blocking AE damage actions.", npcs + npcPets, haters + haterPets)
                     end
@@ -1800,10 +1801,23 @@ return {
             Answer =
             "You can adjust the AE Target Count to control when you will use actions with AE damage attached.",
         },
+        ['MaxAETargetCnt'] = {
+            DisplayName = "Max AE Targets",
+            Category = "Damage Spells",
+            Index = 3,
+            Tooltip =
+            "Maximum number of valid targets before using AE Spells, Disciplines or AA.\nUseful for setting up AE Mez at a higher threshold on another character in case you are overwhelmed.",
+            Default = 5,
+            Min = 2,
+            Max = 30,
+            FAQ = "How do I take advantage of the Max AE Targets setting?",
+            Answer =
+            "Use this setting to set a value just under your mezzer's AE mez count, if desired.",
+        },
         ['SafeAEDamage']   = {
             DisplayName = "AE Proximity Check",
             Category = "Combat",
-            Index = 3,
+            Index = 4,
             Tooltip = "Check to ensure there aren't neutral mobs in range we could aggro if AE damage is used. May result in non-use due to false positives.",
             Default = false,
             FAQ = "Can you better explain the AE Proximity Check?",
@@ -1814,7 +1828,7 @@ return {
         ['EmergencyStart'] = {
             DisplayName = "Emergency HP%",
             Category = "Combat",
-            Index = 4,
+            Index = 5,
             Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
             Default = 50,
             Min = 1,
@@ -1826,7 +1840,7 @@ return {
         ['AggroFeign']     = {
             DisplayName = "Emergency Feign",
             Category = "Combat",
-            Index = 5,
+            Index = 6,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a RGMercsNamed/SpawnMaster mob.",
             Default = true,
             FAQ = "How do I use my Feign Death?",
@@ -1836,7 +1850,7 @@ return {
         ['DoCoating']      = {
             DisplayName = "Use Coating",
             Category = "Combat",
-            Index = 6,
+            Index = 7,
             Tooltip = "Click your Blood/Spirit Drinker's Coating in an emergency.",
             Default = false,
             FAQ = "What is a Coating?",
@@ -1845,7 +1859,7 @@ return {
         ['DoChestClick']   = {
             DisplayName = "Do Chest Click",
             Category = "Combat",
-            Index = 7,
+            Index = 8,
             Tooltip = "Click your chest item during burns.",
             Default = true,
             ConfigType = "Advanced",

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -261,14 +261,15 @@ local _ClassConfig = {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage or non-taunt AE hate abilities
         AETargetCheck = function(printDebug)
-            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 50 zradius 50")()
-            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 50 zradius 50")()
-            if (haters + haterPets) < Config:GetSetting('AETargetCnt') then return false end
+            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()
+            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 80 zradius 50")()
+            local totalHaters = haters + haterPets
+            if totalHaters < Config:GetSetting('AETargetCnt') or totalHaters > Config:GetSetting('MaxAETargetCnt') then return false end
 
             if Config:GetSetting('SafeAEDamage') then
-                local npcs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-                local npcPets = mq.TLO.SpawnCount("NPCpet radius 50 zradius 50")()
-                if (haters + haterPets) < (npcs + npcPets) then
+                local npcs = mq.TLO.SpawnCount("NPC radius 80 zradius 50")()
+                local npcPets = mq.TLO.SpawnCount("NPCpet radius 80 zradius 50")()
+                if totalHaters < (npcs + npcPets) then
                     if printDebug then
                         Logger.log_verbose("AETargetCheck(): %d mobs in range but only %d xtarget haters, blocking AE damage actions.", npcs + npcPets, haters + haterPets)
                     end
@@ -1021,10 +1022,23 @@ local _ClassConfig = {
             Answer =
             "You can adjust the AE Target Count to control when you will use actions with AE damage attached.",
         },
+        ['MaxAETargetCnt']   = {
+            DisplayName = "Max AE Targets",
+            Category = "Damage Spells",
+            Index = 3,
+            Tooltip =
+            "Maximum number of valid targets before using AE Spells, Disciplines or AA.\nUseful for setting up AE Mez at a higher threshold on another character in case you are overwhelmed.",
+            Default = 5,
+            Min = 2,
+            Max = 30,
+            FAQ = "How do I take advantage of the Max AE Targets setting?",
+            Answer =
+            "Use this setting to set a value just under your mezzer's AE mez count, if desired.",
+        },
         ['SafeAEDamage']     = {
             DisplayName = "AE Proximity Check",
             Category = "Abilities",
-            Index = 3,
+            Index = 4,
             Tooltip = "Check to ensure there aren't neutral mobs in range we could aggro if AE damage is used. May result in non-use due to false positives.",
             Default = false,
             FAQ = "Can you better explain the AE Proximity Check?",

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -780,14 +780,15 @@ return {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage or non-taunt AE hate abilities
         AETargetCheck = function(printDebug)
-            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 50 zradius 50")()
-            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 50 zradius 50")()
-            if (haters + haterPets) < Config:GetSetting('AETargetCnt') then return false end
+            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()
+            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 80 zradius 50")()
+            local totalHaters = haters + haterPets
+            if totalHaters < Config:GetSetting('AETargetCnt') or totalHaters > Config:GetSetting('MaxAETargetCnt') then return false end
 
             if Config:GetSetting('SafeAEDamage') then
-                local npcs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-                local npcPets = mq.TLO.SpawnCount("NPCpet radius 50 zradius 50")()
-                if (haters + haterPets) < (npcs + npcPets) then
+                local npcs = mq.TLO.SpawnCount("NPC radius 80 zradius 50")()
+                local npcPets = mq.TLO.SpawnCount("NPCpet radius 80 zradius 50")()
+                if totalHaters < (npcs + npcPets) then
                     if printDebug then
                         Logger.log_verbose("AETargetCheck(): %d mobs in range but only %d xtarget haters, blocking AE damage actions.", npcs + npcPets, haters + haterPets)
                     end
@@ -1809,10 +1810,23 @@ return {
             Answer =
             "You can adjust the AE Target Count to control when you will use actions with AE damage attached.",
         },
+        ['MaxAETargetCnt'] = {
+            DisplayName = "Max AE Targets",
+            Category = "Damage Spells",
+            Index = 3,
+            Tooltip =
+            "Maximum number of valid targets before using AE Spells, Disciplines or AA.\nUseful for setting up AE Mez at a higher threshold on another character in case you are overwhelmed.",
+            Default = 5,
+            Min = 2,
+            Max = 30,
+            FAQ = "How do I take advantage of the Max AE Targets setting?",
+            Answer =
+            "Use this setting to set a value just under your mezzer's AE mez count, if desired.",
+        },
         ['SafeAEDamage']   = {
             DisplayName = "AE Proximity Check",
             Category = "Combat",
-            Index = 3,
+            Index = 4,
             Tooltip = "Check to ensure there aren't neutral mobs in range we could aggro if AE damage is used. May result in non-use due to false positives.",
             Default = false,
             FAQ = "Can you better explain the AE Proximity Check?",
@@ -1823,7 +1837,7 @@ return {
         ['EmergencyStart'] = {
             DisplayName = "Emergency HP%",
             Category = "Combat",
-            Index = 4,
+            Index = 5,
             Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
             Default = 50,
             Min = 1,
@@ -1835,7 +1849,7 @@ return {
         ['AggroFeign']     = {
             DisplayName = "Emergency Feign",
             Category = "Combat",
-            Index = 5,
+            Index = 6,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a RGMercsNamed/SpawnMaster mob.",
             Default = true,
             FAQ = "How do I use my Feign Death?",
@@ -1845,7 +1859,7 @@ return {
         ['DoChestClick']   = {
             DisplayName = "Do Chest Click",
             Category = "Combat",
-            Index = 6,
+            Index = 7,
             Tooltip = "Click your chest item during burns.",
             Default = false,
             ConfigType = "Advanced",

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -261,14 +261,15 @@ local _ClassConfig = {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage or non-taunt AE hate abilities
         AETargetCheck = function(printDebug)
-            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 50 zradius 50")()
-            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 50 zradius 50")()
-            if (haters + haterPets) < Config:GetSetting('AETargetCnt') then return false end
+            local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()
+            local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 80 zradius 50")()
+            local totalHaters = haters + haterPets
+            if totalHaters < Config:GetSetting('AETargetCnt') or totalHaters > Config:GetSetting('MaxAETargetCnt') then return false end
 
             if Config:GetSetting('SafeAEDamage') then
-                local npcs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-                local npcPets = mq.TLO.SpawnCount("NPCpet radius 50 zradius 50")()
-                if (haters + haterPets) < (npcs + npcPets) then
+                local npcs = mq.TLO.SpawnCount("NPC radius 80 zradius 50")()
+                local npcPets = mq.TLO.SpawnCount("NPCpet radius 80 zradius 50")()
+                if totalHaters < (npcs + npcPets) then
                     if printDebug then
                         Logger.log_verbose("AETargetCheck(): %d mobs in range but only %d xtarget haters, blocking AE damage actions.", npcs + npcPets, haters + haterPets)
                     end
@@ -1035,10 +1036,23 @@ local _ClassConfig = {
             Answer =
             "You can adjust the AE Target Count to control when you will use actions with AE damage attached.",
         },
+        ['MaxAETargetCnt']   = {
+            DisplayName = "Max AE Targets",
+            Category = "Damage Spells",
+            Index = 3,
+            Tooltip =
+            "Maximum number of valid targets before using AE Spells, Disciplines or AA.\nUseful for setting up AE Mez at a higher threshold on another character in case you are overwhelmed.",
+            Default = 5,
+            Min = 2,
+            Max = 30,
+            FAQ = "How do I take advantage of the Max AE Targets setting?",
+            Answer =
+            "Use this setting to set a value just under your mezzer's AE mez count, if desired.",
+        },
         ['SafeAEDamage']     = {
             DisplayName = "AE Proximity Check",
             Category = "Abilities",
-            Index = 3,
+            Index = 4,
             Tooltip = "Check to ensure there aren't neutral mobs in range we could aggro if AE damage is used. May result in non-use due to false positives.",
             Default = false,
             FAQ = "Can you better explain the AE Proximity Check?",


### PR DESCRIPTION
All: Added support for AE abilities, to include target count and optional safety (see Note) checks.
*Laz: Added initial support new/revamped spells (Grasp of Lhranc, Spear of Decay/Muram).
* * Gem and rotation place may be adjusted, feedback welcome.

* Live: Added support for Insidious Line (AE Tap).

Special Note: Safety checks will check for "aggroable" mobs in proximity. These abilities, as annotated in the settings, can and will break Mez. Unfortunately, "Mez checks" or similar for AE Damage is not on the current planned feature list.