### PR TITLE
bulk edit, toggle INFO messages off, Actors work

### DIFF
--- a/lib/lootnscoot/.gitignore
+++ b/lib/lootnscoot/.gitignore
@@ -1,0 +1,6 @@
+
+lib/dannet/helpers.lua
+
+lib/Lemons/
+
+lib/LIP.lua

--- a/lib/lootnscoot/init.lua
+++ b/lib/lootnscoot/init.lua
@@ -393,7 +393,7 @@ loot.CurrentPage                        = loot.CurrentPage or 1
 
 ---
 ---This will keep your table sorted by columns instead of rows.
----@param input_table table|nil  the table to sort (optional) You can send a set of sorted keys if you have already custom sorted it.
+---@param input_table table|nil the table to sort (optional) You can send a set of sorted keys if you have already custom sorted it.
 ---@param sorted_keys table|nil  the sorted keys table (optional) if you have already sorted the keys
 ---@param num_columns integer  the number of column groups to sort the keys into
 ---@return table
@@ -1918,12 +1918,15 @@ function loot.getRule(item, from)
             local _, position = string.find(lootDecision, "|")
             if position then qKeep = lootDecision:sub(position + 1) else qKeep = tostring(loot.Settings.QuestKeep) end
             if countHave < tonumber(qKeep) then
+                ---@diagnostic disable-next-line: return-type-mismatch
                 return "Keep", tonumber(qKeep), newRule
             end
             if loot.Settings.AlwaysDestroy then
+                ---@diagnostic disable-next-line: return-type-mismatch
                 return "Destroy", tonumber(qKeep), newRule
             end
         end
+        ---@diagnostic disable-next-line: return-type-mismatch
         return "Ignore", tonumber(qKeep), newRule
     end
 
@@ -1936,6 +1939,7 @@ function loot.getRule(item, from)
         -- else
         --     lootDecision = 'Ignore'
         -- end
+        ---@diagnostic disable-next-line: undefined-field
         if not item.CanUse() then
             lootDecision = 'Ignore'
             cantWear = true
@@ -2346,7 +2350,7 @@ function loot.commandHandler(...)
             loot.addRule(itemID, 'GlobalItems', 'Quest|' .. args[3], 'All', item.ItemLink('CLICKABLE')())
             Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \agGlobal Item \ayQuest|%s\ax", item.Name(), args[3], item.ItemLink('CLICKABLE')())
         elseif args[1] == 'globalitem' and validActions[args[2]] and item() then
-            loot.addRule(item.ID(), 'GlobalItems', validActions[args[2]], args[3] ~= nil or 'All', item.ItemLink('CLICKABLE')())
+            loot.addRule(item.ID(), 'GlobalItems', validActions[args[2]], args[3] or 'All', item.ItemLink('CLICKABLE')())
             Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \agGlobal Item \ay%s \ax(\at%s\ax)", item.Name(), item.ID(), validActions[args[2]])
         elseif args[1] == 'globalitem' and validActions[args[2]] and args[3] ~= nil then
             local itemName = args[3]
@@ -2773,7 +2777,7 @@ function loot.SellToVendor(itemID, bag, slot, name)
     if NEVER_SELL[itemName] then return end
     if mq.TLO.Window('MerchantWnd').Open() then
         Logger.Info(loot.guiLoot.console, 'Selling item: %s', itemName)
-        local notify = slot == nil or slot == -1
+        local notify = slot == (nil or -1)
             and ('/itemnotify %s leftmouseup'):format(bag)
             or ('/itemnotify in pack%s %s leftmouseup'):format(bag, slot)
         mq.cmdf(notify)
@@ -2792,7 +2796,7 @@ function loot.openBanker()
 end
 
 function loot.bankItem(itemID, bag, slot)
-    local notify = slot == nil or slot == -1
+    local notify = slot == (nil or -1)
         and ('/shift /itemnotify %s leftmouseup'):format(bag)
         or ('/shift /itemnotify in pack%s %s leftmouseup'):format(bag, slot)
     mq.cmdf(notify)
@@ -4614,6 +4618,7 @@ function loot.renderSettingsSection(who)
     end
     ImGui.SameLine()
     if ImGui.SmallButton("Clone Settings") then
+        if not loot.TempSettings.CloneWho or not loot.TempSettings.CloneTo then return end
         loot.Boxes[loot.TempSettings.CloneTo] = {}
         for k, v in pairs(loot.Boxes[loot.TempSettings.CloneWho]) do
             if type(v) == 'table' then
@@ -4732,6 +4737,7 @@ local function renderBtn()
         else
             animMini:SetTextureCell(644 - EQ_ICON_OFFSET)
         end
+        ---@diagnostic disable-next-line: param-type-mismatch --Bool/Boolean mismatch
         ImGui.DrawTextureAnimation(animMini, 34, 34, true)
     end
     if ImGui.IsItemHovered() then
@@ -4899,7 +4905,7 @@ end
 
 function loot.processArgs(args)
     loot.Terminate = true
-    local mercsRunnig = mq.TLO.Lua.Script('rgmercs').Status() == 'RUNNING' or false
+    local mercsRunning = mq.TLO.Lua.Script('rgmercs').Status() == 'RUNNING' or false
     if args == nil then return end
     if #args == 1 then
         if args[1] == 'directed' then
@@ -4912,17 +4918,17 @@ function loot.processArgs(args)
             loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
             loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
         elseif args[1] == 'sellstuff' then
-            if mercsRunnig then mq.cmd('/rgl pause') end
+            if mercsRunning then mq.cmd('/rgl pause') end
             loot.processItems('Sell')
-            if mercsRunnig then mq.cmd('/rgl unpause') end
+            if mercsRunning then mq.cmd('/rgl unpause') end
         elseif args[1] == 'tributestuff' then
-            if mercsRunnig then mq.cmd('/rgl pause') end
+            if mercsRunning then mq.cmd('/rgl pause') end
             loot.processItems('Tribute')
-            if mercsRunnig then mq.cmd('/rgl unpause') end
+            if mercsRunning then mq.cmd('/rgl unpause') end
         elseif args[1] == 'cleanup' then
-            if mercsRunnig then mq.cmd('/rgl pause') end
+            if mercsRunning then mq.cmd('/rgl pause') end
             loot.processItems('Cleanup')
-            if mercsRunnig then mq.cmd('/rgl unpause') end
+            if mercsRunning then mq.cmd('/rgl unpause') end
         elseif args[1] == 'once' then
             loot.lootMobs()
         elseif args[1] == 'standalone' then

--- a/lib/lootnscoot/init.lua
+++ b/lib/lootnscoot/init.lua
@@ -110,7 +110,6 @@ There is also no flag for combat looting. It will only loot if no mobs are withi
 
 ]]
 ---@diagnostic disable: undefined-global
----@diagnostic disable: undefined-field
 
 local mq              = require 'mq'
 local PackageMan      = require('mq.PackageMan')
@@ -141,48 +140,49 @@ Logger.prefix                        = "[\atLootnScoot\ax] "
 -- Public default settings, also read in from Loot.ini [Settings] section
 local loot                           = {}
 loot.Settings                        = {
-    Version         = '"' .. tostring(version) .. '"',
-    GlobalLootOn    = true,   -- Enable Global Loot Items. not implimented yet
-    CombatLooting   = false,  -- Enables looting during combat. Not recommended on the MT
-    CorpseRadius    = 100,    -- Radius to activly loot corpses
-    MobsTooClose    = 40,     -- Don't loot if mobs are in this range.
-    SaveBagSlots    = 3,      -- Number of bag slots you would like to keep empty at all times. Stop looting if we hit this number
-    TributeKeep     = false,  -- Keep items flagged Tribute
-    MinTributeValue = 100,    -- Minimun Tribute points to keep item if TributeKeep is enabled.
-    MinSellPrice    = -1,     -- Minimum Sell price to keep item. -1                                    = any
-    StackPlatValue  = 0,      -- Minimum sell value for full stack
-    StackableOnly   = false,  -- Only loot stackable items
-    AlwaysEval      = false,  -- Re-Evaluate all *Non Quest* items. useful to update loot.ini after changing min sell values.
-    BankTradeskills = true,   -- Toggle flagging Tradeskill items as Bank or not.
-    DoLoot          = true,   -- Enable auto looting in standalone mode
-    LootForage      = true,   -- Enable Looting of Foraged Items
-    LootNoDrop      = false,  -- Enable Looting of NoDrop items.
-    LootNoDropNew   = false,  -- Enable looting of new NoDrop items.
-    LootQuest       = false,  -- Enable Looting of Items Marked 'Quest', requires LootNoDrop on to loot NoDrop quest items
-    DoDestroy       = false,  -- Enable Destroy functionality. Otherwise 'Destroy' acts as 'Ignore'
-    AlwaysDestroy   = false,  -- Always Destroy items to clean corpese Will Destroy Non-Quest items marked 'Ignore' items REQUIRES DoDestroy set to true
-    QuestKeep       = 10,     -- Default number to keep if item not set using Quest|# format.
-    LootChannel     = "dgt",  -- Channel we report loot to.
-    GroupChannel    = "dgze", -- Channel we use for Group Commands Default(dgze)
-    ReportLoot      = true,   -- Report loot items to group or not.
-    SpamLootInfo    = false,  -- Echo Spam for Looting
-    LootForageSpam  = false,  -- Echo spam for Foraged Items
-    AddNewSales     = true,   -- Adds 'Sell' Flag to items automatically if you sell them while the script is running.
-    AddNewTributes  = true,   -- Adds 'Tribute' Flag to items automatically if you Tribute them while the script is running.
-    GMLSelect       = true,   -- not implimented yet
-    LootLagDelay    = 0,      -- not implimented yet
-    HideNames       = false,  -- Hides names and uses class shortname in looted window
-    LookupLinks     = false,  -- Enables Looking up Links for items not on that character. *recommend only running on one charcter that is monitoring.
-    RecordData      = false,  -- Enables recording data to report later.
-    AutoTag         = false,  -- Automatically tag items to sell if they meet the MinSellPrice
-    AutoRestock     = false,  -- Automatically restock items from the BuyItems list when selling
-    LootMyCorpse    = false,  -- Loot your own corpse if its nearby (Does not check for REZ)
-    LootAugments    = false,  -- Loot Augments
-    CheckCorpseOnce = false,  -- Check Corpse once and move on. Ignore the next time it is in range if enabled
-    AutoShowNewItem = false,  -- Automatically show new items in the looted window
-    KeepSpells      = true,   -- Keep spells
-    CanWear         = false,  -- Only loot items you can wear
-    BuyItemsTable   = {
+    Version          = '"' .. tostring(version) .. '"',
+    GlobalLootOn     = true,   -- Enable Global Loot Items. not implimented yet
+    CombatLooting    = false,  -- Enables looting during combat. Not recommended on the MT
+    CorpseRadius     = 100,    -- Radius to activly loot corpses
+    MobsTooClose     = 40,     -- Don't loot if mobs are in this range.
+    SaveBagSlots     = 3,      -- Number of bag slots you would like to keep empty at all times. Stop looting if we hit this number
+    TributeKeep      = false,  -- Keep items flagged Tribute
+    MinTributeValue  = 100,    -- Minimun Tribute points to keep item if TributeKeep is enabled.
+    MinSellPrice     = -1,     -- Minimum Sell price to keep item. -1                                    = any
+    StackPlatValue   = 0,      -- Minimum sell value for full stack
+    StackableOnly    = false,  -- Only loot stackable items
+    AlwaysEval       = false,  -- Re-Evaluate all *Non Quest* items. useful to update loot.ini after changing min sell values.
+    BankTradeskills  = true,   -- Toggle flagging Tradeskill items as Bank or not.
+    DoLoot           = true,   -- Enable auto looting in standalone mode
+    LootForage       = true,   -- Enable Looting of Foraged Items
+    LootNoDrop       = false,  -- Enable Looting of NoDrop items.
+    LootNoDropNew    = false,  -- Enable looting of new NoDrop items.
+    LootQuest        = false,  -- Enable Looting of Items Marked 'Quest', requires LootNoDrop on to loot NoDrop quest items
+    DoDestroy        = false,  -- Enable Destroy functionality. Otherwise 'Destroy' acts as 'Ignore'
+    AlwaysDestroy    = false,  -- Always Destroy items to clean corpese Will Destroy Non-Quest items marked 'Ignore' items REQUIRES DoDestroy set to true
+    QuestKeep        = 10,     -- Default number to keep if item not set using Quest|# format.
+    LootChannel      = "dgt",  -- Channel we report loot to.
+    GroupChannel     = "dgze", -- Channel we use for Group Commands Default(dgze)
+    ReportLoot       = true,   -- Report loot items to group or not.
+    SpamLootInfo     = false,  -- Echo Spam for Looting
+    LootForageSpam   = false,  -- Echo spam for Foraged Items
+    AddNewSales      = true,   -- Adds 'Sell' Flag to items automatically if you sell them while the script is running.
+    AddNewTributes   = true,   -- Adds 'Tribute' Flag to items automatically if you Tribute them while the script is running.
+    GMLSelect        = true,   -- not implimented yet
+    LootLagDelay     = 0,      -- not implimented yet
+    HideNames        = false,  -- Hides names and uses class shortname in looted window
+    LookupLinks      = false,  -- Enables Looking up Links for items not on that character. *recommend only running on one charcter that is monitoring.
+    RecordData       = false,  -- Enables recording data to report later.
+    AutoTag          = false,  -- Automatically tag items to sell if they meet the MinSellPrice
+    AutoRestock      = false,  -- Automatically restock items from the BuyItems list when selling
+    LootMyCorpse     = false,  -- Loot your own corpse if its nearby (Does not check for REZ)
+    LootAugments     = false,  -- Loot Augments
+    CheckCorpseOnce  = false,  -- Check Corpse once and move on. Ignore the next time it is in range if enabled
+    AutoShowNewItem  = false,  -- Automatically show new items in the looted window
+    KeepSpells       = true,   -- Keep spells
+    CanWear          = false,  -- Only loot items you can wear
+    ShowInfoMessages = true,
+    BuyItemsTable    = {
         ['Iron Ration'] = 20,
         ['Water Flask'] = 20,
     },
@@ -358,9 +358,15 @@ local settingsEnum                      = {
     autorestock = 'AutoRestock',
     lootmycorpse = 'LootMyCorpse',
     lootaugments = 'LootAugments',
+    showinfomessages = 'ShowInfoMessages',
 
 }
-
+local tableList                         = {
+    "Global_Items", "Normal_Items", loot.PersonalTableName,
+}
+local tableListRules                    = {
+    "Global_Rules", "Normal_Rules", loot.PersonalTableName,
+}
 local doSell, doBuy, doTribute, areFull = false, false, false, false
 local settingList                       = {
     "CanUse",
@@ -372,6 +378,7 @@ local settingList                       = {
     "Tribute",
     "Bank",
 }
+
 local settingsNoDraw                    = { Version = true, logger = true, LootFile = true, SettingsFile = true, NoDropDefaults = true, CorpseRotTime = true, LootLagDelay = true, Terminate = true, BuyItemsTable = true, }
 
 local selectedIndex                     = 1
@@ -386,7 +393,7 @@ loot.CurrentPage                        = loot.CurrentPage or 1
 
 ---
 ---This will keep your table sorted by columns instead of rows.
----@param input_table table  the table to sort You can send a set of sorted keys if you have already custom sorted it.
+---@param input_table table|nil  the table to sort (optional) You can send a set of sorted keys if you have already custom sorted it.
 ---@param sorted_keys table|nil  the sorted keys table (optional) if you have already sorted the keys
 ---@param num_columns integer  the number of column groups to sort the keys into
 ---@return table
@@ -478,15 +485,14 @@ function loot.load(fileName, sec)
         end
     end
     file:close();
-    Logger.Debug("Loot::load()")
+    Logger.Debug(loot.guiLoot.console, "Loot::load()")
     return data;
 end
 
 function loot.writeSettings()
     loot.Settings.BuyItemsTable = loot.BuyItemsTable
     mq.pickle(SettingsFile, loot.Settings)
-
-    Logger.Debug("Loot::writeSettings()")
+    Logger.Debug(loot.guiLoot.console, "Loot::writeSettings()")
 end
 
 function loot.split(input, sep)
@@ -515,24 +521,7 @@ end
 
 function loot.LoadRuleDB()
     -- Create the database and its table if it doesn't exist
-    -- local db = SQLite3.open(RulesDB)
-    -- db:exec([[
-    --     CREATE TABLE IF NOT EXISTS Global_Rules (
-    --     "item_id" INTEGER PRIMARY KEY NOT NULL UNIQUE,
-    --     "item_name" TEXT NOT NULL,
-    --     "item_rule" TEXT NOT NULL,
-    --     "item_rule_classes" TEXT,
-    --     "item_link" TEXT
-    --     );
-    --     CREATE TABLE IF NOT EXISTS Normal_Rules (
-    --     "item_id" INTEGER PRIMARY KEY NOT NULL UNIQUE,
-    --     "item_name" TEXT NOT NULL,
-    --     "item_rule" TEXT NOT NULL,
-    --     "item_rule_classes" TEXT,
-    --     "item_link" TEXT
-    --     );
-    --     ]])
-    -- db:close()
+
     local db = SQLite3.open(RulesDB)
     local charTableName = string.format("%s_Rules", MyName)
 
@@ -619,7 +608,7 @@ function loot.loadSettings(firstRun)
     local tmpSettings  = {}
 
     if not Files.File.Exists(SettingsFile) then
-        Logger.Warn("Settings file not found, creating it now.")
+        Logger.Warn(loot.guiLoot.console, "Settings file not found, creating it now.")
         needSave = true
         mq.pickle(SettingsFile, loot.Settings)
     else
@@ -651,9 +640,9 @@ function loot.loadSettings(firstRun)
             tmpSettings[k] = loot.Settings[k]
             needSave       = true
             if type(tmpSettings[k]) ~= 'table' then
-                Logger.Info("\agAdded\ax \ayNEW\ax \aySetting\ax: \at%s \aoDefault\ax: \at(\ay%s\ax)", k, v)
+                Logger.Info(loot.guiLoot.console, "\agAdded\ax \ayNEW\ax \aySetting\ax: \at%s \aoDefault\ax: \at(\ay%s\ax)", k, v)
             else
-                Logger.Info("\agAdded\ax \ayNEW\ax \aySetting\ax: \at%s \aoTable\ax", k)
+                Logger.Warn(loot.guiLoot.console, "\agAdded\ax \ayNEW\ax \aySetting\ax: \at%s \aoTable\ax", k)
             end
         end
     end
@@ -662,9 +651,10 @@ function loot.loadSettings(firstRun)
         if loot.Settings[k] == nil and settingsNoDraw[k] == nil then
             tmpSettings[k] = nil
             needSave       = true
-            Logger.Warn("\arRemoved\ax \atdeprecated setting\ax: \ao%s", k)
+            Logger.Warn(loot.guiLoot.console, "\arRemoved\ax \atdeprecated setting\ax: \ao%s", k)
         end
     end
+    Logger.loglevel = loot.Settings.ShowInfoMessages and 'info' or 'warn'
 
     tmpCmd = loot.Settings.GroupChannel or 'dgge'
     if tmpCmd == string.find(tmpCmd, 'dg') then
@@ -680,10 +670,10 @@ function loot.loadSettings(firstRun)
     if firstRun then
         -- SQL setup
         if not Files.File.Exists(RulesDB) then
-            Logger.Warn("\ayLoot Rules Database \arNOT found\ax, \atCreating it now\ax. Please run \at/rgl lootimport\ax to Import your \atloot.ini \axfile.")
-            Logger.Warn("\arOnly run this one One Character\ax. use \at/rgl lootreload\ax to update the data on the other characters.")
+            Logger.Warn(loot.guiLoot.console, "\ayLoot Rules Database \arNOT found\ax, \atCreating it now\ax. Please run \at/rgl lootimport\ax to Import your \atloot.ini \axfile.")
+            Logger.Warn(loot.guiLoot.console, "\arOnly run this one One Character\ax. use \at/rgl lootreload\ax to update the data on the other characters.")
         else
-            Logger.Info("Loot Rules Database found, loading it now.")
+            Logger.Info(loot.guiLoot.console, "Loot Rules Database found, loading it now.")
         end
 
         -- load the rules database
@@ -774,6 +764,7 @@ function loot.loadSettings(firstRun)
         db:close()
     end
     loot.Settings = tmpSettings
+
     -- Modules:ExecModule("Loot", "ModifyLootSettings")
     return needSave
 end
@@ -876,7 +867,7 @@ end
 function loot.addMyInventoryToDB()
     local counter = 0
     local counterBank = 0
-    Logger.Info("\atImporting Inventory\ax into the DB")
+    Logger.Info(loot.guiLoot.console, "\atImporting Inventory\ax into the DB")
 
     for i = 1, 22 do
         if i < 11 then
@@ -928,10 +919,11 @@ function loot.addMyInventoryToDB()
             end
         end
     end
-    Logger.Info("\at%s \axImported \ag%d\ax items from \aoInventory\ax, and \ag%d\ax items from the \ayBank\ax, into the DB", MyName, counter, counterBank)
+    Logger.Info(loot.guiLoot.console, "\at%s \axImported \ag%d\ax items from \aoInventory\ax, and \ag%d\ax items from the \ayBank\ax, into the DB", MyName, counter, counterBank)
     loot.report(string.format("%s Imported %d items from Inventory, and %d items from the Bank, into the DB", MyName, counter, counterBank))
-    loot.lootActor:send({ mailbox = 'lootnscoot', },
-        { who = MyName, Server = eqServer, action = 'ItemsDB_UPDATE', })
+    local message = { who = MyName, Server = eqServer, action = 'ItemsDB_UPDATE', }
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, message)
 end
 
 function loot.addToItemDB(item)
@@ -939,7 +931,7 @@ function loot.addToItemDB(item)
         if mq.TLO.Cursor() ~= nil then
             item = mq.TLO.Cursor
         else
-            Logger.Error("Item is \arnil.")
+            Logger.Error(loot.guiLoot.console, "Item is \arnil.")
             return
         end
     end
@@ -949,7 +941,7 @@ function loot.addToItemDB(item)
 
     local db = SQLite3.open(lootDB)
     if not db then
-        Logger.Error("\arFailed to open\ax loot database.")
+        Logger.Error(loot.guiLoot.console, "\arFailed to open\ax loot database.")
         return
     end
 
@@ -1036,7 +1028,7 @@ function loot.addToItemDB(item)
         ]]
     local stmt = db:prepare(sql)
     if not stmt then
-        Logger.Error("\arFailed to prepare \ax[\ayINSERT\ax] \aoSQL\ax statement: \at%s", db:errmsg())
+        Logger.Error(loot.guiLoot.console, "\arFailed to prepare \ax[\ayINSERT\ax] \aoSQL\ax statement: \at%s", db:errmsg())
         db:close()
         return
     end
@@ -1109,7 +1101,7 @@ function loot.addToItemDB(item)
     end)
 
     if not success then
-        Logger.Error("Error executing SQL statement: %s", errmsg)
+        Logger.Error(loot.guiLoot.console, "Error executing SQL statement: %s", errmsg)
     end
     db:exec("BEGIN TRANSACTION")
     stmt:finalize()
@@ -1200,7 +1192,7 @@ end
 
 function loot.addNewItem(corpseItem, itemRule, itemLink, corpseID)
     if not corpseItem or not itemRule then
-        Logger.Warn("\aoInvalid parameters for addNewItem:\ax corpseItem=\at%s\ax, itemRule=\ag%s",
+        Logger.Warn(loot.guiLoot.console, "\aoInvalid parameters for addNewItem:\ax corpseItem=\at%s\ax, itemRule=\ag%s",
             tostring(corpseItem), tostring(itemRule))
         return
     end
@@ -1208,7 +1200,7 @@ function loot.addNewItem(corpseItem, itemRule, itemLink, corpseID)
     -- Retrieve the itemID from corpseItem
     local itemID = corpseItem.ID()
     if not itemID then
-        Logger.Warn("\arFailed to retrieve \axitemID\ar for corpseItem:\ax %s", tostring(corpseItem.Name()))
+        Logger.Warn(loot.guiLoot.console, "\arFailed to retrieve \axitemID\ar for corpseItem:\ax %s", tostring(corpseItem.Name()))
         return
     end
     if loot.NewItems[itemID] ~= nil then return end
@@ -1242,32 +1234,31 @@ function loot.addNewItem(corpseItem, itemRule, itemLink, corpseID)
     end
 
     -- Notify the loot actor of the new item
-    Logger.Info("\agNew Loot\ay Item Detected! \ax[\at %s\ax ]\ao Sending actors", corpseItem.Name())
-    loot.lootActor:send(
-        { mailbox = 'lootnscoot', },
-        {
-            who        = MyName,
-            action     = 'new',
-            item       = corpseItem.Name(),
-            itemID     = itemID,
-            Server     = eqServer,
-            rule       = isNoDrop and "CanUse" or itemRule,
-            classes    = loot.retrieveClassList(corpseItem),
-            races      = loot.retrieveRaceList(corpseItem),
-            link       = itemLink,
-            lore       = corpseItem.Lore(),
-            icon       = corpseItem.Icon(),
-            aug        = corpseItem.AugType() > 0 and true or false,
-            noDrop     = isNoDrop,
-            tradeskill = corpseItem.Tradeskills(),
-            stackable  = corpseItem.Stackable(),
-            maxStacks  = corpseItem.StackSize() or 0,
-            sellPrice  = loot.valueToCoins(corpseItem.Value()),
-            corpse     = corpseID,
-        }
-    )
+    Logger.Info(loot.guiLoot.console, "\agNew Loot\ay Item Detected! \ax[\at %s\ax ]\ao Sending actors", corpseItem.Name())
+    local newMessage = {
+        who        = MyName,
+        action     = 'new',
+        item       = corpseItem.Name(),
+        itemID     = itemID,
+        Server     = eqServer,
+        rule       = isNoDrop and "CanUse" or itemRule,
+        classes    = loot.retrieveClassList(corpseItem),
+        races      = loot.retrieveRaceList(corpseItem),
+        link       = itemLink,
+        lore       = corpseItem.Lore(),
+        icon       = corpseItem.Icon(),
+        aug        = corpseItem.AugType() > 0 and true or false,
+        noDrop     = isNoDrop,
+        tradeskill = corpseItem.Tradeskills(),
+        stackable  = corpseItem.Stackable(),
+        maxStacks  = corpseItem.StackSize() or 0,
+        sellPrice  = loot.valueToCoins(corpseItem.Value()),
+        corpse     = corpseID,
+    }
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, newMessage)
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, newMessage)
 
-    Logger.Info("\agAdding \ayNEW\ax item: \at%s \ay(\axID: \at%s\at) \axwith rule: \ag%s", corpseItem.Name(), itemID, itemRule)
+    Logger.Info(loot.guiLoot.console, "\agAdding \ayNEW\ax item: \at%s \ay(\axID: \at%s\at) \axwith rule: \ag%s", corpseItem.Name(), itemID, itemRule)
 end
 
 function loot.checkCursor()
@@ -1276,7 +1267,7 @@ function loot.checkCursor()
         -- can't do anything if there's nowhere to put the item, either due to no free inventory space
         -- or no slot of appropriate size
         if mq.TLO.Me.FreeInventory() == 0 or mq.TLO.Cursor() == currentItem then
-            if loot.Settings.SpamLootInfo then Logger.Debug('Inventory full, item stuck on cursor') end
+            if loot.Settings.SpamLootInfo then Logger.Debug(loot.guiLoot.console, 'Inventory full, item stuck on cursor') end
             mq.cmdf('/autoinv')
             return
         end
@@ -1309,7 +1300,7 @@ end
 ---@param link string|nil The item link if available for the item
 function loot.modifyItemRule(itemID, action, tableName, classes, link)
     if not itemID or not tableName or not action then
-        Logger.Warn("Invalid parameters for modifyItemRule. itemID: %s, tableName: %s, action: %s",
+        Logger.Warn(loot.guiLoot.console, "Invalid parameters for modifyItemRule. itemID: %s, tableName: %s, action: %s",
             tostring(itemID), tostring(tableName), tostring(action))
         return
     end
@@ -1318,14 +1309,14 @@ function loot.modifyItemRule(itemID, action, tableName, classes, link)
     section = tableName == loot.PersonalTableName and 'PersonalItems' or section
     -- Validate RulesDB
     if not RulesDB or type(RulesDB) ~= "string" then
-        Logger.Warn("Invalid RulesDB path: %s", tostring(RulesDB))
+        Logger.Warn(loot.guiLoot.console, "Invalid RulesDB path: %s", tostring(RulesDB))
         return
     end
 
     -- Retrieve the item name from loot.ALLITEMS
     local itemName = loot.ALLITEMS[itemID] and loot.ALLITEMS[itemID].Name
     if not itemName then
-        Logger.Warn("Item ID \at%s\ax \arNOT\ax found in \ayloot.ALLITEMS", tostring(itemID))
+        Logger.Warn(loot.guiLoot.console, "Item ID \at%s\ax \arNOT\ax found in \ayloot.ALLITEMS", tostring(itemID))
         return
     end
 
@@ -1338,16 +1329,16 @@ function loot.modifyItemRule(itemID, action, tableName, classes, link)
     -- Open the database
     local db = SQLite3.open(RulesDB)
     if not db then
-        Logger.Warn("Failed to open database.")
+        Logger.Warn(loot.guiLoot.console, "Failed to open database.")
         return
     end
 
     local stmt
     local sql
-
+    db:exec("BEGIN TRANSACTION")
     if action == 'delete' then
         -- DELETE operation
-        Logger.Info("\aoloot.modifyItemRule\ax \arDeleting rule\ax for item \at%s\ax in table \at%s", itemName, tableName)
+        Logger.Info(loot.guiLoot.console, "\aoloot.modifyItemRule\ax \arDeleting rule\ax for item \at%s\ax in table \at%s", itemName, tableName)
         sql = string.format("DELETE FROM %s WHERE item_id = ?", tableName)
         stmt = db:prepare(sql)
 
@@ -1371,26 +1362,10 @@ function loot.modifyItemRule(itemID, action, tableName, classes, link)
         if stmt then
             stmt:bind_values(itemID, itemName, action, classes, link)
         end
-        -- elseif tableName == "Global_Rules" then
-        --     sql  = [[
-        --         INSERT INTO Global_Rules
-        --         (item_id, item_name, item_rule, item_rule_classes, item_link)
-        --         VALUES (?, ?, ?, ?, ?)
-        --         ON CONFLICT(item_id) DO UPDATE SET
-        --         item_name                                    = excluded.item_name,
-        --         item_rule                                    = excluded.item_rule,
-        --         item_rule_classes                                    = excluded.item_rule_classes,
-        --         item_link                                    = excluded.item_link
-        --         ]]
-        --     stmt = db:prepare(sql)
-        --     if stmt then
-        --         stmt:bind_values(itemID, itemName, action, classes, link)
-        --     end
-        -- end
     end
 
     if not stmt then
-        Logger.Warn("Failed to prepare SQL statement for table: %s, item:%s (%s), rule: %s, classes: %s", tableName, itemName, itemID, action, classes)
+        Logger.Warn(loot.guiLoot.console, "Failed to prepare SQL statement for table: %s, item:%s (%s), rule: %s, classes: %s", tableName, itemName, itemID, action, classes)
         db:close()
         return
     end
@@ -1398,18 +1373,19 @@ function loot.modifyItemRule(itemID, action, tableName, classes, link)
     -- Execute the statement
     local success, errmsg = pcall(function() stmt:step() end)
     if not success then
-        Logger.Warn("Failed to execute SQL statement for table %s. Error: %s", tableName, errmsg)
+        Logger.Warn(loot.guiLoot.console, "Failed to execute SQL statement for table %s. Error: %s", tableName, errmsg)
     else
-        Logger.Info("SQL statement executed successfully for item %s in table %s.", itemName, tableName)
+        Logger.Debug(loot.guiLoot.console, "SQL statement executed successfully for item %s in table %s.", itemName, tableName)
     end
 
     -- Finalize and close the database
     stmt:finalize()
+    db:exec("COMMIT")
     db:close()
 
     if success then
         -- Notify other actors about the rule change
-        loot.lootActor:send({ mailbox = 'lootnscoot', }, {
+        local message = {
             who     = MyName,
             Server  = eqServer,
             action  = action ~= 'delete' and 'addrule' or 'deleteitem',
@@ -1419,7 +1395,9 @@ function loot.modifyItemRule(itemID, action, tableName, classes, link)
             section = section,
             link    = link,
             classes = classes,
-        })
+        }
+        loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
+        loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, message)
     end
 end
 
@@ -1432,7 +1410,7 @@ end
 ---@return boolean success
 function loot.addRule(itemID, section, rule, classes, link)
     if not itemID or not section or not rule then
-        Logger.Warn("Invalid parameters for addRule. itemID: %s, section: %s, rule: %s",
+        Logger.Warn(loot.guiLoot.console, "Invalid parameters for addRule. itemID: %s, section: %s, rule: %s",
             tostring(itemID), tostring(section), tostring(rule))
         return false
     end
@@ -1440,7 +1418,7 @@ function loot.addRule(itemID, section, rule, classes, link)
     -- Retrieve the item name from loot.ALLITEMS
     local itemName = loot.ALLITEMS[itemID] and loot.ALLITEMS[itemID].Name or nil
     if not itemName then
-        Logger.Warn("Item ID \at%s\ax \arNOT\ax found in \ayloot.ALLITEMS", tostring(itemID))
+        Logger.Warn(loot.guiLoot.console, "Item ID \at%s\ax \arNOT\ax found in \ayloot.ALLITEMS", tostring(itemID))
         return false
     end
 
@@ -1449,7 +1427,7 @@ function loot.addRule(itemID, section, rule, classes, link)
     link                               = link or 'NULL'
 
     -- Log the action
-    -- Logger.Info("\agAdding\ax rule for item \at%s\ax\ao (\ayID\ax:\ag %s\ax\ao)\ax in [section] \at%s \axwith [rule] \at%s\ax and [classes] \at%s",
+    -- Logger.Info(loot.guiLoot.console,"\agAdding\ax rule for item \at%s\ax\ao (\ayID\ax:\ag %s\ax\ao)\ax in [section] \at%s \axwith [rule] \at%s\ax and [classes] \at%s",
     -- itemName, itemID, section, rule, classes)
 
     -- Update the in-memory data structure
@@ -1535,7 +1513,7 @@ function loot.lookupLootRule(itemID, tablename)
         local db = SQLite3.open(RulesDB)
         local found = false
         if not db then
-            Logger.Warn("\atSQL \arFailed\ax to open \atRulesDB:\ax for \aolookupLootRule\ax.")
+            Logger.Warn(loot.guiLoot.console, "\atSQL \arFailed\ax to open \atRulesDB:\ax for \aolookupLootRule\ax.")
             return found, 'NULL', 'All', 'NULL'
         end
 
@@ -1543,7 +1521,7 @@ function loot.lookupLootRule(itemID, tablename)
         local stmt = db:prepare(sql)
 
         if not stmt then
-            Logger.Warn("\atSQL \arFAILED \axto prepare statement for \atlookupLootRule\ax.")
+            Logger.Warn(loot.guiLoot.console, "\atSQL \arFAILED \axto prepare statement for \atlookupLootRule\ax.")
             db:close()
             return found, 'NULL', 'All', 'NULL'
         end
@@ -1639,7 +1617,7 @@ end
 
 function loot.processPendingItem()
     if not loot.pendingItemData and not loot.pendingItemData.selectedItem then
-        Logger.Warn("No item selected for processing.")
+        Logger.Warn(loot.guiLoot.console, "No item selected for processing.")
         return
     end
 
@@ -1651,7 +1629,7 @@ function loot.processPendingItem()
     if callback then
         callback(selectedItem)
     else
-        Logger.Warn("No callback defined for selected item.")
+        Logger.Warn(loot.guiLoot.console, "No callback defined for selected item.")
     end
 
     -- Clear pending data after processing
@@ -1758,7 +1736,7 @@ function loot.resolveItemIDbyName(itemName, allowDuplicates)
     local foundItems = loot.GetItemFromDB(itemName, 0)
 
     if foundItems > 1 and not allowDuplicates then
-        printf("\ayMultiple \atMatches Found for ItemName: \am%s \ax #\ag%d\ax", itemName, foundItems)
+        Logger.Warn(loot.guiLoot.console, "\ayMultiple \atMatches Found for ItemName: \am%s \ax #\ag%d\ax", itemName, foundItems)
     end
 
     for id, item in pairs(loot.ALLITEMS or {}) do
@@ -1802,11 +1780,14 @@ function loot.sendMySettings()
             tmpTable[k] = v
         end
     end
-    loot.lootActor:send({ mailbox = 'lootnscoot', }, {
+    local message = {
         who      = MyName,
         action   = 'sendsettings',
         settings = tmpTable,
-    })
+    }
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, message)
+
     loot.Boxes[MyName] = {}
     for k, v in pairs(loot.Settings) do
         if type(v) == 'table' then
@@ -1847,7 +1828,7 @@ function loot.getRule(item, from)
 
     -- Lookup existing rule in the databases
     local lootRule, lootClasses, lootLink = loot.lookupLootRule(itemID)
-    Logger.Info("Item: %s, Rule: %s, Classes: %s, Link: %s", itemName, lootRule, lootClasses, lootLink)
+    Logger.Info(loot.guiLoot.console, "Item: %s, Rule: %s, Classes: %s, Link: %s", itemName, lootRule, lootClasses, lootLink)
     if lootRule == 'NULL' and item.NoDrop() then
         lootRule = "CanUse"
         loot.addRule(itemID, 'NormalItems', lootRule, lootClasses, item.ItemLink('CLICKABLE')())
@@ -1898,12 +1879,21 @@ function loot.getRule(item, from)
 
     -- Handle GlobalItems override
     if loot.Settings.GlobalLootOn then
+        local personalRule, personalClasses = loot.PersonalItemsRules[itemID] or "NULL", loot.PersonalItemsClasses[itemID] or "All"
         local globalRule, globalClasses = loot.GlobalItemsRules[itemID] or "NULL", loot.GlobalItemsClasses[itemID] or "All"
-        if globalRule ~= "NULL" then
-            if globalClasses:lower() ~= "all" and from == "loot" and not string.find(globalClasses:lower(), loot.MyClass) then
+        if personalRule == 'NULL' then
+            if globalRule ~= "NULL" then
+                if globalClasses:lower() ~= "all" and from == "loot" and not string.find(globalClasses:lower(), loot.MyClass) then
+                    lootDecision = "Ignore"
+                else
+                    lootDecision = globalRule
+                end
+            end
+        elseif personalRule ~= "NULL" then
+            if personalClasses:lower() ~= "all" and from == "loot" and not string.find(personalClasses:lower(), loot.MyClass) then
                 lootDecision = "Ignore"
             else
-                lootDecision = globalRule
+                lootDecision = personalRule
             end
         end
     end
@@ -1927,15 +1917,12 @@ function loot.getRule(item, from)
             local _, position = string.find(lootDecision, "|")
             if position then qKeep = lootDecision:sub(position + 1) else qKeep = tostring(loot.Settings.QuestKeep) end
             if countHave < tonumber(qKeep) then
-                ---@diagnostic disable-next-line: return-type-mismatch
                 return "Keep", tonumber(qKeep), newRule
             end
             if loot.Settings.AlwaysDestroy then
-                ---@diagnostic disable-next-line: return-type-mismatch
                 return "Destroy", tonumber(qKeep), newRule
             end
         end
-        ---@diagnostic disable-next-line: return-type-mismatch
         return "Ignore", tonumber(qKeep), newRule
     end
 
@@ -2004,7 +1991,7 @@ function loot.RegisterActors()
             loot.sendMySettings()
             return
         end
-        -- Logger.Info("loot.RegisterActors: \agReceived\ax message:\atSub \ay%s\aw, \atItem \ag%s\aw, \atRule \ag%s", action, itemID, rule)
+        Logger.Debug(loot.guiLoot.console, "loot.RegisterActors: \agReceived\ax message:\atSub \ay%s\aw, \atItem \ag%s\aw, \atRule \ag%s", action, itemID, rule)
         if action == 'sendsettings' and who ~= MyName then
             loot.Boxes[who] = {}
             for k, v in pairs(boxSettings) do
@@ -2036,8 +2023,13 @@ function loot.RegisterActors()
         if server ~= eqServer then return end
 
         -- Reload loot settings
-        if action == 'lootreload' then
-            loot.commandHandler('reload')
+        if action == 'reloadrules' and who ~= MyName then
+            loot[lootMessage.bulkLabel .. 'Rules']   = {}
+            loot[lootMessage.bulkLabel .. 'Classes'] = {}
+            loot[lootMessage.bulkLabel .. 'Link']    = {}
+            loot[lootMessage.bulkLabel .. 'Rules']   = lootMessage.bulkRules or {}
+            loot[lootMessage.bulkLabel .. 'Classes'] = lootMessage.bulkClasses or {}
+            loot[lootMessage.bulkLabel .. 'Link']    = lootMessage.bulkLink or {}
             return
         end
         -- Handle actions
@@ -2048,7 +2040,7 @@ function loot.RegisterActors()
 
             loot.NewItems[itemID] = nil
             loot.NewItemsCount = loot.NewItemsCount - 1
-            Logger.Info("loot.RegisterActors: \atNew Item Rule \ax\agConfirmed:\ax [\ay%s\ax] NewItemCount Remaining \ag%s\ax", itemLink, loot.NewItemsCount)
+            Logger.Info(loot.guiLoot.console, "loot.RegisterActors: \atNew Item Rule \ax\agConfirmed:\ax [\ay%s\ax] NewItemCount Remaining \ag%s\ax", itemLink, loot.NewItemsCount)
             return
         end
 
@@ -2058,19 +2050,21 @@ function loot.RegisterActors()
                 loot.PersonalItemsClasses[itemID] = itemClasses
                 loot.PersonalItemsLink[itemID]    = itemLink
                 loot.ItemNames[itemID]            = itemName
+                Logger.Info(loot.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax]  \ayPersonal Rule\ax: \ag%s\ax for item \at%s\ax", action, rule, lootMessage.item)
             elseif section == 'GlobalItems' then
                 loot.GlobalItemsRules[itemID]   = rule
                 loot.GlobalItemsClasses[itemID] = itemClasses
                 loot.GlobalItemsLink[itemID]    = itemLink
                 loot.ItemNames[itemID]          = itemName
+                Logger.Info(loot.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \atGlobal Rule\ax: \ag%s\ax for item \at%s\ax", action, rule, lootMessage.item)
             else
                 loot.NormalItemsRules[itemID]   = rule
                 loot.NormalItemsClasses[itemID] = itemClasses
                 loot.NormalItemsLink[itemID]    = itemLink
                 loot.ItemNames[itemID]          = itemName
+                Logger.Info(loot.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \aoNormal Rule\ax: \ag%s\ax for item \at%s\ax", action, rule, lootMessage.item)
             end
 
-            Logger.Info("loot.RegisterActors: \atAction:\ax [\ay%s\ax] \ag%s\ax rule for item \at%s\ax", action, rule, lootMessage.item)
             if lootMessage.entered then
                 if lootedCorpses[lootMessage.corpse] then
                     lootedCorpses[lootMessage.corpse] = nil
@@ -2078,7 +2072,8 @@ function loot.RegisterActors()
 
                 loot.NewItems[itemID] = nil
                 loot.NewItemsCount = loot.NewItemsCount - 1
-                Logger.Info("loot.RegisterActors: \atNew Item Rule \ax\agUpdated:\ax [\ay%s\ax] NewItemCount Remaining \ag%s\ax", lootMessage.entered, loot.NewItemsCount)
+                Logger.Info(loot.guiLoot.console, "loot.RegisterActors: \atNew Item Rule \ax\agUpdated:\ax [\ay%s\ax] NewItemCount Remaining \ag%s\ax", lootMessage.entered,
+                    loot.NewItemsCount)
             end
 
             local db = loot.OpenItemsSQL()
@@ -2094,7 +2089,7 @@ function loot.RegisterActors()
             loot[action .. 'Rules'][itemID]   = nil
             loot[action .. 'Classes'][itemID] = nil
             loot[action .. 'Link'][itemID]    = nil
-            Logger.Info("loot.RegisterActors: \atAction:\ax [\ay%s\ax] \ag%s\ax rule for item \at%s\ax", action, rule, lootMessage.item)
+            Logger.Info(loot.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \ag%s\ax rule for item \at%s\ax", action, rule, lootMessage.item)
         elseif action == 'new' and who ~= MyName and loot.NewItems[itemID] == nil then
             loot.NewItems[itemID] = {
                 Name       = lootMessage.item,
@@ -2111,7 +2106,7 @@ function loot.RegisterActors()
                 Races      = itemRaces,
                 CorpseID   = lootMessage.corpse,
             }
-            Logger.Info("loot.RegisterActors: \atAction:\ax [\ay%s\ax] \ag%s\ax rule for item \at%s\ax", action, rule, lootMessage.item)
+            Logger.Info(loot.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \ag%s\ax rule for item \at%s\ax", action, rule, lootMessage.item)
             loot.NewItemsCount = loot.NewItemsCount + 1
             if loot.Settings.AutoShowNewItem then
                 showNewItem = true
@@ -2162,7 +2157,7 @@ end
 -- Sets a Global Item rule
 function loot.setGlobalItem(itemID, val, classes, link)
     if itemID == nil then
-        Logger.Warn("Invalid itemID for setGlobalItem.")
+        Logger.Warn(loot.guiLoot.console, "Invalid itemID for setGlobalItem.")
         return
     end
     loot.modifyItemRule(itemID, val, 'Global_Rules', classes, link)
@@ -2180,7 +2175,7 @@ end
 -- Sets a Normal Item rule
 function loot.setNormalItem(itemID, val, classes, link)
     if itemID == nil then
-        Logger.Warn("Invalid itemID for setNormalItem.")
+        Logger.Warn(loot.guiLoot.console, "Invalid itemID for setNormalItem.")
         return
     end
     loot.NormalItemsRules[itemID] = val ~= 'delete' and val or nil
@@ -2196,7 +2191,7 @@ end
 
 function loot.setPersonalItem(itemID, val, classes, link)
     if itemID == nil then
-        Logger.Warn("Invalid itemID for setPersonalItem.")
+        Logger.Warn(loot.guiLoot.console, "Invalid itemID for setPersonalItem.")
         return
     end
     loot.PersonalItemsRules[itemID] = val ~= 'delete' and val or nil
@@ -2227,7 +2222,7 @@ function loot.commandHandler(...)
         if settingsEnum[setting] ~= nil then
             local settingName = settingsEnum[setting]
             if type(loot.Settings[settingName]) == 'table' then
-                Logger.Error("Setting \ay%s\ax is a table and cannot be set directly.", settingName)
+                Logger.Error(loot.guiLoot.console, "Setting \ay%s\ax is a table and cannot be set directly.", settingName)
                 return
             end
             if type(loot.Settings[settingName]) == 'boolean' then
@@ -2237,16 +2232,16 @@ function loot.commandHandler(...)
             else
                 loot.Settings[settingName] = settingVal
             end
-            Logger.Info("Setting \ay%s\ax to \ag%s\ax", settingName, settingVal)
+            Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \ag%s\ax", settingName, settingVal)
             loot.writeSettings()
         else
-            Logger.Warn("Invalid setting name: %s", setting)
+            Logger.Warn(loot.guiLoot.console, "Invalid setting name: %s", setting)
         end
         loot.writeSettings()
         loot.sendMySettings()
         return
     end
-    Logger.Debug("arg1: %s, arg2: %s, arg3: %s, arg4: %s", tostring(args[1]), tostring(args[2]), tostring(args[3]), tostring(args[4]))
+    Logger.Debug(loot.guiLoot.console, "arg1: %s, arg2: %s, arg3: %s, arg4: %s", tostring(args[1]), tostring(args[2]), tostring(args[3]), tostring(args[4]))
 
     if args[1] == 'find' and args[2] ~= nil then
         if tonumber(args[2]) then
@@ -2276,7 +2271,7 @@ function loot.commandHandler(...)
                     'lootnscoot', false
                 )
             end
-            Logger.Info("\ayReloaded Settings \axand \atLoot Files")
+            Logger.Info(loot.guiLoot.console, "\ayReloaded Settings \axand \atLoot Files")
         elseif command == 'update' then
             if loot.guiLoot then
                 loot.guiLoot.GetSettings(
@@ -2289,7 +2284,7 @@ function loot.commandHandler(...)
                 )
             end
             loot.UpdateDB()
-            Logger.Info("\ayUpdated the DB from loot.ini \axand \atreloaded settings")
+            Logger.Info(loot.guiLoot.console, "\ayUpdated the DB from loot.ini \axand \atreloaded settings")
         elseif command == 'importinv' then
             loot.addMyInventoryToDB()
         elseif command == 'bank' then
@@ -2309,7 +2304,7 @@ function loot.commandHandler(...)
                     confReport = confReport .. string.format("\n\at%s\ax                                    = \ag%s\ax", key, tostring(value))
                 end
             end
-            Logger.Info(confReport)
+            Logger.Info(loot.guiLoot.console, confReport)
         elseif command == 'tributestuff' then
             loot.processItems('Tribute')
         elseif command == 'shownew' or command == 'newitems' then
@@ -2323,12 +2318,12 @@ function loot.commandHandler(...)
         elseif validActions[command] and item() then
             local itemID = item.ID()
             loot.addRule(itemID, 'NormalItems', validActions[command], 'All', item.ItemLink('CLICKABLE')())
-            Logger.Info("Setting \ay%s\ax to \ay%s\ax", item.Name(), validActions[command])
+            Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \ay%s\ax", item.Name(), validActions[command])
         elseif string.find(command, "quest%|") and item() then
             local itemID = item.ID()
             local val    = string.gsub(command, "quest", "Quest")
             loot.addRule(itemID, 'NormalItems', val, 'All', item.ItemLink('CLICKABLE')())
-            Logger.Info("Setting \ay%s\ax to \ay%s\ax", item.Name(), val)
+            Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \ay%s\ax", item.Name(), val)
         elseif command == 'quit' or command == 'exit' then
             loot.Terminate = true
         end
@@ -2336,11 +2331,11 @@ function loot.commandHandler(...)
         local action, itemName = args[1], args[2]
         if validActions[action] then
             local lootID = loot.resolveItemIDbyName(itemName, false)
-            Logger.Warn("lootID: %s", lootID)
+            Logger.Warn(loot.guiLoot.console, "lootID: %s", lootID)
             if lootID then
                 if loot.ALLITEMS[lootID] then
                     loot.addRule(lootID, 'NormalItems', validActions[action], 'All', loot.ALLITEMS[lootID].Link)
-                    Logger.Info("Setting \ay%s (%s)\ax to \ay%s\ax", itemName, lootID, validActions[action])
+                    Logger.Info(loot.guiLoot.console, "Setting \ay%s (%s)\ax to \ay%s\ax", itemName, lootID, validActions[action])
                 end
             end
         end
@@ -2348,20 +2343,20 @@ function loot.commandHandler(...)
         if args[1] == 'globalitem' and args[2] == 'quest' and item() then
             local itemID = item.ID()
             loot.addRule(itemID, 'GlobalItems', 'Quest|' .. args[3], 'All', item.ItemLink('CLICKABLE')())
-            Logger.Info("Setting \ay%s\ax to \agGlobal Item \ayQuest|%s\ax", item.Name(), args[3], item.ItemLink('CLICKABLE')())
+            Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \agGlobal Item \ayQuest|%s\ax", item.Name(), args[3], item.ItemLink('CLICKABLE')())
         elseif args[1] == 'globalitem' and validActions[args[2]] and item() then
-            loot.addRule(item.ID(), 'GlobalItems', validActions[args[2]], args[3] or 'All', item.ItemLink('CLICKABLE')())
-            Logger.Info("Setting \ay%s\ax to \agGlobal Item \ay%s \ax(\at%s\ax)", item.Name(), item.ID(), validActions[args[2]])
+            loot.addRule(item.ID(), 'GlobalItems', validActions[args[2]], args[3] ~= nil or 'All', item.ItemLink('CLICKABLE')())
+            Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \agGlobal Item \ay%s \ax(\at%s\ax)", item.Name(), item.ID(), validActions[args[2]])
         elseif args[1] == 'globalitem' and validActions[args[2]] and args[3] ~= nil then
             local itemName = args[3]
             local itemID   = loot.resolveItemIDbyName(itemName, false)
             if itemID then
                 if loot.ALLITEMS[itemID] then
                     loot.addRule(itemID, 'GlobalItems', validActions[args[2]], 'All', loot.ALLITEMS[itemID].Link)
-                    Logger.Info("Setting \ay%s\ax to \agGlobal Item \ay%s|%s\ax", loot.ALLITEMS[itemID].Name, validActions[args[2]], args[3])
+                    Logger.Info(loot.guiLoot.console, "Setting \ay%s\ax to \agGlobal Item \ay%s|%s\ax", loot.ALLITEMS[itemID].Name, validActions[args[2]], args[3])
                 end
             else
-                Logger.Warn("Item \ay%s\ax ID: %s\ax not found in loot.ALLITEMS.", itemName, itemID)
+                Logger.Warn(loot.guiLoot.console, "Item \ay%s\ax ID: %s\ax not found in loot.ALLITEMS.", itemName, itemID)
             end
         end
     end
@@ -2381,13 +2376,14 @@ function loot.findItemInDb(itemName, itemId)
     local counter = 0
     for row in stmt:nrows() do
         if counter > 20 then break end
-        Logger.Info("\aoItem:\ax\ay %s\ax \ayID:\ax \at%d\ax, \aoValue:\ax \ag%s\ax Link: %s,", row.name, row.link, row.item_id, row.sell_value)
+        Logger.Info(loot.guiLoot.console, "\ao[\ax\ayLNS Find Item\ao]\ax:\ax\ay %s\ax \ayID:\ax \at%d\ax, \aoValue:\ax \ag%s\ax Link: %s,", row.name, row.item_id, row.sell_value,
+            row.link)
         counter = counter + 1
     end
     stmt:finalize()
     db:exec("COMMIT")
     db:close()
-    if counter > 20 then Logger.Info("\aoMore than\ax \ay20\ax items found, \aoonly showing first\ax \at20\ax.") end
+    if counter > 20 then Logger.Info(loot.guiLoot.console, "\aoMore than\ax \ay20\ax items found, \aoonly showing first\ax \at20\ax.") end
 end
 
 function loot.setupBinds()
@@ -2399,7 +2395,7 @@ end
 
 function loot.CheckBags()
     if loot.Settings.SaveBagSlots == nil then return false end
-    -- printf("\agBag CHECK\ax free: \at%s\ax, save: \ag%s\ax", mq.TLO.Me.FreeInventory(), loot.Settings.SaveBagSlots)
+    -- Logger.Warn(loot.guiLoot.console,"\agBag CHECK\ax free: \at%s\ax, save: \ag%s\ax", mq.TLO.Me.FreeInventory(), loot.Settings.SaveBagSlots)
     areFull = mq.TLO.Me.FreeInventory() <= loot.Settings.SaveBagSlots
 end
 
@@ -2422,7 +2418,7 @@ end
 ---@param allItems table @A table of all items seen on the corpse, left or looted.
 ---@param cantWear boolean|nil @ Whether the character canwear the item
 function loot.lootItem(index, doWhat, button, qKeep, allItems, cantWear)
-    Logger.Debug('Enter lootItem')
+    Logger.Debug(loot.guiLoot.console, 'Enter lootItem')
 
     local corpseItem = mq.TLO.Corpse.Item(index)
     if corpseItem and not shouldLootActions[doWhat] then
@@ -2507,18 +2503,18 @@ function loot.reportSkippedItems(noDropItems, loreItems, corpseName, corpseID)
 
     -- Log skipped items
     if next(noDropItems) then
-        Logger.Info("Skipped NoDrop items from corpse %s (ID: %s): %s",
+        Logger.Info(loot.guiLoot.console, "Skipped NoDrop items from corpse %s (ID: %s): %s",
             corpseName, tostring(corpseID), table.concat(noDropItems, ", "))
     end
 
     if next(loreItems) then
-        Logger.Info("Skipped Lore items from corpse %s (ID: %s): %s",
+        Logger.Info(loot.guiLoot.console, "Skipped Lore items from corpse %s (ID: %s): %s",
             corpseName, tostring(corpseID), table.concat(loreItems, ", "))
     end
 end
 
 function loot.lootCorpse(corpseID)
-    Logger.Debug('Enter lootCorpse')
+    Logger.Debug(loot.guiLoot.console, 'Enter lootCorpse')
     shouldLootActions.Destroy = loot.Settings.DoDestroy
     shouldLootActions.Tribute = loot.Settings.TributeKeep
 
@@ -2536,7 +2532,7 @@ function loot.lootCorpse(corpseID)
 
     if not mq.TLO.Window('LootWnd').Open() then
         if mq.TLO.Target.CleanName() then
-            Logger.Warn("lootCorpse(): Can't loot %s right now", mq.TLO.Target.CleanName())
+            Logger.Warn(loot.guiLoot.console, "lootCorpse(): Can't loot %s right now", mq.TLO.Target.CleanName())
             cantLootList[corpseID] = os.time()
         end
         return
@@ -2544,7 +2540,7 @@ function loot.lootCorpse(corpseID)
 
     mq.delay(1000, function() return (mq.TLO.Corpse.Items() or 0) > 0 end)
     local items = mq.TLO.Corpse.Items() or 0
-    Logger.Debug("lootCorpse(): Loot window open. Items: %s", items)
+    Logger.Debug(loot.guiLoot.console, "lootCorpse(): Loot window open. Items: %s", items)
 
     local corpseName = mq.TLO.Corpse.Name()
     if mq.TLO.Window('LootWnd').Open() and items > 0 then
@@ -2575,7 +2571,7 @@ function loot.lootCorpse(corpseID)
                 end
                 local itemRule, qKeep, newRule, cantWear = loot.getRule(corpseItem, 'loot')
 
-                Logger.Debug("LootCorpse(): itemID=\ao%s\ax, rule=\at%s\ax, qKeep=\ay%s\ax, newRule=\ag%s", corpseItemID, itemRule, qKeep, newRule)
+                Logger.Debug(loot.guiLoot.console, "LootCorpse(): itemID=\ao%s\ax, rule=\at%s\ax, qKeep=\ay%s\ax, newRule=\ag%s", corpseItemID, itemRule, qKeep, newRule)
                 newRule         = newNoDrop == true and true or newRule
 
                 local stackable = corpseItem.Stackable()
@@ -2657,12 +2653,12 @@ function loot.lootMobs(limit)
         lootedCorpses = {}
     end
 
-    Logger.Debug('lootMobs(): Entering lootMobs function.')
+    Logger.Debug(loot.guiLoot.console, 'lootMobs(): Entering lootMobs function.')
     local deadCount  = mq.TLO.SpawnCount(string.format('npccorpse radius %s zradius 50', loot.Settings.CorpseRadius or 100))()
     local mobsNearby = mq.TLO.SpawnCount(string.format('xtarhater radius %s zradius 50', loot.Settings.MobsTooClose or 40))()
     local corpseList = {}
 
-    Logger.Debug('lootMobs(): Found %s corpses in range.', deadCount)
+    Logger.Debug(loot.guiLoot.console, 'lootMobs(): Found %s corpses in range.', deadCount)
 
     -- Handle looting of the player's own corpse
     local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius %d zradius 100", mq.TLO.Me.CleanName(), loot.Settings.CorpseRadius))()
@@ -2671,7 +2667,7 @@ function loot.lootMobs(limit)
         for i = 1, (limit or myCorpseCount) do
             local corpse = mq.TLO.NearestSpawn(string.format("%d, pccorpse %s radius %d zradius 100", i, mq.TLO.Me.CleanName(), loot.Settings.CorpseRadius))
             if corpse() then
-                Logger.Debug('lootMobs(): Adding my corpse to loot list. Corpse ID: %d', corpse.ID())
+                Logger.Debug(loot.guiLoot.console, 'lootMobs(): Adding my corpse to loot list. Corpse ID: %d', corpse.ID())
                 table.insert(corpseList, corpse)
             end
         end
@@ -2691,34 +2687,34 @@ function loot.lootMobs(limit)
             end
         end
     else
-        Logger.Debug('lootMobs(): Skipping other corpses due to nearby player corpse.')
+        Logger.Debug(loot.guiLoot.console, 'lootMobs(): Skipping other corpses due to nearby player corpse.')
     end
 
     -- Process the collected corpse list
     local didLoot = false
     if #corpseList > 0 then
-        Logger.Debug('lootMobs(): Attempting to loot %d corpses.', #corpseList)
+        Logger.Debug(loot.guiLoot.console, 'lootMobs(): Attempting to loot %d corpses.', #corpseList)
         for _, corpse in ipairs(corpseList) do
             local corpseID = corpse.ID()
 
             if not corpseID or corpseID <= 0 or loot.corpseLocked(corpseID) or
                 (mq.TLO.Navigation.PathLength('spawn id ' .. corpseID)() or 100) >= 60 then
-                Logger.Debug('lootMobs(): Skipping corpse ID: %d.', corpseID)
+                Logger.Debug(loot.guiLoot.console, 'lootMobs(): Skipping corpse ID: %d.', corpseID)
                 goto continue
             end
 
             -- Attempt to move and loot the corpse
             if corpse.DisplayName() == mq.TLO.Me.DisplayName() then
-                Logger.Debug('lootMobs(): Pulling own corpse closer. Corpse ID: %d', corpseID)
+                Logger.Debug(loot.guiLoot.console, 'lootMobs(): Pulling own corpse closer. Corpse ID: %d', corpseID)
                 mq.cmdf("/corpse")
                 mq.delay(10)
             end
 
-            Logger.Debug('lootMobs(): Navigating to corpse ID=%d.', corpseID)
+            Logger.Debug(loot.guiLoot.console, 'lootMobs(): Navigating to corpse ID=%d.', corpseID)
             loot.navToID(corpseID)
 
             if mobsNearby > 0 and not loot.Settings.CombatLooting then
-                Logger.Debug('lootMobs(): Stopping looting due to aggro.')
+                Logger.Debug(loot.guiLoot.console, 'lootMobs(): Stopping looting due to aggro.')
                 return didLoot
             end
 
@@ -2729,7 +2725,7 @@ function loot.lootMobs(limit)
 
             ::continue::
         end
-        Logger.Debug('lootMobs(): Finished processing corpse list.')
+        Logger.Debug(loot.guiLoot.console, 'lootMobs(): Finished processing corpse list.')
     end
 
     return didLoot
@@ -2742,18 +2738,18 @@ function loot.eventSell(_, itemName)
     local itemID = loot.resolveItemIDbyName(itemName, false)
 
     if not itemID then
-        Logger.Warn("Unable to resolve item ID for: " .. itemName)
+        Logger.Warn(loot.guiLoot.console, "Unable to resolve item ID for: " .. itemName)
         return
     end
 
     -- Add a rule to mark the item as "Sell"
     loot.addRule(itemID, "NormalItems", "Sell", "All", loot.ALLITEMS[itemID].Link)
-    Logger.Info("Added rule: \ay%s\ax set to \agSell\ax.", itemName)
+    Logger.Info(loot.guiLoot.console, "Added rule: \ay%s\ax set to \agSell\ax.", itemName)
 end
 
 function loot.goToVendor()
     if not mq.TLO.Target() then
-        Logger.Warn('Please target a vendor')
+        Logger.Warn(loot.guiLoot.console, 'Please target a vendor')
         return false
     end
     local vendorID = mq.TLO.Target.ID()
@@ -2764,7 +2760,7 @@ function loot.goToVendor()
 end
 
 function loot.openVendor()
-    Logger.Debug('Opening merchant window')
+    Logger.Debug(loot.guiLoot.console, 'Opening merchant window')
     mq.cmdf('/nomodkey /click right target')
     mq.delay(1000, function() return mq.TLO.Window('MerchantWnd').Open() end)
     return mq.TLO.Window('MerchantWnd').Open()
@@ -2775,8 +2771,8 @@ function loot.SellToVendor(itemID, bag, slot, name)
     if itemName == 'Unknown' and name ~= nil then itemName = name end
     if NEVER_SELL[itemName] then return end
     if mq.TLO.Window('MerchantWnd').Open() then
-        Logger.Info('Selling item: %s', itemName)
-        local notify = slot == (nil or -1)
+        Logger.Info(loot.guiLoot.console, 'Selling item: %s', itemName)
+        local notify = slot == nil or slot == -1
             and ('/itemnotify %s leftmouseup'):format(bag)
             or ('/itemnotify in pack%s %s leftmouseup'):format(bag, slot)
         mq.cmdf(notify)
@@ -2788,14 +2784,14 @@ end
 
 -- BANKING
 function loot.openBanker()
-    Logger.Debug('Opening bank window')
+    Logger.Debug(loot.guiLoot.console, 'Opening bank window')
     mq.cmdf('/nomodkey /click right target')
     mq.delay(1000, function() return mq.TLO.Window('BigBankWnd').Open() end)
     return mq.TLO.Window('BigBankWnd').Open()
 end
 
 function loot.bankItem(itemID, bag, slot)
-    local notify = slot == (nil or -1)
+    local notify = slot == nil or slot == -1
         and ('/shift /itemnotify %s leftmouseup'):format(bag)
         or ('/shift /itemnotify in pack%s %s leftmouseup'):format(bag, slot)
     mq.cmdf(notify)
@@ -2819,21 +2815,21 @@ end
 function loot.RestockItems()
     local rowNum = 0
     for itemName, qty in pairs(loot.BuyItemsTable) do
-        Logger.Info('Checking \ao%s \axfor \at%s \axto \agRestock', mq.TLO.Target.CleanName(), itemName)
+        Logger.Info(loot.guiLoot.console, 'Checking \ao%s \axfor \at%s \axto \agRestock', mq.TLO.Target.CleanName(), itemName)
         local tmpVal = tonumber(qty) or 0
         rowNum       = mq.TLO.Window("MerchantWnd/MW_ItemList").List(string.format("=%s", itemName), 2)() or 0
         mq.delay(20)
         local onHand = mq.TLO.FindItemCount(itemName)()
         local tmpQty = tmpVal - onHand
         if rowNum ~= 0 and tmpQty > 0 then
-            Logger.Info("\ayRestocking \ax%s \aoHave\ax: \at%s\ax \agBuying\ax: \ay%s", itemName, onHand, tmpVal)
+            Logger.Info(loot.guiLoot.console, "\ayRestocking \ax%s \aoHave\ax: \at%s\ax \agBuying\ax: \ay%s", itemName, onHand, tmpVal)
             mq.TLO.Window("MerchantWnd/MW_ItemList").Select(rowNum)()
             mq.delay(100)
             mq.TLO.Window("MerchantWnd/MW_Buy_Button").LeftMouseUp()
             mq.delay(500, function() return mq.TLO.Window("QuantityWnd").Open() end)
             mq.TLO.Window("QuantityWnd/QTYW_SliderInput").SetText(tostring(tmpQty))()
             mq.delay(100, function() return mq.TLO.Window("QuantityWnd/QTYW_SliderInput").Text() == tostring(tmpQty) end)
-            Logger.Info("\agBuying\ay " .. tmpQty .. "\at " .. itemName)
+            Logger.Info(loot.guiLoot.console, "\agBuying\ay " .. tmpQty .. "\at " .. itemName)
             mq.TLO.Window("QuantityWnd/QTYW_Accept_Button").LeftMouseUp()
             mq.delay(100)
         end
@@ -2846,9 +2842,9 @@ end
 -- TRIBUTEING
 
 function loot.openTribMaster()
-    Logger.Debug('Opening Tribute Window')
+    Logger.Debug(loot.guiLoot.console, 'Opening Tribute Window')
     mq.cmdf('/nomodkey /click right target')
-    Logger.Debug('Waiting for Tribute Window to populate')
+    Logger.Debug(loot.guiLoot.console, 'Waiting for Tribute Window to populate')
     mq.delay(1000, function() return mq.TLO.Window('TributeMasterWnd').Open() end)
     if not mq.TLO.Window('TributeMasterWnd').Open() then return false end
     return mq.TLO.Window('TributeMasterWnd').Open()
@@ -2861,19 +2857,19 @@ function loot.eventTribute(_, itemName)
     local itemID = loot.resolveItemIDbyName(itemName)
 
     if not itemID then
-        Logger.Warn("Unable to resolve item ID for: " .. itemName)
+        Logger.Warn(loot.guiLoot.console, "Unable to resolve item ID for: " .. itemName)
         return
     end
 
     -- Add a rule to mark the item as "Tribute"
     loot.addRule(itemID, "NormalItems", "Tribute", "All", loot.ALLITEMS[itemID].Link)
-    Logger.Info("Added rule: \ay%s\ax set to \agTribute\ax.", itemName)
+    Logger.Info(loot.guiLoot.console, "Added rule: \ay%s\ax set to \agTribute\ax.", itemName)
 end
 
 function loot.TributeToVendor(itemToTrib, bag, slot)
     if NEVER_SELL[itemToTrib.Name()] then return end
     if mq.TLO.Window('TributeMasterWnd').Open() then
-        Logger.Info('Tributeing ' .. itemToTrib.Name())
+        Logger.Info(loot.guiLoot.console, 'Tributeing ' .. itemToTrib.Name())
         loot.report('\ayTributing \at%s \axfor\ag %s \axpoints!', itemToTrib.Name(), itemToTrib.Tribute())
         mq.cmdf('/shift /itemnotify in pack%s %s leftmouseup', bag, slot)
         mq.delay(1) -- progress frame
@@ -2899,7 +2895,7 @@ end
 function loot.DestroyItem(itemToDestroy, bag, slot)
     if itemToDestroy == nil then return end
     if NEVER_SELL[itemToDestroy.Name()] then return end
-    Logger.Info('!!Destroying!! ' .. itemToDestroy.Name())
+    Logger.Info(loot.guiLoot.console, '!!Destroying!! ' .. itemToDestroy.Name())
     mq.cmdf('/shift /itemnotify in pack%s %s leftmouseup', bag, slot)
     mq.delay(1) -- progress frame
     mq.cmdf('/destroy')
@@ -2912,7 +2908,7 @@ end
 
 function loot.eventForage()
     if not loot.Settings.LootForage then return end
-    Logger.Debug('Enter eventForage')
+    Logger.Debug(loot.guiLoot.console, 'Enter eventForage')
     -- allow time for item to be on cursor incase message is faster or something?
     mq.delay(1000, function() return mq.TLO.Cursor() end)
     -- there may be more than one item on cursor so go until its cleared
@@ -2926,17 +2922,17 @@ function loot.eventForage()
         -- >= because .. does finditemcount not count the item on the cursor?
         if not shouldLootActions[ruleAction] or (ruleAction == 'Quest' and currentItemAmount >= ruleAmount) then
             if mq.TLO.Cursor.Name() == foragedItem then
-                if loot.Settings.LootForageSpam then Logger.Info('Destroying foraged item ' .. foragedItem) end
+                if loot.Settings.LootForageSpam then Logger.Info(loot.guiLoot.console, 'Destroying foraged item ' .. foragedItem) end
                 mq.cmdf('/destroy')
                 mq.delay(500)
             end
             -- will a lore item we already have even show up on cursor?
             -- free inventory check won't cover an item too big for any container so may need some extra check related to that?
         elseif (shouldLootActions[ruleAction] or currentItemAmount < ruleAmount) and (not cursorItem.Lore() or currentItemAmount == 0) and (mq.TLO.Me.FreeInventory() or (cursorItem.Stackable() and cursorItem.FreeStack())) then
-            if loot.Settings.LootForageSpam then Logger.Info('Keeping foraged item ' .. foragedItem) end
+            if loot.Settings.LootForageSpam then Logger.Info(loot.guiLoot.console, 'Keeping foraged item ' .. foragedItem) end
             mq.cmdf('/autoinv')
         else
-            if loot.Settings.LootForageSpam then Logger.Warn('Unable to process item ' .. foragedItem) end
+            if loot.Settings.LootForageSpam then Logger.Warn(loot.guiLoot.console, 'Unable to process item ' .. foragedItem) end
             break
         end
         mq.delay(50)
@@ -2962,7 +2958,7 @@ function loot.processItems(action)
                 end
                 local sellPrice = item.Value() and item.Value() / 1000 or 0
                 if sellPrice == 0 then
-                    Logger.Warn('Item \ay%s\ax is set to Sell but has no sell value!', item.Name())
+                    Logger.Warn(loot.guiLoot.console, 'Item \ay%s\ax is set to Sell but has no sell value!', item.Name())
                 else
                     loot.SellToVendor(itemID, bag, slot, item.Name())
                     -- loot.SellToVendor(item.Name(), bag, slot, item.ItemLink('CLICKABLE')() or "NULL")
@@ -3184,11 +3180,11 @@ function loot.handleSelectedItem(itemID)
     -- Process the selected item (e.g., add to a rule, perform an action, etc.)
     local itemData = loot.ALLITEMS[itemID]
     if not itemData then
-        Logger.Error("Invalid item selected: " .. tostring(itemID))
+        Logger.Error(loot.guiLoot.console, "Invalid item selected: " .. tostring(itemID))
         return
     end
 
-    Logger.Info("Item selected: " .. itemData.Name .. " (ID: " .. itemID .. ")")
+    Logger.Info(loot.guiLoot.console, "Item selected: " .. itemData.Name .. " (ID: " .. itemID .. ")")
     -- You can now use itemID for further actions
 end
 
@@ -3253,7 +3249,7 @@ end
 
 function loot.RenderModifyItemWindow()
     if not loot.TempSettings.ModifyItemRule then
-        Logger.Error("Item not found in ALLITEMS %s %s", loot.TempSettings.ModifyItemID, loot.TempSettings.ModifyItemTable)
+        Logger.Error(loot.guiLoot.console, "Item not found in ALLITEMS %s %s", loot.TempSettings.ModifyItemID, loot.TempSettings.ModifyItemTable)
         loot.TempSettings.ModifyItemRule = false
         loot.TempSettings.ModifyItemID = nil
         tempValues = {}
@@ -3269,10 +3265,7 @@ function loot.RenderModifyItemWindow()
     ImGui.SetNextWindowSizeConstraints(ImVec2(300, 200), ImVec2(-1, -1))
     local open, show = ImGui.Begin("Modify Item", nil, ImGuiWindowFlags.AlwaysAutoResize)
     if show then
-        local tableList = {
-            "Global_Items", "Normal_Items", loot.PersonalTableName,
-        }
-        local item      = loot.ALLITEMS[loot.TempSettings.ModifyItemID]
+        local item = loot.ALLITEMS[loot.TempSettings.ModifyItemID]
         if not item then
             item = {
                 Name = loot.TempSettings.ModifyItemName,
@@ -3282,7 +3275,7 @@ function loot.RenderModifyItemWindow()
         end
         local questRule = "Quest"
         if item == nil then
-            Logger.Error("Item not found in ALLITEMS %s %s", loot.TempSettings.ModifyItemID, loot.TempSettings.ModifyItemTable)
+            Logger.Error(loot.guiLoot.console, "Item not found in ALLITEMS %s %s", loot.TempSettings.ModifyItemID, loot.TempSettings.ModifyItemTable)
             ImGui.End()
             return
         end
@@ -3438,7 +3431,7 @@ function loot.drawNewItemsTable()
             for itemID, item in pairs(loot.NewItems) do
                 -- Ensure tmpRules has a default value
                 if itemID == nil or item == nil then
-                    Logger.Error("Invalid item in NewItems table: %s", itemID)
+                    Logger.Error(loot.guiLoot.console, "Invalid item in NewItems table: %s", itemID)
                     loot.NewItemsCount = 0
                     break
                 end
@@ -3560,7 +3553,7 @@ function loot.drawNewItemsTable()
                         CorpseID = item.CorpseID,
                     })
                     table.insert(itemsToRemove, itemID)
-                    Logger.Debug("\agSaving\ax --\ayNEW ITEM RULE\ax-- Item: \at%s \ax(ID:\ag %s\ax) with rule: \at%s\ax, classes: \at%s\ax, link: \at%s\ax",
+                    Logger.Debug(loot.guiLoot.console, "\agSaving\ax --\ayNEW ITEM RULE\ax-- Item: \at%s \ax(ID:\ag %s\ax) with rule: \at%s\ax, classes: \at%s\ax, link: \at%s\ax",
                         item.Name, itemID, tmpRules[itemID], tmpClasses[itemID], item.Link)
                 end
                 ImGui.PopStyleColor()
@@ -3608,6 +3601,7 @@ end
 
 function loot.drawTable(label)
     local varSub = label .. 'Items'
+
     if ImGui.BeginTabItem(varSub .. "##") then
         if loot.TempSettings.varSub == nil then
             loot.TempSettings.varSub = {}
@@ -3719,7 +3713,7 @@ function loot.drawTable(label)
         ImGui.SameLine()
         ImGui.SetNextItemWidth(80)
         if ImGui.BeginCombo("Max Items", tostring(ITEMS_PER_PAGE)) then
-            for i = 25, 100, 25 do
+            for i = 10, 100, 10 do
                 if ImGui.Selectable(tostring(i), ITEMS_PER_PAGE == i) then
                     ITEMS_PER_PAGE = i
                 end
@@ -3730,6 +3724,56 @@ function loot.drawTable(label)
         local startIndex = (loot.CurrentPage - 1) * ITEMS_PER_PAGE + 1
         local endIndex = math.min(startIndex + ITEMS_PER_PAGE - 1, totalItems)
 
+        if ImGui.CollapsingHeader('BulkSet') then
+            ImGui.Indent(2)
+            ImGui.Text("Set all items to the same rule")
+            ImGui.SetNextItemWidth(100)
+            ImGui.PushID("BulkSet")
+            if loot.TempSettings.BulkRule == nil then
+                loot.TempSettings.BulkRule = settingList[1]
+            end
+            if ImGui.BeginCombo("Rule", loot.TempSettings.BulkRule) then
+                for i, setting in ipairs(settingList) do
+                    local isSelected = loot.TempSettings.BulkRulee == setting
+                    if ImGui.Selectable(setting, isSelected) then
+                        loot.TempSettings.BulkRule = setting
+                    end
+                end
+                ImGui.EndCombo()
+            end
+            ImGui.SameLine()
+            ImGui.SetNextItemWidth(100)
+            if loot.TempSettings.BulkClasses == nil then
+                loot.TempSettings.BulkClasses = "All"
+            end
+            loot.TempSettings.BulkClasses = ImGui.InputTextWithHint("Classes", "who can loot or all ex: shm clr dru", loot.TempSettings.BulkClasses)
+
+            ImGui.SameLine()
+            ImGui.SetNextItemWidth(100)
+            if loot.TempSettings.BulkSetTable == nil then
+                loot.TempSettings.BulkSetTable = label .. "_Rules"
+            end
+            if ImGui.BeginCombo("Table", loot.TempSettings.BulkSetTable) then
+                for i, v in ipairs(tableListRules) do
+                    if ImGui.Selectable(v, loot.TempSettings.BulkSetTable == v) then
+                        loot.TempSettings.BulkSetTable = v
+                    end
+                end
+                ImGui.EndCombo()
+            end
+
+            ImGui.PopID()
+            ImGui.SameLine()
+            if ImGui.Button("Set All") then
+                loot.TempSettings.BulkSet = {}
+                for i = startIndex, endIndex do
+                    local itemID = filteredItems[i].id
+                    loot.TempSettings.BulkSet[itemID] = loot.TempSettings.BulkRule
+                end
+                loot.TempSettings.doBulkSet = true
+            end
+            ImGui.Unindent(2)
+        end
 
         if ImGui.BeginTable(label .. " Items", colCount, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.Resizable, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
             ImGui.TableSetupScrollFreeze(colCount, 1)
@@ -3834,7 +3878,7 @@ function loot.drawItemsTables()
         fontScale = ImGui.SliderFloat("Font Scale", fontScale, 1, 2)
         ImGui.SetWindowFontScale(fontScale)
 
-        if ImGui.BeginTabBar("Items") then
+        if ImGui.BeginTabBar("Items", bit32.bor(ImGuiTabBarFlags.Reorderable, ImGuiTabBarFlags.FittingPolicyScroll)) then
             local col = math.max(2, math.floor(ImGui.GetContentRegionAvail() / 150))
             col = col + (col % 2)
 
@@ -3965,15 +4009,16 @@ function loot.drawItemsTables()
                 ImGui.EndTabItem()
             end
 
+
+            -- Personal Items
+            loot.drawTable("Personal")
+
             -- Global Items
 
             loot.drawTable("Global")
 
             -- Normal Items
             loot.drawTable("Normal")
-
-            -- Personal Items
-            loot.drawTable("Personal")
 
             -- Lookup Items
 
@@ -3989,7 +4034,7 @@ function loot.drawItemsTables()
                         if ImGui.IsWindowHovered() and ImGui.IsMouseClicked(0) then
                             if mq.TLO.Cursor() ~= nil then
                                 loot.addToItemDB(mq.TLO.Cursor)
-                                Logger.Info("Added Item to DB: %s", mq.TLO.Cursor.Name())
+                                Logger.Info(loot.guiLoot.console, "Added Item to DB: %s", mq.TLO.Cursor.Name())
                                 mq.cmdf("/autoinv")
                             end
                         end
@@ -4062,7 +4107,7 @@ function loot.drawItemsTables()
                     ImGui.SameLine()
                     ImGui.SetNextItemWidth(80)
                     if ImGui.BeginCombo("Max Items", tostring(ITEMS_PER_PAGE)) then
-                        for i = 25, 100, 25 do
+                        for i = 10, 100, 10 do
                             if ImGui.Selectable(tostring(i), ITEMS_PER_PAGE == i) then
                                 ITEMS_PER_PAGE = i
                             end
@@ -4073,6 +4118,58 @@ function loot.drawItemsTables()
                     -- Calculate the range of items to display
                     local startIndex = (loot.CurrentPage - 1) * ITEMS_PER_PAGE + 1
                     local endIndex = math.min(startIndex + ITEMS_PER_PAGE - 1, totalItems)
+
+                    if ImGui.CollapsingHeader('BulkSet') then
+                        ImGui.Indent(2)
+                        ImGui.Text("Set all items to the same rule")
+                        ImGui.SetNextItemWidth(100)
+                        ImGui.PushID("BulkSet")
+                        if loot.TempSettings.BulkRule == nil then
+                            loot.TempSettings.BulkRule = settingList[1]
+                        end
+                        if ImGui.BeginCombo("Rule", loot.TempSettings.BulkRule) then
+                            for i, setting in ipairs(settingList) do
+                                local isSelected = loot.TempSettings.BulkRulee == setting
+                                if ImGui.Selectable(setting, isSelected) then
+                                    loot.TempSettings.BulkRule = setting
+                                end
+                            end
+                            ImGui.EndCombo()
+                        end
+                        ImGui.SameLine()
+                        ImGui.SetNextItemWidth(100)
+                        if loot.TempSettings.BulkClasses == nil then
+                            loot.TempSettings.BulkClasses = "All"
+                        end
+                        loot.TempSettings.BulkClasses = ImGui.InputTextWithHint("Classes", "who can loot or all ex: shm clr dru", loot.TempSettings.BulkClasses)
+
+                        ImGui.SameLine()
+                        ImGui.SetNextItemWidth(100)
+                        if loot.TempSettings.BulkSetTable == nil then
+                            loot.TempSettings.BulkSetTable = "Normal_Rules"
+                        end
+                        if ImGui.BeginCombo("Table", loot.TempSettings.BulkSetTable) then
+                            for i, v in ipairs(tableListRules) do
+                                if ImGui.Selectable(v, loot.TempSettings.BulkSetTable == v) then
+                                    loot.TempSettings.BulkSetTable = v
+                                end
+                            end
+                            ImGui.EndCombo()
+                        end
+
+                        ImGui.PopID()
+                        ImGui.SameLine()
+                        if ImGui.Button("Set All") then
+                            loot.TempSettings.BulkSet = {}
+                            for i = startIndex, endIndex do
+                                local itemID = filteredItems[i].id
+                                loot.TempSettings.BulkSet[itemID] = loot.TempSettings.BulkRule
+                            end
+                            loot.TempSettings.doBulkSet = true
+                        end
+                        ImGui.Unindent(2)
+                    end
+
 
                     -- Render the table
                     if ImGui.BeginTable("DB", 59, bit32.bor(ImGuiTableFlags.Borders,
@@ -4323,6 +4420,69 @@ function loot.DrawRuleToolTip(name, setting, classes)
     ImGui.EndTooltip()
 end
 
+---comment
+---@param item_table table Index of ItemId's to set
+---@param setting any Setting to set all items to
+---@param classes any Classes to set all items to
+---@param which_table string Which Rules table
+function loot.bulkSet(item_table, setting, classes, which_table)
+    if item_table == nil or type(item_table) ~= "table" then return end
+    local localName = which_table == 'Normal_Rules' and 'NormalItems' or 'GlobalItems'
+    localName = which_table == loot.PersonalTableName and 'PersonalItems' or localName
+
+    local db = SQLite3.open(RulesDB)
+    if not db then return end
+
+    local stmt = db:prepare(string.format([[
+        INSERT INTO %s (item_id, item_name, item_rule, item_rule_classes, item_link)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(item_id) DO UPDATE SET
+            item_name = excluded.item_name,
+            item_rule = excluded.item_rule,
+            item_rule_classes = excluded.item_rule_classes,
+            item_link = excluded.item_link;
+    ]], which_table))
+
+    if not stmt then
+        db:close()
+        return
+    end
+
+    db:exec("BEGIN TRANSACTION;")
+
+    for itemID, data in pairs(item_table) do
+        local item = loot.ALLITEMS[itemID]
+        if item then
+            stmt:bind_values(itemID, item.Name, setting, classes, item.Link)
+            stmt:step()
+            stmt:reset()
+
+            loot[localName .. 'Rules'][itemID] = setting
+            loot[localName .. 'Classes'][itemID] = classes
+            loot[localName .. 'Link'][itemID] = item.Link
+            loot.ItemNames[itemID] = item.Name
+        end
+    end
+
+    db:exec("COMMIT;")
+    stmt:finalize()
+    db:close()
+    if localName ~= 'PersonalItems' then
+        loot.TempSettings.NeedSave = true
+        local message = {
+            action = 'reloadrules',
+            who = MyName,
+            Server = eqServer,
+            bulkLabel = localName,
+            bulkRules = loot[localName .. 'Rules'],
+            bulkClasses = loot[localName .. 'Classes'],
+            bulkLink = loot[localName .. 'Link'],
+        }
+        loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
+        loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, message)
+    end
+end
+
 function loot.drawSettingIcon(setting)
     if string.find(setting, 'Destroy') then
         ImGui.TextColored(0.860, 0.104, 0.104, 1.000, Icons.MD_DELETE)
@@ -4422,11 +4582,13 @@ function loot.renderSettingsSection(who)
                     tmpSet[k] = v
                 end
             end
-            loot.lootActor:send({ mailbox = 'lootnscoot', }, {
+            local message = {
                 action = 'updatesettings',
                 who = who,
                 settings = tmpSet,
-            })
+            }
+            loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
+            loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, message)
         end
     end
     ImGui.SeparatorText("Clone Settings")
@@ -4451,38 +4613,37 @@ function loot.renderSettingsSection(who)
     end
     ImGui.SameLine()
     if ImGui.SmallButton("Clone Settings") then
-        if loot.TempSettings.CloneWho and loot.TempSettings.CloneTo then
-            loot.Boxes[loot.TempSettings.CloneTo] = {}
-            for k, v in pairs(loot.Boxes[loot.TempSettings.CloneWho]) do
-                if type(v) == 'table' then
-                    loot.Boxes[loot.TempSettings.CloneTo][k] = {}
-                    for k2, v2 in pairs(v) do
-                        loot.Boxes[loot.TempSettings.CloneTo][k][k2] = v2
-                    end
-                else
-                    loot.Boxes[loot.TempSettings.CloneTo][k] = v
+        loot.Boxes[loot.TempSettings.CloneTo] = {}
+        for k, v in pairs(loot.Boxes[loot.TempSettings.CloneWho]) do
+            if type(v) == 'table' then
+                loot.Boxes[loot.TempSettings.CloneTo][k] = {}
+                for k2, v2 in pairs(v) do
+                    loot.Boxes[loot.TempSettings.CloneTo][k][k2] = v2
                 end
+            else
+                loot.Boxes[loot.TempSettings.CloneTo][k] = v
             end
-            local tmpSet = {}
-            for k, v in pairs(loot.Boxes[loot.TempSettings.CloneTo]) do
-                if type(v) == 'table' then
-                    tmpSet[k] = {}
-                    for k2, v2 in pairs(v) do
-                        tmpSet[k][k2] = v2
-                    end
-                else
-                    tmpSet[k] = v
-                end
-            end
-            loot.lootActor:send({ mailbox = 'lootnscoot', }, {
-                action = 'updatesettings',
-                who = loot.TempSettings.CloneTo,
-                settings = tmpSet,
-            })
-            loot.TempSettings.CloneTo = nil
-        else
-            Logger.Error("Cannot clone settings unless a source and a target are provided.")
         end
+        local tmpSet = {}
+        for k, v in pairs(loot.Boxes[loot.TempSettings.CloneTo]) do
+            if type(v) == 'table' then
+                tmpSet[k] = {}
+                for k2, v2 in pairs(v) do
+                    tmpSet[k][k2] = v2
+                end
+            else
+                tmpSet[k] = v
+            end
+        end
+        local message = {
+            action = 'updatesettings',
+            who = loot.TempSettings.CloneTo,
+            settings = tmpSet,
+        }
+        loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
+        loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, message)
+
+        loot.TempSettings.CloneTo = nil
     end
 
     local sorted_names = loot.SortTableColums(loot.Boxes[who], loot.TempSettings.SortedSettingsKeys, colCount / 2)
@@ -4570,7 +4731,6 @@ local function renderBtn()
         else
             animMini:SetTextureCell(644 - EQ_ICON_OFFSET)
         end
-        ---@diagnostic disable-next-line: param-type-mismatch --Bool/Boolean mismatch
         ImGui.DrawTextureAnimation(animMini, 34, 34, true)
     end
     if ImGui.IsItemHovered() then
@@ -4613,10 +4773,10 @@ function loot.enterNewItemRuleInfo(data_table)
     end
 
     if data_table.ID == nil then
-        Logger.Error("loot.enterNewItemRuleInfo \arInvalid item \atID \axfor new item rule.")
+        Logger.Error(loot.guiLoot.console, "loot.enterNewItemRuleInfo \arInvalid item \atID \axfor new item rule.")
         return
     end
-    Logger.Debug(
+    Logger.Debug(loot.guiLoot.console,
         "\aoloot.enterNewItemRuleInfo() \axSending \agNewItem Data\ax message \aoMailbox\ax \atlootnscoot actor\ax: item\at %s \ax, ID\at %s \ax, rule\at %s\ax, classes\at %s\ax, link\at %s\ax, corpseID\at %s\ax",
         data_table.ItemName, data_table.ItemID, data_table.Rule, data_table.Classes, data_table.Link, data_table.CorpseID)
 
@@ -4643,14 +4803,15 @@ function loot.enterNewItemRuleInfo(data_table)
     if (classes == loot.NormalItemsClasses[itemID] and rule == loot.NormalItemsRules[itemID]) then
         modMessage.noChange = true
 
-        Logger.Debug("\ayNo Changes Made to Item: \at%s \ax(ID:\ag %s\ax) with rule: \at%s\ax, classes: \at%s\ax",
+        Logger.Debug(loot.guiLoot.console, "\ayNo Changes Made to Item: \at%s \ax(ID:\ag %s\ax) with rule: \at%s\ax, classes: \at%s\ax",
             link, itemID, rule, classes)
     else
-        Logger.Debug(
+        Logger.Debug(loot.guiLoot.console,
             "\aoloot.enterNewItemRuleInfo() \axSending \agENTERED ITEM\ax message \aoMailbox\ax \atlootnscoot actor\ax: item\at %s \ax, ID\at %s \ax, rule\at %s\ax, classes\at %s\ax, link\at %s\ax, corpseID\at %s\ax",
             item, itemID, rule, classes, link, corpse)
     end
-    loot.lootActor:send({ mailbox = 'lootnscoot', }, modMessage)
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, modMessage)
+    loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, modMessage)
 end
 
 local showSettings = false
@@ -4682,11 +4843,17 @@ function loot.renderMainUI()
 
             local labelBtn = not showSettings and
                 string.format("%s Settings", Icons.FA_COG) or string.format("%s   Items  ", Icons.FA_SHOPPING_BASKET)
-
-            if ImGui.SmallButton(labelBtn) then
-                showSettings = not showSettings
+            if showSettings and loot.NewItemsCount > 0 then
+                ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(1.0, 0.4, 0.4, 0.4))
+                if ImGui.SmallButton(labelBtn) then
+                    showSettings = not showSettings
+                end
+                ImGui.PopStyleColor()
+            else
+                if ImGui.SmallButton(labelBtn) then
+                    showSettings = not showSettings
+                end
             end
-
             -- Settings Section
             if showSettings then
                 if loot.TempSettings.SelectedActor == nil then
@@ -4722,13 +4889,16 @@ function loot.renderMainUI()
         if styCount > 0 then
             ImGui.PopStyleVar(styCount)
         end
+        if ImGui.IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows) and ImGui.IsMouseClicked(2) then
+            loot.ShowUI = not loot.ShowUI
+        end
         ImGui.End()
     end
 end
 
 function loot.processArgs(args)
     loot.Terminate = true
-    local mercsRunning = mq.TLO.Lua.Script('rgmercs').Status() == 'RUNNING' or false
+    local mercsRunnig = mq.TLO.Lua.Script('rgmercs').Status() == 'RUNNING' or false
     if args == nil then return end
     if #args == 1 then
         if args[1] == 'directed' then
@@ -4738,19 +4908,20 @@ function loot.processArgs(args)
 
             Mode = 'directed'
             loot.Terminate = false
-            loot.lootActor:send({ mailbox = 'lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
+            loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
+            loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
         elseif args[1] == 'sellstuff' then
-            if mercsRunning then mq.cmd('/rgl pause') end
+            if mercsRunnig then mq.cmd('/rgl pause') end
             loot.processItems('Sell')
-            if mercsRunning then mq.cmd('/rgl unpause') end
+            if mercsRunnig then mq.cmd('/rgl unpause') end
         elseif args[1] == 'tributestuff' then
-            if mercsRunning then mq.cmd('/rgl pause') end
+            if mercsRunnig then mq.cmd('/rgl pause') end
             loot.processItems('Tribute')
-            if mercsRunning then mq.cmd('/rgl unpause') end
+            if mercsRunnig then mq.cmd('/rgl unpause') end
         elseif args[1] == 'cleanup' then
-            if mercsRunning then mq.cmd('/rgl pause') end
+            if mercsRunnig then mq.cmd('/rgl pause') end
             loot.processItems('Cleanup')
-            if mercsRunning then mq.cmd('/rgl unpause') end
+            if mercsRunnig then mq.cmd('/rgl unpause') end
         elseif args[1] == 'once' then
             loot.lootMobs()
         elseif args[1] == 'standalone' then
@@ -4759,7 +4930,8 @@ function loot.processArgs(args)
             end
             Mode = 'standalone'
             loot.Terminate = false
-            loot.lootActor:send({ mailbox = 'lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
+            loot.lootActor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
+            loot.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, { action = 'Hello', Server = eqServer, who = MyName, })
         end
     end
 end
@@ -4776,7 +4948,7 @@ function loot.init(args)
     loot.setupEvents()
     loot.setupBinds()
     zoneID = mq.TLO.Zone.ID()
-    Logger.Debug("Loot::init() \aoSaveRequired: \at%s", needsSave and "TRUE" or "FALSE")
+    Logger.Debug(loot.guiLoot.console, "Loot::init() \aoSaveRequired: \at%s", needsSave and "TRUE" or "FALSE")
     loot.processArgs(args)
     loot.sendMySettings()
     mq.imgui.init('LootnScoot', loot.RenderUIs)
@@ -4798,6 +4970,8 @@ while not loot.Terminate do
         loot.Terminate = true
     end
     if mq.TLO.MacroQuest.GameState() ~= "INGAME" then loot.Terminate = true end -- exit sctipt if at char select.
+    Logger.loglevel = loot.Settings.ShowInfoMessages and 'info' or 'warn'
+
     if loot.Settings.DoLoot and Mode ~= 'directed' then loot.lootMobs() end
     if loot.LootNow then
         loot.LootNow = false
@@ -4814,6 +4988,12 @@ while not loot.Terminate do
     if doTribute then
         loot.processItems('Tribute')
         doTribute = false
+    end
+
+    if loot.TempSettings.BulkSet then
+        loot.bulkSet(loot.TempSettings.BulkSet, loot.TempSettings.BulkRule, loot.TempSettings.BulkClasses, loot.TempSettings.BulkSetTable)
+        loot.TempSettings.BulkSet = false
+        loot.TempSettings.BulkSet = {}
     end
 
     mq.doevents()
@@ -4849,7 +5029,7 @@ while not loot.Terminate do
 
     if loot.MyClass:lower() == 'brd' and loot.Settings.DoDestroy then
         loot.Settings.DoDestroy = false
-        Logger.Warn("\aoBard \aoDetected\ax, \arDisabling\ax [\atDoDestroy\ax].")
+        Logger.Warn(loot.guiLoot.console, "\aoBard \aoDetected\ax, \arDisabling\ax [\atDoDestroy\ax].")
     end
     mq.delay(1)
 end

--- a/lib/lootnscoot/init.lua.bak
+++ b/lib/lootnscoot/init.lua.bak
@@ -1,0 +1,2161 @@
+--[[
+loot.lua v1.7 - aquietone, grimmier
+
+This is a port of the RedGuides copy of ninjadvloot.inc with some updates as well.
+I may have glossed over some of the events or edge cases so it may have some issues
+around things like:
+- lore items
+- full inventory
+- not full inventory but no slot large enough for an item
+- ...
+Or those things might just work, I just haven't tested it very much using lvl 1 toons
+on project lazarus.
+
+Settings are saved per character in config\LootNScoot_[ServerName]_[CharName].ini
+if you would like to use a global settings file. you can Change this inside the above file to point at your global file instead.
+example= SettingsFile=D:\MQ_EMU\Config/LootNScoot_GlobalSettings.ini
+
+This script can be used in two ways:
+    1. Included within a larger script using require, for example if you have some KissAssist-like lua script:
+        To loot mobs, call lootutils.lootMobs():
+
+            local mq = require 'mq'
+            local lootutils = require 'lootnscoot'
+            while true do
+                lootutils.lootMobs()
+                mq.delay(1000)
+            end
+
+        lootUtils.lootMobs() will run until it has attempted to loot all corpses within the defined radius.
+
+        To sell to a vendor, call lootutils.sellStuff():
+
+            local mq = require 'mq'
+            local lootutils = require 'lootnscoot'
+            local doSell = false
+            function loot.binds(...)
+                local args = {...}
+                if args[1] == 'sell' then doSell = true end
+            end
+            mq.bind('/myscript', binds)
+            while true do
+                lootutils.lootMobs()
+                if doSell then lootutils.sellStuff() doSell = false end
+                mq.delay(1000)
+            end
+
+        lootutils.sellStuff() will run until it has attempted to sell all items marked as sell to the targeted vendor.
+
+        Note that in the above example, loot.sellStuff() isn't being called directly from the bind callback.
+        Selling may take some time and includes delays, so it is best to be called from your main loop.
+
+        Optionally, configure settings using:
+            Set the radius within which corpses should be looted (radius from you, not a camp location)
+                lootutils.CorpseRadius = number
+            Set whether loot.ini should be updated based off of sell item events to add manually sold items.
+                lootutils.AddNewSales = boolean
+            Set your own instance of Write.lua to configure a different prefix, log level, etc.
+                lootutils.logger = Write
+            Several other settings can be found in the "loot" table defined in the code.
+
+    2. Run as a standalone script:
+        /lua run lootnscoot standalone
+            Will keep the script running, checking for corpses once per second.
+        /lua run lootnscoot once
+            Will run one iteration of loot.lootMobs().
+        /lua run lootnscoot sell
+            Will run one iteration of loot.sellStuff().
+        /lua run lootnscoot cleanup
+            Will run one iteration of loot.cleanupBags().
+
+The script will setup a bind for "/lootutils":
+    /lootutils <action> "${Cursor.Name}"
+        Set the loot rule for an item. "action" may be one of:
+            - Keep
+            - Bank
+            - Sell
+            - Tribute
+            - Ignore
+            - Destroy
+            - Quest|#
+
+    /lootutils reload
+        Reload the contents of Loot.ini
+    /lootutils bank
+        Put all items from inventory marked as Bank into the bank
+    /lootutils tsbank
+        Mark all tradeskill items in inventory as Bank
+
+If running in standalone mode, the bind also supports:
+    /lootutils sellstuff
+        Runs lootutils.sellStuff() one time
+    /lootutils tributestuff
+        Runs lootutils.tributeStuff() one time
+    /lootutils cleanup
+        Runs lootutils.cleanupBags() one time
+
+The following events are used:
+    - eventCantLoot - #*#may not loot this corpse#*#
+        Add corpse to list of corpses to avoid for a few minutes if someone is already looting it.
+    - eventSell - #*#You receive#*# for the #1#(s)#*#
+        Set item rule to Sell when an item is manually sold to a vendor
+    - eventInventoryFull - #*#Your inventory appears full!#*#
+        Stop attempting to loot once inventory is full. Note that currently this never gets set back to false
+        even if inventory space is made available.
+    - loot.eventNovalue - #*#give you absolutely nothing for the #1#.#*#
+        Warn and move on when attempting to sell an item which the merchant will not buy.
+
+This script depends on having Write.lua in your lua/lib folder.
+    https://gitlab.com/Knightly1/knightlinc/-/blob/master/Write.lua
+
+This does not include the buy routines from ninjadvloot. It does include the sell routines
+but lootly sell routines seem more robust than the code that was in ninjadvloot.inc.
+The forage event handling also does not handle fishing events like ninjadvloot did.
+There is also no flag for combat looting. It will only loot if no mobs are within the radius.
+
+]]
+
+local mq = require 'mq'
+local ImGui = require 'ImGui'
+local success, Write = pcall(require, 'lib.Write')
+if not success then
+    printf('\arERROR: Write.lua could not be loaded\n%s\ax', Write)
+    return
+end
+local eqServer = string.gsub(mq.TLO.EverQuest.Server(), ' ', '_')
+-- Check for looted module, if found use that. else fall back on our copy, which may be outdated.
+local req, guiLoot = pcall(require, string.format('../looted/init'))
+if not req then
+    req, guiLoot = pcall(require, 'loot_hist')
+    print('Looted Not Found! Using Local Copy!')
+else
+    print('Looted Loaded!')
+end
+if not req then
+    guiLoot = nil
+    print('NO LOOTED Found, Disabling Looted Features.')
+end
+local eqChar                = mq.TLO.Me.Name()
+local actors                = require('actors')
+local SettingsFile          = mq.configDir .. '/LootNScoot_' .. eqServer .. '_' .. eqChar .. '.ini'
+local LootFile              = mq.configDir .. '/Loot.ini'
+local needDBUpdate          = false
+local lootDBUpdateFile      = mq.configDir .. '/DB_Updated_' .. eqServer .. '.lua'
+
+local version               = 4
+-- Public default settings, also read in from Loot.ini [Settings] section
+local loot                  = {
+    Settings = {
+        logger = Write,
+        Version = '"' .. tostring(version) .. '"',
+        LootFile = mq.configDir .. '/Loot.ini',
+        SettingsFile = mq.configDir .. '/LootNScoot_' .. eqServer .. '_' .. eqChar .. '.ini',
+        GlobalLootOn = true,                       -- Enable Global Loot Items. not implimented yet
+        CombatLooting = false,                     -- Enables looting during combat. Not recommended on the MT
+        CorpseRadius = 100,                        -- Radius to activly loot corpses
+        MobsTooClose = 40,                         -- Don't loot if mobs are in this range.
+        SaveBagSlots = 3,                          -- Number of bag slots you would like to keep empty at all times. Stop looting if we hit this number
+        TributeKeep = false,                       -- Keep items flagged Tribute
+        MinTributeValue = 100,                     -- Minimun Tribute points to keep item if TributeKeep is enabled.
+        MinSellPrice = -1,                         -- Minimum Sell price to keep item. -1 = any
+        StackPlatValue = 0,                        -- Minimum sell value for full stack
+        StackableOnly = false,                     -- Only loot stackable items
+        AlwaysEval = false,                        -- Re-Evaluate all *Non Quest* items. useful to update loot.ini after changing min sell values.
+        BankTradeskills = true,                    -- Toggle flagging Tradeskill items as Bank or not.
+        DoLoot = true,                             -- Enable auto looting in standalone mode
+        LootForage = true,                         -- Enable Looting of Foraged Items
+        LootNoDrop = false,                        -- Enable Looting of NoDrop items.
+        LootNoDropNew = false,                     -- Enable looting of new NoDrop items.
+        LootQuest = false,                         -- Enable Looting of Items Marked 'Quest', requires LootNoDrop on to loot NoDrop quest items
+        DoDestroy = false,                         -- Enable Destroy functionality. Otherwise 'Destroy' acts as 'Ignore'
+        AlwaysDestroy = false,                     -- Always Destroy items to clean corpese Will Destroy Non-Quest items marked 'Ignore' items REQUIRES DoDestroy set to true
+        QuestKeep = 10,                            -- Default number to keep if item not set using Quest|# format.
+        LootChannel = "dgt",                       -- Channel we report loot to.
+        GroupChannel = "dgae",                     -- Channel we use for Group Commands
+        ReportLoot = true,                         -- Report loot items to group or not.
+        SpamLootInfo = false,                      -- Echo Spam for Looting
+        LootForageSpam = false,                    -- Echo spam for Foraged Items
+        AddNewSales = true,                        -- Adds 'Sell' Flag to items automatically if you sell them while the script is running.
+        AddNewTributes = true,                     -- Adds 'Tribute' Flag to items automatically if you Tribute them while the script is running.
+        GMLSelect = true,                          -- not implimented yet
+        ExcludeBag1 = "Extraplanar Trade Satchel", -- Name of Bag to ignore items in when selling
+        NoDropDefaults = "Quest|Keep|Ignore",      -- not implimented yet
+        LootLagDelay = 0,                          -- not implimented yet
+        CorpseRotTime = "440s",                    -- not implimented yet
+        HideNames = false,                         -- Hides names and uses class shortname in looted window
+        LookupLinks = false,                       -- Enables Looking up Links for items not on that character. *recommend only running on one charcter that is monitoring.
+        RecordData = false,                        -- Enables recording data to report later.
+        AutoTag = false,                           -- Automatically tag items to sell if they meet the MinSellPrice
+        AutoRestock = false,                       -- Automatically restock items from the BuyItems list when selling
+        Terminate = true,
+    },
+    TempSettings = {},
+}
+
+-- SQL information
+local PackageMan            = require('mq/PackageMan')
+local SQLite3               = PackageMan.Require('lsqlite3')
+local ItemsDB               = string.format('%s/LootRules_%s.db', mq.configDir, eqServer)
+
+loot.Settings.logger.prefix = 'lootnscoot'
+if guiLoot ~= nil then
+    loot.Settings.UseActors = true
+    guiLoot.addItem = loot.addRule
+    guiLoot.modifyItem = loot.modifyItem
+    guiLoot.setNormalItem = loot.setNormalItem
+    guiLoot.setGlobalItem = loot.setGlobalItem
+    guiLoot.setBuyItem = loot.setBuyItem
+
+    guiLoot.GetSettings(loot.Settings.HideNames, loot.Settings.LookupLinks, loot.Settings.RecordData, true, loot.Settings.UseActors, 'lootnscoot')
+end
+
+-- Internal settings
+local lootData, cantLootList = {}, {}
+local doSell, doBuy, doTribute, areFull = false, false, false, false
+local cantLootID = 0
+-- Constants
+local spawnSearch = '%s radius %d zradius 50'
+-- If you want destroy to actually loot and destroy items, change DoDestroy=false to DoDestroy=true in the Settings Ini.
+-- Otherwise, destroy behaves the same as ignore.
+local shouldLootActions = { Keep = true, Bank = true, Sell = true, Destroy = false, Ignore = false, Tribute = false, }
+local validActions = { keep = 'Keep', bank = 'Bank', sell = 'Sell', ignore = 'Ignore', destroy = 'Destroy', quest = 'Quest', tribute = 'Tribute', }
+local saveOptionTypes = { string = 1, number = 1, boolean = 1, }
+local NEVER_SELL = { ['Diamond Coin'] = true, ['Celestial Crest'] = true, ['Gold Coin'] = true, ['Taelosian Symbols'] = true, ['Planar Symbols'] = true, }
+local tmpCmd = loot.GroupChannel or 'dgae'
+local showSettings = false
+local settingsNoDraw = { Version = true, logger = true, LootFile = true, SettingsFile = true, NoDropDefaults = true, CorpseRotTime = true, LootLagDelay = true, Terminate = true, }
+
+loot.BuyItems = {}
+loot.GlobalItems = {}
+loot.NormalItems = {}
+
+-- UTILITIES
+--- Returns a table containing all the data from the INI file.
+--@param fileName The name of the INI file to parse. [string]
+--@return The table containing all data from the INI file. [table]
+function loot.load(fileName, sec)
+    if sec == nil then sec = "items" end
+    -- this came from Knightly's LIP.lua
+    assert(type(fileName) == 'string', 'Parameter "fileName" must be a string.');
+    local file = assert(io.open(fileName, 'r'), 'Error loading file : ' .. fileName);
+    local data = {};
+    local section;
+    local count = 0
+    for line in file:lines() do
+        local tempSection = line:match('^%[([^%[%]]+)%]$');
+        if (tempSection) then
+            -- print(tempSection)
+            section = tonumber(tempSection) and tonumber(tempSection) or tempSection;
+            -- data[section] = data[section] or {};
+            count = 0
+        end
+        local param, value = line:match("^([%w|_'.%s-]+)=%s-(.+)$");
+
+        if (param and value ~= nil) then
+            if (tonumber(value)) then
+                value = tonumber(value);
+            elseif (value == 'true') then
+                value = true;
+            elseif (value == 'false') then
+                value = false;
+            end
+            if (tonumber(param)) then
+                param = tonumber(param);
+            end
+            if string.find(tostring(param), 'Spawn') then
+                count = count + 1
+                param = string.format("Spawn%d", count)
+            end
+            if sec == "items" and param ~= nil then
+                if section ~= "Settings" and section ~= "GlobalItems" then
+                    data[param] = value;
+                end
+            elseif section == sec and param ~= nil then
+                data[param] = value;
+            end
+        end
+    end
+    file:close();
+    return data;
+end
+
+local function File_Exists(name)
+    local f = io.open(name, "r")
+    if f ~= nil then
+        io.close(f)
+        return true
+    else
+        return false
+    end
+end
+
+function loot.writeSettings()
+    for option, value in pairs(loot.Settings) do
+        local valueType = type(value)
+        if saveOptionTypes[valueType] then
+            mq.cmdf('/ini "%s" "%s" "%s" "%s"', SettingsFile, 'Settings', option, value)
+            loot.Settings[option] = value
+        end
+    end
+    for option, value in pairs(loot.BuyItems) do
+        local valueType = type(value)
+        if saveOptionTypes[valueType] then
+            mq.cmdf('/ini "%s" "%s" "%s" "%s"', SettingsFile, 'BuyItems', option, value)
+            loot.BuyItems[option] = value
+        end
+    end
+    for option, value in pairs(loot.GlobalItems) do
+        local valueType = type(value)
+        if saveOptionTypes[valueType] then
+            mq.cmdf('/ini "%s" "%s" "%s" "%s"', LootFile, 'GlobalItems', option, value)
+            loot.modifyItem(option, value, 'Global_Rules')
+            loot.GlobalItems[option] = value
+        end
+    end
+end
+
+function loot.split(input, sep)
+    if sep == nil then
+        sep = "|"
+    end
+    local t = {}
+    for str in string.gmatch(input, "([^" .. sep .. "]+)") do
+        table.insert(t, str)
+    end
+    return t
+end
+
+function loot.UpdateDB()
+    loot.NormalItems = loot.load(LootFile, 'items')
+    loot.GlobalItems = loot.load(LootFile, 'GlobalItems')
+
+    local db = SQLite3.open(ItemsDB)
+    local batchSize = 500
+    local count = 0
+
+    db:exec("BEGIN TRANSACTION") -- Start transaction for NormalItems
+
+    -- Insert NormalItems in batches
+    for k, v in pairs(loot.NormalItems) do
+        local stmt, err = db:prepare("INSERT INTO Normal_Rules (item_name, item_rule) VALUES (?, ?)")
+        stmt:bind_values(k, v)
+        stmt:step()
+        stmt:finalize()
+
+        count = count + 1
+        if count % batchSize == 0 then
+            print("Inserted " .. count .. " NormalItems so far...")
+            db:exec("COMMIT")
+            db:exec("BEGIN TRANSACTION")
+        end
+    end
+
+    db:exec("COMMIT")
+    print("Inserted all " .. count .. " NormalItems.")
+
+    -- Reset counter for GlobalItems
+    count = 0
+
+    db:exec("BEGIN TRANSACTION")
+
+    -- Insert GlobalItems in batches
+    for k, v in pairs(loot.GlobalItems) do
+        local stmt, err = db:prepare("INSERT INTO Global_Rules (item_name, item_rule) VALUES (?, ?)")
+        stmt:bind_values(k, v)
+        stmt:step()
+        stmt:finalize()
+
+        count = count + 1
+        if count % batchSize == 0 then
+            print("Inserted " .. count .. " GlobalItems so far...")
+            db:exec("COMMIT")
+            db:exec("BEGIN TRANSACTION")
+        end
+    end
+
+    db:exec("COMMIT")
+    print("Inserted all " .. count .. " GlobalItems.")
+    db:close()
+end
+
+function loot.loadSettings()
+    loot.NormalItems = {}
+    loot.GlobalItems = {}
+
+    -- check if the DB structure needs updating
+    if not File_Exists(lootDBUpdateFile) then
+        needDBUpdate = true
+        loot.Settings.Version = version
+    else
+        local tmp = dofile(lootDBUpdateFile)
+        if tmp.version < version then
+            needDBUpdate = true
+            loot.Settings.Version = version
+        end
+    end
+
+    -- SQL setup
+    if not File_Exists(ItemsDB) then
+        loot.Settings.logger.Warn(string.format(
+            "\ayLoot Rules Database \arNOT found\ax, \atCreating it now\ax. Please run \at/lootutils import\ax to Import your \atloot.ini \axfile."))
+        loot.Settings.logger.Warn(string.format("\arOnly run this one One Character\ax.\nAnd use \at/lootutils reload\ax to update the data on the other characters."))
+    else
+        loot.Settings.logger.Info("Loot Rules Database found, loading it now.")
+    end
+
+    if not needDBUpdate then
+        -- Create the database and its table if it doesn't exist
+        local db = SQLite3.open(ItemsDB)
+        db:exec([[
+                CREATE TABLE IF NOT EXISTS Global_Rules (
+                    "item_name" TEXT PRIMARY KEY NOT NULL UNIQUE,
+                    "item_rule" TEXT NOT NULL,
+                    "item_classes" TEXT
+                );
+                    CREATE TABLE IF NOT EXISTS Normal_Rules (
+                    "item_name" TEXT PRIMARY KEY NOT NULL UNIQUE,
+                    "item_rule" TEXT NOT NULL,
+                    "item_classes" TEXT
+                );
+            ]])
+        db:close()
+    else -- DB needs to be updated
+        local db = SQLite3.open(ItemsDB)
+        db:exec([[
+                CREATE TABLE IF NOT EXISTS my_table_copy(
+                    "item_name" TEXT PRIMARY KEY NOT NULL UNIQUE,
+                    "item_rule" TEXT NOT NULL,
+                    "item_classes" TEXT
+                );
+                INSERT INTO my_table_copy (item_name,item_rule,item_classes)
+                    SELECT item_name, item_rule, item_classes FROM Global_Rules;
+                DROP TABLE Global_Rules;
+                ALTER TABLE my_table_copy RENAME TO Global_Rules;
+
+                CREATE TABLE IF NOT EXISTS my_table_copy(
+                    "item_name" TEXT PRIMARY KEY NOT NULL UNIQUE,
+                    "item_rule" TEXT NOT NULL,
+                    "item_classes" TEXT
+                );
+                INSERT INTO my_table_copy (item_name,item_rule,item_classes)
+                    SELECT item_name, item_rule, item_classes FROM Normal_Rules;
+                DROP TABLE Normal_Rules;
+                ALTER TABLE my_table_copy RENAME TO Normal_Rules;
+                );
+            ]])
+        db:close()
+        mq.pickle(lootDBUpdateFile, { ['version'] = version, })
+
+        loot.Settings.logger.Info(string.format("DB Version less than %s, Updating it now.", version))
+        needDBUpdate = false
+    end
+
+    local db = SQLite3.open(ItemsDB)
+    local stmt = db:prepare("SELECT * FROM Global_Rules")
+    for row in stmt:nrows() do
+        loot.GlobalItems[row.item_name] = row.item_rule
+    end
+    stmt:finalize()
+    stmt = db:prepare("SELECT * FROM Normal_Rules")
+    for row in stmt:nrows() do
+        loot.NormalItems[row.item_name] = row.item_rule
+    end
+    stmt:finalize()
+    db:close()
+
+    local tmpSettings = loot.load(SettingsFile, 'Settings')
+    for k, v in pairs(loot.Settings) do
+        if tmpSettings[k] == nil then
+            tmpSettings[k] = loot.Settings[k]
+        end
+    end
+    loot.Settings = tmpSettings
+    tmpCmd = loot.Settings.GroupChannel or 'dgae'
+    if tmpCmd == string.find(tmpCmd, 'dg') then
+        tmpCmd = '/' .. tmpCmd
+    elseif tmpCmd == string.find(tmpCmd, 'bc') then
+        tmpCmd = '/' .. tmpCmd .. ' /'
+    end
+    shouldLootActions.Destroy = loot.Settings.DoDestroy
+    shouldLootActions.Tribute = loot.Settings.TributeKeep
+    loot.BuyItems = loot.load(SettingsFile, 'BuyItems')
+    for k, v in pairs(loot.BuyItems) do
+        if v == 'delete' then
+            loot.BuyItems[k] = nil
+            loot.TempSettings.NeedSave = true
+        end
+    end
+    if guiLoot ~= nil then
+        guiLoot.NormItemsTable = loot.NormalItems
+        guiLoot.GlobItemsTable = loot.GlobalItems
+        guiLoot.BuyItemsTable = loot.BuyItems
+    end
+    if loot.TempSettings.NeedSave then
+        loot.writeSettings()
+        loot.TempSettings.NeedSave = false
+    end
+    loot.SortTables()
+end
+
+function loot.checkCursor()
+    local currentItem = nil
+    while mq.TLO.Cursor() do
+        -- can't do anything if there's nowhere to put the item, either due to no free inventory space
+        -- or no slot of appropriate size
+        if mq.TLO.Me.FreeInventory() == 0 or mq.TLO.Cursor() == currentItem then
+            if loot.Settings.SpamLootInfo then loot.Settings.logger.Debug('Inventory full, item stuck on cursor') end
+            mq.cmdf('/autoinv')
+            return
+        end
+        currentItem = mq.TLO.Cursor()
+        mq.cmdf('/autoinv')
+        mq.delay(100)
+    end
+end
+
+function loot.navToID(spawnID)
+    mq.cmdf('/nav id %d log=off', spawnID)
+    mq.delay(50)
+    if mq.TLO.Navigation.Active() then
+        local startTime = os.time()
+        while mq.TLO.Navigation.Active() do
+            mq.delay(100)
+            if os.difftime(os.time(), startTime) > 5 then
+                break
+            end
+        end
+    end
+end
+
+function loot.modifyItem(item, action, tableName)
+    local db = SQLite3.open(ItemsDB)
+    if not db then
+        loot.Settings.logger.Warn(string.format("Failed to open database."))
+        return
+    end
+
+    if action == 'delete' then
+        local stmt, err = db:prepare("DELETE FROM " .. tableName .. " WHERE item_name = ?")
+        if not stmt then
+            loot.Settings.logger.Warn(string.format("Failed to prepare statement: %s", err))
+            db:close()
+            return
+        end
+        stmt:bind_values(item)
+        stmt:step()
+        stmt:finalize()
+    else
+        -- Use INSERT OR REPLACE to handle conflicts by replacing existing rows
+        local sql = string.format([[
+            INSERT OR REPLACE INTO %s (item_name, item_rule)
+            VALUES (?, ?)
+        ]], tableName)
+
+        local stmt, err = db:prepare(sql)
+        if not stmt then
+            loot.Settings.logger.Warn(string.format("Failed to prepare statement: %s\nSQL: %s", err, sql))
+            db:close()
+            return
+        end
+        stmt:bind_values(item, action)
+        stmt:step()
+        stmt:finalize()
+    end
+
+    db:close()
+end
+
+function loot.addRule(itemName, section, rule)
+    if not lootData[section] then
+        lootData[section] = {}
+    end
+    lootData[section][itemName] = rule
+    loot.NormalItems[itemName] = rule
+    if section == 'GlobalItems' then
+        loot.GlobalItems[itemName] = rule
+        loot.modifyItem(itemName, rule, 'Global_Rules')
+    else
+        loot.modifyItem(itemName, rule, 'Normal_Rules')
+    end
+    loot.lootActor:send({ mailbox = 'lootnscoot', }, { who = eqChar, action = 'addrule', item = itemName, rule = rule, section = section, })
+
+    mq.cmdf('/ini "%s" "%s" "%s" "%s"', LootFile, section, itemName, rule)
+end
+
+function loot.lookupLootRule(section, key)
+    if key == nil then return 'NULL' end
+    local db = SQLite3.open(ItemsDB)
+    local sql = "SELECT item_rule FROM Normal_Rules WHERE item_name = ?"
+    local stmt = db:prepare(sql)
+
+    if not stmt then
+        db:close()
+        return 'NULL'
+    end
+
+    stmt:bind_values(key)
+    local stepResult = stmt:step()
+
+    local rule = 'NULL'
+    if stepResult == SQLite3.ROW then
+        local row = stmt:get_named_values()
+        rule = row.item_rule or 'NULL'
+    end
+
+    stmt:finalize()
+    db:close()
+    return rule
+end
+
+-- moved this function up so we can report Quest Items.
+local reportPrefix = '/%s \a-t[\at%s\a-t][\ax\ayLootUtils\ax\a-t]\ax '
+function loot.report(message, ...)
+    if loot.Settings.ReportLoot then
+        local prefixWithChannel = reportPrefix:format(loot.Settings.LootChannel, mq.TLO.Time())
+        mq.cmdf(prefixWithChannel .. message, ...)
+    end
+end
+
+function loot.AreBagsOpen()
+    local total = {
+        bags = 0,
+        open = 0,
+    }
+    for i = 23, 32 do
+        local slot = mq.TLO.Me.Inventory(i)
+        if slot and slot.Container() and slot.Container() > 0 then
+            total.bags = total.bags + 1
+            ---@diagnostic disable-next-line: undefined-field
+            if slot.Open() then
+                total.open = total.open + 1
+            end
+        end
+    end
+    if total.bags == total.open then
+        return true
+    else
+        return false
+    end
+end
+
+---@return string,number,boolean|nil
+function loot.getRule(item)
+    local itemName = item.Name()
+    local lootDecision = 'Keep'
+    local tradeskill = item.Tradeskills()
+    local sellPrice = item.Value() and item.Value() / 1000 or 0
+    local stackable = item.Stackable()
+    local tributeValue = item.Tribute()
+    local firstLetter = itemName:sub(1, 1):upper()
+    local stackSize = item.StackSize()
+    local countHave = mq.TLO.FindItemCount(string.format("%s", itemName))() + mq.TLO.FindItemBankCount(string.format("%s", itemName))()
+    local qKeep = '0'
+    local globalItem = loot.GlobalItems[itemName] ~= nil and loot.GlobalItems[itemName] or 'NULL'
+    globalItem = loot.BuyItems[itemName] ~= nil and 'Keep' or globalItem
+    local newRule = false
+
+    lootData[firstLetter] = lootData[firstLetter] or {}
+    lootData[firstLetter][itemName] = lootData[firstLetter][itemName] or loot.lookupLootRule(firstLetter, itemName)
+
+    -- Re-Evaluate the settings if AlwaysEval is on. Items that do not meet the Characters settings are reset to NUll and re-evaluated as if they were new items.
+    if loot.Settings.AlwaysEval then
+        local oldDecision = lootData[firstLetter][itemName] -- whats on file
+        local resetDecision = 'NULL'
+        if string.find(oldDecision, 'Quest') or oldDecision == 'Keep' or oldDecision == 'Destroy' then resetDecision = oldDecision end
+        -- If sell price changed and item doesn't meet the new value re-evalute it otherwise keep it set to sell
+        if oldDecision == 'Sell' and not stackable and sellPrice >= loot.Settings.MinSellPrice then resetDecision = oldDecision end
+        -- -- Do the same for stackable items.
+        if (oldDecision == 'Sell' and stackable) and (sellPrice * stackSize >= loot.Settings.StackPlatValue) then resetDecision = oldDecision end
+        -- if banking tradeskills settings changed re-evaluate
+        if oldDecision == 'Bank' and tradeskill and loot.Settings.BankTradeskills then resetDecision = oldDecision end
+
+        lootData[firstLetter][itemName] = resetDecision -- pass value on to next check. Items marked 'NULL' will be treated as new and evaluated properly.
+    end
+    if lootData[firstLetter][itemName] == 'NULL' then
+        if tradeskill and loot.Settings.BankTradeskills then lootDecision = 'Bank' end
+        if not stackable and sellPrice < loot.Settings.MinSellPrice then lootDecision = 'Ignore' end -- added stackable check otherwise it would stay set to Ignore when checking Stackable items in next steps.
+        if not stackable and loot.Settings.StackableOnly then lootDecision = 'Ignore' end
+        if (stackable and loot.Settings.StackPlatValue > 0) and (sellPrice * stackSize < loot.Settings.StackPlatValue) then lootDecision = 'Ignore' end
+        -- set Tribute flag if tribute value is greater than minTributeValue and the sell price is less than min sell price or has no value
+        if tributeValue >= loot.Settings.MinTributeValue and (sellPrice < loot.Settings.MinSellPrice or sellPrice == 0) then lootDecision = 'Tribute' end
+        loot.addRule(itemName, firstLetter, lootDecision)
+        if loot.Settings.AutoTag and lootDecision == 'Keep' then                                       -- Do we want to automatically tag items 'Sell'
+            if not stackable and sellPrice > loot.Settings.MinSellPrice then lootDecision = 'Sell' end -- added stackable check otherwise it would stay set to Ignore when checking Stackable items in next steps.
+            if (stackable and loot.Settings.StackPlatValue > 0) and (sellPrice * stackSize >= loot.Settings.StackPlatValue) then lootDecision = 'Sell' end
+            loot.addRule(itemName, firstLetter, lootDecision)
+        end
+        newRule = true
+    end
+    -- check this before quest item checks. so we have the proper rule to compare.
+    -- Check if item is on global Items list, ignore everything else and use those rules insdead.
+    if loot.Settings.GlobalLootOn and globalItem ~= 'NULL' then
+        lootData[firstLetter][itemName] = globalItem or lootData[firstLetter][itemName]
+    end
+    -- Check if item marked Quest
+    if string.find(lootData[firstLetter][itemName], 'Quest') then
+        local qVal = 'Ignore'
+        -- do we want to loot quest items?
+        if loot.Settings.LootQuest then
+            --look to see if Quantity attached to Quest|qty
+            local _, position = string.find(lootData[firstLetter][itemName], '|')
+            if position then qKeep = string.sub(lootData[firstLetter][itemName], position + 1) else qKeep = '0' end
+            -- if Quantity is tied to the entry then use that otherwise use default Quest Keep Qty.
+            if qKeep == '0' then
+                qKeep = tostring(loot.Settings.QuestKeep)
+            end
+            -- If we have less than we want to keep loot it.
+            if countHave < tonumber(qKeep) then
+                qVal = 'Keep'
+            end
+            if loot.Settings.AlwaysDestroy and qVal == 'Ignore' then qVal = 'Destroy' end
+        end
+        return qVal, tonumber(qKeep) or 0
+    end
+
+    if loot.Settings.AlwaysDestroy and lootData[firstLetter][itemName] == 'Ignore' then return 'Destroy', 0 end
+
+    return lootData[firstLetter][itemName], 0, newRule
+end
+
+-- EVENTS
+function loot.RegisterActors()
+    loot.lootActor = actors.register('lootnscoot', function(message)
+        local lootMessage = message()
+        local who = lootMessage.who
+        local action = lootMessage.action
+        if action == 'lootreload' then
+            loot.commandHandler('reload')
+        end
+        if who == eqChar then return end
+        if action == 'addrule' then
+            local item = lootMessage.item
+            local rule = lootMessage.rule
+            local section = lootMessage.section
+            if section == 'GlobalItems' then
+                loot.GlobalItems[item] = rule
+            else
+                loot.NormalItems[item] = rule
+            end
+        elseif action == 'deleteitem' then
+            local item = lootMessage.item
+            local section = lootMessage.section
+            if section == 'GlobalItems' then
+                loot.GlobalItems[item] = nil
+            else
+                loot.NormalItems[item] = nil
+            end
+        elseif action == 'modifyitem' then
+            local item = lootMessage.item
+            local rule = lootMessage.rule
+            local section = lootMessage.section
+            if section == 'GlobalItems' then
+                loot.GlobalItems[item] = rule
+            else
+                loot.NormalItems[item] = rule
+            end
+        end
+    end)
+end
+
+local itemNoValue = nil
+function loot.eventNovalue(line, item)
+    itemNoValue = item
+end
+
+function loot.setupEvents()
+    mq.event("CantLoot", "#*#may not loot this corpse#*#", loot.eventCantLoot)
+    mq.event("NoSlot", "#*#There are no open slots for the held item in your inventory#*#", loot.eventNoSlot)
+    mq.event("Sell", "#*#You receive#*# for the #1#(s)#*#", loot.eventSell)
+    -- if loot.Settings.LootForage then
+    mq.event("ForageExtras", "Your forage mastery has enabled you to find something else!", loot.eventForage)
+    mq.event("Forage", "You have scrounged up #*#", loot.eventForage)
+    -- end
+    mq.event("Novalue", "#*#give you absolutely nothing for the #1#.#*#", loot.eventNovalue)
+    mq.event("Tribute", "#*#We graciously accept your #1# as tribute, thank you!#*#", loot.eventTribute)
+end
+
+-- BINDS
+function loot.setBuyItem(item, qty)
+    loot.BuyItems[item] = qty
+    mq.cmdf('/ini "%s" "BuyItems" "%s" "%s"', SettingsFile, item, qty)
+end
+
+function loot.setGlobalItem(item, val)
+    loot.GlobalItems[item] = val ~= 'delete' and val or nil
+    loot.modifyItem(item, val, 'Global_Rules')
+end
+
+function loot.setNormalItem(item, val)
+    loot.NormalItems[item] = val ~= 'delete' and val or nil
+    loot.modifyItem(item, val, 'Normal_Rules')
+end
+
+function loot.commandHandler(...)
+    local args = { ..., }
+    if #args == 1 then
+        if args[1] == 'sellstuff' then
+            loot.processItems('Sell')
+        elseif args[1] == 'restock' then
+            loot.processItems('Buy')
+        elseif args[1] == 'reload' then
+            lootData = {}
+            local needSave = loot.loadSettings()
+            if needSave then
+                loot.writeSettings()
+            end
+            if guiLoot ~= nil then
+                guiLoot.GetSettings(loot.Settings.HideNames, loot.Settings.LookupLinks, loot.Settings.RecordData, true, loot.Settings.UseActors,
+                    'lootnscoot')
+            end
+            loot.Settings.logger.Info("\ayReloaded Settings \axAnd \atLoot Files")
+        elseif args[1] == 'import' then
+            lootData = {}
+            if guiLoot ~= nil then
+                guiLoot.GetSettings(loot.Settings.HideNames, loot.Settings.LookupLinks, loot.Settings.RecordData, true, loot.Settings.UseActors,
+                    'lootnscoot')
+            end
+            loot.UpdateDB()
+            loot.Settings.logger.Info("\ayImporting the DB from loot.ini \ax and \at Reloading Settings")
+        elseif args[1] == 'settings' then
+            showSettings = not showSettings
+        elseif args[1] == 'bank' then
+            loot.processItems('Bank')
+        elseif args[1] == 'cleanup' then
+            loot.processItems('Cleanup')
+        elseif args[1] == 'gui' then
+            print('Opening GUI')
+            guiLoot.openGUI = not guiLoot.openGUI
+        elseif args[1] == 'report' and guiLoot ~= nil then
+            guiLoot.ReportLoot()
+        elseif args[1] == 'hidenames' and guiLoot ~= nil then
+            loot.guiloot.Settings.HideNames = not loot.guiloot.Settings.HideNames
+        elseif args[1] == 'config' then
+            local confReport = string.format("\ayLoot N Scoot Settings\ax")
+            for key, value in pairs(loot.Settings) do
+                if type(value) ~= "function" and type(value) ~= "table" then
+                    confReport = confReport .. string.format("\n\at%s\ax = \ag%s\ax", key, tostring(value))
+                end
+            end
+            loot.Settings.logger.Info(confReport)
+        elseif args[1] == 'tributestuff' then
+            loot.processItems('Tribute')
+        elseif args[1] == 'loot' then
+            loot.lootMobs()
+        elseif args[1] == 'tsbank' then
+            loot.markTradeSkillAsBank()
+        elseif validActions[args[1]] and mq.TLO.Cursor() then
+            loot.addRule(mq.TLO.Cursor(), mq.TLO.Cursor():sub(1, 1), validActions[args[1]])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", mq.TLO.Cursor(), validActions[args[1]]))
+        end
+    elseif #args == 2 then
+        if args[1] == 'quest' and mq.TLO.Cursor() then
+            loot.addRule(mq.TLO.Cursor(), mq.TLO.Cursor():sub(1, 1), 'Quest|' .. args[2])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \ayQuest|%s\ax", mq.TLO.Cursor(), args[2]))
+        elseif args[1] == 'buy' and mq.TLO.Cursor() then
+            loot.BuyItems[mq.TLO.Cursor()] = args[2]
+            mq.cmdf('/ini "%s" "BuyItems" "%s" "%s"', SettingsFile, mq.TLO.Cursor(), args[2])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \ayBuy|%s\ax", mq.TLO.Cursor(), args[2]))
+        elseif args[1] == 'globalitem' and validActions[args[2]] and mq.TLO.Cursor() then
+            loot.GlobalItems[mq.TLO.Cursor()] = validActions[args[2]]
+            loot.addRule(mq.TLO.Cursor(), 'GlobalItems', validActions[args[2]])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \agGlobal Item \ay%s\ax", mq.TLO.Cursor(), validActions[args[2]]))
+        elseif validActions[args[1]] and args[2] ~= 'NULL' then
+            loot.addRule(args[2], args[2]:sub(1, 1), validActions[args[1]])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", args[2], validActions[args[1]]))
+        end
+    elseif #args == 3 then
+        if args[1] == 'globalitem' and args[2] == 'quest' and mq.TLO.Cursor() then
+            loot.addRule(mq.TLO.Cursor(), 'GlobalItems', 'Quest|' .. args[3])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \agGlobal Item \ayQuest|%s\ax", mq.TLO.Cursor(), args[3]))
+        elseif args[1] == 'globalitem' and validActions[args[2]] and args[3] ~= 'NULL' then
+            loot.addRule(args[3], 'GlobalItems', validActions[args[2]])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \agGlobal Item \ay%s\ax", args[3], validActions[args[2]]))
+        elseif args[1] == 'buy' then
+            loot.BuyItems[args[2]] = args[3]
+            mq.cmdf('/ini "%s" "BuyItems" "%s" "%s"', SettingsFile, args[2], args[3])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \ayBuy|%s\ax", args[2], args[3]))
+        elseif validActions[args[1]] and args[2] ~= 'NULL' then
+            loot.addRule(args[2], args[2]:sub(1, 1), validActions[args[1]] .. '|' .. args[3])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \ay%s|%s\ax", args[2], validActions[args[1]], args[3]))
+        end
+    elseif #args == 4 then
+        if args[1] == 'globalitem' and validActions[args[2]] and args[3] ~= 'NULL' then
+            loot.addRule(args[3], 'GlobalItems', validActions[args[2]] .. '|' .. args[4])
+            loot.Settings.logger.Info(string.format("Setting \ay%s\ax to \agGlobal Item \ay%s|%s\ax", args[3], validActions[args[2]], args[4]))
+        end
+    end
+    loot.writeSettings()
+end
+
+function loot.setupBinds()
+    mq.bind('/lootutils', loot.commandHandler)
+end
+
+-- LOOTING
+
+function loot.CheckBags()
+    areFull = mq.TLO.Me.FreeInventory() <= loot.Settings.SaveBagSlots
+end
+
+function loot.eventCantLoot()
+    cantLootID = mq.TLO.Target.ID()
+end
+
+function loot.eventNoSlot()
+    -- we don't have a slot big enough for the item on cursor. Dropping it to the ground.
+    local cantLootItemName = mq.TLO.Cursor()
+    mq.cmdf('/drop')
+    mq.delay(1)
+    loot.report("\ay[WARN]\arI can't loot %s, dropping it on the ground!\ax", cantLootItemName)
+end
+
+---@param index number @The current index we are looking at in loot window, 1-based.
+---@param doWhat string @The action to take for the item.
+---@param button string @The mouse button to use to loot the item. Currently only leftmouseup implemented.
+---@param qKeep number @The count to keep, for quest items.
+---@param allItems table @Table of all items seen so far on the corpse, left or looted.
+function loot.lootItem(index, doWhat, button, qKeep, allItems)
+    local eval = doWhat
+    loot.Settings.logger.Debug('Enter lootItem')
+    local corpseItem = mq.TLO.Corpse.Item(index)
+    if not shouldLootActions[doWhat] then
+        table.insert(allItems, { Name = corpseItem.Name(), Action = 'Left', Link = corpseItem.ItemLink('CLICKABLE')(), Eval = doWhat, })
+        return
+    end
+    local corpseItemID = corpseItem.ID()
+    local itemName = corpseItem.Name()
+    local itemLink = corpseItem.ItemLink('CLICKABLE')()
+    local globalItem = (loot.Settings.GlobalLootOn and (loot.GlobalItems[itemName] ~= nil or loot.BuyItems[itemName] ~= nil)) and true or false
+
+    mq.cmdf('/nomodkey /shift /itemnotify loot%s %s', index, button)
+    -- Looting of no drop items is currently disabled with no flag to enable anyways
+    -- added check to make sure the cursor isn't empty so we can exit the pause early.-- or not mq.TLO.Corpse.Item(index).NoDrop()
+    mq.delay(1) -- for good measure.
+    mq.delay(5000, function() return mq.TLO.Window('ConfirmationDialogBox').Open() or mq.TLO.Cursor() == nil end)
+    if mq.TLO.Window('ConfirmationDialogBox').Open() then mq.cmdf('/nomodkey /notify ConfirmationDialogBox Yes_Button leftmouseup') end
+    mq.delay(5000, function() return mq.TLO.Cursor() ~= nil or not mq.TLO.Window('LootWnd').Open() end)
+    mq.delay(1) -- force next frame
+    -- The loot window closes if attempting to loot a lore item you already have, but lore should have already been checked for
+    if not mq.TLO.Window('LootWnd').Open() then return end
+    if doWhat == 'Destroy' and mq.TLO.Cursor.ID() == corpseItemID then
+        eval = globalItem and 'Global Destroy' or 'Destroy'
+        mq.cmdf('/destroy')
+        table.insert(allItems, { Name = itemName, Action = 'Destroyed', Link = itemLink, Eval = eval, })
+    end
+    loot.checkCursor()
+    if qKeep > 0 and doWhat == 'Keep' then
+        eval = globalItem and 'Global Quest' or 'Quest'
+        local countHave = mq.TLO.FindItemCount(string.format("%s", itemName))() + mq.TLO.FindItemBankCount(string.format("%s", itemName))()
+        loot.report("\awQuest Item:\ag %s \awCount:\ao %s \awof\ag %s", itemLink, tostring(countHave), qKeep)
+    else
+        eval = globalItem and 'Global ' .. doWhat or doWhat
+        loot.report('%sing \ay%s\ax', doWhat, itemLink)
+    end
+    if doWhat ~= 'Destroy' then
+        if not string.find(eval, 'Quest') then
+            eval = globalItem and 'Global ' .. doWhat or doWhat
+        end
+        table.insert(allItems, { Name = itemName, Action = 'Looted', Link = itemLink, Eval = eval, })
+    end
+    loot.CheckBags()
+    if areFull then loot.report('My bags are full, I can\'t loot anymore! Turning OFF Looting Items until we sell.') end
+end
+
+function loot.lootCorpse(corpseID)
+    loot.Settings.logger.Debug('Enter lootCorpse')
+    shouldLootActions.Destroy = loot.Settings.DoDestroy
+    shouldLootActions.Tribute = loot.Settings.TributeKeep
+    if mq.TLO.Cursor() then loot.checkCursor() end
+    for i = 1, 3 do
+        mq.cmd('/loot')
+        mq.delay(1000, function() return mq.TLO.Window('LootWnd').Open() end)
+        if mq.TLO.Window('LootWnd').Open() then break end
+    end
+
+    mq.doevents('CantLoot')
+    mq.delay(3000, function() return cantLootID > 0 or mq.TLO.Window('LootWnd').Open() end)
+    if not mq.TLO.Window('LootWnd').Open() then
+        if mq.TLO.Target.CleanName() ~= nil then
+            loot.Settings.logger.Warn(('\awlootCorpse(): \ayCan\'t loot %s right now'):format(mq.TLO.Target.CleanName()))
+            cantLootList[corpseID] = os.time()
+        end
+        return
+    end
+    mq.delay(1000, function() return (mq.TLO.Corpse.Items() or 0) > 0 end)
+    local items = mq.TLO.Corpse.Items() or 0
+    loot.Settings.logger.Debug(string.format('\awlootCorpse(): \ayLoot window open. Items: %s', items))
+    local corpseName = mq.TLO.Corpse.Name()
+    if mq.TLO.Window('LootWnd').Open() and items > 0 then
+        if mq.TLO.Corpse.DisplayName() == mq.TLO.Me.DisplayName() then
+            mq.cmdf('/lootall')
+            return
+        end -- if its our own corpse just loot it.
+        local noDropItems = {}
+        local loreItems = {}
+        local allItems = {}
+        for i = 1, items do
+            local freeSpace = mq.TLO.Me.FreeInventory()
+            local corpseItem = mq.TLO.Corpse.Item(i)
+            local itemLink = corpseItem.ItemLink('CLICKABLE')()
+            if corpseItem() then
+                local itemRule, qKeep, newRule = loot.getRule(corpseItem)
+                local stackable = corpseItem.Stackable()
+                local freeStack = corpseItem.FreeStack()
+                if corpseItem.Lore() then
+                    local haveItem = mq.TLO.FindItem(('=%s'):format(corpseItem.Name()))()
+                    local haveItemBank = mq.TLO.FindItemBank(('=%s'):format(corpseItem.Name()))()
+                    if haveItem or haveItemBank or freeSpace <= loot.Settings.SaveBagSlots then
+                        table.insert(loreItems, itemLink)
+                        loot.lootItem(i, 'Ignore', 'leftmouseup', 0, allItems)
+                    elseif corpseItem.NoDrop() then
+                        if loot.Settings.LootNoDrop then
+                            if not newRule or (newRule and loot.Settings.LootNoDropNew) then
+                                loot.lootItem(i, itemRule, 'leftmouseup', qKeep, allItems)
+                            end
+                        else
+                            table.insert(noDropItems, itemLink)
+                            loot.lootItem(i, 'Ignore', 'leftmouseup', 0, allItems)
+                        end
+                    else
+                        loot.lootItem(i, itemRule, 'leftmouseup', qKeep, allItems)
+                    end
+                elseif corpseItem.NoDrop() then
+                    if loot.Settings.LootNoDrop then
+                        if not newRule or (newRule and loot.Settings.LootNoDropNew) then
+                            loot.lootItem(i, itemRule, 'leftmouseup', qKeep, allItems)
+                        end
+                    else
+                        table.insert(noDropItems, itemLink)
+                        loot.lootItem(i, 'Ignore', 'leftmouseup', 0, allItems)
+                    end
+                elseif freeSpace > loot.Settings.SaveBagSlots or (stackable and freeStack > 0) then
+                    loot.lootItem(i, itemRule, 'leftmouseup', qKeep, allItems)
+                end
+            end
+            mq.delay(1)
+            if mq.TLO.Cursor() then loot.checkCursor() end
+            mq.delay(1)
+            if not mq.TLO.Window('LootWnd').Open() then break end
+        end
+        if loot.Settings.ReportLoot and (#noDropItems > 0 or #loreItems > 0) then
+            local skippedItems = '/%s Skipped loots (%s - %s) '
+            for _, noDropItem in ipairs(noDropItems) do
+                skippedItems = skippedItems .. ' ' .. noDropItem .. ' (nodrop) '
+            end
+            for _, loreItem in ipairs(loreItems) do
+                skippedItems = skippedItems .. ' ' .. loreItem .. ' (lore) '
+            end
+            mq.cmdf(skippedItems, loot.Settings.LootChannel, corpseName, corpseID)
+        end
+        if #allItems > 0 then
+            -- send to self and others running lootnscoot
+            loot.lootActor:send({ mailbox = 'looted', }, { ID = corpseID, Items = allItems, LootedAt = mq.TLO.Time(), LootedBy = eqChar, })
+            -- send to standalone looted gui
+            loot.lootActor:send({ mailbox = 'looted', script = 'looted', },
+                { ID = corpseID, Items = allItems, LootedAt = mq.TLO.Time(), LootedBy = eqChar, })
+        end
+    end
+    if mq.TLO.Cursor() then loot.checkCursor() end
+    mq.cmdf('/nomodkey /notify LootWnd LW_DoneButton leftmouseup')
+    mq.delay(3000, function() return not mq.TLO.Window('LootWnd').Open() end)
+    -- if the corpse doesn't poof after looting, there may have been something we weren't able to loot or ignored
+    -- mark the corpse as not lootable for a bit so we don't keep trying
+    if mq.TLO.Spawn(('corpse id %s'):format(corpseID))() then
+        cantLootList[corpseID] = os.time()
+    end
+end
+
+function loot.corpseLocked(corpseID)
+    if not cantLootList[corpseID] then return false end
+    if os.difftime(os.time(), cantLootList[corpseID]) > 60 then
+        cantLootList[corpseID] = nil
+        return false
+    end
+    return true
+end
+
+function loot.lootMobs(limit)
+    loot.Settings.logger.Debug('\awlootMobs(): \ayEnter lootMobs')
+    local deadCount = mq.TLO.SpawnCount(spawnSearch:format('npccorpse', loot.Settings.CorpseRadius))()
+    loot.Settings.logger.Debug(string.format('\awlootMobs(): \ayThere are %s corpses in range.', deadCount))
+    local mobsNearby = mq.TLO.SpawnCount(spawnSearch:format('xtarhater', loot.Settings.MobsTooClose))()
+    local corpseList = {}
+
+    -- options for combat looting or looting disabled
+    if deadCount == 0 or ((mobsNearby > 0 or mq.TLO.Me.Combat()) and not loot.Settings.CombatLooting) then return false end
+
+    for i = 1, (limit or deadCount) do
+        local corpse = mq.TLO.NearestSpawn(('%d,' .. spawnSearch):format(i, 'npccorpse', loot.Settings.CorpseRadius))
+        table.insert(corpseList, corpse)
+        -- why is there a deity check?
+    end
+    local didLoot = false
+    if #corpseList > 0 then
+        loot.Settings.logger.Debug(string.format('\awlootMobs(): \ayTrying to loot %d corpses.', #corpseList))
+        for i = 1, #corpseList do
+            local corpse = corpseList[i]
+            local corpseID = corpse.ID()
+            if corpseID and corpseID > 0 and not loot.corpseLocked(corpseID) and (mq.TLO.Navigation.PathLength('spawn id ' .. tostring(corpseID))() or 100) < 60 then
+                loot.Settings.logger.Debug(string.format('Moving to corpse ID=' .. tostring(corpseID)))
+                loot.navToID(corpseID)
+                corpse.DoTarget()
+                loot.lootCorpse(corpseID)
+                didLoot = true
+                mq.doevents('InventoryFull')
+            end
+        end
+        loot.Settings.logger.Debug('\awlootMobs(): \agDone with corpse list.')
+    end
+    return didLoot
+end
+
+-- SELLING
+
+function loot.eventSell(_, itemName)
+    if NEVER_SELL[itemName] then return end
+    local firstLetter = itemName:sub(1, 1):upper()
+    if lootData[firstLetter] and lootData[firstLetter][itemName] == 'Sell' then return end
+    if loot.lookupLootRule(firstLetter, itemName) == 'Sell' then
+        lootData[firstLetter] = lootData[firstLetter] or {}
+        lootData[firstLetter][itemName] = 'Sell'
+        return
+    end
+    if loot.Settings.AddNewSales then
+        loot.Settings.logger.Info(string.format('Setting %s to Sell', itemName))
+        if not lootData[firstLetter] then lootData[firstLetter] = {} end
+        mq.cmdf('/ini "%s" "%s" "%s" "%s"', LootFile, firstLetter, itemName, 'Sell')
+        loot.modifyItem(itemName, 'Sell', 'Normal_Rules')
+        lootData[firstLetter][itemName] = 'Sell'
+        loot.NormalItems[itemName] = 'Sell'
+        loot.lootActor:send({ mailbox = 'lootnscoot', },
+            { who = eqChar, action = 'modifyitem', item = itemName, rule = 'Sell', section = "NormalItems", })
+    end
+end
+
+function loot.goToVendor()
+    if not mq.TLO.Target() then
+        loot.Settings.logger.Warn('Please target a vendor')
+        return false
+    end
+    local vendorName = mq.TLO.Target.CleanName()
+
+    loot.Settings.logger.Info(string.format('Doing business with ' .. vendorName))
+    if mq.TLO.Target.Distance() > 15 then
+        loot.navToID(mq.TLO.Target.ID())
+    end
+    return true
+end
+
+function loot.openVendor()
+    loot.Settings.logger.Debug('Opening merchant window')
+    mq.cmdf('/nomodkey /click right target')
+    loot.Settings.logger.Debug(string.format('Waiting for merchant window to populate'))
+    mq.delay(1000, function() return mq.TLO.Window('MerchantWnd').Open() end)
+    if not mq.TLO.Window('MerchantWnd').Open() then return false end
+    mq.delay(5000, function() return mq.TLO.Merchant.ItemsReceived() end)
+    return mq.TLO.Merchant.ItemsReceived()
+end
+
+function loot.SellToVendor(itemToSell, bag, slot)
+    if NEVER_SELL[itemToSell] then return end
+    if mq.TLO.Window('MerchantWnd').Open() then
+        loot.Settings.logger.Info('Selling ' .. itemToSell)
+        if slot == nil or slot == -1 then
+            mq.cmdf('/nomodkey /itemnotify %s leftmouseup', bag)
+        else
+            mq.cmdf('/nomodkey /itemnotify in pack%s %s leftmouseup', bag, slot)
+        end
+        mq.delay(1000, function() return mq.TLO.Window('MerchantWnd/MW_SelectedItemLabel').Text() == itemToSell end)
+        mq.cmdf('/nomodkey /shiftkey /notify merchantwnd MW_Sell_Button leftmouseup')
+        mq.doevents('eventNovalue')
+        if itemNoValue == itemToSell then
+            loot.addRule(itemToSell, itemToSell:sub(1, 1), 'Ignore')
+            itemNoValue = nil
+        end
+        -- TODO: handle vendor not wanting item / item can't be sold
+        mq.delay(1000, function() return mq.TLO.Window('MerchantWnd/MW_SelectedItemLabel').Text() == '' end)
+    end
+end
+
+-- BUYING
+
+function loot.RestockItems()
+    local rowNum = 0
+    for itemName, qty in pairs(loot.BuyItems) do
+        if tonumber(qty) then
+            rowNum = mq.TLO.Window("MerchantWnd/MW_ItemList").List(itemName, 2)() or 0
+            mq.delay(20)
+            local tmpQty = qty - mq.TLO.FindItemCount(itemName)()
+            if rowNum ~= 0 and tmpQty > 0 then
+                mq.TLO.Window("MerchantWnd/MW_ItemList").Select(rowNum)()
+                mq.delay(100)
+                mq.TLO.Window("MerchantWnd/MW_Buy_Button").LeftMouseUp()
+                mq.delay(500, function() return mq.TLO.Window("QuantityWnd").Open() end)
+                mq.TLO.Window("QuantityWnd/QTYW_SliderInput").SetText(tostring(tmpQty))()
+                mq.delay(100, function() return mq.TLO.Window("QuantityWnd/QTYW_SliderInput").Text() == tostring(tmpQty) end)
+                loot.Settings.logger.Info(string.format("\agBuying\ay " .. tmpQty .. "\at " .. itemName))
+                mq.TLO.Window("QuantityWnd/QTYW_Accept_Button").LeftMouseUp()
+                mq.delay(100)
+            end
+            mq.delay(500, function() return mq.TLO.FindItemCount(itemName)() == qty end)
+        end
+    end
+    -- close window when done buying
+    return mq.TLO.Window('MerchantWnd').DoClose()
+end
+
+-- TRIBUTEING
+
+function loot.openTribMaster()
+    loot.Settings.logger.Debug('Opening Tribute Window')
+    mq.cmdf('/nomodkey /click right target')
+    loot.Settings.logger.Debug('Waiting for Tribute Window to populate')
+    mq.delay(1000, function() return mq.TLO.Window('TributeMasterWnd').Open() end)
+    if not mq.TLO.Window('TributeMasterWnd').Open() then return false end
+    return mq.TLO.Window('TributeMasterWnd').Open()
+end
+
+function loot.eventTribute(line, itemName)
+    local firstLetter = itemName:sub(1, 1):upper()
+    if lootData[firstLetter] and lootData[firstLetter][itemName] == 'Tribute' then return end
+    if loot.lookupLootRule(firstLetter, itemName) == 'Tribute' then
+        lootData[firstLetter] = lootData[firstLetter] or {}
+        lootData[firstLetter][itemName] = 'Tribute'
+        return
+    end
+    if loot.Settings.AddNewTributes then
+        loot.Settings.logger.Info(string.format('Setting %s to Tribute', itemName))
+        if not lootData[firstLetter] then lootData[firstLetter] = {} end
+        mq.cmdf('/ini "%s" "%s" "%s" "%s"', LootFile, firstLetter, itemName, 'Tribute')
+
+        loot.modifyItem(itemName, 'Tribute', 'Normal_Rules')
+        lootData[firstLetter][itemName] = 'Tribute'
+        loot.NormalItems[itemName] = 'Tribute'
+        loot.lootActor:send({ mailbox = 'lootnscoot', },
+            { who = eqChar, action = 'modifyitem', item = itemName, rule = 'Tribute', section = "NormalItems", })
+    end
+end
+
+function loot.TributeToVendor(itemToTrib, bag, slot)
+    if NEVER_SELL[itemToTrib.Name()] then return end
+    if mq.TLO.Window('TributeMasterWnd').Open() then
+        loot.Settings.logger.Info('Tributeing ' .. itemToTrib.Name())
+        loot.report('\ayTributing \at%s \axfor\ag %s \axpoints!', itemToTrib.Name(), itemToTrib.Tribute())
+        mq.cmdf('/shift /itemnotify in pack%s %s leftmouseup', bag, slot)
+        mq.delay(1) -- progress frame
+
+        mq.delay(5000, function()
+            return mq.TLO.Window('TributeMasterWnd').Child('TMW_ValueLabel').Text() == tostring(itemToTrib.Tribute()) and
+                mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled()
+        end)
+
+        mq.TLO.Window('TributeMasterWnd/TMW_DonateButton').LeftMouseUp()
+        mq.delay(1)
+        mq.delay(5000, function() return not mq.TLO.Window('TributeMasterWnd/TMW_DonateButton').Enabled() end)
+        if mq.TLO.Window("QuantityWnd").Open() then
+            mq.TLO.Window("QuantityWnd/QTYW_Accept_Button").LeftMouseUp()
+            mq.delay(5000, function() return not mq.TLO.Window("QuantityWnd").Open() end)
+        end
+        mq.delay(1000) -- This delay is necessary because there is seemingly a delay between donating and selecting the next item.
+    end
+end
+
+-- CLEANUP
+
+function loot.DestroyItem(itemToDestroy, bag, slot)
+    if NEVER_SELL[itemToDestroy.Name()] then return end
+    loot.Settings.logger.Info('!!Destroying!! ' .. itemToDestroy.Name())
+    mq.cmdf('/shift /itemnotify in pack%s %s leftmouseup', bag, slot)
+    mq.delay(1) -- progress frame
+    mq.cmdf('/destroy')
+    mq.delay(1)
+    mq.delay(1000, function() return not mq.TLO.Cursor() end)
+    mq.delay(1)
+end
+
+-- BANKING
+
+function loot.markTradeSkillAsBank()
+    for i = 1, 10 do
+        local bagSlot = mq.TLO.InvSlot('pack' .. i).Item
+        if bagSlot.Container() == 0 then
+            if bagSlot.ID() then
+                if bagSlot.Tradeskills() then
+                    local itemToMark = bagSlot.Name()
+                    loot.NormalItems[itemToMark] = 'Bank'
+                    loot.addRule(itemToMark, itemToMark:sub(1, 1), 'Bank')
+                end
+            end
+        end
+    end
+    -- sell any items in bags which are marked as sell
+    for i = 1, 10 do
+        local bagSlot = mq.TLO.InvSlot('pack' .. i).Item
+        local containerSize = bagSlot.Container()
+        if containerSize and containerSize > 0 then
+            for j = 1, containerSize do
+                local item = bagSlot.Item(j)
+                if item.ID() and item.Tradeskills() then
+                    local itemToMark = bagSlot.Item(j).Name()
+                    loot.NormalItems[itemToMark] = 'Bank'
+                    loot.addRule(itemToMark, itemToMark:sub(1, 1), 'Bank')
+                end
+            end
+        end
+    end
+end
+
+function loot.bankItem(itemName, bag, slot)
+    if not slot or slot == -1 then
+        mq.cmdf('/shift /itemnotify %s leftmouseup', bag)
+    else
+        mq.cmdf('/shift /itemnotify in pack%s %s leftmouseup', bag, slot)
+    end
+    mq.delay(100, function() return mq.TLO.Cursor() end)
+    mq.cmdf('/notify BigBankWnd BIGB_AutoButton leftmouseup')
+    mq.delay(100, function() return not mq.TLO.Cursor() end)
+end
+
+-- FORAGING
+
+function loot.eventForage()
+    if not loot.Settings.LootForage then return end
+    loot.Settings.logger.Debug('Enter eventForage')
+    -- allow time for item to be on cursor incase message is faster or something?
+    mq.delay(1000, function() return mq.TLO.Cursor() end)
+    -- there may be more than one item on cursor so go until its cleared
+    while mq.TLO.Cursor() do
+        local cursorItem = mq.TLO.Cursor
+        local foragedItem = cursorItem.Name()
+        local forageRule = loot.split(loot.getRule(cursorItem))
+        local ruleAction = forageRule[1] -- what to do with the item
+        local ruleAmount = forageRule[2] -- how many of the item should be kept
+        local currentItemAmount = mq.TLO.FindItemCount('=' .. foragedItem)()
+        -- >= because .. does finditemcount not count the item on the cursor?
+        if not shouldLootActions[ruleAction] or (ruleAction == 'Quest' and currentItemAmount >= ruleAmount) then
+            if mq.TLO.Cursor.Name() == foragedItem then
+                if loot.Settings.LootForageSpam then loot.Settings.logger.Info(string.format('Destroying foraged item ' .. foragedItem)) end
+                mq.cmdf('/destroy')
+                mq.delay(500)
+            end
+            -- will a lore item we already have even show up on cursor?
+            -- free inventory check won't cover an item too big for any container so may need some extra check related to that?
+        elseif (shouldLootActions[ruleAction] or currentItemAmount < ruleAmount) and (not cursorItem.Lore() or currentItemAmount == 0) and (mq.TLO.Me.FreeInventory() or (cursorItem.Stackable() and cursorItem.FreeStack())) then
+            if loot.Settings.LootForageSpam then loot.Settings.logger.Info(string.format('Keeping foraged item ' .. foragedItem)) end
+            mq.cmdf('/autoinv')
+        else
+            if loot.Settings.LootForageSpam then loot.Settings.logger.Warn('Unable to process item ' .. foragedItem) end
+            break
+        end
+        mq.delay(50)
+    end
+end
+
+-- Process Items
+
+function loot.processItems(action)
+    local flag = false
+    local totalPlat = 0
+
+    local function processItem(item, action, bag, slot)
+        local rule = loot.getRule(item)
+        if rule == action then
+            if action == 'Sell' then
+                if not mq.TLO.Window('MerchantWnd').Open() then
+                    if not loot.goToVendor() then return end
+                    if not loot.openVendor() then return end
+                end
+                --totalPlat = mq.TLO.Me.Platinum()
+                local sellPrice = item.Value() and item.Value() / 1000 or 0
+                if sellPrice == 0 then
+                    loot.Settings.logger.Warn(string.format('Item \ay%s\ax is set to Sell but has no sell value!', item.Name()))
+                else
+                    loot.SellToVendor(item.Name(), bag, slot)
+                    totalPlat = totalPlat + sellPrice
+                    mq.delay(1)
+                end
+            elseif action == 'Tribute' then
+                if not mq.TLO.Window('TributeMasterWnd').Open() then
+                    if not loot.goToVendor() then return end
+                    if not loot.openTribMaster() then return end
+                end
+                mq.cmdf('/keypress OPEN_INV_BAGS')
+                mq.delay(1)
+                -- tributes requires the bags to be open
+                mq.delay(1000, loot.AreBagsOpen)
+                mq.delay(1)
+                loot.TributeToVendor(item, bag, slot)
+                mq.delay(1)
+            elseif action == 'Destroy' then
+                loot.DestroyItem(item, bag, slot)
+                mq.delay(1)
+            elseif action == 'Bank' then
+                if not mq.TLO.Window('BigBankWnd').Open() then
+                    loot.Settings.logger.Warn('Bank window must be open!')
+                    return
+                end
+                loot.bankItem(item.Name(), bag, slot)
+                mq.delay(1)
+            end
+        end
+    end
+
+    if loot.Settings.AlwaysEval then
+        flag, loot.Settings.AlwaysEval = true, false
+    end
+
+    for i = 1, 10 do
+        local bagSlot = mq.TLO.InvSlot('pack' .. i).Item
+        local containerSize = bagSlot.Container()
+
+        if containerSize then
+            for j = 1, containerSize do
+                local item = bagSlot.Item(j)
+                if item.ID() then
+                    if action == 'Cleanup' then
+                        processItem(item, 'Destroy', i, j)
+                    elseif action == 'Sell' then
+                        processItem(item, 'Sell', i, j)
+                    elseif action == 'Tribute' then
+                        processItem(item, 'Tribute', i, j)
+                    elseif action == 'Bank' then
+                        processItem(item, 'Bank', i, j)
+                    end
+                end
+            end
+        end
+    end
+    if action == 'Sell' and loot.Settings.AutoRestock then
+        loot.RestockItems()
+    end
+    if action == 'Buy' then
+        if not mq.TLO.Window('MerchantWnd').Open() then
+            if not loot.goToVendor() then return end
+            if not loot.openVendor() then return end
+        end
+        loot.RestockItems()
+    end
+
+    if flag then
+        flag, loot.Settings.AlwaysEval = false, true
+    end
+
+    if action == 'Tribute' then
+        mq.flushevents('Tribute')
+        if mq.TLO.Window('TributeMasterWnd').Open() then
+            mq.TLO.Window('TributeMasterWnd').DoClose()
+            mq.delay(1)
+        end
+        mq.cmdf('/keypress CLOSE_INV_BAGS')
+        mq.delay(1)
+    elseif action == 'Sell' then
+        if mq.TLO.Window('MerchantWnd').Open() then
+            mq.TLO.Window('MerchantWnd').DoClose()
+            mq.delay(1)
+        end
+        mq.delay(1)
+        totalPlat = math.floor(totalPlat)
+        loot.report('Total plat value sold: \ag%s\ax', totalPlat)
+    elseif action == 'Bank' then
+        if mq.TLO.Window('BigBankWnd').Open() then
+            mq.TLO.Window('BigBankWnd').DoClose()
+            mq.delay(1)
+        end
+    end
+
+    loot.CheckBags()
+end
+
+-- Legacy functions for backward compatibility
+
+function loot.sellStuff()
+    loot.processItems('Sell')
+end
+
+function loot.bankStuff()
+    loot.processItems('Bank')
+end
+
+function loot.cleanupBags()
+    loot.processItems('Cleanup')
+end
+
+function loot.tributeStuff()
+    loot.processItems('Tribute')
+end
+
+-- GUI stuff
+
+function loot.SearchLootTable(search, key, value)
+    if (search == nil or search == "") or key:lower():find(search:lower()) or value:lower():find(search:lower()) then
+        return true
+    else
+        return false
+    end
+end
+
+function loot.SortTables()
+    loot.TempSettings.SortedGlobalItemKeys = {}
+    loot.TempSettings.SortedBuyItemKeys = {}
+    loot.TempSettings.SortedNormalItemKeys = {}
+    loot.TempSettings.SortedSettingsKeys = {}
+
+    for k in pairs(loot.GlobalItems) do
+        table.insert(loot.TempSettings.SortedGlobalItemKeys, k)
+    end
+    table.sort(loot.TempSettings.SortedGlobalItemKeys, function(a, b) return a < b end)
+
+    for k in pairs(loot.BuyItems) do
+        table.insert(loot.TempSettings.SortedBuyItemKeys, k)
+    end
+    table.sort(loot.TempSettings.SortedBuyItemKeys, function(a, b) return a < b end)
+
+    for k in pairs(loot.NormalItems) do
+        table.insert(loot.TempSettings.SortedNormalItemKeys, k)
+    end
+    table.sort(loot.TempSettings.SortedNormalItemKeys, function(a, b) return a < b end)
+
+    for k in pairs(loot.Settings) do
+        table.insert(loot.TempSettings.SortedSettingsKeys, k)
+    end
+    table.sort(loot.TempSettings.SortedSettingsKeys, function(a, b) return a < b end)
+end
+
+function loot.SettingsUI()
+    if not showSettings then return end
+    if ImGui.CollapsingHeader("Loot N Scoot Settings") then
+        local col = math.max(2, math.floor(ImGui.GetContentRegionAvail() / 150))
+        col = col + (col % 2)
+        if ImGui.SmallButton("Save Settings##LootnScoot") then
+            loot.writeSettings()
+        end
+
+        if ImGui.BeginTable("Settings##LootnScoot", 2, ImGuiTableFlags.ScrollY) then
+            ImGui.TableSetupScrollFreeze(2, 1)
+            ImGui.TableSetupColumn("Setting")
+            ImGui.TableSetupColumn("Value")
+            ImGui.TableHeadersRow()
+
+            for i, settingName in ipairs(if ImGui.CollapsingHeader("Loot N Scoot Settings") then
+                    local col = math.max(2, math.floor(ImGui.GetContentRegionAvail() / 150))
+                    col = col + (col % 2)
+                    if ImGui.SmallButton("Save Settings##LootnScoot") then
+                        loot.writeSettings()
+                    end
+
+                    if ImGui.BeginTable("Settings##LootnScoot", 2, ImGuiTableFlags.ScrollY) then
+                        ImGui.TableSetupScrollFreeze(2, 1)
+                        ImGui.TableSetupColumn("Setting")
+                        ImGui.TableSetupColumn("Value")
+                        ImGui.TableHeadersRow()
+
+                        for i, settingName in ipairs(loot.TempSettings.SortedSettingsKeys) do
+                            if settingsNoDraw[settingName] == nil or settingsNoDraw[settingName] == false then
+                                ImGui.TableNextColumn()
+                                ImGui.Text(settingName)
+                                ImGui.TableNextColumn()
+                                if type(loot.Settings[settingName]) == "boolean" then
+                                    loot.Settings[settingName] = loot.drawSwitch(settingName)
+                                elseif type(loot.Settings[settingName]) == "number" then
+                                    loot.Settings[settingName] = ImGui.InputInt("##" .. settingName, loot.Settings[settingName])
+                                elseif type(loot.Settings[settingName]) == "string" then
+                                    loot.Settings[settingName] = ImGui.InputText("##" .. settingName, loot.Settings[settingName])
+                                end
+                            end
+                        end
+                        ImGui.EndTable()
+                    end
+                end) do
+                if settingsNoDraw[settingName] == nil or settingsNoDraw[settingName] == false then
+                    ImGui.TableNextColumn()
+                    ImGui.Text(settingName)
+                    ImGui.TableNextColumn()
+                    if type(loot.Settings[settingName]) == "boolean" then
+                        loot.Settings[settingName] = ImGui.Checkbox("##" .. settingName, loot.Settings[settingName])
+                    elseif type(loot.Settings[settingName]) == "number" then
+                        loot.Settings[settingName] = ImGui.InputInt("##" .. settingName, loot.Settings[settingName])
+                    elseif type(loot.Settings[settingName]) == "string" then
+                        loot.Settings[settingName] = ImGui.InputText("##" .. settingName, loot.Settings[settingName])
+                    end
+                end
+            end
+            ImGui.EndTable()
+        end
+    end
+
+    if ImGui.CollapsingHeader("Items Tables") then
+        if ImGui.BeginTabBar("Items") then
+            local col = math.max(2, math.floor(ImGui.GetContentRegionAvail() / 150))
+            col = col + (col % 2)
+
+            -- Buy Items
+            if ImGui.BeginTabItem("Buy Items##LootModule") then
+                if loot.TempSettings.BuyItems == nil then
+                    loot.TempSettings.BuyItems = {}
+                end
+                ImGui.Text("Delete the Item Name to remove it from the table")
+
+                if ImGui.SmallButton("Save Changes##BuyItems") then
+                    for k, v in pairs(loot.TempSettings.UpdatedBuyItems) do
+                        if k ~= "" then
+                            loot.BuyItems[k] = v
+                            loot.setBuyItem(k, v)
+                        end
+                    end
+
+                    for k in pairs(loot.TempSettings.DeletedBuyKeys) do
+                        loot.BuyItems[k] = nil
+                        loot.setBuyItem(k, 'delete')
+                    end
+
+                    loot.TempSettings.UpdatedBuyItems = {}
+                    loot.TempSettings.DeletedBuyKeys = {}
+                end
+
+                loot.TempSettings.SearchBuyItems = ImGui.InputText("Search Items##NormalItems",
+                    loot.TempSettings.SearchBuyItems) or nil
+                ImGui.SeparatorText("Add New Item")
+                if ImGui.BeginTable("AddItem", 3, ImGuiTableFlags.Borders) then
+                    ImGui.TableSetupColumn("Item")
+                    ImGui.TableSetupColumn("Qty")
+                    ImGui.TableSetupColumn("Add")
+                    ImGui.TableHeadersRow()
+                    ImGui.TableNextColumn()
+
+                    ImGui.SetNextItemWidth(150)
+                    loot.TempSettings.NewBuyItem = ImGui.InputText("New Item##BuyItems", loot.TempSettings.NewBuyItem)
+                    if ImGui.IsItemHovered() and mq.TLO.Cursor() ~= nil then
+                        if ImGui.IsMouseClicked(0) then
+                            loot.TempSettings.NewBuyItem = mq.TLO.Cursor()
+                            mq.cmd("/autoinv")
+                        end
+                    end
+                    ImGui.TableNextColumn()
+                    ImGui.SetNextItemWidth(120)
+
+                    loot.TempSettings.NewBuyQty = ImGui.InputInt("New Qty##BuyItems", (loot.TempSettings.NewBuyQty or 1),
+                        1, 50)
+                    if loot.TempSettings.NewBuyQty > 1000 then loot.TempSettings.NewBuyQty = 1000 end
+
+                    ImGui.TableNextColumn()
+
+                    if ImGui.Button("Add Item##BuyItems") then
+                        loot.BuyItems[loot.TempSettings.NewBuyItem] = loot.TempSettings.NewBuyQty
+                        loot.setBuyItem(loot.TempSettings.NewBuyItem, loot.TempSettings.NewBuyQty)
+                        loot.TempSettings.NeedSave = true
+                        loot.TempSettings.NewBuyItem = ""
+                        loot.TempSettings.NewBuyQty = 1
+                    end
+                    ImGui.EndTable()
+                end
+                ImGui.SeparatorText("Buy Items Table")
+                if ImGui.BeginTable("Buy Items", col, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
+                    ImGui.TableSetupScrollFreeze(col, 1)
+                    for i = 1, col / 2 do
+                        ImGui.TableSetupColumn("Item")
+                        ImGui.TableSetupColumn("Qty")
+                    end
+                    ImGui.TableHeadersRow()
+
+                    local numDisplayColumns = col / 2
+
+                    if loot.BuyItems ~= nil and loot.TempSettings.SortedBuyItemKeys ~= nil then
+                        loot.TempSettings.UpdatedBuyItems = {}
+                        loot.TempSettings.DeletedBuyKeys = {}
+
+                        local numItems = #loot.TempSettings.SortedBuyItemKeys
+                        local numRows = math.ceil(numItems / numDisplayColumns)
+
+                        for row = 1, numRows do
+                            for column = 0, numDisplayColumns - 1 do
+                                local index = row + column * numRows
+                                local k = loot.TempSettings.SortedBuyItemKeys[index]
+                                if k then
+                                    local v = loot.BuyItems[k]
+                                    if v ~= "delete" then
+                                        if loot.SearchLootTable(loot.TempSettings.SearchBuyItems, k, v) then
+                                            loot.TempSettings.BuyItems[k] = loot.TempSettings.BuyItems[k] or
+                                                { Key = k, Value = v, }
+
+                                            ImGui.TableNextColumn()
+                                            local newKey = ImGui.InputText("##Key" .. k, loot.TempSettings.BuyItems[k].Key)
+
+                                            ImGui.TableNextColumn()
+                                            local newValue = ImGui.InputText("##Value" .. k,
+                                                loot.TempSettings.BuyItems[k].Value)
+
+                                            if newValue ~= v and newKey == k then
+                                                if newValue == "" then newValue = "NULL" end
+                                                loot.TempSettings.UpdatedBuyItems[newKey] = newValue
+                                            elseif newKey ~= "" and newKey ~= k then
+                                                loot.TempSettings.DeletedBuyKeys[k] = true
+                                                if newValue == "" then newValue = "NULL" end
+                                                loot.TempSettings.UpdatedBuyItems[newKey] = newValue
+                                            elseif newKey ~= k and newKey == "" then
+                                                loot.TempSettings.DeletedBuyKeys[k] = true
+                                            end
+
+                                            loot.TempSettings.BuyItems[k].Key = newKey
+                                            loot.TempSettings.BuyItems[k].Value = newValue
+                                        end
+                                    end
+                                end
+                            end
+                        end
+                    end
+
+                    ImGui.EndTable()
+                end
+                ImGui.EndTabItem()
+            end
+
+            -- Global Items
+            if ImGui.BeginTabItem("Global Items##LootModule") then
+                if loot.TempSettings.GlobalItems == nil then
+                    loot.TempSettings.GlobalItems = {}
+                end
+                ImGui.Text("Delete the Item Name to remove it from the table")
+
+                if ImGui.SmallButton("Save Changes##GlobalItems") then
+                    for k, v in pairs(loot.TempSettings.UpdatedGlobalItems) do
+                        if k ~= "" then
+                            loot.GlobalItems[k] = v
+                            loot.setGlobalItem(k, v)
+                            loot.lootActor:send({ mailbox = 'lootnscoot', },
+                                {
+                                    who = eqChar,
+                                    action = 'modifyitem',
+                                    section =
+                                    "GlobalItems",
+                                    item = k,
+                                    rule = v,
+                                })
+                        end
+                    end
+
+                    for k in pairs(loot.TempSettings.DeletedGlobalKeys) do
+                        loot.GlobalItems[k] = nil
+                        loot.setGlobalItem(k, 'delete')
+                        loot.lootActor:send({ mailbox = 'lootnscoot', },
+                            {
+                                who = eqChar,
+                                section = "GlobalItems",
+                                action = 'deleteitem',
+                                item =
+                                    k,
+                            })
+                    end
+                    loot.TempSettings.UpdatedGlobalItems = {}
+                    loot.TempSettings.DeletedGlobalKeys = {}
+                    loot.TempSettings.NeedSave = true
+                    loot.SortTables()
+                end
+
+                loot.TempSettings.SearchGlobalItems = ImGui.InputText("Search Items##NormalItems",
+                    loot.TempSettings.SearchGlobalItems) or nil
+                ImGui.SeparatorText("Add New Item##GlobalItems")
+                if ImGui.BeginTable("AddItem##GlobalItems", 3, ImGuiTableFlags.Borders) then
+                    ImGui.TableSetupColumn("Item")
+                    ImGui.TableSetupColumn("Value")
+                    ImGui.TableSetupColumn("Add")
+                    ImGui.TableHeadersRow()
+                    ImGui.TableNextColumn()
+
+                    ImGui.SetNextItemWidth(150)
+                    loot.TempSettings.NewGlobalItem = ImGui.InputText("New Item##GlobalItems",
+                        loot.TempSettings.NewGlobalItem) or nil
+                    if ImGui.IsItemHovered() and mq.TLO.Cursor() ~= nil then
+                        if ImGui.IsMouseClicked(0) then
+                            loot.TempSettings.NewGlobalItem = mq.TLO.Cursor()
+                            mq.cmdf("/autoinv")
+                        end
+                    end
+                    ImGui.TableNextColumn()
+                    ImGui.SetNextItemWidth(120)
+
+                    loot.TempSettings.NewGlobalValue = ImGui.InputTextWithHint("New Value##GlobalItems",
+                        "Quest, Keep, Sell, Tribute, Bank, Ignore, Destroy",
+                        loot.TempSettings.NewGlobalValue) or nil
+
+                    ImGui.TableNextColumn()
+
+                    if ImGui.Button("Add Item##GlobalItems") then
+                        if loot.TempSettings.NewGlobalValue ~= "" and loot.TempSettings.NewGlobalValue ~= "" then
+                            loot.GlobalItems[loot.TempSettings.NewGlobalItem] = loot.TempSettings.NewGlobalValue
+                            loot.setGlobalItem(loot.TempSettings.NewGlobalItem, loot.TempSettings.NewGlobalValue)
+                            loot.lootActor:send({ mailbox = 'lootnscoot', },
+                                {
+                                    who = eqChar,
+                                    action = 'addrule',
+                                    section = "GlobalItems",
+                                    item = loot.TempSettings.NewGlobalItem,
+                                    rule = loot.TempSettings.NewGlobalValue,
+                                })
+
+                            loot.TempSettings.NewGlobalItem = ""
+                            loot.TempSettings.NewGlobalValue = ""
+                            loot.TempSettings.NeedSave = true
+                        end
+                    end
+                    ImGui.EndTable()
+                end
+                ImGui.SeparatorText("Global Items Table")
+                if ImGui.BeginTable("GlobalItems", col, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
+                    ImGui.TableSetupScrollFreeze(col, 1)
+                    for i = 1, col / 2 do
+                        ImGui.TableSetupColumn("Item")
+                        ImGui.TableSetupColumn("Setting")
+                    end
+                    ImGui.TableHeadersRow()
+
+                    local numDisplayColumns = col / 2
+
+                    if loot.GlobalItems ~= nil and loot.TempSettings.SortedGlobalItemKeys ~= nil then
+                        loot.TempSettings.UpdatedGlobalItems = {}
+                        loot.TempSettings.DeletedGlobalKeys = {}
+
+                        local numItems = #loot.TempSettings.SortedGlobalItemKeys
+                        local numRows = math.ceil(numItems / numDisplayColumns)
+
+                        for row = 1, numRows do
+                            for column = 0, numDisplayColumns - 1 do
+                                local index = row + column * numRows
+                                local k = loot.TempSettings.SortedGlobalItemKeys[index]
+                                if k then
+                                    local v = loot.GlobalItems[k]
+                                    if loot.SearchLootTable(loot.TempSettings.SearchGlobalItems, k, v) then
+                                        loot.TempSettings.GlobalItems[k] = loot.TempSettings.GlobalItems[k] or
+                                            { Key = k, Value = v, }
+
+                                        ImGui.TableNextColumn()
+                                        ImGui.SetNextItemWidth(140)
+                                        local newKey = ImGui.InputText("##Key" .. k, loot.TempSettings.GlobalItems[k].Key)
+
+                                        ImGui.TableNextColumn()
+                                        local newValue = ImGui.InputText("##Value" .. k,
+                                            loot.TempSettings.GlobalItems[k].Value)
+
+                                        if newValue ~= v and newKey == k then
+                                            if newValue == "" then newValue = "NULL" end
+                                            loot.TempSettings.UpdatedGlobalItems[newKey] = newValue
+                                        elseif newKey ~= "" and newKey ~= k then
+                                            loot.TempSettings.DeletedGlobalKeys[k] = true
+                                            if newValue == "" then newValue = "NULL" end
+                                            loot.TempSettings.UpdatedGlobalItems[newKey] = newValue
+                                        elseif newKey ~= k and newKey == "" then
+                                            loot.TempSettings.DeletedGlobalKeys[k] = true
+                                        end
+
+                                        loot.TempSettings.GlobalItems[k].Key = newKey
+                                        loot.TempSettings.GlobalItems[k].Value = newValue
+                                    end
+                                end
+                            end
+                        end
+                    end
+
+                    ImGui.EndTable()
+                end
+
+                ImGui.EndTabItem()
+            end
+
+            -- Normal Items
+            if ImGui.BeginTabItem("Normal Items##LootModule") then
+                if loot.TempSettings.NormalItems == nil then
+                    loot.TempSettings.NormalItems = {}
+                end
+                ImGui.Text("Delete the Item Name to remove it from the table")
+
+                if ImGui.SmallButton("Save Changes##NormalItems") then
+                    for k, v in pairs(loot.TempSettings.UpdatedNormalItems) do
+                        loot.NormalItems[k] = v
+                        loot.setNormalItem(k, v)
+                        loot.lootActor:send({ mailbox = 'lootnscoot', },
+                            {
+                                who = eqChar,
+                                action = 'modifyitem',
+                                section = "NormalItems",
+                                item =
+                                    k,
+                                rule = v,
+                            })
+                    end
+                    loot.TempSettings.UpdatedNormalItems = {}
+
+                    for k in pairs(loot.TempSettings.DeletedNormalKeys) do
+                        loot.NormalItems[k] = nil
+                        loot.setNormalItem(k, 'delete')
+                        loot.lootActor:send({ mailbox = 'lootnscoot', },
+                            {
+                                who = eqChar,
+                                action = 'deleteitem',
+                                section = "NormalItems",
+                                item =
+                                    k,
+                            })
+                    end
+                    loot.TempSettings.DeletedNormalKeys = {}
+                    loot.SortTables()
+                end
+
+                loot.TempSettings.SearchItems = ImGui.InputText("Search Items##NormalItems",
+                    loot.TempSettings.SearchItems) or nil
+
+                if ImGui.BeginTable("NormalItems", col, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
+                    ImGui.TableSetupScrollFreeze(col, 1)
+                    for i = 1, col / 2 do
+                        ImGui.TableSetupColumn("Item")
+                        ImGui.TableSetupColumn("Setting")
+                    end
+                    ImGui.TableHeadersRow()
+
+                    local numDisplayColumns = col / 2
+
+                    if loot.NormalItems ~= nil and loot.TempSettings.SortedNormalItemKeys ~= nil then
+                        loot.TempSettings.UpdatedNormalItems = {}
+                        loot.TempSettings.DeletedNormalKeys = {}
+
+                        local numItems = #loot.TempSettings.SortedNormalItemKeys
+                        local numRows = math.ceil(numItems / numDisplayColumns)
+
+                        for row = 1, numRows do
+                            for column = 0, numDisplayColumns - 1 do
+                                local index = row + column * numRows
+                                local k = loot.TempSettings.SortedNormalItemKeys[index]
+                                if k then
+                                    local v = loot.NormalItems[k]
+                                    if loot.SearchLootTable(loot.TempSettings.SearchItems, k, v) then
+                                        loot.TempSettings.NormalItems[k] = loot.TempSettings.NormalItems[k] or
+                                            { Key = k, Value = v, }
+
+                                        ImGui.TableNextColumn()
+                                        ImGui.SetNextItemWidth(140)
+                                        local newKey = ImGui.InputText("##Key" .. k, loot.TempSettings.NormalItems[k]
+                                            .Key)
+
+                                        ImGui.TableNextColumn()
+                                        local newValue = ImGui.InputText("##Value" .. k,
+                                            loot.TempSettings.NormalItems[k].Value)
+
+                                        if newValue ~= v and newKey == k then
+                                            if newValue == "" then newValue = "NULL" end
+                                            loot.TempSettings.UpdatedNormalItems[newKey] = newValue
+                                        elseif newKey ~= "" and newKey ~= k then
+                                            loot.TempSettings.DeletedNormalKeys[k] = true
+                                            if newValue == "" then newValue = "NULL" end
+                                            loot.TempSettings.UpdatedNormalItems[newKey] = newValue
+                                        elseif newKey ~= k and newKey == "" then
+                                            loot.TempSettings.DeletedNormalKeys[k] = true
+                                        end
+
+                                        loot.TempSettings.NormalItems[k].Key = newKey
+                                        loot.TempSettings.NormalItems[k].Value = newValue
+                                    end
+                                end
+                            end
+                        end
+                    end
+
+                    ImGui.EndTable()
+                end
+                ImGui.EndTabItem()
+            end
+
+            ImGui.EndTabBar()
+        end
+    end
+end
+
+local function RenderUI()
+    if not showSettings then return end
+    ImGui.SetNextWindowSize(ImVec2(500, 500), ImGuiCond.FirstUseEver)
+    local open, show = ImGui.Begin("Loot N Scoot##" .. eqChar, showSettings, ImGuiWindowFlags.None)
+    if not open then
+        showSettings = false
+    end
+    if show then
+        loot.SettingsUI()
+    end
+    ImGui.End()
+end
+
+function loot.guiExport()
+    -- Define a new menu element function
+    local function customMenu()
+        if ImGui.BeginMenu('Loot N Scoot') then
+            -- Add menu items here
+            if ImGui.BeginMenu('Toggles') then
+                -- Add menu items here
+                _, loot.Settings.DoLoot = ImGui.MenuItem("DoLoot", nil, loot.Settings.DoLoot)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.GlobalLootOn = ImGui.MenuItem("GlobalLootOn", nil, loot.Settings.GlobalLootOn)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.CombatLooting = ImGui.MenuItem("CombatLooting", nil, loot.Settings.CombatLooting)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.LootNoDrop = ImGui.MenuItem("LootNoDrop", nil, loot.Settings.LootNoDrop)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.LootNoDropNew = ImGui.MenuItem("LootNoDropNew", nil, loot.Settings.LootNoDropNew)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.LootForage = ImGui.MenuItem("LootForage", nil, loot.Settings.LootForage)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.LootQuest = ImGui.MenuItem("LootQuest", nil, loot.Settings.LootQuest)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.TributeKeep = ImGui.MenuItem("TributeKeep", nil, loot.Settings.TributeKeep)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.BankTradeskills = ImGui.MenuItem("BankTradeskills", nil, loot.Settings.BankTradeskills)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.StackableOnly = ImGui.MenuItem("StackableOnly", nil, loot.Settings.StackableOnly)
+                if _ then loot.writeSettings() end
+                ImGui.Separator()
+                _, loot.Settings.AlwaysEval = ImGui.MenuItem("AlwaysEval", nil, loot.Settings.AlwaysEval)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.AddNewSales = ImGui.MenuItem("AddNewSales", nil, loot.Settings.AddNewSales)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.AddNewTributes = ImGui.MenuItem("AddNewTributes", nil, loot.Settings.AddNewTributes)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.AutoTag = ImGui.MenuItem("AutoTagSell", nil, loot.Settings.AutoTag)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.AutoRestock = ImGui.MenuItem("AutoRestock", nil, loot.Settings.AutoRestock)
+                if _ then loot.writeSettings() end
+                ImGui.Separator()
+                _, loot.Settings.DoDestroy = ImGui.MenuItem("DoDestroy", nil, loot.Settings.DoDestroy)
+                if _ then loot.writeSettings() end
+                _, loot.Settings.AlwaysDestroy = ImGui.MenuItem("AlwaysDestroy", nil, loot.Settings.AlwaysDestroy)
+                if _ then loot.writeSettings() end
+
+                ImGui.EndMenu()
+            end
+            if ImGui.BeginMenu('Group Commands') then
+                -- Add menu items here
+                if ImGui.MenuItem("Sell Stuff##group") then
+                    mq.cmd(string.format('/%s /lootutils sellstuff', tmpCmd))
+                end
+
+                if ImGui.MenuItem('Restock Items##group') then
+                    mq.cmd(string.format('/%s /lootutils restock', tmpCmd))
+                end
+
+                if ImGui.MenuItem("Tribute Stuff##group") then
+                    mq.cmd(string.format('/%s /lootutils tributestuff', tmpCmd))
+                end
+
+                if ImGui.MenuItem("Bank##group") then
+                    mq.cmd(string.format('/%s /lootutils bank', tmpCmd))
+                end
+
+                if ImGui.MenuItem("Cleanup##group") then
+                    mq.cmd(string.format('/%s /lootutils cleanup', tmpCmd))
+                end
+
+                ImGui.Separator()
+
+                if ImGui.MenuItem("Reload##group") then
+                    mq.cmd(string.format('/%s /lootutils reload', tmpCmd))
+                end
+
+                ImGui.EndMenu()
+            end
+            if ImGui.MenuItem('Sell Stuff') then
+                mq.cmd('/lootutils sellstuff')
+            end
+
+            if ImGui.MenuItem('Restock') then
+                mq.cmd('/lootutils restock')
+            end
+
+            if ImGui.MenuItem('Tribute Stuff') then
+                mq.cmd('/lootutils tributestuff')
+            end
+
+            if ImGui.MenuItem('Bank') then
+                mq.cmd('/lootutils bank')
+            end
+
+            if ImGui.MenuItem('Cleanup') then
+                mq.cmd('/lootutils cleanup')
+            end
+
+            ImGui.Separator()
+
+            if ImGui.MenuItem('Reload') then
+                mq.cmd('/lootutils reload')
+            end
+
+            ImGui.Separator()
+
+            if ImGui.MenuItem('Exit LNS') then
+                loot.Settings.Terminate = true
+            end
+
+            ImGui.EndMenu()
+        end
+    end
+    -- Add the custom menu element function to the importGUIElements table
+    if guiLoot ~= nil then table.insert(guiLoot.importGUIElements, customMenu) end
+end
+
+local function processArgs(args)
+    loot.Settings.Terminate = true
+    if #args == 1 then
+        if args[1] == 'sellstuff' then
+            loot.processItems('Sell')
+        elseif args[1] == 'tributestuff' then
+            loot.processItems('Tribute')
+        elseif args[1] == 'cleanup' then
+            loot.processItems('Cleanup')
+        elseif args[1] == 'once' then
+            loot.lootMobs()
+        elseif args[1] == 'standalone' then
+            if guiLoot ~= nil then
+                guiLoot.GetSettings(loot.Settings.HideNames, loot.Settings.LookupLinks, loot.Settings.RecordData, true, loot.Settings.UseActors, 'lootnscoot')
+                guiLoot.init(true, true, 'lootnscoot')
+            end
+            loot.Settings.Terminate = false
+        end
+    end
+end
+
+function loot.init(args)
+    local iniFile = mq.TLO.Ini.File(SettingsFile)
+    if not (iniFile.Exists() and iniFile.Section('Settings').Exists()) then
+        loot.writeSettings()
+    else
+        loot.loadSettings()
+    end
+    mq.imgui.init("LootNScoot", RenderUI)
+    loot.RegisterActors()
+    loot.CheckBags()
+    loot.setupEvents()
+    loot.setupBinds()
+    processArgs(args)
+    loot.guiExport()
+end
+
+loot.init({ ..., })
+
+while not loot.Settings.Terminate do
+    if mq.TLO.Window('CharacterListWnd').Open() then loot.Settings.Terminate = true end -- exit sctipt if at char select.
+    if loot.Settings.DoLoot then loot.lootMobs() end
+    if doSell then
+        loot.processItems('Sell')
+        doSell = false
+    end
+    if doBuy then
+        loot.processItems('Buy')
+        doBuy = false
+    end
+    if doTribute then
+        loot.processItems('Tribute')
+        doTribute = false
+    end
+    mq.doevents()
+    if loot.TempSettings.NeedSave then
+        loot.writeSettings()
+        loot.TempSettings.NeedSave = false
+        loot.SortTables()
+    end
+    mq.delay(1000)
+end
+
+return loot

--- a/lib/lootnscoot/lib/Write.lua
+++ b/lib/lootnscoot/lib/Write.lua
@@ -53,41 +53,47 @@ local function GetCallerString()
     return string.format('(%s) ', callString)
 end
 
-local function Output(paramLogLevel, message)
+local function Output(paramLogLevel, console, message)
     if Write.loglevels[Write.loglevel:lower()].level <= Write.loglevels[paramLogLevel].level then
-        print(string.format('%s%s%s[%s]%s :: %s', type(Write.prefix) == 'function' and Write.prefix() or Write.prefix, GetCallerString(), GetColorStart(paramLogLevel),
-            Write.loglevels[paramLogLevel].abbreviation, GetColorEnd(), message))
+        if console ~= nil then
+            console:AppendText(string.format('%s%s%s[%s]%s :: %s', type(Write.prefix) == 'function' and Write.prefix() or Write.prefix, GetCallerString(),
+                GetColorStart(paramLogLevel),
+                Write.loglevels[paramLogLevel].abbreviation, GetColorEnd(), message))
+        else
+            print(string.format('%s%s%s[%s]%s :: %s', type(Write.prefix) == 'function' and Write.prefix() or Write.prefix, GetCallerString(), GetColorStart(paramLogLevel),
+                Write.loglevels[paramLogLevel].abbreviation, GetColorEnd(), message))
+        end
     end
 end
 
-function Write.Debug(message, ...)
+function Write.Debug(console, message, ...)
     if (... ~= nil) then message = string.format(message, ...) end
 
-    Output('debug', message)
+    Output('debug', console, message)
 end
 
-function Write.Info(message, ...)
+function Write.Info(console, message, ...)
     if (... ~= nil) then message = string.format(message, ...) end
 
-    Output('info', message)
+    Output('info', console, message)
 end
 
-function Write.Warn(message, ...)
+function Write.Warn(console, message, ...)
     if (... ~= nil) then message = string.format(message, ...) end
 
-    Output('warn', message)
+    Output('warn', console, message)
 end
 
-function Write.Error(message, ...)
+function Write.Error(console, message, ...)
     if (... ~= nil) then message = string.format(message, ...) end
 
-    Output('error', message)
+    Output('error', console, message)
 end
 
-function Write.Fatal(message, ...)
+function Write.Fatal(console, message, ...)
     if (... ~= nil) then message = string.format(message, ...) end
 
-    Output('fatal', message)
+    Output('fatal', console, message)
     Terminate()
 end
 

--- a/lib/lootnscoot/loot_hist.lua
+++ b/lib/lootnscoot/loot_hist.lua
@@ -143,7 +143,7 @@ end
 ---@param imported boolean
 ---@param useactors boolean
 ---@param caller string
----@param report boolean
+---@param report boolean|nil
 function guiLoot.GetSettings(names, links, record, imported, useactors, caller, report)
 	local repVal = report and not guiLoot.showReport
 	guiLoot.imported = imported

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -191,11 +191,9 @@ end
 function Module:GiveTime(combat_state)
 	if not Config:GetSetting('DoLoot') then return end
 
-	if Targeting.GetXTHaterCount() == 0 then
-		-- send actors message to loot
-		Module.Actor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', },
-			{ who = Config.Globals.CurLoadedChar, directions = 'doloot', })
-	end
+	-- send actors message to loot
+	Module.Actor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', },
+		{ who = Config.Globals.CurLoadedChar, directions = 'doloot', })
 end
 
 function Module:OnDeath()


### PR DESCRIPTION
You can now Bulk set rules for entire pages of items

refined the number of items to show down to increments of 10 to help.

you can now toggle the INFO messages off.
these also now go to the lootnscoot console and not the main mq console

actors should properly communicate with standalone and mercs clients on the same machine.