### PR TITLE
ENC - Azure Mind Crystal

### DIFF
--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -882,7 +882,7 @@ local _ClassConfig = {
     },
     ['HelperFunctions'] = { --used to autoinventory our azure crystal after summon
         StashCrystal = function()
-            mq.delay("2s", function() return mq.TLO.Cursor() and mq.TLO.Cursor.ID() == mq.TLO.Spell("Azure Mind Crystal").Base(1)() end)
+            mq.delay("2s", function() return mq.TLO.Cursor() and mq.TLO.Cursor.ID() == mq.TLO.Me.AltAbility("Azure Mind Crystal").Spell.Base(1)() end)
 
             if not mq.TLO.Cursor() then
                 Logger.log_debug("No valid item found on cursor, item handling aborted.")
@@ -1197,20 +1197,6 @@ local _ClassConfig = {
                     return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90 and Casting.AAReady(aaName)
                 end,
 
-            },
-            {
-                name = "UseAzureMindCrystal",
-                type = "CustomFunc",
-                cond = function(self)
-                    if not Casting.CanUseAA("Azure Mind Crystal") then return false end
-                    local crystal = mq.TLO.FindItem("Azure Mind Crystal")
-                    if not crystal or crystal() then return false end
-                    return crystal.TimerReady() == 0 and mq.TLO.Me.PctMana() <= Config:GetSetting('ModRodManaPct')
-                end,
-                custom_func = function(self)
-                    local crystal = mq.TLO.FindItem("Azure Mind Crystal")
-                    return Casting.UseItem(crystal.Name(), mq.TLO.Me.ID())
-                end,
             },
         },
         ['DPS(Default)'] = {

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -48,7 +48,7 @@ Config.Constants.RGHybrid            = Set.new({ "SHD", "PAL", "RNG", "BST", "BR
 Config.Constants.RGTank              = Set.new({ "WAR", "PAL", "SHD", })
 Config.Constants.RGPetClass          = Set.new({ "BST", "NEC", "MAG", "SHM", "ENC", "SHD", })
 Config.Constants.RGMezAnims          = Set.new({ 1, 5, 6, 27, 43, 44, 45, 80, 82, 112, 134, 135, })
-Config.Constants.ModRods             = { "Modulation Shard", "Transvergence", "Modulation", "Modulating", }
+Config.Constants.ModRods             = { "Modulation Shard", "Transvergence", "Modulation", "Modulating", "Azure Mind Crystal", }
 Config.Constants.SpellBookSlots      = 1120
 Config.Constants.CastCompleted       = Set.new({ "CAST_SUCCESS", "CAST_IMMUNE", "CAST_TAKEHOLD", "CAST_RESISTED", "CAST_RECOVER", })
 


### PR DESCRIPTION
* [Laz] Added support for a group-wide /autoinventory after crystal summon.
* [All] For simplicity, Azure Mind Crystals are now treated as mod rods for all intents and purposes, since their use was already tied to the same settings.
* * Removed the individual entries to use the crystals from ENC configs.