### PR TITLE
Ready refactor

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -743,7 +743,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.SpellReady(spell) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Casting.GemReady(spell) and Targeting.TargetIsMA(target)
                 end,
             },
             {
@@ -751,21 +751,18 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.AAReady(aaName) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Convergence of Spirits",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Blessing of Tunare",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
@@ -778,9 +775,6 @@ local _ClassConfig = {
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ["GroupHealPoint"] = {
@@ -788,53 +782,48 @@ local _ClassConfig = {
                 name = "Blessing of Tunare",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell)
+                    return Casting.GemReady(spell)
                 end,
             },
             {
                 name = "Wildtender's Survival",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "LongGroupHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell)
+                    return Casting.GemReady(spell)
                 end,
             },
-
         },
         ["MainHealPoint"] = {
-            doFullRotation = true,
             {
                 name = "QuickHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell)
+                    return Casting.GemReady(spell)
                 end,
             },
             {
                 name = "QuickHealSurge",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell)
+                    return Casting.GemReady(spell)
                 end,
             },
             {
                 name = "LongHeal1",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell)
+                    return Casting.GemReady(spell)
                 end,
             },
         },
@@ -933,58 +922,58 @@ local _ClassConfig = {
             {
                 name = "NaturesWrathDot",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "SunDot",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self, spell)
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "HordeDot",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DetGOMCheck() or Targeting.IsNamed(mq.TLO.Target)) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DetGOMCheck() or Targeting.IsNamed(target))
                 end,
             },
             {
                 name = "DichoSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= Config:GetSetting('LightHealPoint')
+                cond = function(self, spell)
+                    if not Casting.GemReady(spell) then return false end
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= Config:GetSetting('LightHealPoint')
                 end,
             },
             {
                 name = "RemoteSunDD",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= Config:GetSetting('LightHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= Config:GetSetting('LightHealPoint')
                 end,
             },
             {
                 name = "Nature's Frost",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Nature's Fire",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Nature's Bolt",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -992,36 +981,36 @@ local _ClassConfig = {
             {
                 name = "StunDD",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                cond = function(self, spell)
+                    return Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "WinterFireDD",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Nature's Frost",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Nature's Fire",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Nature's Bolt",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1038,15 +1027,15 @@ local _ClassConfig = {
             {
                 name = "Distant Conflagration",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.Buff("Twincast").ID() == 0
+                cond = function(self)
+                    return mq.TLO.Me.Buff("Twincast").ID() == 0
                 end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not Casting.BuffActiveByName("Twincast")
+                cond = function(self)
+                    return not Casting.BuffActiveByName("Twincast")
                 end,
             },
             {
@@ -1063,57 +1052,36 @@ local _ClassConfig = {
             {
                 name = "Destructive Vortex",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Nature's Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spirit of the Wood",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Nature's Boon",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Nature's Guardian",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spirit of Nature",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spire of Nature",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "TwincastSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and mq.TLO.Me.Buff("Twincast").ID() == 0
+                    return Casting.GemReady(spell) and mq.TLO.Me.Buff("Twincast").ID() == 0
                 end,
             },
         },
@@ -1122,7 +1090,7 @@ local _ClassConfig = {
                 name = "TwinHealNuke",
                 type = "Spell",
                 retries = 0,
-                cond = function(self, spell) return Casting.SpellReady(spell) and not Casting.SongActiveByName("Healing Twincast") end,
+                cond = function(self) return not Casting.SongActiveByName("Healing Twincast") end,
             },
         },
         ['Debuff'] = {
@@ -1130,16 +1098,15 @@ local _ClassConfig = {
                 name = "Blessing of Ro",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and not Casting.TargetHasBuff(mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1)) and
-                        mq.TLO.FindItemCount(mq.TLO.Me.AltAbility("Blessing of Ro").Spell.Trigger(1).NoExpendReagentID(1)())() >
-                        0
+                    return not Casting.TargetHasBuff(mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1)) and
+                        mq.TLO.FindItemCount(mq.TLO.Me.AltAbility("Blessing of Ro").Spell.Trigger(1).NoExpendReagentID(1)())() > 0
                 end,
             },
             {
                 name = "Season's Wrath",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                cond = function(self, aaName)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1147,7 +1114,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoRoDebuff') then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1155,8 +1122,8 @@ local _ClassConfig = {
             {
                 name = "SnareSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell) and Targeting.GetTargetPctHPs(target) < 50
+                cond = function(self, spell)
+                    return Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
         },
@@ -1165,7 +1132,7 @@ local _ClassConfig = {
                 name = "Swarm of Fireflies",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return target.ID() == (mq.TLO.Group.MainTank.ID() or 0) and Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Targeting.TargetIsMA(target) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1247,7 +1214,7 @@ local _ClassConfig = {
                 type = "AA",
                 active_cond = function(self, aaName) return true end,
                 cond = function(self, aaName, target)
-                    return target.ID() == Core.GetMainAssistId() and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Targeting.TargetIsMA(target) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
         },
@@ -1324,7 +1291,6 @@ local _ClassConfig = {
                 name = "PetSpell",
                 type = "Spell",
                 active_cond = function() return mq.TLO.Me.Pet.ID() ~= 0 end,
-                cond = function() return true end,
             },
         },
     },

--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -768,9 +768,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
             {
                 name = "Forceful Rejuvenation",
@@ -999,13 +996,12 @@ local _ClassConfig = {
             },
         },
         ['HealBurn'] = {
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and
-                        item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -737,13 +737,13 @@ local _ClassConfig = {
         },
     },
     ['HealRotations']     = {
-        ["BigHealPoint"] = {
+        ['BigHealPoint'] = {
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.GemReady(spell) and Targeting.TargetIsMA(target)
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
@@ -777,7 +777,7 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ["GroupHealPoint"] = {
+        ['GroupHealPoint'] = {
             {
                 name = "Blessing of Tunare",
                 type = "AA",
@@ -788,9 +788,6 @@ local _ClassConfig = {
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell)
-                end,
             },
             {
                 name = "Wildtender's Survival",
@@ -799,32 +796,20 @@ local _ClassConfig = {
             {
                 name = "LongGroupHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell)
-                end,
             },
         },
-        ["MainHealPoint"] = {
+        ['MainHealPoint'] = {
             {
                 name = "QuickHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell)
-                end,
             },
             {
                 name = "QuickHealSurge",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell)
-                end,
             },
             {
                 name = "LongHeal1",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell)
-                end,
             },
         },
     },
@@ -944,7 +929,6 @@ local _ClassConfig = {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    if not Casting.GemReady(spell) then return false end
                     return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= Config:GetSetting('LightHealPoint')
                 end,
             },
@@ -1028,14 +1012,14 @@ local _ClassConfig = {
                 name = "Distant Conflagration",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.Buff("Twincast").ID() == 0
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
                 cond = function(self)
-                    return not Casting.BuffActiveByName("Twincast")
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
@@ -1080,8 +1064,8 @@ local _ClassConfig = {
             {
                 name = "TwincastSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and mq.TLO.Me.Buff("Twincast").ID() == 0
+                cond = function(self)
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
         },

--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -846,9 +846,9 @@ local _ClassConfig = {
             state = 1,
             steps = 2,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and not Casting.IAmFeigning() and Core.OkayToNotHeal() and
-                    Casting.DebuffConCheck() and (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    Casting.DebuffConCheck() and (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         { --Keep things from running

--- a/class_configs/Alpha (Live)/nec_class_config.lua
+++ b/class_configs/Alpha (Live)/nec_class_config.lua
@@ -793,7 +793,7 @@ local _ClassConfig = {
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
                 return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99))
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(Targeting.GetAutoTarget())) and mq.TLO.Me.PctAggro() > 99)
             end,
         },
         {
@@ -860,9 +860,9 @@ local _ClassConfig = {
             {
                 name = "Death's Effigy",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
+                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
                 end,
             },
             {

--- a/class_configs/Alpha (Live)/nec_class_config.lua
+++ b/class_configs/Alpha (Live)/nec_class_config.lua
@@ -983,9 +983,6 @@ local _ClassConfig = {
             {
                 name = "OoW_Chest",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0
-                end,
             },
             {
                 name = "Funeral Pyre",
@@ -1033,16 +1030,12 @@ local _ClassConfig = {
                 name = "Spire of Necromancy",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and Casting.TargetHasBuff(item.Spell, mq.TLO.Me)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and Casting.SpellStacksOnMe(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Alpha (Live)/nec_class_config.lua
+++ b/class_configs/Alpha (Live)/nec_class_config.lua
@@ -863,28 +863,24 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     if not Config:GetSetting('AggroFeign') then return false end
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
-                        and Casting.AAReady(aaName)
                 end,
             },
             {
                 name = "Dying Grasp",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.TargetedAAReady(aaName)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {
                 name = "Embalmer's Carapace",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Harm Shield",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100)) and Casting.AAReady(aaName)
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100))
                 end,
             },
         },
@@ -893,14 +889,14 @@ local _ClassConfig = {
                 name = "Wake the Dead",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.SpawnCount("corpse radius 100")() >= Config:GetSetting('WakeDeadCorpseCnt')
+                    return mq.TLO.SpawnCount("corpse radius 100")() >= Config:GetSetting('WakeDeadCorpseCnt')
                 end,
             },
             {
                 name = "FireDot2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -915,51 +911,49 @@ local _ClassConfig = {
                 name = "Combo",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Poison2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Magic2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "GroupLeech",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "SwarmPet",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return ((not Casting.DotSpellCheck(spell) and Casting.HaveManaToNuke()) or Casting.BurnCheck()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return ((not Casting.DotSpellCheck(spell) and Casting.HaveManaToNuke()) or Casting.BurnCheck())
                 end,
             },
             {
                 name = "PoisonNuke2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "FireNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return ((not Casting.DotSpellCheck(spell) and Casting.HaveManaToNuke()) or Casting.BurnCheck()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return ((not Casting.DotSpellCheck(spell) and Casting.HaveManaToNuke()) or Casting.BurnCheck())
                 end,
             },
             {
@@ -974,7 +968,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     ---@diagnostic disable-next-line: undefined-field
-                    return mq.TLO.Me.TotalCounters() > 0 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.TotalCounters() > 0
                 end,
             },
         },
@@ -982,8 +976,8 @@ local _ClassConfig = {
             {
                 name = "Scent of Thule",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IsNamed(mq.TLO.Target) and Casting.TargetedAAReady(aaName)
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             {
@@ -996,59 +990,48 @@ local _ClassConfig = {
             {
                 name = "Funeral Pyre",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Hand of Death",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Mercurial Torment",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Heretic's Twincast",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Gathering Dusk",
                 type = "AA",
-                cond = function(self, aaName) return Targeting.IsNamed(mq.TLO.Target) and Casting.AAReady(aaName) end,
+                cond = function(self, aaName, target) return Targeting.IsNamed(target) end,
             },
             {
                 name = "Swarm of Decay",
                 type = "AA",
-                cond = function(self, aaName) return Casting.TargetedAAReady(aaName) end,
             },
             {
                 name = "Companion's Fury",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Rise of Bones",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName) return Targeting.IsNamed(mq.TLO.Target) and Casting.AAReady(aaName) end,
+                cond = function(self, aaName, target) return Targeting.IsNamed(target) end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Spire of Necromancy",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -1071,15 +1054,15 @@ local _ClassConfig = {
             {
                 name = "Silent Casting",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 60
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 60
                 end,
             },
             {
                 name = "Dying Grasp",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.TargetedAAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() <= 50
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() <= 50
                 end,
             },
         },
@@ -1106,7 +1089,7 @@ local _ClassConfig = {
                 name = "Death Bloom",
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.SongActiveByName(mq.TLO.AltAbility(aaName).Spell()) end,
-                cond = function(self, aaName) return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('DeathBloomPercent') end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() < Config:GetSetting('DeathBloomPercent') end,
             },
             {
                 name = "BestowBuff",
@@ -1170,7 +1153,7 @@ local _ClassConfig = {
                 name = "Companion's Aegis",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Alpha (Live)/pal_class_config.lua
+++ b/class_configs/Alpha (Live)/pal_class_config.lua
@@ -834,15 +834,6 @@ local _ClassConfig = {
                     return Casting.GemReady(spell) and mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt')
                 end,
             },
-            -- {
-            --     name = "WaveHeal2",
-            --     type = "Spell",
-            --     cond = function(self, spell)
-            --         if not mq.TLO.Group() then return false end
-            --         return Casting.SpellLoaded(spell) and Casting.SpellReady(spell) and
-            --             mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt')
-            --     end,
-            -- },
             {
                 name = "Aurora",
                 type = "Spell",
@@ -1307,9 +1298,6 @@ local _ClassConfig = {
             -- {
             -- name = "Inquisitor's Judgment",
             -- type = "AA",
-            -- cond = function(self, aaName)
-            -- return Casting.AAReady(aaName)
-            -- end,
             -- },
         },
         ['Defenses'] = {
@@ -1468,58 +1456,6 @@ local _ClassConfig = {
                 name = "Force of Disruption",
                 type = "AA",
             },
-            --below stuff thrown in, not vetted
-            -- {
-            -- name = "Healtaunt",
-            -- type = "Spell",
-            -- cond = function(self, spell)
-            -- return Casting.TargetedSpellReady(spell, target.ID())
-            -- end,
-            -- },
-            -- {
-            --     name = "Force of Disruption",
-            --     type = "AA",
-            --     cond = function(self, aaName)
-            --         return (mq.TLO.Me.AltAbility(aaName).Rank() or 0) > 7 and not Casting.BuffActiveByName("Knight's Yaulp") and
-            --             Targeting.GetTargetDistance() < 30 and Casting.AAReady(aaName)
-            --     end,
-            -- },
-            -- {
-            -- name = "StunTimer5",
-            -- type = "Spell",
-            -- cond = function(self, spell)
-            -- return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
-            -- end,
-            -- },
-            -- {
-            --     name = "LessonStun",
-            --     type = "Spell",
-            --     cond = function(self, spell)
-            --         return Casting.SpellReady(spell) and Casting.DetSpellCheck(spell)
-            --     end,
-            -- },
-            -- {
-            -- name = "DebuffNuke",
-            -- type = "Spell",
-            -- cond = function(self, spell)
-            -- return Casting.TargetedSpellReady(spell, target.ID()) and
-            -- ((Targeting.TargetBodyIs(mq.TLO.Target, "Undead") or mq.TLO.Me.Level() >= 96) and not Casting.TargetHasBuff(spell) and Config:GetSetting('DoNuke'))
-            -- end,
-            -- },
-            -- {
-            -- name = "AntiUndeadNuke",
-            -- type = "Spell",
-            -- cond = function(self, spell)
-            -- return Casting.TargetedSpellReady(spell, target.ID()) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
-            -- end,
-            -- },
-            -- {
-            -- name = "Reverseds",
-            -- type = "Spell",
-            -- cond = function(self, spell)
-            -- return Casting.TargetedSpellReady(spell, target.ID()) and Casting.TargetHasBuff(spell) and Config:GetSetting('DoReverseDS')
-            -- end,
-            -- },
         },
         ['Weapon Management'] = {
             {

--- a/class_configs/Alpha (Live)/pal_class_config.lua
+++ b/class_configs/Alpha (Live)/pal_class_config.lua
@@ -13,7 +13,7 @@ local _ClassConfig = {
     ['ModeChecks']        = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
         IsHealing = function() return true end,
-        IsCuring = function() return Config:GetSetting('DoCures') end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.AAReady("Radiant Cure") end,
         IsRezing = function() return (Config:GetSetting('DoBattleRez') and not Core.IsTanking()) or Targeting.GetXTHaterCount() == 0 end,
         --Disabling tank battle rez is not optional to prevent settings in different areas and to avoid causing more potential deaths
     },

--- a/class_configs/Alpha (Live)/pal_class_config.lua
+++ b/class_configs/Alpha (Live)/pal_class_config.lua
@@ -1064,16 +1064,12 @@ local _ClassConfig = {
                     return Casting.SpellStacksOnMe(spell.RankName) and Core.IsModeActive("Tank") and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
                 end,
             },
-            {
-                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "None" end,
+            { --Charm Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "CharmClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return item() and Casting.TargetHasBuff(item.Spell, mq.TLO.Me)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return Config:GetSetting('DoCharmClick') and item() and Casting.SelfBuffCheck(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoCharmClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1081,8 +1077,8 @@ local _ClassConfig = {
                 type = "Item",
                 active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
                 cond = function(self)
-                    return Config:GetSetting('SummonArrows') and mq.TLO.Me.Level() > 89 and mq.TLO.FindItemCount("Ethereal Arrow")() < 101 and
-                        mq.TLO.Me.ItemReady("Huntsman's Ethereal Quiver")()
+                    if not Config:GetSetting('SummonArrows') then return false end
+                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
                 end,
             },
         },
@@ -1184,13 +1180,12 @@ local _ClassConfig = {
                     return not mq.TLO.Me.Song("Armor of the Inquisitor")() --searches for single and group version
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1336,10 +1331,9 @@ local _ClassConfig = {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Alpha (Live)/wiz_class_config.lua
+++ b/class_configs/Alpha (Live)/wiz_class_config.lua
@@ -773,7 +773,7 @@ return {
                 name = "Improved Twincast",
                 type = "AA",
                 cond = function(self)
-                    return not Casting.BuffActiveByName("Twincast")
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
@@ -867,7 +867,7 @@ return {
                 name = "TwincastSpell",
                 type = "Spell",
                 cond = function(self)
-                    return not mq.TLO.Me.Buff("Improved Twincast")()
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
@@ -946,7 +946,7 @@ return {
                 name = "FireClaw",
                 type = "Spell",
                 cond = function(self)
-                    return not Casting.BuffActiveByID(mq.TLO.Me.AltAbility("Improved Twincast").Spell.ID())
+                    return not mq.TLO.Me.Buff("Improved Twincast")()
                 end,
             },
             {

--- a/class_configs/Alpha (Live)/wiz_class_config.lua
+++ b/class_configs/Alpha (Live)/wiz_class_config.lua
@@ -620,7 +620,7 @@ return {
         RainCheck = function(target) -- I made a funny
             if not (Config:GetSetting('DoRain') and Config:GetSetting('DoAEDamage')) then return false end
             return Targeting.GetTargetDistance() >= Config:GetSetting('RainDistance') and
-                (Targeting.GetTargetPctHPs(target) >= Config:GetSetting('HPStopBigNuke') or Targeting.IsNamed(target))
+                (Targeting.GetAutoTargetPctHPs() >= Config:GetSetting('HPStopBigNuke') or Targeting.IsNamed(target))
         end,
     },
     ['RotationOrder']   = {
@@ -756,74 +756,55 @@ return {
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Arcane Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Fury of the Gods",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spire of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not Casting.BuffActiveByName("Twincast")
+                cond = function(self)
+                    return not Casting.BuffActiveByName("Twincast")
                 end,
             },
             {
                 name = "Arcane Destruction",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not mq.TLO.Me.Buff("Spire of Arcanum")
+                cond = function(self)
+                    return not mq.TLO.Me.Buff("Spire of Arcanum")
                 end,
             },
             {
                 name = "Frenzied Devastation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not mq.TLO.Me.Buff("Spire of Arcanum")
+                cond = function(self)
+                    return not mq.TLO.Me.Buff("Spire of Arcanum")
                 end,
             },
             {
                 name = "Silent Casting",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Mana Burn",
                 type = "AA",
-                cond = function(self, aaName, target)
+                cond = function(self)
                     if not Config:GetSetting('DoManaBurn') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and not Casting.TargetHasBuffByName("Mana Burn") and
-                        Casting.HaveManaToNuke()
+                    return not Casting.TargetHasBuffByName("Mana Burn") and Casting.HaveManaToNuke()
                 end,
             },
             {
                 name = "Call of Xuzl",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ['Aggro Management'] =
@@ -832,35 +813,35 @@ return {
                 name = "Mind Crash",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 90
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 90
                 end,
             },
             {
                 name = "Arcane Whisper",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 90
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 90
                 end,
             },
             {
                 name = "A Hole in Space",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.IHaveAggro(100)
+                cond = function(self)
+                    return Targeting.IHaveAggro(100)
                 end,
             },
             {
                 name = "Concussion",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro')
+                cond = function(self)
+                    return mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro')
                 end,
             },
             {
                 name = "JoltSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro')
+                cond = function(self)
+                    return mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro')
                 end,
             },
         },
@@ -869,14 +850,14 @@ return {
                 name = "Atol's Shackles",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Targeting.GetTargetPctHPs(target) < 50
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
             {
                 name = "SnareSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell) and Targeting.GetTargetPctHPs(target) < 50
+                    return Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
         },
@@ -885,31 +866,31 @@ return {
             {
                 name = "TwincastSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell) and not mq.TLO.Me.Buff("Improved Twincast")()
+                cond = function(self)
+                    return not mq.TLO.Me.Buff("Improved Twincast")()
                 end,
             },
             {
                 name = "GambitSpell",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('GambitManaPct')
+                cond = function(self)
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('GambitManaPct')
                 end,
             },
             {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 allowDead = true,
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct')
+                cond = function(self)
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct')
                 end,
             },
             {
                 name = "HarvestSpell",
                 type = "Spell",
                 allowDead = true,
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct')
+                cond = function(self)
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct')
                 end,
             },
         },
@@ -917,150 +898,120 @@ return {
             {
                 name = "Lower Element",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
+                cond = function(self, aaName)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Force of Ice",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Force of Will",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Force of Flame",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
         },
         ['DPS(HighLevel)'] = {
             {
                 name = "VortexNuke",
                 type = "Spell",
-                cond = function(self, spell, target) --using DotSpellCheck to leverage HPStopDot settings to ensure we aren't casting just before trash dies (default: stop at 25% on named, 50% on trash)
-                    return (Casting.DetGambitCheck() or Casting.DotSpellCheck(spell)) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self, spell) --using DotSpellCheck to leverage HPStopDot settings to ensure we aren't casting just before trash dies (default: stop at 25% on named, 50% on trash)
+                    return (Casting.DetGambitCheck() or Casting.DotSpellCheck(spell))
                 end,
             },
             {
                 name = "CloudburstNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.DetGambitCheck() or mq.TLO.Me.Song("Evoker's Synergy")()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.DetGambitCheck() or mq.TLO.Me.Song("Evoker's Synergy")())
                 end,
             },
             {
                 name = "FuseNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID())
-                end,
             },
             {
                 name = "AEBeam",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not (Config:GetSetting('DoAEBeam') and Config:GetSetting('DoAEDamage')) then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('BeamTargetCnt'), true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('BeamTargetCnt'), true)
                 end,
             },
             {
                 name = "FireClaw",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return not Casting.BuffActiveByID(mq.TLO.Me.AltAbility("Improved Twincast").Spell.ID()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return not Casting.BuffActiveByID(mq.TLO.Me.AltAbility("Improved Twincast").Spell.ID())
                 end,
             },
             {
                 name = "PBFlame",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not (Config:GetSetting('DoPBAE') and Config:GetSetting('DoAEDamage')) then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('PBAETargetCnt'), true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('PBAETargetCnt'), true)
                 end,
             },
             {
                 name = "FireEtherealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID())
-                end,
             },
             {
                 name = "WildNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.DetGambitCheck() and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return Casting.DetGambitCheck()
                 end,
             },
             {
                 name = "IceEtherealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID())
-                end,
             },
         },
         ['DPS(MidLevel)'] = {
             {
                 name = "SnapNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID())
-                end,
             },
             {
                 name = "FireEtherealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (Casting.DetGOMCheck() or (Casting.BurnCheck() and Casting.HaveManaToNuke))
+                cond = function(self)
+                    return (Casting.DetGOMCheck() or (Casting.BurnCheck() and Casting.HaveManaToNuke))
                 end,
             },
             {
                 name = "IceEtherealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (Casting.DetGOMCheck() or (Casting.BurnCheck() and Casting.HaveManaToNuke))
+                cond = function(self)
+                    return (Casting.DetGOMCheck() or (Casting.BurnCheck() and Casting.HaveManaToNuke))
                 end,
             },
             {
                 name = "WildNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID())
-                end,
             },
             {
                 name = "WildNuke2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID())
-                end,
             },
             {
                 name = "ChaosNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID())
-                end,
             },
         },
         ['DPS(FireLowLevel)'] = {
             {
                 name = "StunSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoStun') then return false end
-                    return (Casting.HaveManaToDebuff() or Casting.BurnCheck()) and Casting.DetSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToDebuff() or Casting.BurnCheck()) and Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1068,22 +1019,22 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not self.ClassConfig.HelperFunctions.RainCheck(target) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "BigFireNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if (Targeting.GetTargetPctHPs(target) < Config:GetSetting('HPStopBigNuke') and not Targeting.IsNamed(target)) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    if (Targeting.GetAutoTargetPctHPs() < Config:GetSetting('HPStopBigNuke') and not Targeting.IsNamed(target)) then return false end
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "FireNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1091,9 +1042,9 @@ return {
             {
                 name = "StunSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoStun') then return false end
-                    return (Casting.HaveManaToDebuff() or Casting.BurnCheck()) and Casting.DetSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToDebuff() or Casting.BurnCheck()) and Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1101,22 +1052,22 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not self.ClassConfig.HelperFunctions.RainCheck(target) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "BigIceNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if (Targeting.GetTargetPctHPs(target) < Config:GetSetting('BigNukeMinHealth') and not Targeting.IsNamed(target)) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    if (Targeting.GetAutoTargetPctHPs() < Config:GetSetting('BigNukeMinHealth') and not Targeting.IsNamed(target)) then return false end
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "IceNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1124,24 +1075,24 @@ return {
             {
                 name = "StunSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoStun') then return false end
-                    return (Casting.HaveManaToDebuff() or Casting.BurnCheck()) and Casting.DetSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToDebuff() or Casting.BurnCheck()) and Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "BigMagicNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if (Targeting.GetTargetPctHPs(target) < Config:GetSetting('BigNukeMinHealth') and not Targeting.IsNamed(target)) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    if (Targeting.GetAutoTargetPctHPs() < Config:GetSetting('BigNukeMinHealth') and not Targeting.IsNamed(target)) then return false end
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "MagicNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1149,29 +1100,29 @@ return {
             {
                 name = "PBTimer4",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return Casting.HaveManaToNuke()
                 end,
             },
             {
                 name = "FireJyll",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return Casting.HaveManaToNuke()
                 end,
             },
             {
                 name = "IceJyll",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return Casting.HaveManaToNuke()
                 end,
             },
             {
                 name = "MagicJyll",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return Casting.HaveManaToNuke()
                 end,
             },
         },
@@ -1229,15 +1180,15 @@ return {
             {
                 name = "Harvest of Druzzil",
                 type = "AA",
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.AAReady(aaName)
+                cond = function(self)
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {
                 name = "HarvestSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {

--- a/class_configs/Alpha (Live)/wiz_class_config.lua
+++ b/class_configs/Alpha (Live)/wiz_class_config.lua
@@ -1191,17 +1191,12 @@ return {
                     return Casting.GemReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Casting.BuffActive(item.Spell)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    if not Config:GetSetting('DoChestClick') or not item or not item() then return false end
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },

--- a/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
+++ b/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
@@ -768,9 +768,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
             {
                 name = "Forceful Rejuvenation",
@@ -914,13 +911,12 @@ local _ClassConfig = {
             },
         },
         ['HealBurn'] = {
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and
-                        item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
+++ b/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
@@ -737,7 +737,7 @@ local _ClassConfig = {
         },
     },
     ['HealRotations']     = {
-        ["BigHealPoint"] = {
+        ['BigHealPoint'] = {
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
@@ -777,7 +777,7 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ["GroupHealPoint"] = {
+        ['GroupHealPoint'] = {
             {
                 name = "Blessing of Tunare",
                 type = "AA",
@@ -798,7 +798,7 @@ local _ClassConfig = {
                 type = "Spell",
             },
         },
-        ["MainHealPoint"] = {
+        ['MainHealPoint'] = {
             {
                 name = "QuickHeal",
                 type = "Spell",
@@ -927,14 +927,14 @@ local _ClassConfig = {
                 name = "Distant Conflagration",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.Buff("Twincast").ID() == 0
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
                 cond = function(self)
-                    return not Casting.BuffActiveByName("Twincast")
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
@@ -980,7 +980,7 @@ local _ClassConfig = {
                 name = "TwincastSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return mq.TLO.Me.Buff("Twincast").ID() == 0
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
         },

--- a/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
+++ b/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
@@ -846,9 +846,9 @@ local _ClassConfig = {
             state = 1,
             steps = 2,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and not Casting.IAmFeigning() and Core.OkayToNotHeal() and
-                    Casting.DebuffConCheck() and (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    Casting.DebuffConCheck() and (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         { --Keep things from running

--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -422,7 +422,7 @@ return {
                 name = "Communion of Blood",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctEndurance() <= 75
+                    return mq.TLO.Me.PctEndurance() <= 75
                 end,
             },
             {
@@ -465,7 +465,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -473,7 +473,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -481,7 +481,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -489,7 +489,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -497,7 +497,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -505,7 +505,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -513,7 +513,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -521,7 +521,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -529,7 +529,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -552,7 +552,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -560,7 +560,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -590,7 +590,7 @@ return {
                 name = "War Cry of the Braxi",
                 type = "Disc",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Casting.SpellStacksOnMe(mq.TLO.Spell(aaName))
+                    return Casting.SpellStacksOnMe(mq.TLO.Spell(aaName))
                 end,
             },
             {
@@ -677,9 +677,6 @@ return {
             {
                 name = "Binding Axe",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intimidation",
@@ -748,7 +745,7 @@ return {
                 name = "Communion of Blood",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctEndurance() <= 75
+                    return mq.TLO.Me.PctEndurance() <= 75
                 end,
             },
             {
@@ -785,7 +782,7 @@ return {
                 name = "Drawn to Blood",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetTargetDistance() > 15
+                    return Targeting.GetTargetDistance() > 15
                 end,
             },
         },

--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -535,7 +535,7 @@ return {
                 name = "Coat",
                 type = "Item",
                 cond = function(self, itemName)
-                    return not mq.TLO.Me.PetBuff("Primal Fusion")() and mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return not mq.TLO.Me.PetBuff("Primal Fusion")()
                 end,
             },
             {
@@ -604,10 +604,9 @@ return {
             {
                 name = "Epic",
                 type = "Item",
-                cond = function(self, itemName)
-                    local epicItem = mq.TLO.FindItem(itemName)
-                    return Config:GetSetting('DoEpic') and epicItem() and epicItem.Spell.Stacks() and
-                        epicItem.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoEpic') then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -429,8 +429,7 @@ return {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() <= 21 and
-                        not mq.TLO.Me.Invis()
+                    return mq.TLO.Me.PctEndurance() <= 21
                 end,
             },
             {
@@ -544,7 +543,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc() and not Casting.DiscReady(burndisc)
+                    return not mq.TLO.Me.ActiveDisc() and not Casting.DiscReady(burndisc)
                 end,
             },
             {
@@ -570,7 +569,7 @@ return {
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
                     local cleavingdisc = self:GetResolvedActionMapItem('CleavingDisc')
                     local discondisc = self:GetResolvedActionMapItem('DisconDisc')
-                    return Casting.DiscReady(discSpell) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
                         and not (Casting.DiscReady(burndisc) or Casting.DiscReady(cleavingdisc))
                 end,
             },
@@ -582,7 +581,7 @@ return {
                     local cleavingdisc = self:GetResolvedActionMapItem('CleavingDisc')
                     local discondisc = self:GetResolvedActionMapItem('DisconDisc')
                     local resolvedisc = self:GetResolvedActionMapItem('ResolveDisc')
-                    return Casting.DiscReady(discSpell) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
                         and not (Casting.DiscReady(burndisc) or Casting.DiscReady(cleavingdisc) or Casting.DiscReady(resolvedisc))
                 end,
             },
@@ -614,65 +613,44 @@ return {
             {
                 name = "Frenzy",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)()
-                end,
             },
             {
                 name = "Dfrenzy",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Dvolley",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Daxeof",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Daxethrow",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "SharedBuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not Casting.SongActiveByName(discSpell.RankName())
+                    return not Casting.SongActiveByName(discSpell.RankName())
                 end,
             },
             {
                 name = "RageStrike",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Phantom",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Config:GetSetting('DoPet')
+                    return Config:GetSetting('DoPet')
                 end,
             },
             {
                 name = "SappingStrike",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Binding Axe",
@@ -682,14 +660,14 @@ return {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return Config:GetSetting('DoIntimidate') and mq.TLO.Me.AbilityReady(abilityName)()
+                    return Config:GetSetting('DoIntimidate')
                 end,
             },
             {
                 name = "AESlice",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Config:GetSetting('DoAoe') and Casting.DiscReady(discSpell)
+                    return Config:GetSetting('DoAoe')
                 end,
             },
             {
@@ -717,7 +695,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoDisconDisc') then return false end
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc()
+                    return not mq.TLO.Me.ActiveDisc()
                 end,
             },
             {
@@ -754,16 +732,12 @@ return {
                     if not self.ModuleLoaded then return "" end
                     return mq.TLO.Spell("Reflexive Retaliation").RankName()
                 end,
-                type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return Config:GetSetting('DoIntimidate') and mq.TLO.Me.AbilityReady(abilityName)()
+                    return Config:GetSetting('DoIntimidate')
                 end,
             },
         },
@@ -790,16 +764,10 @@ return {
             {
                 name = "Dicho",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Bfrenzy",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
         },
     },

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -921,58 +921,34 @@ local _ClassConfig = {
             {
                 name = "Quick Time",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Funeral Dirge",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) -- and Config:GetSetting('UseFuneralDirge') --see note in config settings
-                end,
             },
             {
                 name = "Spire of the Minstrels",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Bladed Song",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Song of Stone",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Thousand Blades",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Flurry of Notes",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Dance of Blades",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -989,23 +965,16 @@ local _ClassConfig = {
             {
                 name = "Cacophony",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Frenzied Kicks",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -1059,8 +1028,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if Config:GetSetting('UseFierceEye') == 1 then return false end
-                    return (Config:GetSetting('UseFierceEye') == 3 or (Config:GetSetting('UseFierceEye') == 2 and Casting.BurnCheck())) and
-                        Casting.AAReady(aaName)
+                    return (Config:GetSetting('UseFierceEye') == 3 or (Config:GetSetting('UseFierceEye') == 2 and Casting.BurnCheck()))
                 end,
             },
             {
@@ -1078,7 +1046,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ReflexStrike,
                 cond = function(self, discSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return Casting.TargetedDiscReady(discSpell) and (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
+                    return (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
                 end,
             },
             {
@@ -1087,15 +1055,14 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if Config:GetSetting('UseBellow') == 1 then return false end
                     return ((Config:GetSetting('UseBellow') == 3 and mq.TLO.Me.PctEndurance() > Config:GetSetting('SelfEndPct')) or (Config:GetSetting('UseBellow') == 2 and Casting.BurnCheck())) and
-                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
+                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)()
+                    return (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) > 1
                 end,
             },
         },
@@ -1114,7 +1081,7 @@ local _ClassConfig = {
                 type = "Song",
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseInsult') then return false end
-                    return (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0 and (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
                 end,
             },
             {
@@ -1162,7 +1129,7 @@ local _ClassConfig = {
                 type = "Song",
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseInsult') then return false end
-                    return (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0 and (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
                 end,
             },
             {
@@ -1234,7 +1201,7 @@ local _ClassConfig = {
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseCrescendo') then return false end
                     local pct = Config:GetSetting('GroupManaPct')
-                    return (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0 and (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
+                    return (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
                 end,
             },
             {
@@ -1365,14 +1332,14 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     if Config:GetSetting('UseRunBuff') ~= 1 then return false end
                     --refreshes slightly before expiry for better uptime
-                    return Casting.AAReady(aaName) and (mq.TLO.Me.Buff(mq.TLO.AltAbility(aaName).Spell.Trigger(1)).Duration.TotalSeconds() or 0) < 30
+                    return (mq.TLO.Me.Buff(mq.TLO.AltAbility(aaName).Spell.Trigger(1)).Duration.TotalSeconds() or 0) < 30
                 end,
             },
             {
                 name = "Rallying Solo", --Rallying Call theoretically possible but problematic, needs own rotation akin to Focused Paragon, etc
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and (mq.TLO.Me.PctEndurance() < 30 or mq.TLO.Me.PctMana() < 30)
+                    return (mq.TLO.Me.PctEndurance() < 30 or mq.TLO.Me.PctMana() < 30)
                 end,
             },
             {
@@ -1421,7 +1388,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoVetAA') then return false end
-                    return mq.TLO.Me.PctHPs() < 35 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
@@ -1429,7 +1396,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('UseFading') then return false end
-                    return Casting.AAReady(aaName) and self.ClassConfig.HelperFunctions.UnwantedAggroCheck(self)
+                    return self.ClassConfig.HelperFunctions.UnwantedAggroCheck(self)
                     --I wanted to use XTAggroCount here but it doesn't include your current target in the number it returns and I don't see a good workaround. For Loop it is.
                 end,
             },
@@ -1437,14 +1404,14 @@ local _ClassConfig = {
                 name = "Hymn of the Last Stand",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {
                 name = "Shield of Notes",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -950,16 +950,12 @@ local _ClassConfig = {
                 name = "Dance of Blades",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and mq.TLO.Me.Song(item.Spell.RankName.Name())() ~= nil
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1000,6 +996,14 @@ local _ClassConfig = {
                     return Config:GetSetting('DoDispel') and mq.TLO.Target.Beneficial()
                 end,
             },
+            {
+                name = "Dreadstone",
+                type = "Item",
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('UseDreadstone') then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
+                end,
+            },
         },
         ['Combat'] = {
             -- Kludge that addresses bards not attempting to start attacking until after a song completes
@@ -1019,8 +1023,7 @@ local _ClassConfig = {
                 type = "Item",
                 cond = function(self, itemName)
                     if Config:GetSetting('UseEpic') == 1 then return false end
-                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck())) and mq.TLO.FindItem(itemName)() and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck()))
                 end,
             },
             {
@@ -1029,15 +1032,6 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     if Config:GetSetting('UseFierceEye') == 1 then return false end
                     return (Config:GetSetting('UseFierceEye') == 3 or (Config:GetSetting('UseFierceEye') == 2 and Casting.BurnCheck()))
-                end,
-            },
-            {
-                name = "Dreadstone",
-                type = "Item",
-                cond = function(self, itemName)
-                    -- This item is instant cast for free with almost no CD, just mash it forever when it's available
-                    if not Config:GetSetting('UseDreadstone') then return false end
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0
                 end,
             },
             {
@@ -1367,10 +1361,9 @@ local _ClassConfig = {
             {
                 name = "SymphonyOfBattle",
                 type = "Item",
-                targetId = function(self) return { mq.TLO.Me.ID(), } end,
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('UseSoBItems') then return false end
-                    return Casting.SelfBuffCheck("Symphony of Battle") and mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1417,10 +1410,9 @@ local _ClassConfig = {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -834,7 +834,7 @@ local _ClassConfig = {
         end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending
             if not songSpell or not songSpell() then return false end
-            local named = Targeting.IsNamed(mq.TLO.Target)
+            local named = Targeting.IsNamed(Targeting.GetAutoTarget())
             local targethp = Targeting.GetTargetPctHPs()
 
             return Casting.SpellStacksOnTarget(songSpell) and ((named and (Config:GetSetting('NamedStopDOT') < targethp)) or

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -715,7 +715,7 @@ return {
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
                 return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99))
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(Targeting.GetAutoTarget()) and mq.TLO.Me.PctAggro() > 99))
             end,
         },
         {
@@ -1008,8 +1008,7 @@ return {
                     --This checks to see if the Growl portion is up on the pet (or about to expire) before using this, those who prefer the swarm pets can use the actual swarm pet spell in conjunction with this for mana savings.
                     --There are some instances where the Growl isn't needed, but that is a giant TODO and of minor benefit.
                     ---@diagnostic disable-next-line: undefined-field
-                    return (mq.TLO.Pet.BuffDuration(spell.RankName.Trigger(2)).TotalSeconds() or 0) < 10 and Casting.TargetedSpellReady(spell, target.ID())
-                        and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
+                    return (mq.TLO.Pet.BuffDuration(spell.RankName.Trigger(2)).TotalSeconds() or 0) < 10
                 end,
             },
             {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -837,16 +837,12 @@ return {
                 name = "Companion's Fury",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and Casting.TargetHasBuff(item.Spell, mq.TLO.Me)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and Casting.SpellStacksOnMe(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -901,7 +897,7 @@ return {
                 name = "OoW_Chest",
                 type = "Item",
                 cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
@@ -964,10 +960,9 @@ return {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },
@@ -1287,9 +1282,8 @@ return {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName)
-                    return Config:GetSetting('DoEpic') and
-                        mq.TLO.FindItem(itemName)() and mq.TLO.Me.ItemReady(itemName)() and
-                        (mq.TLO.Me.PetBuff("Savage Wildcaller's Blessing")() == nil and mq.TLO.Me.PetBuff("Might of the Wild Spirits")() == nil)
+                    if not Config:GetSetting('DoEpic') then return false end
+                    return not mq.TLO.Me.PetBuff("Savage Wildcaller's Blessing")() and not mq.TLO.Me.PetBuff("Might of the Wild Spirits")()
                 end,
             },
             {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -654,29 +654,22 @@ return {
         },
     },
     ['HealRotations']     = {
-        ["PetHealAA"] = {
+        ['PetHealAA'] = {
             {
                 name = "Mend Companion",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
         },
-        ["PetHealSpell"] = {
+        ['PetHealSpell'] = {
             {
                 name = "PetHealSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
         },
-        ["MainHealPoint"] = {
+        ['MainHealPoint'] = {
             {
                 name = "HealSpell",
                 type = "Spell",
-                cond = function(self, spell, target) return Casting.TargetedSpellReady(spell, target.ID(), true) end,
             },
         },
     },
@@ -817,50 +810,32 @@ return {
                 name = "Group Bestial Alignment",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
                 name = "Attack of the Warder",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Frenzy of Spirit",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Bloodlust",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "VinDisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Spire of the Savage Lord",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Companion's Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -877,9 +852,6 @@ return {
             {
                 name = "Frenzied Swipes",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "BloodDot",
@@ -887,43 +859,42 @@ return {
                 cond = function(self, spell, target)
                     local vinDisc = self.ResolvedActionMap['VinDisc']
                     if not vinDisc then return false end
-                    return Casting.BuffActive(vinDisc) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.BuffActive(vinDisc)
                 end,
             },
             {
                 name = "FuryDisc",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return Casting.DiscReady(discSpell) and not self.ClassConfig.HelperFunctions.FlurryActive(self)
+                    return not self.ClassConfig.HelperFunctions.FlurryActive(self)
                 end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.FlurryActive(self) and
-                        (mq.TLO.Me.GemTimer(self.ResolvedActionMap['DichoSpell'])() or -1) > 15
+                    return not self.ClassConfig.HelperFunctions.FlurryActive(self) and (mq.TLO.Me.GemTimer(self.ResolvedActionMap['DichoSpell'])() or -1) > 15
                 end,
             },
             {
                 name = "DmgModDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
                 name = "Ferociousness",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
                 name = "Bestial Alignment",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
@@ -937,8 +908,7 @@ return {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -948,8 +918,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
-                        Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct())
                 end,
             },
             {
@@ -957,8 +926,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Sha's Reprisal") then return false end
-                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct())
                 end,
             },
         },
@@ -966,10 +934,9 @@ return {
             {
                 name = "Falsified Death",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
-                        and Casting.AAReady(aaName) and not Core.IAmMA
+                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99) and not Core.IAmMA
                 end,
             },
             {
@@ -977,21 +944,21 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoVetAA') then return false end
-                    return mq.TLO.Me.PctHPs() < 35 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
                 name = "Warder's Gift",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.Pet.PctHPs() and mq.TLO.Me.Pet.PctHPs() > 50) and Casting.AAReady(aaName)
+                    return (mq.TLO.Me.Pet.PctHPs() and mq.TLO.Me.Pet.PctHPs() > 50)
                 end,
             },
             {
                 name = "Protection of the Warder",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and Casting.AAReady(aaName)
+                    return Targeting.IHaveAggro(100)
                 end,
             },
             {
@@ -1008,9 +975,6 @@ return {
             {
                 name = "Focused Paragon of Spirits",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ['DPS'] = {
@@ -1026,14 +990,14 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoParagon') then return false end
-                    return (mq.TLO.Group.LowMana(Config:GetSetting('ParaPct'))() or -1) > 0 and Casting.AAReady(aaName)
+                    return (mq.TLO.Group.LowMana(Config:GetSetting('ParaPct'))() or -1) > 0
                 end,
             },
             {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and not self.ClassConfig.HelperFunctions.FlurryActive(self)
+                    return not self.ClassConfig.HelperFunctions.FlurryActive(self)
                 end,
             },
             {
@@ -1053,7 +1017,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1061,7 +1025,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1069,35 +1033,35 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Maelstrom",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "FrozenPoi",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "PoiBite",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Icelance1",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1105,7 +1069,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Config:GetSetting("DoAERoar") then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1113,8 +1077,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not (Config:GetSetting("DoAERoar") and Config:GetSetting("DoAEDamage")) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID()) and
-                        self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
@@ -1124,9 +1087,7 @@ return {
                     if not Config:GetSetting('DoSwarmPet') then return false end
                     --We will let Feralgia apply swarm pets if our pet currently doesn't have its Growl Effect.
                     local feralgia = self.ResolvedActionMap['Feralgia']
-                    return (feralgia and feralgia() and mq.TLO.Me.PetBuff(mq.TLO.Spell(feralgia).RankName.Trigger(2).ID()))
-                        and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
-                        and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
+                    return (feralgia and feralgia() and mq.TLO.Me.PetBuff(mq.TLO.Spell(feralgia).RankName.Trigger(2).ID())) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1135,50 +1096,43 @@ return {
                 name = "Round Kick",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    return Casting.CanUseAA("Feral Swipe") and mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
+                    return Casting.CanUseAA("Feral Swipe")
                 end,
             },
             {
                 name = "Kick",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    return not Casting.CanUseAA("Feral Swipe") and mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
+                    return not Casting.CanUseAA("Feral Swipe")
                 end,
             },
             {
                 name = "Tiger Claw",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Enduring Frenzy",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Targeting.GetTargetPctHPs() > 90 and Casting.TargetedAAReady(aaName, target.ID())
+                    return Targeting.GetTargetPctHPs() > 90
                 end,
             },
             {
                 name = "EndRegenProcDisc",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return mq.TLO.Me.PctEndurance() < Config:GetSetting('ParaPct') and Casting.TargetedDiscReady(discSpell)
+                    return mq.TLO.Me.PctEndurance() < Config:GetSetting('ParaPct')
                 end,
             },
             {
                 name = "Chameleon Strike",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "SingleClaws",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    if Config:GetSetting('DoAEDamage') then return false end
-                    return Casting.TargetedDiscReady(discSpell, target.ID())
+                    return not Config:GetSetting('DoAEDamage')
                 end,
             },
             {
@@ -1186,28 +1140,25 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     if not Config:GetSetting('DoAEDamage') then return false end
-                    return Casting.TargetedDiscReady(discSpell, target.ID()) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
                 name = "Maul",
                 type = "Disc",
-                cond = function(self, discSpell, target)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "BestialBuffDisc",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return not Casting.BuffActive(discSpell) and Casting.DiscReady(discSpell)
+                    return not Casting.BuffActive(discSpell)
                 end,
             },
             {
                 name = "Consumption of Spirit",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.PctHPs() > 90 and mq.TLO.Me.PctMana() < 60) and Casting.AAReady(aaName)
+                    return (mq.TLO.Me.PctHPs() > 90 and mq.TLO.Me.PctMana() < 60)
                 end,
             },
             {
@@ -1215,7 +1166,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     ---@diagnostic disable-next-line: undefined-field
-                    return mq.TLO.Me.TotalCounters() > 0 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.TotalCounters() > 0
                 end,
             },
         },
@@ -1306,14 +1257,14 @@ return {
                 name = "Consumption of Spirit",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.PctHPs() > 70 and mq.TLO.Me.PctMana() < 80) and Casting.AAReady(aaName)
+                    return (mq.TLO.Me.PctHPs() > 70 and mq.TLO.Me.PctMana() < 80)
                 end,
             },
             {
                 name = "Feralist's Unity",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
             {
@@ -1328,7 +1279,7 @@ return {
                 name = "Pact of The Wurine",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
         },
@@ -1426,7 +1377,7 @@ return {
                 name = "Companion's Aegis",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -1029,7 +1029,7 @@ local _ClassConfig = {
                 name = "CompleteHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting("DoCompleteHeal") or target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Config:GetSetting("DoCompleteHeal") or not Targeting.TargetIsMA(target) then return false end
                     return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct')
                 end,
             },
@@ -1037,7 +1037,7 @@ local _ClassConfig = {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return not (Config:GetSetting("DoCompleteHeal") and target.ID() == Core.GetMainAssistId())
+                    return not (Config:GetSetting("DoCompleteHeal") and Targeting.TargetIsMA(target))
                 end,
             },
         },

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -854,7 +854,8 @@ local _ClassConfig = {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName, target)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and target.ID() == Core.GetMainAssistId
+                    if not Targeting.GroupedWithTarget(target) then return false end
+                    return target.ID() == Core.GetMainAssistId
                 end,
             },
             {
@@ -878,9 +879,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
             { --if we hit this we need spells back ASAP
                 name = "Forceful Rejuvenation",
@@ -913,9 +911,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
         },
         ['GroupHeal(1-97)'] = { --Level 1-97
@@ -1004,9 +999,8 @@ local _ClassConfig = {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName, target)
-                    if mq.TLO.FindItemCount(itemName)() == 0 or not Targeting.GroupedWithTarget(target) then return false end
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0 and target.ID() == Core.GetMainAssistId and
-                        (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
+                    if not Targeting.GroupedWithTarget(target) then return false end
+                    return target.ID() == Core.GetMainAssistId and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -779,7 +779,7 @@ local _ClassConfig = {
         },
     },
     ['HealRotations']     = {
-        ["GroupHeal(98+)"] = {
+        ['GroupHeal(98+)'] = {
             {
                 name = "DichoHeal",
                 type = "Spell",
@@ -791,67 +791,52 @@ local _ClassConfig = {
             {
                 name = "Beacon of Life",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupFastHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Celestial Regeneration",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupHealCure",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Exquisite Benediction",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupElixir",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
-        ["BigHeal(70+)"] = {
+        ['BigHeal(70+)'] = {
             {
                 name = "ClutchHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Targeting.GetTargetPctHPs() < 35
+                    return Targeting.GetTargetPctHPs() < 35
                 end,
             },
             {
                 name = "Sanctuary",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName)
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "DichoHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and target.ID() == Core.GetMainAssistId
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
@@ -859,15 +844,12 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Burst of Life",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
             {
                 name = "Epic",
@@ -880,22 +862,19 @@ local _ClassConfig = {
                 name = "Blessing of Sanctuary",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == (mq.TLO.Target.AggroHolder.ID() and not Core.GetMainAssistId())
+                    return target.ID() == (mq.TLO.Target.AggroHolder.ID() and not Core.GetMainAssistId())
                 end,
             },
             {
                 name = "Veturika's Perseverence",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName)
+                    return (target.ID() or 0) == mq.TLO.Me.ID()
                 end,
             },
             { --The stuff above is down, lets make mainhealpoint chonkier. Homework: Wondering if we should be using this more/elsewhere.
                 name = "Channeling of the Divine",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -907,39 +886,30 @@ local _ClassConfig = {
             { --if we hit this we need spells back ASAP
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
-        ["MainHeal(101+)"] = {
+        ['MainHeal(101+)'] = {
             {
                 name = "Focused Celestial Regeneration",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                cond = function(self)
+                    return mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "RemedyHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "RemedyHeal2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -949,111 +919,86 @@ local _ClassConfig = {
                 end,
             },
         },
-        ["GroupHeal(1-97)"] = { --Level 1-97
+        ['GroupHeal(1-97)'] = { --Level 1-97
             {
                 name = "GroupHealNoCure",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "GroupElixir",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "Celestial Regeneration",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Exquisite Benediction",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
-        ["MainHeal(70-100)"] = { --Level 70-100
+        ['MainHeal(70-100)'] = { --Level 70-100
             {
                 name = "Focused Celestial Regeneration",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                cond = function(self)
+                    return mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "HealNuke2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                cond = function(self)
+                    return mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "RemedyHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Renewal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Renewal2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Renewal3",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "SingleElixir",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
         },
-        ["Heal(1-69)"] = { --Level 1-69, includes Main and Big Healing
+        ['Heal(1-69)'] = { --Level 1-69, includes Main and Big Healing
             {
                 name = "Divine Arbitration",
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId and
-                        (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
+                    return Targeting.TargetIsMA(target) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
@@ -1069,7 +1014,7 @@ local _ClassConfig = {
                 name = "RemedyHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
@@ -1077,7 +1022,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1085,15 +1030,14 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting("DoCompleteHeal") or target.ID() ~= Core.GetMainAssistId() then return false end
-                    return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct') and Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct')
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if Config:GetSetting("DoCompleteHeal") and target.ID() == Core.GetMainAssistId() then return false end
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return not (Config:GetSetting("DoCompleteHeal") and target.ID() == Core.GetMainAssistId())
                 end,
             },
         },
@@ -1168,7 +1112,7 @@ local _ClassConfig = {
                 name = "Veturika's Perseverence",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName) and Casting.AmIBuffable()
+                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AmIBuffable()
                 end,
             },
             {
@@ -1177,7 +1121,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if target.ID() == mq.TLO.Me.ID() then return false end
                     local rezSearch = string.format("pccorpse %s radius 100 zradius 50", target.DisplayName())
-                    return Casting.TargetedAAReady(aaName, target.ID()) and mq.TLO.SpawnCount(rezSearch)() == 0
+                    return mq.TLO.SpawnCount(rezSearch)() == 0
                 end,
             },
         },
@@ -1186,7 +1130,7 @@ local _ClassConfig = {
                 name = "ReverseDS",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1194,7 +1138,7 @@ local _ClassConfig = {
                 type = "Spell",
                 allowDead = true,
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1202,80 +1146,55 @@ local _ClassConfig = {
             {
                 name = "Celestial Hammer",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Flurry of Life",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Healing Frenzy",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spire of the Vicar",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Divine Avatar",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
+                cond = function(self)
+                    return Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
                 end,
             },
             { --homework: This is a defensive proc, likely need to add elsewhere
                 name = "Divine Retribution",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
+                cond = function(self)
+                    return Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
                 end,
             },
             {
                 name = "Battle Frenzy",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
-                cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                cond = function(self)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
             { --homework: Check if this is necessary (does not exceed 50% spell haste cap)
                 name = "Celestial Rapidity",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Exquisite Benediction",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ['DPS'] = {
@@ -1285,17 +1204,15 @@ local _ClassConfig = {
                 retries = 0,
                 cond = function(self, spell)
                     if not Config:GetSetting('DoTwinHeal') then return false end
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
-                        not Casting.SongActiveByName("Healing Twincast")
+                    return not mq.TLO.Me.Song("Healing Twincast")()
                 end,
             },
             {
                 name = "StunTimer6",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    if not Config:GetSetting('DoHealStun') or ((spell.Level() or 0) > 85 and Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint')) then return false end
-                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self, spell)
+                    if not Config:GetSetting('DoHealStun') then return false end
+                    return Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1303,7 +1220,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1311,7 +1228,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1319,7 +1236,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1336,7 +1253,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if Casting.CanUseAA("Yaulp") then return false end
-                    return Casting.GemReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1345,39 +1262,38 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if (mq.TLO.Me.Level() < 101 and not Casting.DetGOMCheck()) then return false end
-                    return Casting.GemReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
+                    return (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
                 end,
             },
             {
                 name = "LowLevelStun",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoLLStun') then return false end
-                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff()
                 end,
             },
             {
                 name = "Turn Undead",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Targeting.TargetBodyIs(target, "Undead") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Targeting.TargetBodyIs(target, "Undead")
                 end,
             },
             {
                 name = "UndeadNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, aaName, target)
                     if not Config:GetSetting('DoUndeadNuke') or not Targeting.TargetBodyIs(target, "Undead") then return false end
-                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "MagicNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not Config:GetSetting('DoMagicNuke') then return false end
-                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1437,8 +1353,8 @@ local _ClassConfig = {
                 name = "Divine Guardian",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    if not Targeting.TargetIsMA(target) then return false end
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1478,7 +1394,7 @@ local _ClassConfig = {
                 name = "GroupVieBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoVieBuff') or (target.ID() == Core.GetMainAssistId() and self:GetResolvedActionMapItem('ShiningBuff')) then return false end
+                    if not Config:GetSetting('DoVieBuff') or (Targeting.TargetIsMA(target) and self:GetResolvedActionMapItem('ShiningBuff')) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -1486,7 +1402,7 @@ local _ClassConfig = {
                 name = "ShiningBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Targeting.TargetIsMA(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -1494,7 +1410,7 @@ local _ClassConfig = {
                 name = "SingleVieBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoVieBuff') or self:GetResolvedActionMapItem('GroupVieBuff') or target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Config:GetSetting('DoVieBuff') or self:GetResolvedActionMapItem('GroupVieBuff') or not Targeting.TargetIsMA(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -1502,7 +1418,7 @@ local _ClassConfig = {
                 name = "DivineBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDivineBuff') or target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Config:GetSetting('DoDivineBuff') or not Targeting.TargetIsMA(target) then return false end
                     return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -784,8 +784,7 @@ local _ClassConfig = {
                 name = "DichoHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
-                        (mq.TLO.Group.Injured(Config:GetSetting('BigHealPoint'))() or 0) >= Config:GetSetting('GroupInjureCnt')
+                    return (mq.TLO.Group.Injured(Config:GetSetting('BigHealPoint'))() or 0) >= Config:GetSetting('GroupInjureCnt')
                 end,
             },
             {

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -829,107 +829,79 @@ local _ClassConfig = {
         },
     },
     ['HealRotations']     = {
-        ["BigHealPoint"] = {
+        ['BigHealPoint'] = {
             {
                 name = "QuickHealSurge",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.SpellReady(spell) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Blessing of Tunare",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Wildtender's Survival",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Swarm of Fireflies",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Convergence of Spirits",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
-        ["GroupHealPoint"] = {
+        ['GroupHealPoint'] = {
             {
                 name = "Blessing of Tunare",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Wildtender's Survival",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "LongGroupHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
 
         },
-        ["MainHealPoint"] = {
+        ['MainHealPoint'] = {
             {
                 name = "QuickHeal",
                 type = "Spell",
-                cond = function(self, _) return true end,
             },
             {
                 name = "LongHeal1",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "LongHeal2",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
         },
     },
@@ -1027,9 +999,6 @@ local _ClassConfig = {
             {
                 name = "Silent Casting",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Season's Wrath",
@@ -1188,65 +1157,38 @@ local _ClassConfig = {
             {
                 name = "Nature's Boon",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Spirit of the Wood",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Swarm of the Fireflies",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Distant Conflagration",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Nature's Guardian",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Spirits of Nature",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Destructive Vortex",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Nature's Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Spire of Nature",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
         },
         ['Twin Heal'] = {
@@ -1254,7 +1196,7 @@ local _ClassConfig = {
                 name = "TwinHealNuke",
                 type = "Spell",
                 retries = 0,
-                cond = function(self, spell) return Casting.SpellReady(spell) and not Casting.SongActiveByName("Healing Twincast") end,
+                cond = function(self, spell) return not Casting.SongActiveByName("Healing Twincast") end,
             },
         },
         ['Debuff'] = {
@@ -1326,7 +1268,7 @@ local _ClassConfig = {
                 name = "Swarm of Fireflies",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return target.ID() == (mq.TLO.Group.MainTank.ID() or 0) and Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Targeting.TargetIsMA(target) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1409,7 +1351,7 @@ local _ClassConfig = {
                 type = "AA",
                 active_cond = function(self, aaName) return true end,
                 cond = function(self, aaName, target)
-                    return target.ID() == Core.GetMainAssistId() and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Targeting.TargetIsMA(target) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
         },
@@ -1486,7 +1428,6 @@ local _ClassConfig = {
                 name = "PetSpell",
                 type = "Spell",
                 active_cond = function() return mq.TLO.Me.Pet.ID() ~= 0 end,
-                cond = function() return true end,
             },
         },
     },

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1285,7 +1285,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     return not Config:GetSetting('DoFire') and Casting.DetSpellCheck(spell) and
-                        Targeting.GetTargetPctHPs(target) < Config:GetSetting('NukePct') and
+                        Targeting.GetAutoTargetPctHPs() < Config:GetSetting('NukePct') and
                         Config:GetSetting('DoNuke')
                 end,
             },
@@ -1294,7 +1294,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     return not Config:GetSetting('DoFire') and Casting.DetSpellCheck(spell) and
-                        Targeting.GetTargetPctHPs(target) < Config:GetSetting('NukePct') and
+                        Targeting.GetAutoTargetPctHPs() < Config:GetSetting('NukePct') and
                         Config:GetSetting('DoNuke')
                 end,
             },
@@ -1310,7 +1310,7 @@ local _ClassConfig = {
                 name = "SnareSpells",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Config:GetSetting('DoSnare') and Casting.DetSpellCheck(spell) and Targeting.GetTargetPctHPs(target) < 50
+                    return Config:GetSetting('DoSnare') and Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
             {

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1009,15 +1009,6 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
-                type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Core.IsModeActive("Mana") and Config:GetSetting('DoChestClick') and item() and
-                        item.Spell.Stacks() and item.TimerReady() == 0
-                end,
-            },
-            {
                 name = "SunDot",
                 type = "Spell",
                 cond = function(self, spell)
@@ -1145,13 +1136,12 @@ local _ClassConfig = {
             },
         },
         ['Burn'] = {
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and
-                        item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -825,9 +825,9 @@ local _ClassConfig = {
             steps = 1,
             load_cond = function() return Config:GetSetting('DoTash') end,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.DebuffConCheck() and not Casting.IAmFeigning() and
-                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         { --Slow and Tash separated so we use both before we start DPS
@@ -836,9 +836,9 @@ local _ClassConfig = {
             steps = 1,
             load_cond = function() return Config:GetSetting('DoSlow') or Config:GetSetting('DoCripple') end,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.DebuffConCheck() and not Casting.IAmFeigning() and
-                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         {
@@ -1248,7 +1248,7 @@ local _ClassConfig = {
                 name = "ManaDrainSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (target.CurrentMana() or 0) > 10 and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (target.CurrentMana() or 0) > 10 and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -900,7 +900,7 @@ local _ClassConfig = {
                 name = "Orator's Unity",
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.BuffActiveByName(aaName) end,
-                cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) end,
             },
             {
                 name = "SelfGuardShield",
@@ -951,7 +951,7 @@ local _ClassConfig = {
                 name = "Azure Mind Crystal",
                 type = "AA",
                 active_cond = function(self, aaName) return mq.TLO.FindItem(aaName)() ~= nil end,
-                cond = function(self, aaName) return mq.TLO.Me.PctMana() > 90 and not mq.TLO.FindItem(aaName)() and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() > 90 and not mq.TLO.FindItem(aaName)() end,
                 post_activate = function(self, aaName, success)
                     if success then
                         Core.SafeCallFunc("Autoinventory", self.ClassConfig.HelperFunctions.StashCrystal)
@@ -961,15 +961,14 @@ local _ClassConfig = {
             {
                 name = "Gather Mana",
                 type = "AA",
-                active_cond = function(self, aaName) return Casting.AAReady(aaName) end,
-                cond = function(self, aaName) return mq.TLO.Me.PctMana() < 60 and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() < 60 end,
             },
             {
                 name = "LearnersAura",
                 type = "Spell",
                 active_cond = function(self, spell) return Casting.AuraActiveByName(spell.Name()) end,
                 cond = function(self, spell)
-                    return Config:GetSetting('DoLearners') and Casting.SpellReady(spell) and not Casting.AuraActiveByName(spell.Name())
+                    return Config:GetSetting('DoLearners') and not Casting.AuraActiveByName(spell.Name())
                 end,
             },
             {
@@ -978,7 +977,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return Casting.AuraActiveByName(spell.Name()) end,
                 cond = function(self, spell)
                     if Config:GetSetting('DoLearners') and not Casting.CanUseAA('Auroria Mastery') then return false end
-                    return Casting.SpellReady(spell) and not Casting.AuraActiveByName(spell.Name())
+                    return not Casting.AuraActiveByName(spell.Name())
                 end,
             },
             {
@@ -999,7 +998,7 @@ local _ClassConfig = {
                 cond = function(self, spell)
                     if (self:GetResolvedActionMapItem('TwincastAura') or Config:GetSetting('DoLearners')) and not Casting.CanUseAA('Auroria Mastery') then return false end
                     local aura = string.sub(spell.Name() or "", 1, 8)
-                    return Casting.SpellReady(spell) and not Casting.AuraActiveByName(aura)
+                    return not Casting.AuraActiveByName(aura)
                 end,
             },
         },
@@ -1119,41 +1118,37 @@ local _ClassConfig = {
             {
                 name = "Glyph Spray",
                 type = "AA",
-                cond = function(self, aaName)
-                    return ((Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        Core.GetMainAssistPctHPs() < 40) and Casting.AAReady(aaName)
+                cond = function(self, aaName, target)
+                    return ((Targeting.IsNamed(target) and target.Level() > mq.TLO.Me.Level()) or Core.GetMainAssistPctHPs() < 40)
                 end,
             },
             {
                 name = "Reactive Rune",
                 type = "AA",
-                cond = function(self, aaName)
-                    return ((Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        Core.GetMainAssistPctHPs() < 40) and Casting.AAReady(aaName)
+                cond = function(self, aaName, target)
+                    return ((Targeting.IsNamed(target) and target.Level() > mq.TLO.Me.Level()) or Core.GetMainAssistPctHPs() < 40)
                 end,
             },
             -- { --this can be readded once we creat a post_activate to cancel the debuff you receive after
             --     name = "Self Stasis",
             --     type = "AA",
             --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30 and
-            --             Casting.AAReady(aaName)
+            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30
             --     end,
             -- },
             -- { --This can interrupt spellcasting which can just make something worse. Let us trust healers and tanks.
             --     name = "Dimensional Instability",
             --     type = "AA",
             --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30 and
-            --             Casting.AAReady(aaName)
+            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30
             --     end,
             -- },
             {
                 name = "Beguiler's Directed Banishment",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not mq.TLO.Target.ID() == Config.Globals.AutoTargetID then return false end
-                    return mq.TLO.Me.PctAggro() > 99 and mq.TLO.Me.PctHPs() <= 40 and Casting.TargetedAAReady(aaName, target.ID())
+                    if target.ID() == Config.Globals.AutoTargetID then return false end
+                    return mq.TLO.Me.PctAggro() > 99 and mq.TLO.Me.PctHPs() <= 40
                 end,
 
             },
@@ -1161,7 +1156,7 @@ local _ClassConfig = {
                 name = "Beguiler's Banishment",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 50 and mq.TLO.SpawnCount("npc radius 20")() > 2 and Casting.AAReady(aaName)
+                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 50 and mq.TLO.SpawnCount("npc radius 20")() > 2
                 end,
 
             },
@@ -1169,7 +1164,7 @@ local _ClassConfig = {
                 name = "Doppelganger",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 60 and Casting.AAReady(aaName)
+                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 60
                 end,
 
             },
@@ -1177,24 +1172,22 @@ local _ClassConfig = {
             --     name = "Dimensional Shield",
             --     type = "AA",
             --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 80 and
-            --             Casting.AAReady(aaName)
-            --     end,
+            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 80            --     end,
 
             -- },
             {
                 name = "Arcane Whisper",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90 and Casting.TargetedAAReady(aaName, target.ID())
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() >= 90
                 end,
 
             },
             {
                 name = "Silent Casting",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90 and Casting.AAReady(aaName)
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() >= 90
                 end,
 
             },
@@ -1205,22 +1198,19 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoStripBuff') then return false end
-                    return mq.TLO.Target.Beneficial() and Casting.TargetedSpellReady(spell, target.ID())
+                    return target.Beneficial()
                 end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "TwinCastMez",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if Config:GetSetting('TwincastMez') ~= 3 or Modules:ExecModule("Mez", "IsMezImmune", mq.TLO.Target.ID()) then return false end
-                    return not Casting.BuffActiveByID(spell.ID()) and not Casting.BuffActiveByName("Improved Twincast") and Casting.TargetedSpellReady(spell, target.ID())
+                    if Config:GetSetting('TwincastMez') ~= 3 or Modules:ExecModule("Mez", "IsMezImmune", target.ID()) then return false end
+                    return not Casting.BuffActiveByID(spell.ID()) and not mq.TLO.Me.Buff("Improved Twincast")()
                 end,
             },
             {
@@ -1228,15 +1218,15 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "ManaDot",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') and Targeting.IsNamed(mq.TLO.Target) then return false end
-                    return Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    if not Config:GetSetting('DoDot') and Targeting.IsNamed(target) then return false end
+                    return Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1244,21 +1234,21 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDicho') then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "NukeSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "ManaDrainSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (mq.TLO.Target.CurrentMana() or 0) > 10 and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (target.CurrentMana() or 0) > 10 and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
         },
@@ -1268,64 +1258,61 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoStripBuff') then return false end
-                    return mq.TLO.Target.Beneficial() and Casting.TargetedSpellReady(spell, target.ID())
+                    return target.Beneficial()
                 end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "ManaDot",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "NukeSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             { --Mana check used instead of dot mana check because this is spammed like a nuke
                 name = "DotSpell1",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             { --this is not an error, we want the spell twice in a row as part of the rotation.
                 name = "DotSpell1",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "TwinCastMez",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if Config:GetSetting('TwincastMez') ~= 3 or Modules:ExecModule("Mez", "IsMezImmune", mq.TLO.Target.ID()) then return false end
-                    return not Casting.BuffActiveByID(spell.ID()) and not Casting.BuffActiveByName("Improved Twincast") and Casting.TargetedSpellReady(spell, target.ID())
+                    if Config:GetSetting('TwincastMez') ~= 3 or Modules:ExecModule("Mez", "IsMezImmune", target.ID()) then return false end
+                    return not Casting.BuffActiveByID(spell.ID()) and not mq.TLO.Me.Buff("Improved Twincast")()
                 end,
             },
             { --used when the chanter or group members are low mana
                 name = "ManaNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (mq.TLO.Group.LowMana(80)() or -1) > 1 or not Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                    return (mq.TLO.Group.LowMana(80)() or -1) > 1 or not Casting.HaveManaToNuke()
                 end,
             },
         },
@@ -1333,32 +1320,27 @@ local _ClassConfig = {
             {
                 name = "Illusions of Grandeur",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Calculated Insanity",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Mental Contortion",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) end,
+                cond = function(self, aaName, target) return Targeting.IsNamed(target) end,
             },
             {
                 name = "Chromatic Haze",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -1376,14 +1358,11 @@ local _ClassConfig = {
             {
                 name = "Spire of Enchantment",
                 type = "AA",
-                cond = function(self, aaName) return not Casting.SongActiveByName("Illusions of Grandeur") and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return not Casting.SongActiveByName("Illusions of Grandeur") end,
             },
             {
                 name = "Phantasmal Opponent",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
         },
         ['Tash'] = {
@@ -1391,16 +1370,15 @@ local _ClassConfig = {
                 name = "TashSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(spell) and not mq.TLO.Target.Tashed()
-                        and Casting.TargetedSpellReady(spell, target.ID())
+                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "Bite of Tashani",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and not mq.TLO.Target.Tashed() and
-                        Targeting.GetXTHaterCount() > 1 and Casting.TargetedAAReady(aaName, target.ID())
+                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and
+                        Targeting.GetXTHaterCount() > 1
                 end,
             },
         },
@@ -1410,7 +1388,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if Targeting.GetXTHaterCount() < Config:GetSetting('AESlowCount') then return false end
-                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1419,8 +1397,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSlow') then return false end
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
-                        Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct())
                 end,
             },
             {
@@ -1428,7 +1405,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Enveloping Helix") then return false end
-                    return Casting.DetSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1436,8 +1413,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoSlow') or Casting.CanUseAA("Enveloping Helix") then return false end
-                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct())
                 end,
             },
             {
@@ -1445,7 +1421,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoCripple') or Casting.CanUseAA("Enveloping Helix") then return false end
-                    return Casting.DetSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -1342,17 +1342,12 @@ local _ClassConfig = {
                 name = "Chromatic Haze",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Casting.SongActive(item.Spell)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    if not Config:GetSetting('DoChestClick') or not item or not item() then return false end
-                    return not Casting.SongActive(item.Spell) and Casting.SpellStacksOnMe(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -1600,7 +1600,7 @@ _ClassConfig      = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Config:GetSetting('ElementChoice') ~= 1 then return false end
-                    if (Targeting.GetTargetPctHPs(target) < Config:GetSetting('HPStopBigNuke') and not Targeting.IsNamed(target)) then return false end
+                    if (Targeting.GetAutoTargetPctHPs() < Config:GetSetting('HPStopBigNuke') and not Targeting.IsNamed(target)) then return false end
                     return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -885,9 +885,9 @@ _ClassConfig      = {
             steps = 1,
             load_cond = function() return Config:GetSetting('DoMalo') or Config:GetSetting('DoAEMalo') end,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and not Casting.IAmFeigning() and Casting.DebuffConCheck() and
-                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         {
@@ -1416,8 +1416,8 @@ _ClassConfig      = {
             {
                 name = "AllianceBuff",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Targeting.IsNamed(mq.TLO.Target) and not Casting.TargetHasBuff(spell) and
+                cond = function(self, spell, target)
+                    return Targeting.IsNamed(target) and not Casting.TargetHasBuff(spell) and
                         Config:GetSetting('DoAlliance') and Casting.CanAlliance()
                 end,
             },
@@ -1579,8 +1579,8 @@ _ClassConfig      = {
             --   {
             --       name = "AllianceBuff",
             --       type = "Spell",
-            --      cond = function(self, spell)
-            --           return Targeting.IsNamed(mq.TLO.Target) and not Casting.TargetHasBuff(spell) and
+            --      cond = function(self, spell, target)
+            --           return Targeting.IsNamed(target) and not Casting.TargetHasBuff(spell) and
             --               Config:GetSetting('DoAlliance') and Casting.CanAlliance()
             --       end,
             --    },

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -1308,8 +1308,8 @@ _ClassConfig      = {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName)
-                    return not mq.TLO.Me.PetBuff("Primal Fusion")() and not mq.TLO.Me.PetBuff("Elemental Conjuction")() and mq.TLO.FindItemCount(itemName)() ~= 0 and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0 and mq.TLO.Me.Pet.ID() > 0
+                    if not mq.TLO.Me.Pet.ID() > 0 then return false end
+                    return not mq.TLO.Me.PetBuff("Primal Fusion")() and not mq.TLO.Me.PetBuff("Elemental Conjuction")()
                 end,
             },
             {
@@ -1401,16 +1401,12 @@ _ClassConfig      = {
                     return false
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and mq.TLO.Me.Song(item.Spell.RankName.Name())() ~= nil
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1528,14 +1524,6 @@ _ClassConfig      = {
             },
         },
         ['DPS'] = {
-            {
-                name = "SelfModRod",
-                type = "Item",
-                cond = function(self)
-                    return mq.TLO.FindItemCount(Config:GetSetting('SelfModRod'))() == 0 and mq.TLO.Me.PctMana() < Config:GetSetting('ModRodManaPct') and
-                        mq.TLO.Me.PctHPs() >= 60
-                end,
-            },
             {
                 name = "SwarmPet",
                 type = "Spell",

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -1308,7 +1308,7 @@ _ClassConfig      = {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName)
-                    if not mq.TLO.Me.Pet.ID() > 0 then return false end
+                    if mq.TLO.Me.Pet.ID() == 0 then return false end
                     return not mq.TLO.Me.PetBuff("Primal Fusion")() and not mq.TLO.Me.PetBuff("Elemental Conjuction")()
                 end,
             },

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -1236,7 +1236,7 @@ _ClassConfig      = {
         end,
     },
     ['Rotations']         = {
-        ["PetSummon"] = {
+        ['PetSummon'] = {
             {
                 name = "Pet Summon",
                 type = "CustomFunc",
@@ -1266,7 +1266,6 @@ _ClassConfig      = {
             {
                 name = "PetHealSpell",
                 type = "Spell",
-                cond = function(self, spell) return Casting.SpellReady(spell) end,
             },
         },
         ['PetBuff'] = {
@@ -1317,28 +1316,28 @@ _ClassConfig      = {
                 name = "Second Wind Ward",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Host in the Shell",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank") and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank")
                 end,
             },
             {
                 name = "Companion's Aegis",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank") and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank")
                 end,
             },
             {
                 name = "Companion's Intervening Divine Aura",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank") and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank")
                 end,
             },
         },
@@ -1425,37 +1424,33 @@ _ClassConfig      = {
             {
                 name = "Companion's Fury",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Host of the Elements",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Spire of Elements",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Heart of Skyfire",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
+                cond = function(self)
+                    return not mq.TLO.Me.Buff("Twincast")()
+                end,
             },
             {
                 name = "Servant of Ro",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
         },
         ['DPS PET'] = {
@@ -1517,9 +1512,6 @@ _ClassConfig      = {
             {
                 name = "Force of Elements",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "FireOrbItem",
@@ -1576,14 +1568,13 @@ _ClassConfig      = {
                 name = "Turn Summoned",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Targeting.TargetBodyIs(target, "Undead Pet") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                    return Targeting.TargetBodyIs(target, "Undead Pet")
                 end,
             },
             {
                 name = "TwinCast",
                 type = "Spell",
-                cond = function(self, spell) return Casting.SelfBuffCheck(spell) and not Casting.BuffActiveByName("Improved Twincast") end,
+                cond = function(self, spell) return not mq.TLO.Me.Buff("Twincast")() end,
             },
             --   {
             --       name = "AllianceBuff",
@@ -1601,7 +1592,7 @@ _ClassConfig      = {
                 cond = function(self, spell, target)
                     if Config:GetSetting('ElementChoice') ~= 1 then return false end
                     if (Targeting.GetAutoTargetPctHPs() < Config:GetSetting('HPStopBigNuke') and not Targeting.IsNamed(target)) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1609,7 +1600,7 @@ _ClassConfig      = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Config:GetSetting('ElementChoice') ~= 1 then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1617,15 +1608,14 @@ _ClassConfig      = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Config:GetSetting('ElementChoice') ~= 2 then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Turn Summoned",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Targeting.TargetBodyIs(target, "Undead Pet") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                    return Targeting.TargetBodyIs(target, "Undead Pet")
                 end,
             },
         },
@@ -1634,7 +1624,7 @@ _ClassConfig      = {
                 name = "Malaise",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1642,7 +1632,7 @@ _ClassConfig      = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Malaise") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1650,7 +1640,7 @@ _ClassConfig      = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },
@@ -1678,7 +1668,7 @@ _ClassConfig      = {
                 name = "Elemental Conversion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and Casting.AAReady(aaName) and mq.TLO.Me.Pet.ID() > 0
+                    return mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and mq.TLO.Me.Pet.ID() > 0
                 end,
             },
             {
@@ -1686,15 +1676,14 @@ _ClassConfig      = {
                 type = "AA",
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and not mq.TLO.Me.SpellReady(self.ResolvedActionMap['GatherMana'] or "")() and
-                        Casting.AAReady(aaName) and mq.TLO.Me.Pet.ID() > 0
+                        mq.TLO.Me.Pet.ID() > 0
                 end,
             },
             {
                 name = "GatherMana",
                 type = "Spell",
                 cond = function(self, spell)
-                    return spell and spell() and mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and Casting.SpellReady(spell) and
-                        mq.TLO.Me.SpellReady(spell.Name() or "")
+                    return spell and spell() and mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and Casting.GemReady(spell)
                 end,
             },
             {
@@ -1715,7 +1704,7 @@ _ClassConfig      = {
                 name = "Thaumaturge's Unity",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
             {
@@ -1768,7 +1757,7 @@ _ClassConfig      = {
                 name = "Elemental Form",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
         },
@@ -1779,7 +1768,7 @@ _ClassConfig      = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
-                    return modRodItem and Casting.AAReady(aaName) and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
+                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0
                 end,
                 post_activate = function(self, aaName, success)
@@ -1794,7 +1783,7 @@ _ClassConfig      = {
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Summon Modulation Shard") or not Config:GetSetting('SummonModRods') then return false end
                     local modRodItem = spell.RankName.Base(1)()
-                    return modRodItem and Casting.SpellReady(spell) and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
+                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0
                 end,
                 post_activate = function(self, spell, success)

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -313,7 +313,7 @@ local _ClassConfig = {
                     return Casting.AuraActiveByName(discSpell.RankName.Name())
                 end,
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.Aura(1).ID() and Casting.DiscReady(discSpell)
+                    return not mq.TLO.Me.Aura(1).ID()
                 end,
             },
             {
@@ -321,28 +321,28 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if self:GetResolvedActionMapItem("CombatEndRegen") then return false end
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Breaths",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Mend",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.PctHPs() < 50
+                    return mq.TLO.Me.PctHPs() < 50
                 end,
             },
         },
@@ -353,7 +353,7 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     if not Config:GetSetting('AggroFeign') then return false end
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
-                        and Casting.AAReady(aaName) and not Core.IAmMA
+                        and not Core.IAmMA
                 end,
             },
             {
@@ -361,14 +361,14 @@ local _ClassConfig = {
                 type = "Ability",
                 cond = function(self, abilityName)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return Targeting.IHaveAggro(95) and mq.TLO.Me.AbilityReady(abilityName)() and not Core.IAmMA
+                    return Targeting.IHaveAggro(95) and not Core.IAmMA
                 end,
             },
             {
                 name = "Defy Death",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 25 and Casting.DiscReady(discSpell)
+                    return mq.TLO.Me.PctHPs() < 25
                 end,
             },
             {
@@ -376,14 +376,14 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoVetAA') then return false end
-                    return mq.TLO.Me.PctHPs() < 35 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
                 name = "Mend",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
+                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
                 end,
             },
             {
@@ -407,58 +407,34 @@ local _ClassConfig = {
             { -- 5m reuse
                 name = "Dicho",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             { -- 5m reuse
                 name = "Ton Po's Stance",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Heel",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "Speed",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "FistDisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "Palm",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "Spire of the Sensei",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Infusion of Thunder",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -472,15 +448,12 @@ local _ClassConfig = {
             { --10m reuse
                 name = "CraneStance",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             { --20m reuse, using NOT burndisccheck means we will only use this with a burn disc active
                 name = "Poise",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             { --pairs with Speed Focus Disc, AE, T2
@@ -489,7 +462,7 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     local speedDisc = self:GetResolvedActionMapItem("Speed")
                     if not Config:GetSetting("DoAEDamage") or not speedDisc then return false end
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName() and self.ClassConfig.HelperFunctions.AETargetCheck()
+                    return mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName() and self.ClassConfig.HelperFunctions.AETargetCheck()
                 end,
             },
             { --pairs with Speed Focus Disc, single target, T2
@@ -498,29 +471,25 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     local speedDisc = self:GetResolvedActionMapItem("Speed")
                     if Config:GetSetting("DoAEDamage") or not speedDisc then return false end
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName()
+                    return mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName()
                 end,
             },
             {
                 name = "Silent Strikes",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Me.PctAggro() or 0) > 60
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target) and (mq.TLO.Me.PctAggro() or 0) > 60
                 end,
             },
             {
                 name = "Swift Tails' Chant",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -529,21 +498,21 @@ local _ClassConfig = {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Drunken",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Casting.SelfBuffCheck(discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
                 end,
             },
             {
                 name = "Zan Fi's Whistle",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Casting.SelfBuffAACheck(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
             {
@@ -551,7 +520,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if mq.TLO.Me.Level() >= 100 then return false end
-                    return Casting.DiscReady(discSpell) and Casting.SelfBuffCheck(discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
                 end,
             },
             {
@@ -559,21 +528,21 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAlliance') then return false end
-                    return Casting.TargetedDiscReady(discSpell) and not Casting.TargetHasBuffByName(discSpell.Trigger(1))
+                    return not Casting.TargetHasBuffByName(discSpell.Trigger(1))
                 end,
             },
             {
                 name = "Storm",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "EarthDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },
@@ -581,118 +550,80 @@ local _ClassConfig = {
             {
                 name = "Synergy",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Curse",
                 type = "Disc",
                 cond = function(self, discSpell) --DotSpellCheck used in part to not blow this on low-health mobs
-                    return Casting.TargetedDiscReady(discSpell) and Casting.DotSpellCheck(discSpell)
+                    return Casting.DotSpellCheck(discSpell)
                 end,
             },
             {
                 name = "Two-Finger Wasp Touch",
                 type = "AA",
                 cond = function(self, aaName, target) --DotSpellCheck used in part to not blow this on low-health mobs
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DotSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DotSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Fists",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Fang",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Shuriken",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Five Point Palm",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.TargetedAAReady(aaName)
-                end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)()
+                    return (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) > 1
                 end,
             },
             {
                 name = "Flying Kick",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Eagle Strike",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    if mq.TLO.Me.PctEndurance() > 25 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
+                    return mq.TLO.Me.PctEndurance() < 25
                 end,
             },
             {
                 name = "Tiger Claw",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
         },
         ['Precision'] = {
             {
                 name = "Precision5",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision4",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision3",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision2",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision1",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
         },
     },

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -389,18 +389,14 @@ local _ClassConfig = {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell) and mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
                 name = "Epic",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
         },
         ['Burn'] = {
@@ -436,13 +432,12 @@ local _ClassConfig = {
                 name = "Infusion of Thunder",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             { --10m reuse

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -263,7 +263,7 @@ local _ClassConfig = {
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
                 return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99))
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(Targeting.GetAutoTarget()) and mq.TLO.Me.PctAggro() > 99))
             end,
         },
         {
@@ -350,9 +350,9 @@ local _ClassConfig = {
             {
                 name = "Imitate Death",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
+                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
                         and not Core.IAmMA
                 end,
             },

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -1040,9 +1040,6 @@ local _ClassConfig = {
             {
                 name = "OoW_Chest",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0
-                end,
             },
             {
                 name = "Funeral Pyre",

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -842,14 +842,14 @@ local _ClassConfig = {
                 name = "Scent of Thule",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "ScentDebuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1164,7 +1164,7 @@ local _ClassConfig = {
                 name = "Death Bloom",
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.SongActiveByName(mq.TLO.AltAbility(aaName).Spell.RankName()) end,
-                cond = function(self, aaName) return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('DeathBloomPercent') end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() < Config:GetSetting('DeathBloomPercent') end,
             },
         },
         ['PetSummon'] = { --TODO: Double check these lists to ensure someone leveling doesn't have to change options to keep pets current at lower levels

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -815,14 +815,14 @@ local _ClassConfig = {
                 name = "Death Peace",
                 type = "AA",
                 cond = function(self, aaName)
-                    return not Casting.IAmFeigning() and Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < 75
+                    return not Casting.IAmFeigning() and mq.TLO.Me.PctHPs() < 75
                 end,
             },
             {
                 name = "Harm Shield",
                 type = "AA",
                 cond = function(self, aaName)
-                    return not Casting.IAmFeigning() and Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() >= 75
+                    return not Casting.IAmFeigning() and mq.TLO.Me.PctHPs() >= 75
                 end,
             },
             {
@@ -1089,14 +1089,10 @@ local _ClassConfig = {
             {
                 name = "Companion's Fury",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Rise of Bones",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Focus of Arcanum",

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -868,8 +868,8 @@ return {
                 name = "Spire of Chivalry",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.Level() < 80 and not Casting.SongActiveByName('Group Armor of the Inquisitor') and
-                        not Casting.SongActiveByName('Armor of the Inquisitor') and not Casting.BuffActiveByName('Spire of Chivalry')
+                    return mq.TLO.Me.Level() < 80 and not Casting.SongActiveByName('Group Armor of the Inquisitor') and not Casting.SongActiveByName('Armor of the Inquisitor') and
+                        not Casting.BuffActiveByName('Spire of Chivalry')
                 end,
             },
             {
@@ -883,9 +883,6 @@ return {
             {
                 name = "Thunder of Karana",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Config:GetSetting('DoNuke')
-                end,
             },
             {
                 name = "Group Armor of The Inquisitor",
@@ -951,8 +948,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -960,8 +956,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -969,8 +964,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -978,31 +972,28 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "meleemit",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return Casting.DiscReady(discSpell) and not (discSpell.Level() < 108 and mq.TLO.Me.ActiveDisc.ID())
+                    return not ((discSpell.Level() or 0) < 108 and mq.TLO.Me.ActiveDisc.ID())
                 end,
             },
             {
                 name = "TotLightHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
                 name = "BurstHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
@@ -1037,66 +1028,56 @@ return {
             {
                 name = "Taunt",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetDistance() < 30
+                cond = function(self, abilityName, target)
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and target.ID() > 0 and Targeting.GetTargetDistance(target) < 30
                 end,
             },
             {
                 name = "Bash",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target) and
-                        (Core.ShieldEquipped() or Casting.CanUseAA("Improved Bash"))
+                    return Core.ShieldEquipped() or Casting.CanUseAA("2 Hand Bash")
                 end,
             },
             {
                 name = "Disarm",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Challengetaunt",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and not Casting.TargetHasBuff(spell)
+                    return not Casting.TargetHasBuff(spell)
                 end,
             },
             {
                 name = "StunTimer4",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "StunTimer5",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "LessonStun",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "CrushTimer5",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "CrushTimer6",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Armor of the Inquisitor",
@@ -1145,16 +1126,10 @@ return {
             {
                 name = "Bash",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Disarm",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Marr's Gift",
@@ -1167,67 +1142,61 @@ return {
                 name = "Dicho",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= 35
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= 35
                 end,
             },
             {
                 name = "TotLightHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
                 name = "BurstHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
                 name = "DebuffNuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        ((Targeting.TargetBodyIs(mq.TLO.Target, "Undead") or mq.TLO.Me.Level() >= 96) and not Casting.TargetHasBuff(spell) and Config:GetSetting('DoNuke'))
+                    return ((Targeting.TargetBodyIs(mq.TLO.Target, "Undead") or mq.TLO.Me.Level() >= 96) and not Casting.TargetHasBuff(spell) and Config:GetSetting('DoNuke'))
                 end,
             },
             {
                 name = "AntiUndeadNuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
                 name = "Reverseds",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.TargetHasBuff(spell) and Config:GetSetting('DoReverseDS')
+                    return Casting.TargetHasBuff(spell) and Config:GetSetting('DoReverseDS')
                 end,
             },
             {
                 name = "Lowaggronuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Config:GetSetting('DoNuke')
+                    return Config:GetSetting('DoNuke')
                 end,
             },
             {
                 name = "CrushTimer6",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Config:GetSetting('DoNuke') and (mq.TLO.Me.SecondaryPctAggro() or 0) > 60
+                    return Config:GetSetting('DoNuke') and (mq.TLO.Me.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Vanquish The Fallen",
@@ -1257,7 +1226,7 @@ return {
                 name = "aurabuff1",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and not Casting.AuraActiveByName(spell.RankName.Name()) and mq.TLO.Me.PctEndurance() > 10
+                    return not Casting.AuraActiveByName(spell.RankName.Name()) and mq.TLO.Me.PctEndurance() > 10
                 end,
             },
             {
@@ -1271,14 +1240,14 @@ return {
                 name = "ArmorSelfBuff",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "FuryProc",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1286,42 +1255,42 @@ return {
                 type = "Spell",
                 cond = function(self, spell) --use this always until we have a Fury proc, and optionally after that, up until the point that Fury is rolled into DPU
                     if (mq.TLO.Me.AltAbility("Divine Protector's Unity").Rank() or 0) > 1 or (self:GetResolvedActionMapItem("FuryProc") and not Config:GetSetting('DoUndeadProc')) then return false end
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "Remorse",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "Piety",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "Preservation",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
+                    return Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
                 end,
             },
             {
                 name = "TempHP",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
+                    return Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
                 end,
             },
             {
                 name = "Incoming",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
+                    return Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
                 end,
             },
             {
@@ -1347,7 +1316,7 @@ return {
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.ID()) end,
                 cond = function(self, spell)
                     if Config:GetSetting('AegoSymbol') ~= 1 then return false end
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1356,7 +1325,7 @@ return {
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.ID()) end,
                 cond = function(self, spell)
                     if Config:GetSetting('AegoSymbol') ~= 2 then return false end
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -1113,12 +1113,12 @@ return {
                     return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },
@@ -1212,12 +1212,12 @@ return {
                     return mq.TLO.Me.AltAbility(aaName).Rank() >= 3 and not Casting.BuffActiveByName("Knight's Yaulp")
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },
@@ -1298,8 +1298,8 @@ return {
                 type = "Item",
                 active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
                 cond = function(self)
-                    return Config:GetSetting('SummonArrows') and mq.TLO.Me.Level() > 89 and mq.TLO.FindItemCount("Ethereal Arrow")() < 101 and
-                        mq.TLO.Me.ItemReady("Huntsman's Ethereal Quiver")()
+                    if not Config:GetSetting('SummonArrows') then return false end
+                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
                 end,
             },
         },

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -10,7 +10,7 @@ return {
     ['ModeChecks']        = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
         IsHealing = function() return true end,
-        IsCuring = function() return Config:GetSetting('DoCures') end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.AAReady("Radiant Cure") end,
         IsRezing = function() return (Config:GetSetting('DoBattleRez') and not Core.IsTanking()) or Targeting.GetXTHaterCount() == 0 end,
         --Disabling tank battle rez is not optional to prevent settings in different areas and to avoid causing more potential deaths
     },

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -793,8 +793,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not mq.TLO.Group() then return false end
-                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt') and
-                        Casting.AAReady(aaName)
+                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt')
                 end,
             },
             {
@@ -802,15 +801,14 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not mq.TLO.Group() then return false end
-                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt') and
-                        Casting.AAReady(aaName)
+                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt')
                 end,
             },
             {
                 name = "Lay on Hands",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
+                    return Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
                 end,
             },
         },
@@ -870,57 +868,48 @@ return {
                 name = "Spire of Chivalry",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.Level() < 80 and Casting.AAReady(aaName) and not Casting.SongActiveByName('Group Armor of the Inquisitor') and
+                    return mq.TLO.Me.Level() < 80 and not Casting.SongActiveByName('Group Armor of the Inquisitor') and
                         not Casting.SongActiveByName('Armor of the Inquisitor') and not Casting.BuffActiveByName('Spire of Chivalry')
                 end,
             },
             {
                 name = "Valorous Rage",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Inquisitor's Judgment",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Thunder of Karana",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoNuke')
+                    return Config:GetSetting('DoNuke')
                 end,
             },
             {
                 name = "Group Armor of The Inquisitor",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Undeadburn",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.ActiveDisc.ID() and Casting.TargetedDiscReady(discSpell)
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "Righteousstrike",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.ActiveDisc.ID() and Casting.TargetedDiscReady(discSpell)
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "Healproc",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not Core.IsTanking() and Casting.SpellReady(spell)
+                    return not Core.IsTanking()
                 end,
             },
         },
@@ -954,7 +943,7 @@ return {
                 name = "Shield Flash",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < Config:GetSetting('FlashHP')
+                    return mq.TLO.Me.PctHPs() < Config:GetSetting('FlashHP')
                 end,
             },
             {
@@ -1020,21 +1009,21 @@ return {
                 name = "Hallowed Lodestar",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetXTHaterCount() > 2
+                    return Targeting.GetXTHaterCount() > 2
                 end,
             },
             {
                 name = "Beacon of the Righteous",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetXTHaterCount() > 2
+                    return Targeting.GetXTHaterCount() > 2
                 end,
             },
             {
                 name = "Heroic Leap",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetXTHaterCount() > 2
+                    return Targeting.GetXTHaterCount() > 2
                 end,
             },
             {
@@ -1042,14 +1031,14 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     return (mq.TLO.Me.AltAbility(aaName).Rank() or 0) > 7 and not Casting.BuffActiveByName("Knight's Yaulp") and
-                        Targeting.GetTargetDistance() < 30 and Casting.AAReady(aaName)
+                        Targeting.GetTargetDistance() < 30
                 end,
             },
             {
                 name = "Taunt",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetDistance() < 30
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetDistance() < 30
                 end,
             },
             {
@@ -1112,50 +1101,35 @@ return {
             {
                 name = "Armor of the Inquisitor",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Healtaunt",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Lowaggronuke",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Dicho",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "AntiUndeadNuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
                 name = "Vanquish The Fallen",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
@@ -1186,7 +1160,7 @@ return {
                 name = "Marr's Gift",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() <= 60
+                    return mq.TLO.Me.PctMana() <= 60
                 end,
             },
             {
@@ -1259,14 +1233,14 @@ return {
                 name = "Vanquish The Fallen",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
                 name = "Disruptive Persecution",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.AltAbility(aaName).Rank() >= 3 and not Casting.BuffActiveByName("Knight's Yaulp")
+                    return mq.TLO.Me.AltAbility(aaName).Rank() >= 3 and not Casting.BuffActiveByName("Knight's Yaulp")
                 end,
             },
             {
@@ -1390,7 +1364,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSalvation') then return false end
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
         },

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -1489,7 +1489,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },

--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -290,57 +290,45 @@ return {
                 name = "Frenzied",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Twisted",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Executioner",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "EdgeDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Rogue's Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Pinpoint",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "MarkDisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Spire of the Rake",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -354,54 +342,39 @@ return {
             {
                 name = "PoisonBlade",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Dicho",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Shadow's Flanking",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Rake's Rampage",
                 type = "AA",
                 cond = function(self, aaName)
-                    local speedDisc = self:GetResolvedActionMapItem("Speed")
                     if not Config:GetSetting("DoAEDamage") then return false end
-                    return Casting.AAReady(aaName) and self.ClassConfig.HelperFunctions.AETargetCheck(self)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(self)
                 end,
             },
             {
                 name = "Focused Rake's Rampage",
                 type = "AA",
                 cond = function(self, aaName)
-                    if Config:GetSetting("DoAEDamage") then return false end
-                    return Casting.AAReady(aaName)
+                    return not Config:GetSetting("DoAEDamage")
                 end,
             },
             {
                 name = "Phantom",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -419,28 +392,28 @@ return {
                 name = "Knifeplay",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "AspDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "ProcBuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -448,7 +421,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAlliance') then return false end
-                    return Casting.TargetedDiscReady(discSpell) and not Casting.TargetHasBuffByName(discSpell.Trigger(1))
+                    return not Casting.TargetHasBuffByName(discSpell.Trigger(1))
                 end,
             },
             {
@@ -464,7 +437,7 @@ return {
                 name = "Assassin's Premonition",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Casting.BurnCheck()
+                    return Casting.BurnCheck()
                 end,
             },
         },
@@ -473,72 +446,49 @@ return {
                 name = "Backstab",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    if not Casting.CanUseAA("Chaotic Stab") and not mq.TLO.Stick.Behind() then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
+                    return Casting.CanUseAA("Chaotic Stab") or mq.TLO.Stick.Behind()
                 end,
             },
             {
                 name = "Carve",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "SecretBlade",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "FellStrike",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Jugular",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Twisted Shank",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Puncture",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "DaggerThrow",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             { --Check ToT to ensure we are not boosting the hate generation of someone we shouldn't be
                 name = "HateDebuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and mq.TLO.Me.TargetOfTarget.ID() == (mq.TLO.Group.MainTank.ID() or Core.GetMainAssistId())
+                    return mq.TLO.Me.TargetOfTarget.ID() == (mq.TLO.Group.MainTank.ID() or Core.GetMainAssistId())
                 end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)()
+                    return (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) > 1
                 end,
             },
         },
@@ -547,7 +497,7 @@ return {
                 name = "Escape",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.IHaveAggro(100)
+                    return Targeting.IHaveAggro(100)
                 end,
             },
             {
@@ -555,15 +505,12 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoVetAA') then return false end
-                    return mq.TLO.Me.PctHPs() < 35 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
                 name = "Tumble",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Coating",
@@ -578,7 +525,7 @@ return {
                 name = "CADisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Targeting.IHaveAggro(100)
+                    return Targeting.IHaveAggro(100)
                 end,
             },
         },
@@ -587,7 +534,7 @@ return {
                 name = "ThiefBuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.SelfBuffCheck(discSpell) and Casting.DiscReady(discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
                 end,
             },
             {
@@ -595,14 +542,14 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if self:GetResolvedActionMapItem("CombatEndRegen") then return false end
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {

--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -253,7 +253,7 @@ return {
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
                 return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99))
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(Targeting.GetAutoTarget()) and mq.TLO.Me.PctAggro() > 99))
             end,
         },
         {

--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -330,13 +330,12 @@ return {
                 name = "Spire of the Rake",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -384,8 +383,7 @@ return {
                 type = "Item",
                 cond = function(self, itemName)
                     if Config:GetSetting('UseEpic') == 1 then return false end
-                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck())) and mq.TLO.FindItem(itemName)() and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck()))
                 end,
             },
             {
@@ -515,10 +513,9 @@ return {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell) and mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -845,10 +845,10 @@ local _ClassConfig = {
         { --Offensive actions to temporarily boost damage dealt
             name = 'Burn',
             state = 1,
-            steps = 1,
+            steps = 2,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
+                return combat_state == "Combat" and Casting.BurnCheck() and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyStart')
             end,
         },
         { --Non-spell actions that can be used during/between casts
@@ -877,14 +877,14 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if self:GetResolvedActionMapItem("CombatEndRegen") then return false end
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -895,7 +895,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if Config:GetSetting('ProcChoice') ~= 1 then return false end
                     --SelfBuffAACheck does not work for this specific AA, it returns a strange spell in the stacking check
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -906,7 +906,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if Config:GetSetting('ProcChoice') ~= 2 then return false end
                     --SelfBuffAACheck does not work for this specific AA, it returns a strange spell in the stacking check
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -992,7 +992,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Skin,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 60
+                    return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 60
                 end,
             },
             {
@@ -1002,7 +1002,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
                     if not Config:GetSetting('DoTempHP') or not Casting.GemReady(spell) then return false end
-                    return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 45
+                    return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 45
                 end,
             },
             {
@@ -1011,7 +1011,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.HealBurn,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 30
+                    return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 30
                 end,
             },
             {
@@ -1074,7 +1074,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return mq.TLO.Me.Pet.ID() > 0 end,
                 cond = function(self, spell)
                     if mq.TLO.Me.Pet.ID() ~= 0 or not Config:GetSetting('DoPet') then return false end
-                    return Casting.SpellReady(spell) and Casting.ReagentCheck(spell)
+                    return Casting.ReagentCheck(spell)
                 end,
             },
         },
@@ -1085,7 +1085,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PetHaste,
                 active_cond = function(self, spell) return mq.TLO.Me.PetBuff(spell.RankName) ~= nil end,
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffPetCheck(spell)
+                    return Casting.SelfBuffPetCheck(spell)
                 end,
             },
         },
@@ -1099,7 +1099,7 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.ArmorofExperience,
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
+                    return mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
                 end,
             },
             --Note that on named we may already have a mantle/carapace running already, could make this remove other discs, but meh, Shield Flash still a thing.
@@ -1113,7 +1113,7 @@ local _ClassConfig = {
                     end
                 end,
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell) and
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID() and
                         (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000
                 end,
             },
@@ -1127,7 +1127,7 @@ local _ClassConfig = {
                     end
                 end,
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() ~= "Deflection Discipline"
+                    return mq.TLO.Me.ActiveDisc.Name() ~= "Deflection Discipline"
                 end,
             },
             {
@@ -1135,7 +1135,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.LeechCurse,
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             --Influence is in an odd place with Carapace. Usage is very subjective and may be more nuanced than automation can support. Placed here as an alternative to Carapace in low health situations to get you topped back off again for tanks. Should be used in burn for non-tanks (adding non-tank stuff is TODO)
@@ -1144,7 +1144,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.InfluenceDisc,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID() and Core.IsTanking()
+                    return not mq.TLO.Me.ActiveDisc.ID() and Core.IsTanking()
                 end,
             },
             {
@@ -1152,7 +1152,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.Carapace,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -1169,7 +1169,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.Mantle,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             --if we made it this far let's reset our dicho/dire and hope for the best!
@@ -1177,9 +1177,6 @@ local _ClassConfig = {
                 name = "Forceful Rejuvenation",
                 type = "AA",
                 tooltip = Tooltips.ForcefulRejuv,
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ['HateTools'] = {
@@ -1189,7 +1186,7 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.AgelessEnmity,
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.GetTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
+                    return Targeting.GetAutoTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
                 end,
             },
             --used to jumpstart hatred on named from the outset and prevent early rips from burns
@@ -1197,8 +1194,8 @@ local _ClassConfig = {
                 name = "Acrimony",
                 type = "Disc",
                 tooltip = Tooltips.Acrimony,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, discSpell, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             --used to reinforce hatred on named
@@ -1208,7 +1205,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.VeilofDarkness,
                 cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
+                    return Targeting.IsNamed(target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
                 end,
             },
             {
@@ -1217,7 +1214,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.AETaunt,
                 cond = function(self, spell)
                     if Config:GetSetting('AETauntSpell') == 1 then return false end
-                    return Casting.SpellReady(spell) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
@@ -1226,7 +1223,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ExplosionOfHatred,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('AETauntAA') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
@@ -1235,7 +1232,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ExplosionOfSpite,
                 cond = function(self, aaName)
                     if not Config:GetSetting('AETauntAA') then return false end
-                    return Casting.AAReady(aaName) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
@@ -1243,25 +1240,24 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) then return false end
-                    return Casting.SpellReady(spell) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
                 name = "Projection of Doom",
                 type = "AA",
                 tooltip = Tooltips.ProjectionofDoom,
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
+                    return Targeting.IsNamed(target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
                 end,
             },
             {
                 name = "Taunt",
                 type = "Ability",
                 tooltip = Tooltips.Taunt,
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetID() > 0 and
-                        Targeting.GetTargetDistance() < 30
+                cond = function(self, abilityName, target)
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and target.ID() > 0 and Targeting.GetTargetDistance(target) < 30
                 end,
             },
             {
@@ -1271,7 +1267,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if Config:GetSetting('DoTerror') == 1 then return false end
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
+                    return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
@@ -1281,7 +1277,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if Config:GetSetting('DoTerror') == 1 then return false end
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.SpellLoaded(spell) and Casting.TargetedSpellReady(spell, target.ID()) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
+                    return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
@@ -1290,7 +1286,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ForPower,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoForPower') then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1298,41 +1294,29 @@ local _ClassConfig = {
             {
                 name = "Visage of Death",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Crimson",
                 type = "Disc",
                 tooltip = Tooltips.Crimson,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
             {
                 name = "Harm Touch",
                 type = "AA",
-                tooltip = Tooltips.HarmTouch,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Thought Leech",
                 type = "AA",
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
-                    if Config:GetSetting('DoThoughtLeech') == 1 then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                    return Config:GetSetting('DoThoughtLeech') ~= 1
                 end,
             },
             {
@@ -1340,40 +1324,30 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
-                    if Config:GetSetting('DoLeechTouch') == 1 then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                    return Config:GetSetting('DoLeechTouch') ~= 1
                 end,
             },
             {
                 name = "Spire of the Reavers",
                 type = "AA",
                 tooltip = Tooltips.SpireoftheReavers,
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Chattering Bones",
                 type = "AA",
                 tooltip = Tooltips.ChatteringBones,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "T`Vyl's Resolve",
                 type = "AA",
                 tooltip = Tooltips.Tvyls,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "SpiteStrike",
                 type = "Disc",
                 tooltip = Tooltips.SpikeStrike,
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -1381,7 +1355,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.UnholyAura,
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -1389,7 +1363,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.InfluenceDisc,
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },
@@ -1399,7 +1373,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.EncroachingDarkness,
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1408,7 +1382,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.SnareDot,
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Encroaching Darkness") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
+                    return Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
         },
@@ -1418,16 +1392,17 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.MeleeMit,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not (discSpell.Level() < 108 and mq.TLO.Me.ActiveDisc.ID())
+                    if not Core.IsTanking() then return false end
+                    return not ((discSpell.Level() or 0) < 108 and mq.TLO.Me.ActiveDisc.ID())
                 end,
             },
             {
                 name = "Epic",
                 type = "Item",
                 tooltip = Tooltips.Epic,
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and
-                        (self.ClassConfig.HelperFunctions.LeechCheck(self) or Targeting.IsNamed(mq.TLO.Target))
+                        (self.ClassConfig.HelperFunctions.LeechCheck(self) or Targeting.IsNamed(target))
                 end,
             },
             {
@@ -1442,27 +1417,27 @@ local _ClassConfig = {
                 name = "Carapace",
                 type = "Disc",
                 tooltip = Tooltips.Carapace,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
                 name = "Mantle",
                 type = "Disc",
                 tooltip = Tooltips.Mantle,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
                 name = "Guardian",
                 type = "Disc",
                 tooltip = Tooltips.Guardian,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
@@ -1478,9 +1453,9 @@ local _ClassConfig = {
                 name = "UnholyAura",
                 type = "Disc",
                 tooltip = Tooltips.UnholyAura,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
@@ -1489,7 +1464,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PurityofDeath,
                 cond = function(self, aaName)
                     ---@diagnostic disable-next-line: undefined-field
-                    return mq.TLO.Me.TotalCounters() > 0 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.TotalCounters() > 0
                 end,
             },
         },
@@ -1501,7 +1476,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoLeechTouch') == 2 then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and mq.TLO.Me.PctHPs() < 25
+                    return mq.TLO.Me.PctHPs() < 25
                 end,
             },
             --the trick with the next two is to find a sweet spot between using discs and long term CD abilities (we want these to trigger so those don't need to) and using them needlessly (which isn't much of a damage increase). Trying to get it dialed in for a good default value.
@@ -1512,8 +1487,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDicho') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDicho')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDicho')))
                 end,
             },
             {
@@ -1523,8 +1497,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDireTap') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDireTap')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDireTap')))
                 end,
             },
             {
@@ -1533,8 +1506,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LifeTap,
                 cond = function(self, spell, target)
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
                 end,
             },
             {
@@ -1543,8 +1515,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) then return false end
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap'))) and
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap'))) and
                         self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
@@ -1553,7 +1524,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.ReflexStrike,
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {
@@ -1562,8 +1533,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LifeTap,
                 cond = function(self, spell, target)
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
                 end,
             },
         },
@@ -1573,7 +1543,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.ReflexStrike,
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and (mq.TLO.Group.Injured(80)() or 0) > 2
+                    return (mq.TLO.Group.Injured(80)() or 0) > 2
                 end,
             },
             {
@@ -1581,31 +1551,22 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.CombatEndRegen,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Vicious Bite of Chaos",
                 type = "AA",
                 tooltip = Tooltips.ViciousBiteOfChaos,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Blade",
                 type = "Disc",
                 tooltip = Tooltips.Blade,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Gift of the Quick Spear",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Thought Leech",
@@ -1613,7 +1574,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoThoughtLeech') == 2 then return false end
-                    return mq.TLO.Me.PctMana() < 10 and Casting.TargetedAAReady(aaName, target.ID())
+                    return mq.TLO.Me.PctMana() < 10
                 end,
             },
             {
@@ -1621,17 +1582,13 @@ local _ClassConfig = {
                 type = "Ability",
                 -- tooltip = Tooltips.Bash,
                 cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target) and
-                        (Core.ShieldEquipped() or Casting.CanUseAA("Improved Bash"))
+                    return (Core.ShieldEquipped() or Casting.CanUseAA("Improved Bash"))
                 end,
             },
             {
                 name = "Slam",
                 type = "Ability",
                 tooltip = Tooltips.Slam,
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
         },
         ['Combat'] = {
@@ -1641,7 +1598,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.BondTap,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoBondTap') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1649,7 +1606,7 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.SpearNuke,
                 cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1658,7 +1615,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PoisonDot,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoPoisonDot') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1667,7 +1624,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PoisonDot,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoCorruptionDot') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1676,7 +1633,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.DireDot,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDireDot') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1684,7 +1641,7 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.BiteTap,
                 cond = function(self, spell, target) --no mana check here because this returns half the mana cost to the entire group. can adjust later as needed.
-                    return Casting.TargetedSpellReady(spell, target.ID()) and mq.TLO.Me.PctHPs() <= Config:GetSetting('StartLifeTap')
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('StartLifeTap')
                 end,
             },
             {
@@ -1693,7 +1650,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAC,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoACTap') or not spell or not spell() then return false end
-                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.TargetedSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Trigger())()
                 end,
             },
             {
@@ -1702,7 +1659,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAtk,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAtkTap') or not spell or not spell() then return false end
-                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.TargetedSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Trigger())()
                 end,
             },
             {
@@ -1711,7 +1668,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.MaxHPTap,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoMaxHPTap') or not spell or not spell() then return false end
-                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.SpellStacksOnMe(spell.Trigger) and Casting.TargetedSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.SpellStacksOnMe(spell.Trigger)
                 end,
             },
         },
@@ -1722,9 +1679,9 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("Shield").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("Shield").Active() then return false end
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("Shield") end,
             },
@@ -1734,10 +1691,10 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("2Hand").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("2Hand").Active() then return false end
                     return mq.TLO.Me.PctHPs() >= Config:GetSetting('Equip2Hand') and mq.TLO.Me.ActiveDisc.Name() ~= "Deflection Discipline" and
-                        (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000 and not (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                        (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000 and not (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("2Hand") end,
             },

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -1034,16 +1034,12 @@ local _ClassConfig = {
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
-            {
-                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "None" end,
+            { --Charm Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "CharmClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return item() and Casting.TargetHasBuff(item.Spell, mq.TLO.Me)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return Config:GetSetting('DoCharmClick') and item() and Casting.SelfBuffCheck(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoCharmClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1061,8 +1057,8 @@ local _ClassConfig = {
                 type = "Item",
                 active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
                 cond = function(self)
-                    return Config:GetSetting('SummonArrows') and mq.TLO.Me.Level() > 89 and mq.TLO.FindItemCount("Ethereal Arrow")() < 101 and
-                        mq.TLO.Me.ItemReady("Huntsman's Ethereal Quiver")()
+                    if not Config:GetSetting('SummonArrows') then return false end
+                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
                 end,
             },
         },
@@ -1155,13 +1151,12 @@ local _ClassConfig = {
                     return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1401,8 +1396,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName, target)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and
-                        (self.ClassConfig.HelperFunctions.LeechCheck(self) or Targeting.IsNamed(target))
+                    return Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.LeechCheck(self)
                 end,
             },
             {
@@ -1410,7 +1404,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.OoW_BP,
                 cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and self.ClassConfig.HelperFunctions.LeechCheck(self)
+                    return self.ClassConfig.HelperFunctions.LeechCheck(self)
                 end,
             },
             {
@@ -1443,10 +1437,9 @@ local _ClassConfig = {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell) and self.ClassConfig.HelperFunctions.LeechCheck(self)
+                    return Casting.ItemSpellCheck(itemName, target) and self.ClassConfig.HelperFunctions.LeechCheck(self)
                 end,
             },
             {

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -875,18 +875,16 @@ local _ClassConfig = {
             {
                 name = "EndRegen",
                 type = "Disc",
-                tooltip = Tooltips.EndRegen,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.Level() < 106 and mq.TLO.Me.PctEndurance() < 15
+                    if self:GetResolvedActionMapItem("CombatEndRegen") then return false end
+                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
                 end,
             },
-            --If these tables were combined, errors could occur... there is no other good way I can think of to ensure a timer 13 ability that can be used in combat is scribed.
             {
                 name = "CombatEndRegen",
                 type = "Disc",
-                tooltip = Tooltips.CombatEndRegen,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.Level() > 105 and mq.TLO.Me.PctEndurance() < 15
+                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -1410,7 +1408,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.SnareDot,
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Encroaching Darkness") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell) and Targeting.GetTargetPctHPs(target) < 50
+                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
         },

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -788,13 +788,12 @@ local _ClassConfig = {
                 name = "AESpiritualHeal",
                 type = "Spell",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -837,9 +836,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
             { --if we hit this we need intervention back ASAP
                 name = "Forceful Rejuvenation",
@@ -873,9 +869,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
         },
     },
@@ -1139,8 +1132,7 @@ local _ClassConfig = {
                 type = "Item",
                 cond = function(self, itemName)
                     if Config:GetSetting('UseEpic') == 1 then return false end
-                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck())) and mq.TLO.FindItem(itemName)() and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck()))
                 end,
             },
             {

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -749,21 +749,19 @@ local _ClassConfig = {
                 name = "Call of the Ancients",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "RecklessHeal1",
                 type = "Spell",
-                cond = function(self, spell, target) return Casting.TargetedSpellReady(spell, target.ID(), true) end,
             },
             {
                 name = "GroupRenewalHoT",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') or not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                        and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -772,30 +770,23 @@ local _ClassConfig = {
                 name = "InterventionHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.GemReady(spell) and
-                        Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "Soothsayer's Intervention",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.TargetedAAReady(aaName, target.ID(), true)
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "RecourseHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "AESpiritualHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -809,16 +800,13 @@ local _ClassConfig = {
             {
                 name = "Call of the Ancients",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupRenewalHoT",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -827,38 +815,24 @@ local _ClassConfig = {
                 name = "Ancestral Guard",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName)
+                    return (target.ID() or 0) == mq.TLO.Me.ID()
                 end,
             },
             {
                 name = "InterventionHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Soothsayer's Intervention",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
             {
                 name = "Union of Spirits",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
             { --The stuff above is down, lets make mainhealpoint chonkier.
                 name = "Spiritual Blessing",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -870,47 +844,31 @@ local _ClassConfig = {
             { --if we hit this we need intervention back ASAP
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ["MainHealPoint"] = {
             {
                 name = "RecourseHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "AESpiritualHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (target.ID() or 0) == Core.GetMainAssistId() and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "RecklessHeal1",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "RecklessHeal2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "RecklessHeal3",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -1039,8 +997,7 @@ local _ClassConfig = {
                 type = "Spell",
                 retries = 0,
                 cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
-                        not Casting.SongActiveByName("Healing Twincast")
+                    return not Casting.SongActiveByName("Healing Twincast")
                 end,
             },
         },
@@ -1049,7 +1006,7 @@ local _ClassConfig = {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1057,7 +1014,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetResolvedActionMapItem('DichoSpell') then return false end
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1065,51 +1022,38 @@ local _ClassConfig = {
             {
                 name = "Fleeting Spirit",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Ancestral Aid",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spire of Ancestors",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             {
                 name = "Spirit Call",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Rabid Bear",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
+                    return Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
                 end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -1119,8 +1063,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEMalo') then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1128,8 +1071,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAEMalo') or Casting.CanUseAA("Wind of Malaise") then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.TargetedSpellReady(spell, target.ID()) and
-                        Casting.DetSpellCheck(spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1137,7 +1079,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1145,7 +1087,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoSTMalo') or Casting.CanUseAA("Malaise") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1155,8 +1097,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAESlow') then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1164,8 +1105,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAESlow') or Casting.CanUseAA("Turgur's Virulent Swarm") then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.TargetedSpellReady(spell, target.ID()) and
-                        Casting.DetSpellCheck(spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1173,7 +1113,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTSlow') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1181,7 +1121,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoSTSlow') or Casting.CanUseAA("Turgur's Swarm") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1189,7 +1129,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not (Config:GetSetting('DoDiseaseSlow') and Config:GetSetting('DoSTSlow')) or Casting.CanUseAA("Turgur's Swarm") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1208,8 +1148,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.GemReady(spell) and Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1217,7 +1156,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1225,7 +1164,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1233,7 +1172,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if (Core.IsModeActive("Heal") and (Core.GetResolvedActionMapItem('CurseDot2') or not Config:GetSetting('DoHealDPS'))) then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1241,7 +1180,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if (Core.IsModeActive("Heal") and (Core.GetResolvedActionMapItem('ChaoticDot') or not Config:GetSetting('DoHealDPS'))) then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1249,7 +1188,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Core.IsModeActive("Hybrid") then return false end
-                    return Targeting.IsNamed(mq.TLO.Target) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Targeting.IsNamed(target) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1257,7 +1196,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Core.IsModeActive("Hybrid") or Core.GetResolvedActionMapItem('AfflictionDot') then return false end
-                    return Targeting.IsNamed(mq.TLO.Target) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Targeting.IsNamed(target) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1266,8 +1205,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, aaName)
                     if not (Config:GetSetting('DoAACanni') and Config:GetSetting('DoCombatCanni')) then return false end
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and
-                        mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
             {
@@ -1276,8 +1214,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
-                        mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
             {
@@ -1294,7 +1231,7 @@ local _ClassConfig = {
                 name = "FastPoisonNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1302,7 +1239,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and Core.GetResolvedActionMapItem('FastPoisonNuke') then return false end
-                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1310,7 +1247,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetResolvedActionMapItem('PoisonNuke') then return false end
-                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1334,17 +1271,14 @@ local _ClassConfig = {
                 name = "Cannibalization",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Config:GetSetting('DoAACanni') and Casting.AAReady(aaName) and
-                        mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and
-                        mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
+                    return Config:GetSetting('DoAACanni') and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
             {
                 name = "CanniSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Config:GetSetting('DoSpellCanni') and Casting.GemReady(spell) and
-                        mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
+                    return Config:GetSetting('DoSpellCanni') and Casting.GemReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -1387,7 +1321,7 @@ local _ClassConfig = {
                 name = "Companion's Aegis",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },
@@ -1438,7 +1372,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1543,7 +1477,7 @@ local _ClassConfig = {
                 active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoGroupShrink') then return false end
-                    return target.Height() > 2.2 and Casting.TargetedAAReady(aaName, target.ID())
+                    return target.Height() > 2.2
                 end,
             },
             {
@@ -1552,7 +1486,7 @@ local _ClassConfig = {
                 active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoGroupShrink') or Casting.CanUseAA("Group Shrink") then return false end
-                    return target.Height() > 2.2 and Casting.TargetedAAReady(aaName, target.ID())
+                    return target.Height() > 2.2
                 end,
             },
             {
@@ -1561,7 +1495,7 @@ local _ClassConfig = {
                 active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoGroupShrink') or Casting.CanUseAA("Group Shrink") or Casting.CanUseAA("Shrink") then return false end
-                    return target.Height() > 2.2 and Casting.TargetedSpellReady(spell, target.ID())
+                    return target.Height() > 2.2
                 end,
             },
             {

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -385,7 +385,7 @@ local _ClassConfig = {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctEndurance() < 75
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -431,21 +431,24 @@ local _ClassConfig = {
             {
                 name = "Brace for Impact",
                 type = "AA",
+                cond = function(self, aaName, target)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
             },
             {
                 name = "HealHateAE",
                 type = "Disc",
-                cond = function(self, discSpell)
+                cond = function(self, discSpell, target)
                     if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and Casting.GroupBuffCheck(discSpell, target)
                 end,
             },
             {
                 name = "HealHateSingle",
                 type = "Disc",
-                cond = function(self, discSpell)
+                cond = function(self, discSpell, target)
                     if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and Casting.GroupBuffCheck(discSpell, target)
                 end,
             },
             {

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -774,7 +774,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "War Sheol's Heroic Blade",
+                name = "Wars Sheol's Heroic Blade",
                 type = "AA",
             },
             {

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -357,7 +357,7 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 --need to look at rotation and decide if it should fire during emergencies. leaning towards no
                 return combat_state == "Combat" and Core.IsTanking() and (mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') or
-                    Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                    Targeting.IsNamed(Targeting.GetAutoTarget()) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
             end,
         },
         { --Offensive actions to temporarily boost damage dealt
@@ -385,7 +385,7 @@ local _ClassConfig = {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 75
+                    return mq.TLO.Me.PctEndurance() < 75
                 end,
             },
             {
@@ -395,7 +395,7 @@ local _ClassConfig = {
                     return Casting.AuraActiveByName(discSpell.RankName.Name())
                 end,
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.Aura(1).ID() and Casting.DiscReady(discSpell)
+                    return not mq.TLO.Me.Aura(1).ID()
                 end,
             },
             {
@@ -405,7 +405,7 @@ local _ClassConfig = {
                     return Casting.SongActive(discSpell)
                 end,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not Casting.SongActive(discSpell)
+                    return not Casting.SongActive(discSpell)
                 end,
             },
             {
@@ -415,7 +415,7 @@ local _ClassConfig = {
                     return Casting.SongActive(discSpell)
                 end,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not Casting.SongActive(discSpell)
+                    return not Casting.SongActive(discSpell)
                 end,
             },
             {
@@ -425,7 +425,7 @@ local _ClassConfig = {
                     return mq.TLO.Me.ActiveDisc.ID() == discSpell.ID()
                 end,
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -437,7 +437,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell) and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
                 end,
             },
             {
@@ -445,7 +445,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell) and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
                 end,
             },
             {
@@ -490,15 +490,15 @@ local _ClassConfig = {
                 name = "Ageless Enmity",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.GetTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
+                    return Targeting.GetTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
                 end,
             },
             --used to jumpstart hatred on named from the outset and prevent early rips from burns
             {
                 name = "Attention",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, discSpell, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             --used to reinforce hatred after it is initially established
@@ -507,7 +507,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.GetTargetPctHPs() < 90 and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
+                    return Targeting.GetTargetPctHPs() < 90 and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
                 end,
             },
             {
@@ -515,7 +515,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     --if not Config:GetSetting('AETauntAA') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
@@ -567,7 +567,7 @@ local _ClassConfig = {
             --     name = "AERoar",
             --     type = "Disc",
             --     cond = function(self, discSpell)
-            --         return Core.IsModeActive("Tank") and Casting.DiscReady(discSpell) and Targeting.GetXTHaterCount() >= Config:GetSetting('BurnMobCount') and
+            --         return Core.IsModeActive("Tank") and Targeting.GetXTHaterCount() >= Config:GetSetting('BurnMobCount') and
             --             Config:GetSetting('DoAEAgro')
             --     end,
             -- },

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -385,7 +385,7 @@ local _ClassConfig = {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 75
                 end,
             },
             {
@@ -431,9 +431,6 @@ local _ClassConfig = {
             {
                 name = "Brace for Impact",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "HealHateAE",
@@ -449,6 +446,13 @@ local _ClassConfig = {
                 cond = function(self, discSpell)
                     if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
                     return Core.IsTanking() and Casting.DiscReady(discSpell) and not Casting.BuffActiveByID(discSpell.ID())
+                end,
+            },
+            {
+                name = "Infused by Rage",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Core.IsTanking() and Casting.SelfBuffAACheck(aaName) and not Casting.SongActiveByName(aaName)
                 end,
             },
             {
@@ -517,53 +521,46 @@ local _ClassConfig = {
             {
                 name = "Projection of Fury",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
+                    return Targeting.IsNamed(target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
                 end,
             },
             {
                 name = "Taunt",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetID() > 0 and
-                        Targeting.GetTargetDistance() < 30
+                cond = function(self, abilityName, target)
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and target.ID() > 0 and Targeting.GetTargetDistance(target) < 30
                 end,
             },
             {
                 name = "AbsorbTaunt",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "AEBlades",
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAEDamage') then return false end
-                    return Casting.TargetedDiscReady(discSpell) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
                 name = "AddHate1",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Casting.DetSpellCheck(discSpell)
+                    return Casting.DetSpellCheck(discSpell)
                 end,
             },
             {
                 name = "AddHate2",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "AgroPet",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, discSpell, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             -- { --this appears to have incredibly limited usage and the line was discontinued
@@ -582,58 +579,45 @@ local _ClassConfig = {
                 name = "Armor of Experience",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
+                    return mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
                 end,
             },
             {
                 name = "Fortitude",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and Casting.DiscReady(discSpell) and
-                        not Casting.SongActiveByName("Flash of Anger") and not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not Casting.SongActiveByName("Flash of Anger") and
+                        not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
                 end,
             },
             {
                 name = "Flash",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.Name() ~= "Fortitude Discipline" and
-                        not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
+                    return not mq.TLO.Me.ActiveDisc.Name() ~= "Fortitude Discipline" and not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
                 end,
             },
             {
                 name = "Warlord's Tenacity",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Warlord's Resurgence",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "RuneShield",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Mark of the Mage Hunter",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             { --here for use in emergencies regarldless of ability staggering below
                 name = "StandDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
+                    return Core.IsTanking() and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
                 end,
             },
         },
@@ -644,9 +628,9 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("Shield").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("Shield").Active() then return false end
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("Shield") end,
             },
@@ -656,9 +640,9 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("DW").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("DW").Active() then return false end
-                    return mq.TLO.Me.PctHPs() >= Config:GetSetting('EquipDW') and not (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                    return mq.TLO.Me.PctHPs() >= Config:GetSetting('EquipDW') and not (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("DW") end,
             },
@@ -670,7 +654,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local itemSpell = mq.TLO.Me.Inventory("Chest").Spell()
-                    return Casting.DiscReady(discSpell) and not (itemSpell and mq.TLO.Me.Buff(itemSpell)())
+                    return not (itemSpell and mq.TLO.Me.Buff(itemSpell)())
                 end,
             },
             { --shares effect with Dicho Shield
@@ -688,7 +672,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local absorbDisc = Core.GetResolvedActionMapItem('AbsorbDisc')
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.Song(absorbDisc)() and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
+                    return not mq.TLO.Me.Song(absorbDisc)() and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
                 end,
             },
             { --offset from StandDisc for automation flow/coverage
@@ -696,7 +680,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local standDisc = self:GetResolvedActionMapItem('StandDisc')
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName()
+                    return mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName()
                 end,
             },
             { --shares effect with StandDisc and Warlord's Bravery, offset from AbsorbDisc for automation flow/coverage
@@ -715,8 +699,7 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     local absorbDisc = Core.GetResolvedActionMapItem('AbsorbDisc')
                     local standDisc = Core.GetResolvedActionMapItem('StandDisc')
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName() and
-                        mq.TLO.Me.Song(absorbDisc)() and not Casting.BuffActiveByName("Guardian's Boon") and
+                    return mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName() and mq.TLO.Me.Song(absorbDisc)() and not Casting.BuffActiveByName("Guardian's Boon") and
                         not Casting.BuffActiveByName("Guardian's Bravery")
                 end,
             },
@@ -742,73 +725,61 @@ local _ClassConfig = {
             {
                 name = "Spire of the Warlord",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Imperator's Command",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Onslaught",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return not Core.IsTanking() and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "MightyStrike",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return not Core.IsTanking() and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "OffensiveDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return not Core.IsTanking() and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Vehement Rage",
                 type = "AA",
                 cond = function(self, aaName)
-                    return not Core.IsTanking() and Casting.AAReady(aaName)
+                    return not Core.IsTanking()
                 end,
             },
             {
                 name = "Rage of Rallos Zek",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Warlord's Fury",
                 type = "AA",
                 cond = function(self, aaName, target)
                     local dichoShield = Core.GetResolvedActionMapItem('DichoShield')
-                    return Core.IsTanking() and Casting.TargetedAAReady(aaName, target.ID()) and not mq.TLO.Me.Buff(dichoShield)
+                    return Core.IsTanking() and not mq.TLO.Me.Buff(dichoShield)
                 end,
             },
             {
                 name = "War Sheol's Heroic Blade",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "SelfBuffAE",
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking()
                 end,
             },
             {
@@ -816,29 +787,28 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "TongueDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Resplendent Glory",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsTanking() and Casting.AAReady(aaName)
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -846,15 +816,12 @@ local _ClassConfig = {
             {
                 name = "ShieldHit",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -862,31 +829,27 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoBattleLeap') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                        ---@diagnostic disable-next-line: undefined-field --Defs are not updated with HeadWet
-                        and not mq.TLO.Me.HeadWet() --Stops Leap from launching us above the water's surface
+                    ---@diagnostic disable-next-line: undefined-field --Defs are not updated with HeadWet
+                    return not mq.TLO.Me.HeadWet() --Stops Leap from launching us above the water's surface
                 end,
             },
             {
                 name = "Gut Punch",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Core.IsTanking() and Casting.TargetedAAReady(aaName, target.ID())
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Knee Strike",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Rampage",
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting("DoAEDamage") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
@@ -894,7 +857,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSnare') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -902,29 +865,23 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting("DoPress") then return false end
-                    return Core.IsTanking() and Casting.TargetedAAReady(aaName, target.ID())
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Bash",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target) and Core.ShieldEquipped()
+                    return Core.ShieldEquipped()
                 end,
             },
             {
                 name = "Slam",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Kick",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             -- { --todo:homework
             --     name = "Disarm",
@@ -938,9 +895,7 @@ local _ClassConfig = {
                 name = "StrikeDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and
-                        Targeting.GetTargetDistance() < Targeting.GetTargetMaxRangeTo() and
-                        Targeting.GetTargetPctHPs() <= 20
+                    return Targeting.GetTargetDistance() < Targeting.GetTargetMaxRangeTo() and Targeting.GetTargetPctHPs() <= 20
                 end,
             },
             {
@@ -950,7 +905,7 @@ local _ClassConfig = {
                     return mq.TLO.Me.ActiveDisc.ID() == discSpell.ID()
                 end,
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },
@@ -1149,8 +1104,8 @@ local _ClassConfig = {
             Category = "Equipment",
             Index = 4,
             Tooltip = "Enable 1H+S/2H swapping based off of current health. ***YOU MUST HAVE BANDOLIER ENTRIES NAMED \"Shield\" and \"DW\" TO USE THIS FUNCTION.***",
-            Default = false,
             RequiresLoadoutChange = true,
+            Default = false,
             FAQ = "Why is my Warrior not using Dynamic Weapon Swapping?",
             Answer = "Make sure you have [UseBandolier] enabled in your class settings.\n" ..
                 "You must also have Bandolier entries named \"Shield\" and \"DW\" to use this function.",
@@ -1210,6 +1165,5 @@ local _ClassConfig = {
         },
     },
 }
-
 
 return _ClassConfig

--- a/class_configs/Live/wiz_class_config.lua
+++ b/class_configs/Live/wiz_class_config.lua
@@ -1121,17 +1121,12 @@ return {
                     return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Casting.BuffActive(item.Spell)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    if not Config:GetSetting('DoChestClick') or not item or not item() then return false end
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },

--- a/class_configs/Live/wiz_class_config.lua
+++ b/class_configs/Live/wiz_class_config.lua
@@ -753,7 +753,7 @@ return {
                 name = "Improved Twincast",
                 type = "AA",
                 cond = function(self)
-                    return not Casting.BuffActiveByName("Twincast")
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
@@ -767,7 +767,7 @@ return {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.AAReady("Harvest of Druzzil")
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {
@@ -847,7 +847,7 @@ return {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.AAReady("Harvest of Druzzil")
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {
@@ -862,23 +862,14 @@ return {
             {
                 name = "Force of Ice",
                 type = "AA",
-                cond = function(self)
-                    return Casting.AAReady("Force of Ice")
-                end,
             },
             {
                 name = "Force of Will",
                 type = "AA",
-                cond = function(self)
-                    return Casting.AAReady("Force of Will")
-                end,
             },
             {
                 name = "Force of Flame",
                 type = "AA",
-                cond = function(self)
-                    return Casting.AAReady("Force of Flame")
-                end,
             },
         },
         ['Gift of Mana'] = {
@@ -964,7 +955,7 @@ return {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not Casting.DetGambitCheck() and mq.TLO.Me.Buff("Twincast").ID() == 0 and not Casting.BuffActiveByName("Improved Twincast")
+                    return not Casting.DetGambitCheck() and not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
@@ -1120,7 +1111,7 @@ return {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.AAReady("Harvest of Druzzil")
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {

--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -120,7 +120,7 @@ return {
             "Phantom Assailant",
         },
         ['Alliance'] = {
-            "Demolisher's,",
+            "Demolisher's Alliance,",
             "Mangler's Covenant",
             "Vindicator's Coalition",
             "Conqueror's Conjunction",

--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -531,7 +531,7 @@ return {
                 name = "Coat",
                 type = "Item",
                 cond = function(self, itemName)
-                    return not mq.TLO.Me.PetBuff("Primal Fusion")() and mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return not mq.TLO.Me.PetBuff("Primal Fusion")()
                 end,
             },
             {
@@ -600,10 +600,9 @@ return {
             {
                 name = "Epic",
                 type = "Item",
-                cond = function(self, itemName)
-                    local epicItem = mq.TLO.FindItem(itemName)
-                    return Config:GetSetting('DoEpic') and epicItem() and epicItem.Spell.Stacks() and
-                        epicItem.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoEpic') then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -418,15 +418,14 @@ return {
                 name = "Communion of Blood",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctEndurance() <= 75
+                    return mq.TLO.Me.PctEndurance() <= 75
                 end,
             },
             {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() <= 21 and
-                        not mq.TLO.Me.Invis()
+                    return mq.TLO.Me.PctEndurance() <= 21
                 end,
             },
             {
@@ -461,7 +460,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -469,7 +468,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -477,7 +476,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -485,7 +484,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -493,7 +492,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -501,7 +500,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -509,7 +508,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -517,7 +516,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -525,7 +524,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -540,7 +539,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc() and not Casting.DiscReady(burndisc)
+                    return not mq.TLO.Me.ActiveDisc() and not Casting.DiscReady(burndisc)
                 end,
             },
             {
@@ -548,7 +547,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -556,7 +555,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
-                    return Casting.AAReady(aaName) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(burndisc).RankName())
                 end,
             },
             {
@@ -566,7 +565,7 @@ return {
                     local burndisc = self:GetResolvedActionMapItem('PrimaryBurnDisc')
                     local cleavingdisc = self:GetResolvedActionMapItem('CleavingDisc')
                     local discondisc = self:GetResolvedActionMapItem('DisconDisc')
-                    return Casting.DiscReady(discSpell) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
                         and not (Casting.DiscReady(burndisc) or Casting.DiscReady(cleavingdisc))
                 end,
             },
@@ -578,7 +577,7 @@ return {
                     local cleavingdisc = self:GetResolvedActionMapItem('CleavingDisc')
                     local discondisc = self:GetResolvedActionMapItem('DisconDisc')
                     local resolvedisc = self:GetResolvedActionMapItem('ResolveDisc')
-                    return Casting.DiscReady(discSpell) and (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
+                    return (not mq.TLO.Me.ActiveDisc() or mq.TLO.Me.ActiveDisc() == mq.TLO.Spell(discondisc).RankName())
                         and not (Casting.DiscReady(burndisc) or Casting.DiscReady(cleavingdisc) or Casting.DiscReady(resolvedisc))
                 end,
             },
@@ -586,7 +585,7 @@ return {
                 name = "War Cry of the Braxi",
                 type = "Disc",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Casting.SpellStacksOnMe(mq.TLO.Spell(aaName))
+                    return Casting.SpellStacksOnMe(mq.TLO.Spell(aaName))
                 end,
             },
             {
@@ -610,93 +609,69 @@ return {
             {
                 name = "Frenzy",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)()
-                end,
             },
             {
                 name = "Dfrenzy",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Dvolley",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Daxeof",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Daxethrow",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "SharedBuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not Casting.SongActiveByName(discSpell.RankName())
+                    return not Casting.SongActiveByName(discSpell.RankName())
                 end,
             },
             {
                 name = "RageStrike",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Phantom",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Config:GetSetting('DoPet')
+                    return Config:GetSetting('DoPet')
                 end,
             },
             {
                 name = "SappingStrike",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Decapitation",
                 type = "AA",
                 cond = function(self, aaName)
                     -- on emu this is activated on live it is passive.
-                    return Casting.AAReady(aaName) and not Casting.SongActive(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return not Casting.SongActive(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Binding Axe",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return Config:GetSetting('DoIntimidate') and mq.TLO.Me.AbilityReady(abilityName)()
+                    return Config:GetSetting('DoIntimidate')
                 end,
             },
             {
                 name = "AESlice",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Config:GetSetting('DoAoe') and Casting.DiscReady(discSpell)
+                    return Config:GetSetting('DoAoe')
                 end,
             },
             {
@@ -724,7 +699,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoDisconDisc') then return false end
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc()
+                    return not mq.TLO.Me.ActiveDisc()
                 end,
             },
             {
@@ -752,14 +727,14 @@ return {
                 name = "Drawn to Blood",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetTargetDistance() > 15
+                    return Targeting.GetTargetDistance() > 15
                 end,
             },
             {
                 name = "Communion of Blood",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctEndurance() <= 75
+                    return mq.TLO.Me.PctEndurance() <= 75
                 end,
             },
             {
@@ -768,16 +743,12 @@ return {
                     if not self.ModuleLoaded then return "" end
                     return mq.TLO.Spell("Reflexive Retaliation").RankName()
                 end,
-                type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return Config:GetSetting('DoIntimidate') and mq.TLO.Me.AbilityReady(abilityName)()
+                    return Config:GetSetting('DoIntimidate')
                 end,
             },
         },
@@ -797,16 +768,10 @@ return {
             {
                 name = "Dicho",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Bfrenzy",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
         },
     },

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -950,16 +950,12 @@ local _ClassConfig = {
                 name = "Dance of Blades",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and mq.TLO.Me.Song(item.Spell.RankName.Name())() ~= nil
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1000,6 +996,14 @@ local _ClassConfig = {
                     return Config:GetSetting('DoDispel') and mq.TLO.Target.Beneficial()
                 end,
             },
+            {
+                name = "Dreadstone",
+                type = "Item",
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('UseDreadstone') then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
+                end,
+            },
         },
         ['Combat'] = {
             -- Kludge that addresses bards not attempting to start attacking until after a song completes
@@ -1019,8 +1023,7 @@ local _ClassConfig = {
                 type = "Item",
                 cond = function(self, itemName)
                     if Config:GetSetting('UseEpic') == 1 then return false end
-                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck())) and mq.TLO.FindItem(itemName)() and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck()))
                 end,
             },
             {
@@ -1029,15 +1032,6 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     if Config:GetSetting('UseFierceEye') == 1 then return false end
                     return (Config:GetSetting('UseFierceEye') == 3 or (Config:GetSetting('UseFierceEye') == 2 and Casting.BurnCheck()))
-                end,
-            },
-            {
-                name = "Dreadstone",
-                type = "Item",
-                cond = function(self, itemName)
-                    -- This item is instant cast for free with almost no CD, just mash it forever when it's available
-                    if not Config:GetSetting('UseDreadstone') then return false end
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0
                 end,
             },
             {
@@ -1367,10 +1361,9 @@ local _ClassConfig = {
             {
                 name = "SymphonyOfBattle",
                 type = "Item",
-                targetId = function(self) return { mq.TLO.Me.ID(), } end,
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('UseSoBItems') then return false end
-                    return Casting.SelfBuffCheck("Symphony of Battle") and mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1417,10 +1410,9 @@ local _ClassConfig = {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -232,6 +232,10 @@ local _ClassConfig = {
             "Rapier of Somber Notes",
             "Songblade of the Eternal",
         },
+        ['Coating'] = {
+            "Spirit Drinker's Coating",
+            "Blood Drinker's Coating",
+        },
     },
     ['AbilitySets']     = {
         ['ShortRunBuff'] = {
@@ -320,10 +324,10 @@ local _ClassConfig = {
             "Arcane Aria",
         },
         ['InsultSong'] = {
-            --Bard Timers alternate between 6 and 3 every expansion.
-            --If we have push and nopush from the same tier active this will lead to issues with InsultSong2/timer stacking.
-            --Choosing which to prioritize is problematic, but for now, nopush will be prioritized to potentially help reduce movement in combat.
-            --Do to current F2P expansion limits, the ToL push will be chosen over the NoS nopush, I see no good solution for this.
+            --Bard Timers alternate between 6 and 3 every expansion. (Update: TOB has thrown this on its head)
+            --We have to manage selection so we don't have insultsong2 using the same timer.
+            --To circumvent issues with f2p accounts, for now, Sogran's is prioritized over Nord's. The code to distinguish this is excessive IMO.
+            "Yaran's Disdain",  -- 123 nopush, timer 6, TOB *THIS TIMER MAY BE INCORRECT, does not follow pattern*
             "Eoreg's Insult",   -- 122 push, timer 3, LS
             --"Nord's Disdain",       -- 118 nopush, timer 6, NoS
             "Sogran's Insult",  -- 117 push, timer 6, ToL
@@ -344,6 +348,7 @@ local _ClassConfig = {
             -- "Brusco's Boastful Bellow", --12,
         },
         ['InsultSong2'] = {
+            "Yaran's Disdain",  -- 123 nopush, timer 6, TOB *THIS TIMER MAY BE INCORRECT, does not follow pattern*
             "Eoreg's Insult",   -- 122 push, timer 3, LS
             --"Nord's Disdain",       -- 118 nopush, timer 6, NoS
             "Sogran's Insult",  -- 117 push, timer 6, ToL
@@ -360,7 +365,8 @@ local _ClassConfig = {
             "Venimor's Insult", -- 85, nopush, timer 3
         },
         ['DichoSong'] = {
-            -- DichoSong Level Range - 101 - 116
+            -- DichoSong Level Range - 101+
+            "Reciprocal Psalm",
             "Ecliptic Psalm",
             "Composite Psalm",
             "Dissident Psalm",
@@ -644,6 +650,7 @@ local _ClassConfig = {
 
         },
         ['AllianceSong'] = {
+            "Covariance of Sticks and Stones",
             "Conjunction of Sticks and Stones",
             "Alliance of Sticks and Stones",
             "Covenant of Sticks and Stones",
@@ -762,6 +769,17 @@ local _ClassConfig = {
             "Kelin's Lugubrious Lament", -- Level 8 (Max Mob Level of 60)
             "Silent Song of Quellious",  -- Level 61
             "Luvwen's Aria of Serenity", -- Level 66
+            "Whispersong of Veshma",     -- Level 71
+            "Elddar's Dawnsong",         -- Level 76
+            "Silence of the Void",       -- Level 81
+            "Silence of the Dreamer",    -- Level 86
+            "Silence of the Windsong",   -- Level 91
+            "Silence of the Forsaken",   -- Level 96
+            "Silence of the Silisia",    -- Level 101
+            "Silence of Jembel",         -- Level 106
+            "Silence of Zburator",       -- Level 111
+            "Silence of Quietus",        -- Level 116
+            "Silence of the Forgotten",  -- Level 121
         },
     },
     ['HelperFunctions'] = {
@@ -903,58 +921,34 @@ local _ClassConfig = {
             {
                 name = "Quick Time",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Funeral Dirge",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) -- and Config:GetSetting('UseFuneralDirge') --see note in config settings
-                end,
             },
             {
                 name = "Spire of the Minstrels",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Bladed Song",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Song of Stone",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Thousand Blades",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Flurry of Notes",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Dance of Blades",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -971,35 +965,20 @@ local _ClassConfig = {
             {
                 name = "Cacophony",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Frenzied Kicks",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
         ['Debuff'] = {
-            -- {
-            --     name = "MezAESong",
-            --     type = "Song",
-            --     cond = function(self, songSpell)
-            --         if not (Config:GetSetting('MezOn') and Config:GetSetting('UseAEAAMez') and Casting.SongMemed(songSpell)) then return false end
-            --         return Targeting.GetXTHaterCount() >= Config:GetSetting("MezAECount") and (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0
-            --     end,
-            -- },
             {
                 name = "AESlowSong",
                 type = "Song",
@@ -1049,8 +1028,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if Config:GetSetting('UseFierceEye') == 1 then return false end
-                    return (Config:GetSetting('UseFierceEye') == 3 or (Config:GetSetting('UseFierceEye') == 2 and Casting.BurnCheck())) and
-                        Casting.AAReady(aaName)
+                    return (Config:GetSetting('UseFierceEye') == 3 or (Config:GetSetting('UseFierceEye') == 2 and Casting.BurnCheck()))
                 end,
             },
             {
@@ -1068,7 +1046,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ReflexStrike,
                 cond = function(self, discSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return Casting.TargetedDiscReady(discSpell) and (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
+                    return (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
                 end,
             },
             {
@@ -1077,15 +1055,14 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if Config:GetSetting('UseBellow') == 1 then return false end
                     return ((Config:GetSetting('UseBellow') == 3 and mq.TLO.Me.PctEndurance() > Config:GetSetting('SelfEndPct')) or (Config:GetSetting('UseBellow') == 2 and Casting.BurnCheck())) and
-                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
+                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)()
+                    return (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) > 1
                 end,
             },
         },
@@ -1104,7 +1081,7 @@ local _ClassConfig = {
                 type = "Song",
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseInsult') then return false end
-                    return (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0 and (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
                 end,
             },
             {
@@ -1152,7 +1129,7 @@ local _ClassConfig = {
                 type = "Song",
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseInsult') then return false end
-                    return (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0 and (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
                 end,
             },
             {
@@ -1224,7 +1201,7 @@ local _ClassConfig = {
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseCrescendo') then return false end
                     local pct = Config:GetSetting('GroupManaPct')
-                    return (mq.TLO.Me.GemTimer(songSpell.RankName.Name())() or -1) == 0 and (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
+                    return (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
                 end,
             },
             {
@@ -1355,14 +1332,14 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     if Config:GetSetting('UseRunBuff') ~= 1 then return false end
                     --refreshes slightly before expiry for better uptime
-                    return Casting.AAReady(aaName) and (mq.TLO.Me.Buff(mq.TLO.AltAbility(aaName).Spell.Trigger(1)).Duration.TotalSeconds() or 0) < 30
+                    return (mq.TLO.Me.Buff(mq.TLO.AltAbility(aaName).Spell.Trigger(1)).Duration.TotalSeconds() or 0) < 30
                 end,
             },
             {
                 name = "Rallying Solo", --Rallying Call theoretically possible but problematic, needs own rotation akin to Focused Paragon, etc
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and (mq.TLO.Me.PctEndurance() < 30 or mq.TLO.Me.PctMana() < 30)
+                    return (mq.TLO.Me.PctEndurance() < 30 or mq.TLO.Me.PctMana() < 30)
                 end,
             },
             {
@@ -1411,7 +1388,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoVetAA') then return false end
-                    return mq.TLO.Me.PctHPs() < 35 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
@@ -1419,7 +1396,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('UseFading') then return false end
-                    return Casting.AAReady(aaName) and self.ClassConfig.HelperFunctions.UnwantedAggroCheck(self)
+                    return self.ClassConfig.HelperFunctions.UnwantedAggroCheck(self)
                     --I wanted to use XTAggroCount here but it doesn't include your current target in the number it returns and I don't see a good workaround. For Loop it is.
                 end,
             },
@@ -1427,14 +1404,23 @@ local _ClassConfig = {
                 name = "Hymn of the Last Stand",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {
                 name = "Shield of Notes",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                end,
+            },
+            {
+                name = "Coating",
+                type = "Item",
+                cond = function(self, itemName)
+                    if not Config:GetSetting('DoCoating') then return false end
+                    local item = mq.TLO.FindItem(itemName)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
                 end,
             },
         },
@@ -1941,10 +1927,10 @@ local _ClassConfig = {
             Answer = "You can enable Use Accelerando to use your Accelerando song." ..
                 "Options are (Never, In-Combat Only, Always, Out-of-Combat Only).",
         },
-        --Utility/Items/Misc
+        --Equipment
         ['UseEpic']             = {
             DisplayName = "Epic Use:",
-            Category = "Utility/Items/Misc",
+            Category = "Equipment",
             Index = 1,
             Tooltip = "Use Epic 1-Never 2-Burns 3-Always",
             Type = "Combo",
@@ -1959,7 +1945,7 @@ local _ClassConfig = {
         },
         ['DoChestClick']        = {
             DisplayName = "Chest Click",
-            Category = "Utility/Items/Misc",
+            Category = "Equipment",
             Index = 2,
             Tooltip = "Click your equipped chest item.",
             Default = mq.TLO.MacroQuest.BuildName() ~= "Emu",
@@ -1970,7 +1956,7 @@ local _ClassConfig = {
         },
         ['UseSoBItems']         = {
             DisplayName = "Symph. of Battle",
-            Category = "Utility/Items/Misc",
+            Category = "Equipment",
             Index = 3,
             Tooltip = "Click your Symphony of Battle items.",
             Default = false,
@@ -1980,7 +1966,7 @@ local _ClassConfig = {
         },
         ['UseDreadstone']       = {
             DisplayName = "Dreadstone",
-            Category = "Utility/Items/Misc",
+            Category = "Equipment",
             Index = 4,
             Tooltip = "Use your Dreadstone when able.",
             Default = false,
@@ -1988,10 +1974,19 @@ local _ClassConfig = {
             FAQ = "What does the Dreadstone option control?",
             Answer = "Possessed Dreadstone Minstrel's Rapier is a clicky 55% slow item rewarded by the quest \"The Depths of Fear\".",
         },
+        ['DoCoating']           = {
+            DisplayName = "Use Coating",
+            Category = "Equipment",
+            Index = 5,
+            Tooltip = "Click your Blood/Spirit Drinker's Coating in an emergency.",
+            Default = false,
+            FAQ = "What is a Coating?",
+            Answer = "Blood Drinker's Coating is a clickable lifesteal effect added in CotF. Spirit Drinker's Coating is an upgrade added in NoS.",
+        },
         ['UseRunBuff']          = {
             DisplayName = "Runspeed Buff:",
-            Category = "Utility/Items/Misc",
-            Index = 5,
+            Category = "Utility/Misc",
+            Index = 1,
             Tooltip = "Select Runspeed Buff to use. NOTE: This setting may need user adjustment during the early level range!",
             Type = "Combo",
             ComboOptions = { 'AA', 'Song (Long Duration Only)', 'Song (Fastest Available)', 'Off', },
@@ -2004,8 +1999,8 @@ local _ClassConfig = {
         },
         ['UseEndBreath']        = {
             DisplayName = "Use Enduring Breath",
-            Category = "Utility/Items/Misc",
-            Index = 6,
+            Category = "Utility/Misc",
+            Index = 2,
             Tooltip = Tooltips.EndBreathSong,
             Default = false,
             ConfigType = "Advanced",
@@ -2014,8 +2009,8 @@ local _ClassConfig = {
         },
         ['DoVetAA']             = {
             DisplayName = "Use Vet AA",
-            Category = "Utility/Items/Misc",
-            Index = 7,
+            Category = "Utility/Misc",
+            Index = 3,
             Tooltip = "Use Veteran AA's in emergencies or during Burn",
             Default = true,
             ConfigType = "Advanced",
@@ -2024,8 +2019,8 @@ local _ClassConfig = {
         },
         ['EmergencyStart']      = {
             DisplayName = "Emergency HP%",
-            Category = "Utility/Items/Misc",
-            Index = 8,
+            Category = "Utility/Misc",
+            Index = 4,
             Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
             Default = 50,
             Min = 1,
@@ -2037,8 +2032,8 @@ local _ClassConfig = {
         },
         ['UseFading']           = {
             DisplayName = "Use Combat Escape",
-            Category = "Utility/Items/Misc",
-            Index = 9,
+            Category = "Utility/Misc",
+            Index = 5,
             Tooltip = "Use Fading Memories when you have aggro and you aren't the Main Assist.",
             Default = true,
             ConfigType = "Advanced",
@@ -2048,8 +2043,8 @@ local _ClassConfig = {
         },
         ['RefreshDT']           = {
             DisplayName = "Downtime Threshold",
-            Category = "Utility/Items/Misc",
-            Index = 10,
+            Category = "Utility/Misc",
+            Index = 6,
             Tooltip =
             "The duration threshold for refreshing a buff song outside of combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
             Default = 12,
@@ -2062,8 +2057,8 @@ local _ClassConfig = {
         },
         ['RefreshCombat']       = {
             DisplayName = "Combat Threshold",
-            Category = "Utility/Items/Misc",
-            Index = 11,
+            Category = "Utility/Misc",
+            Index = 7,
             Tooltip =
             "The duration threshold for refreshing a buff song in combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
             Default = 6,

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -834,7 +834,7 @@ local _ClassConfig = {
         end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending
             if not songSpell or not songSpell() then return false end
-            local named = Targeting.IsNamed(mq.TLO.Target)
+            local named = Targeting.IsNamed(Targeting.GetAutoTarget())
             local targethp = Targeting.GetTargetPctHPs()
 
             return Casting.SpellStacksOnTarget(songSpell) and ((named and (Config:GetSetting('NamedStopDOT') < targethp)) or

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -722,7 +722,7 @@ return {
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
                 return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99))
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(Targeting.GetAutoTarget()) and mq.TLO.Me.PctAggro() > 99))
             end,
         },
         {
@@ -1019,8 +1019,7 @@ return {
                     --This checks to see if the Growl portion is up on the pet (or about to expire) before using this, those who prefer the swarm pets can use the actual swarm pet spell in conjunction with this for mana savings.
                     --There are some instances where the Growl isn't needed, but that is a giant TODO and of minor benefit.
                     ---@diagnostic disable-next-line: undefined-field
-                    return (mq.TLO.Pet.BuffDuration(spell.RankName.Trigger(2)).TotalSeconds() or 0) < 10 and Casting.TargetedSpellReady(spell, target.ID())
-                        and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
+                    return (mq.TLO.Pet.BuffDuration(spell.RankName.Trigger(2)).TotalSeconds() or 0) < 10
                 end,
             },
             {

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -24,6 +24,10 @@ return {
             "Beast Tamer's Jerkin",
             "Savagesoul Jerkin of the Wilds",
         },
+        ['Coating'] = {
+            "Spirit Drinker's Coating",
+            "Blood Drinker's Coating",
+        },
     },
     ['AbilitySets']       = { --TODO/Under Consideration: Add AoE Roar line, add rotation entry (tie it to Do AoE setting), swap in instead of lance 2, especially since the last lance2 is level 112
         ['SwarmPet'] = {
@@ -117,6 +121,17 @@ return {
             "Kromtus Lance",   -- Level 102 - Timer 11
             "Restless Lance",  -- Level 112 - Timer 11
         },
+        ['AERoar'] = {
+            -- PBAE Roar Timer 11 Ice Nuke Fast Cast
+            "Glacial Roar",   -- Level 89 - Timer 11
+            "Frostrift Roar", -- Level 94 - Timer 11
+            "Kromrif Roar",   -- Level 99 - Timer 11
+            "Kromtus Roar",   -- Level 104 - Timer 11
+            "Frostbite Roar", -- Level 109 - Timer 11
+            "Restless Roar",  -- Level 114 - Timer 11
+            "Polar Roar",     -- Level 119 - Timer 11
+            "Hoarfrost Roar", -- Level 124 - Timer 11
+        },
         ['EndemicDot'] = {
             -- Disease DoT Instant Cast
             "Sicken",                -- Level 14
@@ -180,6 +195,7 @@ return {
             "Dissident Fury",  -- Level 106
             "Composite Fury",  -- Level 111
             "Ecliptic Fury",   -- Level 116
+            "Reciprocal Fury", -- Level 121
         },
         ['HealSpell'] = {
             "Salve",               -- Level 1
@@ -404,7 +420,6 @@ return {
             "Spiritual Radiance",
             "Spiritual Purity",
             "Spiritual Dominion",
-            "Spiritual Rejuvenation",
             "Spiritual Ascendance",
             "Spiritual Enlightenment",
             "Spiritual Epiphany",
@@ -425,6 +440,7 @@ return {
             "Venomous Covenant",    -- Level 108
             "Venomous Coalition",   -- Level 113
             "Venomous Conjunction", -- Level 118
+            "Venomous Covariance",  -- Level 123
         },
         ['PetBlockSpell'] = {
             "Ward of Calliav",       -- Level 49
@@ -451,6 +467,7 @@ return {
             "Auspice of Esianti",    -- Level 107
             "Auspice of Kildrukaun", -- Level 112
             "Auspice of Valia",      -- Level 117
+            "Auspice of Usira",      -- Level 122
         },
         ['PetHotSpell'] = {
             -- Pet Hot Spell
@@ -508,7 +525,6 @@ return {
             -- Group Attack+ Hp Buff
             "Spiritual Vigor",
             "Spiritual Vitality",
-            "Spiritual Vibrance",
             "Spiritual Vim",
             "Spiritual Vivacity",
             "Spiritual Verve",
@@ -518,6 +534,7 @@ return {
             "Spiritual Vivification",
             "Spiritual Vibrancy",
             "Spiritual Vehemence",
+            "Spiritual Vigor",
             "Spiritual Valiancy",
             --Single Target Atk+HP Buff* - Does Not Stack with Pally brells or Ranger Buff - is Middle ground Buff has HP & Atk
             "Spiritual Brawn",
@@ -601,6 +618,7 @@ return {
             "Reflexive Rending",
             "Reflexive Sundering",
             "Reflexive Riving",
+            "Reflexive Slashing", -- Level 124
         },
         ['VinDisc'] = {
             -- Vindication Disc
@@ -609,6 +627,7 @@ return {
             "Ikatiar's Vindication",
             "Kejaan's Vindication",
             "Ikatiar's Vindication",
+            "Xanathan's Vindication", -- Level 125
         },
     },
     ['HealRotationOrder'] = {
@@ -635,36 +654,29 @@ return {
         },
     },
     ['HealRotations']     = {
-        ["PetHealAA"] = {
+        ['PetHealAA'] = {
             {
                 name = "Replenish Companion",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return mq.TLO.Me.Pet.PctHPs() <= Config:GetSetting('BigHealPoint') and Casting.TargetedAAReady(aaName, target.ID(), true)
+                    return mq.TLO.Me.Pet.PctHPs() <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "Mend Companion",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return mq.TLO.Me.Pet.PctHPs() <= Config:GetSetting('BigHealPoint') and Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
         },
-        ["PetHealSpell"] = {
+        ['PetHealSpell'] = {
             {
                 name = "PetHealSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
         },
-        ["MainHealPoint"] = {
+        ['MainHealPoint'] = {
             {
                 name = "HealSpell",
                 type = "Spell",
-                cond = function(self, spell, target) return Casting.TargetedSpellReady(spell, target.ID(), true) end,
             },
         },
     },
@@ -804,58 +816,37 @@ return {
             {
                 name = "Bestial Bloodrage",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Group Bestial Alignment",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
                 name = "Attack of the Warders",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Frenzy of Spirit",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Bloodlust",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "VinDisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Spire of the Savage Lord",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Companion's Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -872,9 +863,6 @@ return {
             {
                 name = "Frenzied Swipes",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "BloodDot",
@@ -882,43 +870,42 @@ return {
                 cond = function(self, spell, target)
                     local vinDisc = self.ResolvedActionMap['VinDisc']
                     if not vinDisc then return false end
-                    return Casting.BuffActive(vinDisc) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.BuffActive(vinDisc)
                 end,
             },
             {
                 name = "FuryDisc",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return Casting.DiscReady(discSpell) and not self.ClassConfig.HelperFunctions.FlurryActive(self)
+                    return not self.ClassConfig.HelperFunctions.FlurryActive(self)
                 end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.FlurryActive(self) and
-                        (mq.TLO.Me.GemTimer(self.ResolvedActionMap['DichoSpell'])() or -1) > 15
+                    return not self.ClassConfig.HelperFunctions.FlurryActive(self) and (mq.TLO.Me.GemTimer(self.ResolvedActionMap['DichoSpell'])() or -1) > 15
                 end,
             },
             {
                 name = "DmgModDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
                 name = "Ferociousness",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
                 name = "Bestial Alignment",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
@@ -928,6 +915,13 @@ return {
                     return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
+            {
+                name = "Intensity of the Resolute",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Config:GetSetting('DoVetAA')
+                end,
+            },
         },
         ['Slow'] = {
             {
@@ -935,8 +929,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
-                        Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct())
                 end,
             },
             {
@@ -944,8 +937,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Sha's Reprisal") then return false end
-                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct())
                 end,
             },
         },
@@ -953,24 +945,40 @@ return {
             {
                 name = "Falsified Death",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
-                        and Casting.AAReady(aaName) and not Core.IAmMA
+                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99) and not Core.IAmMA
+                end,
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                cond = function(self, aaName)
+                    if not Config:GetSetting('DoVetAA') then return false end
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
                 name = "Warder's Gift",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.Pet.PctHPs() and mq.TLO.Me.Pet.PctHPs() > 50) and Casting.AAReady(aaName)
+                    return (mq.TLO.Me.Pet.PctHPs() and mq.TLO.Me.Pet.PctHPs() > 50)
                 end,
             },
             {
                 name = "Protection of the Warder",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and Casting.AAReady(aaName)
+                    return Targeting.IHaveAggro(100)
+                end,
+            },
+            {
+                name = "Coating",
+                type = "Item",
+                cond = function(self, itemName)
+                    if not Config:GetSetting('DoCoating') then return false end
+                    local item = mq.TLO.FindItem(itemName)
+                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
                 end,
             },
         },
@@ -978,9 +986,6 @@ return {
             {
                 name = "Focused Paragon of Spirits",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ['DPS'] = {
@@ -996,14 +1001,14 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoParagon') then return false end
-                    return (mq.TLO.Group.LowMana(Config:GetSetting('ParaPct'))() or -1) > 0 and Casting.AAReady(aaName)
+                    return (mq.TLO.Group.LowMana(Config:GetSetting('ParaPct'))() or -1) > 0
                 end,
             },
             {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and not self.ClassConfig.HelperFunctions.FlurryActive(self)
+                    return not self.ClassConfig.HelperFunctions.FlurryActive(self)
                 end,
             },
             {
@@ -1023,7 +1028,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1031,7 +1036,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1039,42 +1044,51 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Maelstrom",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "FrozenPoi",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "PoiBite",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Icelance1",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Icelance2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    if Config:GetSetting("DoAERoar") then return false end
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                end,
+            },
+            {
+                name = "AERoar",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    if not (Config:GetSetting("DoAERoar") and Config:GetSetting("DoAEDamage")) then return false end
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
@@ -1084,9 +1098,7 @@ return {
                     if not Config:GetSetting('DoSwarmPet') then return false end
                     --We will let Feralgia apply swarm pets if our pet currently doesn't have its Growl Effect.
                     local feralgia = self.ResolvedActionMap['Feralgia']
-                    return (feralgia and feralgia() and mq.TLO.Me.PetBuff(mq.TLO.Spell(feralgia).RankName.Trigger(2).ID()))
-                        and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
-                        and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
+                    return (feralgia and feralgia() and mq.TLO.Me.PetBuff(mq.TLO.Spell(feralgia).RankName.Trigger(2).ID())) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1094,79 +1106,54 @@ return {
             {
                 name = "Roar of Thunder",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Raven's Claw",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Gorilla Smash",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Feral Swipe",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Kick",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Tiger Claw",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Bite of the Asp",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Enduring Frenzy",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Targeting.GetTargetPctHPs() > 90 and Casting.TargetedAAReady(aaName, target.ID())
+                    return Targeting.GetTargetPctHPs() > 90
                 end,
             },
             {
                 name = "EndRegenProcDisc",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return mq.TLO.Me.PctEndurance() < Config:GetSetting('ParaPct') and Casting.TargetedDiscReady(discSpell)
+                    return mq.TLO.Me.PctEndurance() < Config:GetSetting('ParaPct')
                 end,
             },
             {
                 name = "Chameleon Strike",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "SingleClaws",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    if Config:GetSetting('DoAEDamage') then return false end
-                    return Casting.TargetedDiscReady(discSpell, target.ID())
+                    return not Config:GetSetting('DoAEDamage')
                 end,
             },
             {
@@ -1174,28 +1161,25 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     if not Config:GetSetting('DoAEDamage') then return false end
-                    return Casting.TargetedDiscReady(discSpell, target.ID()) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
                 name = "Maul",
                 type = "Disc",
-                cond = function(self, discSpell, target)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "BestialBuffDisc",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return not Casting.BuffActive(discSpell) and Casting.DiscReady(discSpell)
+                    return not Casting.BuffActive(discSpell)
                 end,
             },
             {
                 name = "Consumption of Spirit",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.PctHPs() > 90 and mq.TLO.Me.PctMana() < 60) and Casting.AAReady(aaName)
+                    return (mq.TLO.Me.PctHPs() > 90 and mq.TLO.Me.PctMana() < 60)
                 end,
             },
             {
@@ -1203,7 +1187,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     ---@diagnostic disable-next-line: undefined-field
-                    return mq.TLO.Me.TotalCounters() > 0 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.TotalCounters() > 0
                 end,
             },
         },
@@ -1293,22 +1277,19 @@ return {
             {
                 name = "Gelid Rending",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Consumption of Spirit",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.PctHPs() > 70 and mq.TLO.Me.PctMana() < 80) and Casting.AAReady(aaName)
+                    return (mq.TLO.Me.PctHPs() > 70 and mq.TLO.Me.PctMana() < 80)
                 end,
             },
             {
                 name = "Feralist's Unity",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
             {
@@ -1323,19 +1304,9 @@ return {
                 name = "Pact of The Wurine",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
-            -- TODO: Does anyone even want this?
-            --{
-            --    name = "VerifyFerocity",
-            --    type = "CustomFunc",
-            --    custom_func = function(self, targetId)
-            --        if not Config:GetSetting('DoCombatFero') or not Casting.TargetedSpellReady(self.ResolvedActionMap['SingleAtkBuff'], targetId, false) then return false end
-            --        -- TODO: Ferocity List?
-            --        return false
-            --    end,
-            --},
         },
         ['PetBuff'] = {
             {
@@ -1431,14 +1402,14 @@ return {
                 name = "Fortify Companion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Taste of Blood",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },
@@ -1458,6 +1429,7 @@ return {
             spells = {
                 { name = "PetHealSpell", cond = function(self) return Config:GetSetting('DoPetHeals') end, },
                 { name = "Icelance1", },
+                { name = "AERoar",       cond = function(self) return Config:GetSetting('DoAERoar') end, },
                 { name = "Icelance2", },
             },
         },
@@ -1465,6 +1437,7 @@ return {
             gem = 3,
             spells = {
                 { name = "Icelance1", },
+                { name = "AERoar",    cond = function(self) return Config:GetSetting('DoAERoar') end, },
                 { name = "Icelance2", },
                 { name = "BloodDot", },
             },
@@ -1472,6 +1445,7 @@ return {
         {
             gem = 4,
             spells = {
+                { name = "AERoar",    cond = function(self) return Config:GetSetting('DoAERoar') end, },
                 { name = "Icelance2", },
                 { name = "BloodDot", },
                 { name = "ColdDot",   cond = function(self) return Config:GetSetting('DoDot') end, },
@@ -1801,10 +1775,19 @@ return {
             FAQ = "Why am I using AE damage when there are mezzed mobs around?",
             Answer = "It is not currently possible to properly determine Mez status without direct Targeting. If you are mezzing, consider turning this option off.",
         },
+        ['DoAERoar']       = {
+            DisplayName = "Use AE Roar",
+            Category = "Combat",
+            Index = 2,
+            Tooltip = "Use your AE Roar (Timer 11) spell line.",
+            Default = false,
+            FAQ = "Why am I not using the Roar line? It is better than this weak Ice Lance?",
+            Answer = "Enable Use AE Roar to memorize the spell.\nNote that Do AE Damage must also be enabled for the Roar to be used.",
+        },
         ['AETargetCnt']    = {
             DisplayName = "AE Target Count",
             Category = "Combat",
-            Index = 2,
+            Index = 3,
             Tooltip = "Minimum number of valid targets before using AE Disciplines or AA.",
             Default = 2,
             Min = 1,
@@ -1816,7 +1799,7 @@ return {
         ['MaxAETargetCnt'] = {
             DisplayName = "Max AE Targets",
             Category = "Damage Spells",
-            Index = 3,
+            Index = 4,
             Tooltip =
             "Maximum number of valid targets before using AE Spells, Disciplines or AA.\nUseful for setting up AE Mez at a higher threshold on another character in case you are overwhelmed.",
             Default = 5,
@@ -1829,7 +1812,7 @@ return {
         ['SafeAEDamage']   = {
             DisplayName = "AE Proximity Check",
             Category = "Combat",
-            Index = 4,
+            Index = 5,
             Tooltip = "Check to ensure there aren't neutral mobs in range we could aggro if AE damage is used. May result in non-use due to false positives.",
             Default = false,
             FAQ = "Can you better explain the AE Proximity Check?",
@@ -1840,7 +1823,7 @@ return {
         ['EmergencyStart'] = {
             DisplayName = "Emergency HP%",
             Category = "Combat",
-            Index = 5,
+            Index = 6,
             Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
             Default = 50,
             Min = 1,
@@ -1852,17 +1835,26 @@ return {
         ['AggroFeign']     = {
             DisplayName = "Emergency Feign",
             Category = "Combat",
-            Index = 6,
+            Index = 7,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a RGMercsNamed/SpawnMaster mob.",
             Default = true,
             FAQ = "How do I use my Feign Death?",
             Answer = "Make sure you have [AggroFeign] enabled.\n" ..
                 "This will use your Feign Death AA when you have aggro at low health or aggro on a RGMercsNamed/SpawnMaster mob.",
         },
+        ['DoCoating']      = {
+            DisplayName = "Use Coating",
+            Category = "Combat",
+            Index = 8,
+            Tooltip = "Click your Blood/Spirit Drinker's Coating in an emergency.",
+            Default = false,
+            FAQ = "What is a Coating?",
+            Answer = "Blood Drinker's Coating is a clickable lifesteal effect added in CotF. Spirit Drinker's Coating is an upgrade added in NoS.",
+        },
         ['DoChestClick']   = {
             DisplayName = "Do Chest Click",
             Category = "Combat",
-            Index = 7,
+            Index = 9,
             Tooltip = "Click your chest item during burns.",
             Default = mq.TLO.MacroQuest.BuildName() ~= "Emu",
             ConfigType = "Advanced",

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -848,16 +848,12 @@ return {
                 name = "Companion's Fury",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and Casting.TargetHasBuff(item.Spell, mq.TLO.Me)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and Casting.SpellStacksOnMe(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -912,7 +908,7 @@ return {
                 name = "OoW_Chest",
                 type = "Item",
                 cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and not self.ClassConfig.HelperFunctions.DmgModActive(self)
+                    return not self.ClassConfig.HelperFunctions.DmgModActive(self)
                 end,
             },
             {
@@ -975,10 +971,9 @@ return {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },
@@ -1312,9 +1307,8 @@ return {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName)
-                    return Config:GetSetting('DoEpic') and
-                        mq.TLO.FindItem(itemName)() and mq.TLO.Me.ItemReady(itemName)() and
-                        (mq.TLO.Me.PetBuff("Savage Wildcaller's Blessing")() == nil and mq.TLO.Me.PetBuff("Might of the Wild Spirits")() == nil)
+                    if not Config:GetSetting('DoEpic') then return false end
+                    return not mq.TLO.Me.PetBuff("Savage Wildcaller's Blessing")() and not mq.TLO.Me.PetBuff("Might of the Wild Spirits")()
                 end,
             },
             {

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -1007,7 +1007,7 @@ local _ClassConfig = {
                 name = "CompleteHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting("DoCompleteHeal") or target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Config:GetSetting("DoCompleteHeal") or not Targeting.TargetIsMA(target) then return false end
                     return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct')
                 end,
             },
@@ -1015,7 +1015,7 @@ local _ClassConfig = {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return not (Config:GetSetting("DoCompleteHeal") and target.ID() == Core.GetMainAssistId())
+                    return not (Config:GetSetting("DoCompleteHeal") and Targeting.TargetIsMA(target))
                 end,
             },
         },

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -861,6 +861,13 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Focused Celestial Regeneration",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Targeting.TargetIsMA(target)
+                end,
+            },
+            {
                 name = "Blessing of Sanctuary",
                 type = "AA",
                 cond = function(self, aaName, target)
@@ -958,13 +965,6 @@ local _ClassConfig = {
             },
         },
         ['MainHeal(70-100)'] = { --Level 70-100
-            {
-                name = "Focused Celestial Regeneration",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    return Targeting.TargetIsMA(target)
-                end,
-            },
             {
                 name = "HealNuke",
                 type = "Spell",

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -691,11 +691,11 @@ local _ClassConfig = {
             end
 
             if mq.TLO.Me.CombatState():lower() == "active" or mq.TLO.Me.CombatState():lower() == "resting" then
-                if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence")) then
+                if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
                     rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
                 elseif Casting.AAReady("Blessing of Resurrection") then
                     rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
-                elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell) then
+                elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
                     rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end
@@ -786,52 +786,36 @@ local _ClassConfig = {
             {
                 name = "DichoHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
-                        (mq.TLO.Group.Injured(Config:GetSetting('BigHealPoint'))() or 0) >= Config:GetSetting('GroupInjureCnt')
+                cond = function(self)
+                    return (mq.TLO.Group.Injured(Config:GetSetting('BigHealPoint'))() or 0) >= Config:GetSetting('GroupInjureCnt')
                 end,
             },
             {
                 name = "Beacon of Life",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupFastHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Celestial Regeneration",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupHealCure",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Exquisite Benediction",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupElixir",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -839,15 +823,15 @@ local _ClassConfig = {
             {
                 name = "ClutchHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Targeting.GetTargetPctHPs() < 35
+                cond = function(self)
+                    return Targeting.GetTargetPctHPs() < 35
                 end,
             },
             {
                 name = "Sanctuary",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName)
+                    return (target.ID() or 0) == mq.TLO.Me.ID()
                 end,
             },
             -- {
@@ -862,15 +846,12 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Burst of Life",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
             {
                 name = "Epic",
@@ -883,29 +864,23 @@ local _ClassConfig = {
                 name = "Blessing of Sanctuary",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == (mq.TLO.Target.AggroHolder.ID() and not Core.GetMainAssistId())
+                    return target.ID() == (mq.TLO.Target.AggroHolder.ID() and not Core.GetMainAssistId())
                 end,
             },
             -- {
             --     name = "Veturika's Perseverence",
             --     type = "AA",
             --     cond = function(self, aaName, target)
-            --         return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName)
+            --         return (target.ID() or 0) == mq.TLO.Me.ID()
             --     end,
             -- },
             { --The stuff above is down, lets make mainhealpoint chonkier. Homework: Wondering if we should be using this more/elsewhere.
                 name = "Channeling of the Divine",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             { --The stuff above is down, lets make mainhealpoint faster.
                 name = "Celestial Rapidity",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -917,9 +892,6 @@ local _ClassConfig = {
             { --if we hit this we need spells back ASAP
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ["MainHeal(101+)"] = {
@@ -927,29 +899,23 @@ local _ClassConfig = {
                 name = "Focused Celestial Regeneration",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                cond = function(self)
+                    return mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "RemedyHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "RemedyHeal2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -963,15 +929,12 @@ local _ClassConfig = {
             {
                 name = "Beacon of Life",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Celestial Regeneration",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
@@ -979,22 +942,19 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') or (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "Exquisite Benediction",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Casting.BurnCheck()
+                cond = function(self)
+                    return Casting.BurnCheck()
                 end,
             },
             {
                 name = "GroupHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
         },
         ["MainHeal(70-100)"] = { --Level 70-100
@@ -1002,57 +962,45 @@ local _ClassConfig = {
                 name = "Focused Celestial Regeneration",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true) and target.ID() == Core.GetMainAssistId
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                cond = function(self)
+                    return mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "HealNuke2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                cond = function(self)
+                    return mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "RemedyHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Renewal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Renewal2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Renewal3",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "SingleElixir",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1060,15 +1008,14 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting("DoCompleteHeal") or target.ID() ~= Core.GetMainAssistId() then return false end
-                    return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct') and Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct')
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if Config:GetSetting("DoCompleteHeal") and target.ID() == Core.GetMainAssistId() then return false end
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return not (Config:GetSetting("DoCompleteHeal") and target.ID() == Core.GetMainAssistId())
                 end,
             },
         },
@@ -1077,7 +1024,7 @@ local _ClassConfig = {
                 name = "RemedyHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
@@ -1085,15 +1032,12 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
         },
 
@@ -1167,7 +1111,7 @@ local _ClassConfig = {
                 name = "Veturika's Perseverence",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName) and Casting.AmIBuffable()
+                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AmIBuffable()
                 end,
             },
             {
@@ -1176,7 +1120,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if target.ID() == mq.TLO.Me.ID() then return false end
                     local rezSearch = string.format("pccorpse %s radius 100 zradius 50", target.DisplayName())
-                    return Casting.TargetedAAReady(aaName, target.ID()) and mq.TLO.SpawnCount(rezSearch)() == 0
+                    return mq.TLO.SpawnCount(rezSearch)() == 0
                 end,
             },
         },
@@ -1185,7 +1129,7 @@ local _ClassConfig = {
                 name = "ReverseDS",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1193,7 +1137,7 @@ local _ClassConfig = {
                 type = "Spell",
                 allowDead = true,
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1201,73 +1145,51 @@ local _ClassConfig = {
             {
                 name = "Celestial Hammer",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Flurry of Life",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Healing Frenzy",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spire of the Vicar",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Divine Avatar",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
+                cond = function(self)
+                    return Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
                 end,
             },
             { --homework: This is a defensive proc, likely need to add elsewhere
                 name = "Divine Retribution",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
+                cond = function(self)
+                    return Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
                 end,
             },
             {
                 name = "Battle Frenzy",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
-                cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                cond = function(self)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
             { --homework: Check if this is necessary (does not exceed 50% spell haste cap)
                 name = "Celestial Rapidity",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ['DPS'] = {
@@ -1284,10 +1206,9 @@ local _ClassConfig = {
             {
                 name = "StunTimer6",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoHealStun') then return false end
-                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             -- {
@@ -1328,7 +1249,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if Casting.CanUseAA("Yaulp") then return false end
-                    return Casting.GemReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1337,39 +1258,38 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if (mq.TLO.Me.Level() < 101 and not Casting.DetGOMCheck()) then return false end
-                    return Casting.GemReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
+                    return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
                 end,
             },
             {
                 name = "LowLevelStun",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoLLStun') then return false end
-                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff()
                 end,
             },
             {
                 name = "Turn Undead",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Targeting.TargetBodyIs(target, "Undead") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Targeting.TargetBodyIs(target, "Undead")
                 end,
             },
             {
                 name = "UndeadNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, aaName, target)
                     if not Config:GetSetting('DoUndeadNuke') or not Targeting.TargetBodyIs(target, "Undead") then return false end
-                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "MagicNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not Config:GetSetting('DoMagicNuke') then return false end
-                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1432,7 +1352,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -857,7 +857,7 @@ local _ClassConfig = {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName, target)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and target.ID() == Core.GetMainAssistId
+                    return target.ID() == Core.GetMainAssistId
                 end,
             },
             {
@@ -892,9 +892,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
             { --if we hit this we need spells back ASAP
                 name = "Forceful Rejuvenation",
@@ -927,9 +924,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
         },
         ['GroupHeal(1-97)'] = { --Level 1-97

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -782,7 +782,7 @@ local _ClassConfig = {
         },
     },
     ['HealRotations']     = {
-        ["GroupHeal(98+)"] = {
+        ['GroupHeal(98+)'] = {
             {
                 name = "DichoHeal",
                 type = "Spell",
@@ -819,7 +819,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ["BigHeal(65+)"] = {
+        ['BigHeal(65+)'] = {
             {
                 name = "ClutchHeal",
                 type = "Spell",
@@ -894,7 +894,7 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ["MainHeal(101+)"] = {
+        ['MainHeal(101+)'] = {
             {
                 name = "Focused Celestial Regeneration",
                 type = "AA",
@@ -925,7 +925,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ["GroupHeal(1-97)"] = { --Level 1-97
+        ['GroupHeal(1-97)'] = { --Level 1-97
             {
                 name = "Beacon of Life",
                 type = "AA",
@@ -957,7 +957,7 @@ local _ClassConfig = {
                 type = "Spell",
             },
         },
-        ["MainHeal(70-100)"] = { --Level 70-100
+        ['MainHeal(70-100)'] = { --Level 70-100
             {
                 name = "Focused Celestial Regeneration",
                 type = "AA",
@@ -1019,7 +1019,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ["Heal(1-69)"] = { --Level 1-69, includes Main and emergency Remedy
+        ['Heal(1-69)'] = { --Level 1-69, includes Main and emergency Remedy
             {
                 name = "RemedyHeal",
                 type = "Spell",
@@ -1351,7 +1351,7 @@ local _ClassConfig = {
                 name = "Divine Guardian",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Targeting.TargetIsMA(target) then return false end
                     return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
@@ -1392,7 +1392,7 @@ local _ClassConfig = {
             --     name = "GroupVieBuff",
             --     type = "Spell",
             --     cond = function(self, spell, target)
-            --         if not Config:GetSetting('DoVieBuff') or (target.ID() == Core.GetMainAssistId() and self:GetResolvedActionMapItem('ShiningBuff')) then return false end
+            --         if not Config:GetSetting('DoVieBuff') or (Targeting.TargetIsMA(target) and self:GetResolvedActionMapItem('ShiningBuff')) then return false end
             --         return Casting.GroupBuffCheck(spell, target)
             --     end,
             -- },
@@ -1400,7 +1400,7 @@ local _ClassConfig = {
             --     name = "ShiningBuff",
             --     type = "Spell",
             --     cond = function(self, spell, target)
-            --         if target.ID() ~= Core.GetMainAssistId() then return false end
+            --         if not Targeting.TargetIsMA(target) then return false end
             --         return Casting.GroupBuffCheck(spell, target)
             --     end,
             -- },
@@ -1408,7 +1408,7 @@ local _ClassConfig = {
                 name = "SingleVieBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoVieBuff') or self:GetResolvedActionMapItem('GroupVieBuff') or target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Config:GetSetting('DoVieBuff') or self:GetResolvedActionMapItem('GroupVieBuff') or not Targeting.TargetIsMA(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -1416,7 +1416,7 @@ local _ClassConfig = {
                 name = "DivineBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDivineBuff') or target.ID() ~= Core.GetMainAssistId() then return false end
+                    if not Config:GetSetting('DoDivineBuff') or not Targeting.TargetIsMA(target) then return false end
                     return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -838,7 +838,7 @@ local _ClassConfig = {
             --     name = "DichoHeal",
             --     type = "Spell",
             --     cond = function(self, spell, target)
-            --         return Casting.GemReady(spell) and Casting.SpellReady(spell) and target.ID() == Core.GetMainAssistId
+            --         return Targeting.TargetIsMA(target)
             --     end,
             -- },
             {
@@ -1199,8 +1199,7 @@ local _ClassConfig = {
             --     retries = 0,
             --     cond = function(self, spell)
             --         if not Config:GetSetting('DoTwinHeal') then return false end
-            --         return Casting.GemReady(spell) and Casting.SpellReady(spell) and
-            --             not Casting.SongActiveByName("Healing Twincast")
+            --         return not Casting.SongActiveByName("Healing Twincast")
             --     end,
             -- },
             {
@@ -1216,7 +1215,7 @@ local _ClassConfig = {
             --     type = "Spell",
             --     cond = function(self, spell, target)
             --         if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-            --         return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+            --         return (Casting.HaveManaToNuke() or Casting.BurnCheck())
             --     end,
             -- },
             -- {
@@ -1224,16 +1223,14 @@ local _ClassConfig = {
             --     type = "Spell",
             --     cond = function(self, spell, target)
             --         if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-            --         return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
-            --     end,
+            --         return (Casting.HaveManaToNuke() or Casting.BurnCheck())            --     end,
             -- },
             -- {
             --     name = "NukeHeal3",
             --     type = "Spell",
             --     cond = function(self, spell, target)
             --         if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-            --         return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
-            --     end,
+            --         return (Casting.HaveManaToNuke() or Casting.BurnCheck())            --     end,
             -- },
             {
                 name = "Yaulp",
@@ -1318,7 +1315,7 @@ local _ClassConfig = {
                     if mq.TLO.Me.Aura(1)() then mq.TLO.Me.Aura(1).Remove() end
                 end,
                 cond = function(self, aaName)
-                    return not Casting.AuraActiveByName("Aura of Pious Divinity") and Casting.AAReady(aaName)
+                    return not Casting.AuraActiveByName("Aura of Pious Divinity")
                 end,
             },
             {

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -1079,15 +1079,6 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
-                type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Core.IsModeActive("Mana") and Config:GetSetting('DoChestClick') and item() and
-                        item.Spell.Stacks() and item.TimerReady() == 0
-                end,
-            },
-            {
                 name = "SunDot",
                 type = "Spell",
                 cond = function(self, spell)
@@ -1215,13 +1206,12 @@ local _ClassConfig = {
             },
         },
         ['Burn'] = {
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and
-                        item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -1360,7 +1360,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     return not Config:GetSetting('DoFire') and Casting.DetSpellCheck(spell) and
-                        Targeting.GetTargetPctHPs(target) < Config:GetSetting('NukePct') and
+                        Targeting.GetAutoTargetPctHPs() < Config:GetSetting('NukePct') and
                         Config:GetSetting('DoNuke')
                 end,
             },
@@ -1369,7 +1369,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     return not Config:GetSetting('DoFire') and Casting.DetSpellCheck(spell) and
-                        Targeting.GetTargetPctHPs(target) < Config:GetSetting('NukePct') and
+                        Targeting.GetAutoTargetPctHPs() < Config:GetSetting('NukePct') and
                         Config:GetSetting('DoNuke')
                 end,
             },
@@ -1385,7 +1385,7 @@ local _ClassConfig = {
                 name = "SnareSpells",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Config:GetSetting('DoSnare') and Casting.DetSpellCheck(spell) and Targeting.GetTargetPctHPs(target) < 50
+                    return Config:GetSetting('DoSnare') and Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
             {

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -890,107 +890,79 @@ local _ClassConfig = {
         },
     },
     ['HealRotations']     = {
-        ["BigHealPoint"] = {
+        ['BigHealPoint'] = {
             {
                 name = "QuickHealSurge",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.SpellReady(spell) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Blessing of Tunare",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Wildtender's Survival",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.ID() or 0) == Core.GetMainAssistId()
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "Swarm of Fireflies",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Convergence of Spirits",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
-        ["GroupHealPoint"] = {
+        ['GroupHealPoint'] = {
             {
                 name = "Blessing of Tunare",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "QuickGroupHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Wildtender's Survival",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "LongGroupHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
 
         },
-        ["MainHealPoint"] = {
+        ['MainHealPoint'] = {
             {
                 name = "QuickHeal",
                 type = "Spell",
-                cond = function(self, _) return true end,
             },
             {
                 name = "LongHeal1",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "LongHeal2",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
         },
     },
@@ -1097,9 +1069,6 @@ local _ClassConfig = {
             {
                 name = "Silent Casting",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Season's Wrath",
@@ -1258,70 +1227,43 @@ local _ClassConfig = {
             {
                 name = "Nature's Boon",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Spirit of the Wood",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Swarm of the Fireflies",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Distant Conflagration",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Nature's Guardian",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Spirits of Nature",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Destructive Vortex",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Nature's Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Spire of Nature",
                 type = "AA",
-                cond = function(self, aaName)
-                    return true
-                end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) end,
+                cond = function(self, aaName, target) return Targeting.IsNamed(target) end,
             },
         },
         ['Twin Heal'] = {
@@ -1329,7 +1271,7 @@ local _ClassConfig = {
                 name = "TwinHealNuke",
                 type = "Spell",
                 retries = 0,
-                cond = function(self, spell) return Casting.SpellReady(spell) and not Casting.SongActiveByName("Healing Twincast") end,
+                cond = function(self, spell) return not Casting.SongActiveByName("Healing Twincast") end,
             },
         },
         ['Debuff'] = {
@@ -1401,7 +1343,7 @@ local _ClassConfig = {
                 name = "Swarm of Fireflies",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return target.ID() == (mq.TLO.Group.MainTank.ID() or 0) and Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Targeting.TargetIsMA(target) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1559,7 +1501,6 @@ local _ClassConfig = {
                 name = "PetSpell",
                 type = "Spell",
                 active_cond = function() return mq.TLO.Me.Pet.ID() ~= 0 end,
-                cond = function() return true end,
             },
         },
     },

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -794,9 +794,9 @@ local _ClassConfig = {
             steps = 1,
             load_cond = function() return Config:GetSetting('DoTash') end,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.DebuffConCheck() and not Casting.IAmFeigning() and
-                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         { --Slow and Tash separated so we use both before we start DPS
@@ -805,9 +805,9 @@ local _ClassConfig = {
             steps = 1,
             load_cond = function() return Config:GetSetting('DoSlow') end,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.DebuffConCheck() and not Casting.IAmFeigning() and
-                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         {

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -1132,34 +1132,28 @@ local _ClassConfig = {
             {
                 name = "Glyph Spray",
                 type = "AA",
-                cond = function(self)
-                    return ((Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        Core.GetMainAssistPctHPs() < 40)
+                cond = function(self, aaName, target)
+                    return ((Targeting.IsNamed(target) and target.Level() > mq.TLO.Me.Level()) or Core.GetMainAssistPctHPs() < 40)
                 end,
             },
             {
                 name = "Reactive Rune",
                 type = "AA",
-                cond = function(self)
-                    return ((Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        Core.GetMainAssistPctHPs() < 40)
+                cond = function(self, aaName, target)
+                    return ((Targeting.IsNamed(target) and target.Level() > mq.TLO.Me.Level()) or Core.GetMainAssistPctHPs() < 40)
                 end,
             },
             -- { --this can be readded once we creat a post_activate to cancel the debuff you receive after
             --     name = "Self Stasis",
             --     type = "AA",
             --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30 and
-            --             Casting.AAReady(aaName)
-            --     end,
+            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30            --     end,
             -- },
             -- { --This can interrupt spellcasting which can just make something worse. Let us trust healers and tanks.
             --     name = "Dimensional Instability",
             --     type = "AA",
             --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30 and
-            --             Casting.AAReady(aaName)
-            --     end,
+            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30            --     end,
             -- },
             {
                 name = "Beguiler's Directed Banishment",
@@ -1190,9 +1184,7 @@ local _ClassConfig = {
             --     name = "Dimensional Shield",
             --     type = "AA",
             --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 80 and
-            --             Casting.AAReady(aaName)
-            --     end,
+            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Config.Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 80            --     end,
 
             -- },
             {
@@ -1205,16 +1197,16 @@ local _ClassConfig = {
             {
                 name = "Arcane Whisper",
                 type = "AA",
-                cond = function(self)
-                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() >= 90
                 end,
 
             },
             {
                 name = "Silent Casting",
                 type = "AA",
-                cond = function(self)
-                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() >= 90
                 end,
 
             },
@@ -1231,9 +1223,9 @@ local _ClassConfig = {
             {
                 name = "StripBuffSpell",
                 type = "Spell",
-                cond = function(self)
+                cond = function(self, spell, target)
                     if not Config:GetSetting('DoStripBuff') then return false end
-                    return mq.TLO.Target.Beneficial()
+                    return target.Beneficial()
                 end,
             },
             {
@@ -1405,14 +1397,14 @@ local _ClassConfig = {
                 name = "TashSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(spell) and not mq.TLO.Target.Tashed()
+                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "Bite of Tashani",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and not mq.TLO.Target.Tashed()
+                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -1350,17 +1350,12 @@ local _ClassConfig = {
                 name = "Chromatic Haze",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Casting.SongActive(item.Spell)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    if not Config:GetSetting('DoChestClick') or not item or not item() then return false end
-                    return not Casting.SongActive(item.Spell) and Casting.SpellStacksOnMe(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -881,7 +881,7 @@ local _ClassConfig = {
                 name = "Orator's Unity",
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.BuffActiveByName(aaName) end,
-                cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) end,
             },
             {
                 name = "SelfGuardShield",
@@ -917,13 +917,13 @@ local _ClassConfig = {
                 name = "Veil of Mindshadow",
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.BuffActiveByName(aaName) end,
-                cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) end,
             },
             {
                 name = "Azure Mind Crystal",
                 type = "AA",
                 active_cond = function(self, aaName) return mq.TLO.FindItem(aaName)() ~= nil end,
-                cond = function(self, aaName) return mq.TLO.Me.PctMana() > 90 and not mq.TLO.FindItem(aaName)() and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() > 90 and not mq.TLO.FindItem(aaName)() end,
                 post_activate = function(self, aaName, success)
                     if success then
                         Core.SafeCallFunc("Autoinventory", self.ClassConfig.HelperFunctions.StashCrystal)
@@ -933,8 +933,7 @@ local _ClassConfig = {
             {
                 name = "Gather Mana",
                 type = "AA",
-                active_cond = function(self, aaName) return Casting.AAReady(aaName) end,
-                cond = function(self, aaName) return mq.TLO.Me.PctMana() < 60 and Casting.AAReady(aaName) end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() < 60 end,
             },
             {
                 name = "Auroria Mastery",
@@ -947,7 +946,7 @@ local _ClassConfig = {
                     end
                 end,
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and not Casting.AuraActiveByName("Aura of Bedazzlement")
+                    return not Casting.AuraActiveByName("Aura of Bedazzlement")
                 end,
             },
             {
@@ -967,7 +966,7 @@ local _ClassConfig = {
                 cond = function(self, spell)
                     if Casting.CanUseAA('Auroria Mastery') or Config:GetSetting('UseAura') ~= 1 then return false end
                     local aura = string.sub(spell.Name() or "", 1, 8)
-                    return Casting.SpellReady(spell) and not Casting.AuraActiveByName(aura)
+                    return not Casting.AuraActiveByName(aura)
                 end,
             },
             {
@@ -982,7 +981,7 @@ local _ClassConfig = {
                 end,
                 cond = function(self, spell)
                     if Casting.CanUseAA('Auroria Mastery') or Config:GetSetting('UseAura') ~= 2 then return false end
-                    return Casting.SpellReady(spell) and not Casting.AuraActiveByName(spell.Name())
+                    return not Casting.AuraActiveByName(spell.Name())
                 end,
             },
             {
@@ -997,7 +996,7 @@ local _ClassConfig = {
                 end,
                 cond = function(self, spell)
                     if Casting.CanUseAA('Auroria Mastery') or Config:GetSetting('UseAura') ~= 3 then return false end
-                    return Casting.SpellReady(spell) and not Casting.AuraActiveByName(spell.Name())
+                    return not Casting.AuraActiveByName(spell.Name())
                 end,
             },
         },
@@ -1020,7 +1019,7 @@ local _ClassConfig = {
                 name = "Fortify Companion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },
@@ -1133,17 +1132,17 @@ local _ClassConfig = {
             {
                 name = "Glyph Spray",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self)
                     return ((Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        Core.GetMainAssistPctHPs() < 40) and Casting.AAReady(aaName)
+                        Core.GetMainAssistPctHPs() < 40)
                 end,
             },
             {
                 name = "Reactive Rune",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self)
                     return ((Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Target.Level() > mq.TLO.Me.Level()) or
-                        Core.GetMainAssistPctHPs() < 40) and Casting.AAReady(aaName)
+                        Core.GetMainAssistPctHPs() < 40)
                 end,
             },
             -- { --this can be readded once we creat a post_activate to cancel the debuff you receive after
@@ -1165,25 +1164,25 @@ local _ClassConfig = {
             {
                 name = "Beguiler's Directed Banishment",
                 type = "AA",
-                cond = function(self, aaName, target)
+                cond = function(self)
                     if not mq.TLO.Target.ID() == Config.Globals.AutoTargetID then return false end
-                    return mq.TLO.Me.PctAggro() > 99 and mq.TLO.Me.PctHPs() <= 40 and Casting.TargetedAAReady(aaName, target.ID())
+                    return mq.TLO.Me.PctAggro() > 99 and mq.TLO.Me.PctHPs() <= 40
                 end,
 
             },
             {
                 name = "Beguiler's Banishment",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 50 and mq.TLO.SpawnCount("npc radius 20")() > 2 and Casting.AAReady(aaName)
+                cond = function(self)
+                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 50 and mq.TLO.SpawnCount("npc radius 20")() > 2
                 end,
 
             },
             {
                 name = "Doppelganger",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 60 and Casting.AAReady(aaName)
+                cond = function(self)
+                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= 60
                 end,
 
             },
@@ -1206,24 +1205,24 @@ local _ClassConfig = {
             {
                 name = "Arcane Whisper",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90 and Casting.TargetedAAReady(aaName, target.ID())
+                cond = function(self)
+                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90
                 end,
 
             },
             {
                 name = "Silent Casting",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90 and Casting.AAReady(aaName)
+                cond = function(self)
+                    return Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() >= 90
                 end,
 
             },
             {
                 name = "Color Shock",
                 type = "AA",
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctAggro() >= 90 and Casting.AAReady(aaName)
+                cond = function(self)
+                    return mq.TLO.Me.PctAggro() >= 90
                 end,
 
             },
@@ -1232,47 +1231,47 @@ local _ClassConfig = {
             {
                 name = "StripBuffSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not Config:GetSetting('DoStripBuff') then return false end
-                    return mq.TLO.Target.Beneficial() and Casting.TargetedSpellReady(spell, target.ID())
+                    return mq.TLO.Target.Beneficial()
                 end,
             },
             {
                 name = "DotSpell1",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoDot') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "ManaDot",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') and Targeting.IsNamed(mq.TLO.Target) then return false end
-                    return Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    if not Config:GetSetting('DoDot') and not Targeting.IsNamed(target) then return false end
+                    return Casting.DotSpellCheck(spell)
                 end,
             },
             {
                 name = "DichoSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not Config:GetSetting('DoDicho') then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "NukeSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "ManaDrainSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (mq.TLO.Target.CurrentMana() or 0) > 10 and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (mq.TLO.Target.CurrentMana() or 0) > 10 and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1280,58 +1279,55 @@ local _ClassConfig = {
             {
                 name = "StripBuffSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not Config:GetSetting('DoStripBuff') then return false end
-                    return mq.TLO.Target.Beneficial() and Casting.TargetedSpellReady(spell, target.ID())
+                    return mq.TLO.Target.Beneficial()
                 end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "DichoSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self, spell)
+                    return Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "ManaDot",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self, spell)
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "NukeSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             { --Mana check used instead of dot mana check because this is spammed like a nuke
                 name = "DotSpell1",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             { --this is not an error, we want the spell twice in a row as part of the rotation.
                 name = "DotSpell1",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             { --used when the chanter or group members are low mana
                 name = "ManaNuke",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return (mq.TLO.Group.LowMana(80)() or -1) > 1 or not Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                cond = function(self)
+                    return (mq.TLO.Group.LowMana(80)() or -1) > 1 or not Casting.HaveManaToNuke()
                 end,
             },
         },
@@ -1339,32 +1335,28 @@ local _ClassConfig = {
             {
                 name = "Illusions of Grandeur",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) end,
+                cond = function(self, aaName, target) return Targeting.IsNamed(target) end,
             },
             {
                 name = "Calculated Insanity",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Mental Contortion",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) end,
+                cond = function(self, aaName, target) return Targeting.IsNamed(target) end,
             },
             {
                 name = "Chromatic Haze",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -1382,14 +1374,13 @@ local _ClassConfig = {
             {
                 name = "Spire of Enchantment",
                 type = "AA",
-                cond = function(self, aaName) return not Casting.SongActiveByName("Illusions of Grandeur") and Casting.AAReady(aaName) end,
+                cond = function(self) return not Casting.SongActiveByName("Illusions of Grandeur") end,
             },
             {
                 name = "Crippling Aurora",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoCripple') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                cond = function(self)
+                    return Config:GetSetting('DoCripple')
                 end,
             },
             {
@@ -1397,37 +1388,31 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoCripple') then return false end
-                    return Targeting.IsNamed(mq.TLO.Target) and Casting.DetSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Targeting.IsNamed(target) and Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "Phantasmal Opponent",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
         },
         ['Tash'] = {
             {
                 name = "TashSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     return Config:GetSetting('DoTash') and Casting.DetSpellCheck(spell) and not mq.TLO.Target.Tashed()
-                        and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "Bite of Tashani",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and not mq.TLO.Target.Tashed() and
-                        Casting.TargetedAAReady(aaName, target.ID())
+                cond = function(self, aaName)
+                    return Config:GetSetting('DoTash') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and not mq.TLO.Target.Tashed()
                 end,
             },
         },
@@ -1435,27 +1420,25 @@ local _ClassConfig = {
             {
                 name = "Enveloping Helix",
                 type = "AA",
-                cond = function(self, aaName, target)
+                cond = function(self, aaName)
                     if Targeting.GetXTHaterCount() < Config:GetSetting('AESlowCount') then return false end
-                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Dreary Deeds",
                 type = "AA",
-                cond = function(self, aaName, target)
+                cond = function(self, aaName)
                     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-                    return Casting.DetSpellCheck(aaSpell) and (aaSpell.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and
-                        Casting.TargetedAAReady(aaName, target.ID())
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell) and (aaSpell.SlowPct() or 0) > Targeting.GetTargetSlowedPct()
                 end,
             },
             {
                 name = "SlowSpell",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if Casting.CanUseAA("Dreary Deeds") then return false end
-                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct())
                 end,
             },
         },

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1326,7 +1326,7 @@ _ClassConfig      = {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName)
-                    if not mq.TLO.Me.Pet.ID() > 0 then return false end
+                    if mq.TLO.Me.Pet.ID() == 0 then return false end
                     return not mq.TLO.Me.PetBuff("Primal Fusion")() and not mq.TLO.Me.PetBuff("Elemental Conjuction")()
                 end,
             },
@@ -1666,7 +1666,7 @@ _ClassConfig      = {
                     return Casting.BuffActive(spell)
                 end,
                 cond = function(self, spell, target)
-                    return Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target) and not Casting.BuffActiveByName("Circle of " .. spell.Name())
                 end,
             },
             {

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1276,7 +1276,6 @@ _ClassConfig      = {
             {
                 name = "PetHealSpell",
                 type = "Spell",
-                cond = function(self, spell) return Casting.SpellReady(spell) end,
             },
         },
         ['PetBuff'] = {
@@ -1335,35 +1334,35 @@ _ClassConfig      = {
                 name = "Second Wind Ward",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Host in the Shell",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank") and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank")
                 end,
             },
             {
                 name = "Aegis of Kildrukaun",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Fortify Companion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Companion's Intervening Divine Aura",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank") and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Core.IsModeActive("PetTank")
                 end,
             },
         },
@@ -1450,37 +1449,31 @@ _ClassConfig      = {
             {
                 name = "Companion's Fury",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Host of the Elements",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Spire of Elements",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Heart of Skyfire",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) end,
+                cond = function(self, aaName, target) return Targeting.IsNamed(target) end,
             },
             {
                 name = "Improved Twincast",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Servant of Ro",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
         },
         ['DPS PET'] = {
@@ -1542,9 +1535,6 @@ _ClassConfig      = {
             {
                 name = "Force of Elements",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "FireOrbItem",
@@ -1601,8 +1591,7 @@ _ClassConfig      = {
                 name = "Turn Summoned",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Targeting.TargetBodyIs(target, "Undead Pet") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                    return Targeting.TargetBodyIs(target, "Undead Pet")
                 end,
             },
             {
@@ -1625,32 +1614,31 @@ _ClassConfig      = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Config:GetSetting('ElementChoice') ~= 1 then return false end
-                    if (Targeting.GetTargetPctHPs(target) < Config:GetSetting('HPStopBigNuke') and not Targeting.IsNamed(target)) then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    if (Targeting.GetAutoTargetPctHPs() < Config:GetSetting('HPStopBigNuke') and not Targeting.IsNamed(target)) then return false end
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "FireDD",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if Config:GetSetting('ElementChoice') ~= 1 then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "MagicDD",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self)
                     if Config:GetSetting('ElementChoice') ~= 2 then return false end
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "Turn Summoned",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Targeting.TargetBodyIs(target, "Undead Pet") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                    return Targeting.TargetBodyIs(target, "Undead Pet")
                 end,
             },
         },
@@ -1658,24 +1646,24 @@ _ClassConfig      = {
             {
                 name = "Malosinete",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                cond = function(self, aaName)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "MaloDebuff",
                 type = "Spell",
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if Casting.CanUseAA("Malaise") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "Wind of Malosinete",
                 type = "AA",
-                cond = function(self, aaName, target)
+                cond = function(self, aaName)
                     if not Config:GetSetting('DoAEMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },
@@ -1703,7 +1691,7 @@ _ClassConfig      = {
                 name = "Elemental Conversion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and Casting.AAReady(aaName) and mq.TLO.Me.Pet.ID() > 0
+                    return mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and mq.TLO.Me.Pet.ID() > 0
                 end,
             },
             {
@@ -1711,15 +1699,14 @@ _ClassConfig      = {
                 type = "AA",
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and not mq.TLO.Me.SpellReady(self.ResolvedActionMap['GatherMana'] or "")() and
-                        Casting.AAReady(aaName) and mq.TLO.Me.Pet.ID() > 0
+                        mq.TLO.Me.Pet.ID() > 0
                 end,
             },
             {
                 name = "GatherMana",
                 type = "Spell",
                 cond = function(self, spell)
-                    return spell and spell() and mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and Casting.SpellReady(spell) and
-                        mq.TLO.Me.SpellReady(spell.Name() or "")
+                    return spell and spell() and mq.TLO.Me.PctMana() <= Config:GetSetting('GatherManaPct') and Casting.GemReady(spell)
                 end,
             },
             {
@@ -1740,7 +1727,7 @@ _ClassConfig      = {
                 name = "Thaumaturge's Unity",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
             {
@@ -1783,7 +1770,7 @@ _ClassConfig      = {
                 name = "Elemental Form",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
         },
@@ -1794,7 +1781,7 @@ _ClassConfig      = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
-                    return modRodItem and Casting.AAReady(aaName) and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
+                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0
                 end,
                 post_activate = function(self, aaName, success)
@@ -1809,7 +1796,7 @@ _ClassConfig      = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) or Casting.CanUseAA("Large Modulation Shard") then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
-                    return modRodItem and Casting.AAReady(aaName) and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
+                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0
                 end,
                 post_activate = function(self, aaName, success)
@@ -1824,7 +1811,7 @@ _ClassConfig      = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) or Casting.CanUseAA("Medium Modulation Shard") then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
-                    return modRodItem and Casting.AAReady(aaName) and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
+                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0
                 end,
                 post_activate = function(self, aaName, success)
@@ -1839,7 +1826,7 @@ _ClassConfig      = {
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Small Modulation Shard") or not Config:GetSetting('SummonModRods') then return false end
                     local modRodItem = spell.RankName.Base(1)()
-                    return modRodItem and Casting.SpellReady(spell) and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
+                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0
                 end,
                 post_activate = function(self, spell, success)

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1326,8 +1326,8 @@ _ClassConfig      = {
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName)
-                    return not mq.TLO.Me.PetBuff("Primal Fusion")() and not mq.TLO.Me.PetBuff("Elemental Conjuction")() and mq.TLO.FindItemCount(itemName)() ~= 0 and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0 and mq.TLO.Me.Pet.ID() > 0
+                    if not mq.TLO.Me.Pet.ID() > 0 then return false end
+                    return not mq.TLO.Me.PetBuff("Primal Fusion")() and not mq.TLO.Me.PetBuff("Elemental Conjuction")()
                 end,
             },
             {
@@ -1426,16 +1426,12 @@ _ClassConfig      = {
                     return false
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and mq.TLO.Me.Song(item.Spell.RankName.Name())() ~= nil
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1554,14 +1550,6 @@ _ClassConfig      = {
             },
         },
         ['DPS'] = {
-            {
-                name = "SelfModRod",
-                type = "Item",
-                cond = function(self)
-                    return mq.TLO.FindItemCount(Config:GetSetting('SelfModRod'))() == 0 and mq.TLO.Me.PctMana() < Config:GetSetting('ModRodManaPct') and
-                        mq.TLO.Me.PctHPs() >= 60
-                end,
-            },
             {
                 name = "SwarmPet",
                 type = "Spell",

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1246,7 +1246,7 @@ _ClassConfig      = {
         end,
     },
     ['Rotations']         = {
-        ["PetSummon"] = {
+        ['PetSummon'] = {
             {
                 name = "Pet Summon",
                 type = "CustomFunc",
@@ -1272,7 +1272,7 @@ _ClassConfig      = {
                 custom_func = function(self) return self.ClassConfig.HelperFunctions.pet_management(self) end,
             },
         },
-        ["PetHealPoint"] = {
+        ['PetHealPoint'] = {
             {
                 name = "PetHealSpell",
                 type = "Spell",
@@ -1470,6 +1470,9 @@ _ClassConfig      = {
             {
                 name = "Improved Twincast",
                 type = "AA",
+                cond = function(self)
+                    return not mq.TLO.Me.Buff("Twincast")()
+                end,
             },
             {
                 name = "Servant of Ro",

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -885,9 +885,9 @@ _ClassConfig      = {
             steps = 1,
             load_cond = function() return Config:GetSetting('DoMalo') end,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
-            cond = function(self, combat_state, targetId)
+            cond = function(self, combat_state)
                 return combat_state == "Combat" and not Casting.IAmFeigning() and Casting.DebuffConCheck() and
-                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(mq.TLO.Spawn(targetId)))
+                    (Casting.HaveManaToDebuff() or Targeting.IsNamed(Targeting.GetAutoTarget()))
             end,
         },
         {
@@ -1441,8 +1441,8 @@ _ClassConfig      = {
             {
                 name = "AllianceBuff",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Targeting.IsNamed(mq.TLO.Target) and not Casting.TargetHasBuff(spell) and
+                cond = function(self, spell, target)
+                    return Targeting.IsNamed(target) and not Casting.TargetHasBuff(spell) and
                         Config:GetSetting('DoAlliance') and Casting.CanAlliance()
                 end,
             },
@@ -1605,8 +1605,8 @@ _ClassConfig      = {
             --   {
             --       name = "AllianceBuff",
             --       type = "Spell",
-            --      cond = function(self, spell)
-            --           return Targeting.IsNamed(mq.TLO.Target) and not Casting.TargetHasBuff(spell) and
+            --      cond = function(self, spell, target)
+            --           return Targeting.IsNamed(target) and not Casting.TargetHasBuff(spell) and
             --               Config:GetSetting('DoAlliance') and Casting.CanAlliance()
             --       end,
             --    },

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -313,7 +313,7 @@ local _ClassConfig = {
                     return Casting.AuraActiveByName(discSpell.RankName.Name())
                 end,
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.Aura(1).ID() and Casting.DiscReady(discSpell)
+                    return not mq.TLO.Me.Aura(1).ID()
                 end,
             },
             {
@@ -321,28 +321,28 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if self:GetResolvedActionMapItem("CombatEndRegen") then return false end
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Breaths",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Mend",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.PctHPs() < 50
+                    return mq.TLO.Me.PctHPs() < 50
                 end,
             },
         },
@@ -353,7 +353,7 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     if not Config:GetSetting('AggroFeign') then return false end
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
-                        and Casting.AAReady(aaName) and not Core.IAmMA
+                        and not Core.IAmMA
                 end,
             },
             {
@@ -361,14 +361,14 @@ local _ClassConfig = {
                 type = "Ability",
                 cond = function(self, abilityName)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return Targeting.IHaveAggro(95) and mq.TLO.Me.AbilityReady(abilityName)() and not Core.IAmMA
+                    return Targeting.IHaveAggro(95) and not Core.IAmMA
                 end,
             },
             {
                 name = "Defy Death",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 25 and Casting.DiscReady(discSpell)
+                    return mq.TLO.Me.PctHPs() < 25
                 end,
             },
             {
@@ -376,14 +376,14 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoVetAA') then return false end
-                    return mq.TLO.Me.PctHPs() < 35 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
                 name = "Mend",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
+                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
                 end,
             },
             {
@@ -407,58 +407,34 @@ local _ClassConfig = {
             { -- 5m reuse
                 name = "Dicho",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             { -- 5m reuse
                 name = "Ton Po's Stance",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Heel",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "Speed",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "FistDisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "Palm",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
-                end,
             },
             {
                 name = "Spire of the Sensei",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Infusion of Thunder",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -472,15 +448,12 @@ local _ClassConfig = {
             { --10m reuse
                 name = "CraneStance",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             { --20m reuse, using NOT burndisccheck means we will only use this with a burn disc active
                 name = "Poise",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             { --pairs with Speed Focus Disc, AE, T2
@@ -489,7 +462,7 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     local speedDisc = self:GetResolvedActionMapItem("Speed")
                     if not Config:GetSetting("DoAEDamage") or not speedDisc then return false end
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName() and self.ClassConfig.HelperFunctions.AETargetCheck()
+                    return mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName() and self.ClassConfig.HelperFunctions.AETargetCheck()
                 end,
             },
             { --pairs with Speed Focus Disc, single target, T2
@@ -498,29 +471,25 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     local speedDisc = self:GetResolvedActionMapItem("Speed")
                     if Config:GetSetting("DoAEDamage") or not speedDisc then return false end
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName()
+                    return mq.TLO.Me.ActiveDisc.Name() == speedDisc.RankName()
                 end,
             },
             {
                 name = "Silent Strikes",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Me.PctAggro() or 0) > 60
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target) and (mq.TLO.Me.PctAggro() or 0) > 60
                 end,
             },
             {
                 name = "Swift Tails' Chant",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -529,21 +498,21 @@ local _ClassConfig = {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Drunken",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Casting.SelfBuffCheck(discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
                 end,
             },
             {
                 name = "Zan Fi's Whistle",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Casting.SelfBuffAACheck(aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
             {
@@ -551,7 +520,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if mq.TLO.Me.Level() >= 100 then return false end
-                    return Casting.DiscReady(discSpell) and Casting.SelfBuffCheck(discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
                 end,
             },
             {
@@ -559,21 +528,21 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAlliance') then return false end
-                    return Casting.TargetedDiscReady(discSpell) and not Casting.TargetHasBuffByName(discSpell.Trigger(1))
+                    return not Casting.TargetHasBuffByName(discSpell.Trigger(1))
                 end,
             },
             {
                 name = "Storm",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "EarthDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },
@@ -581,118 +550,80 @@ local _ClassConfig = {
             {
                 name = "Synergy",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Curse",
                 type = "Disc",
                 cond = function(self, discSpell) --DotSpellCheck used in part to not blow this on low-health mobs
-                    return Casting.TargetedDiscReady(discSpell) and Casting.DotSpellCheck(discSpell)
+                    return Casting.DotSpellCheck(discSpell)
                 end,
             },
             {
                 name = "Two-Finger Wasp Touch",
                 type = "AA",
                 cond = function(self, aaName, target) --DotSpellCheck used in part to not blow this on low-health mobs
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DotSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DotSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Fists",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Fang",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Shuriken",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Five Point Palm",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.TargetedAAReady(aaName)
-                end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)()
+                    return (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) > 1
                 end,
             },
             {
                 name = "Flying Kick",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Eagle Strike",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    if mq.TLO.Me.PctEndurance() > 25 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
+                    return mq.TLO.Me.PctEndurance() < 25
                 end,
             },
             {
                 name = "Tiger Claw",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
         },
         ['Precision'] = {
             {
                 name = "Precision5",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision4",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision3",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision2",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Precision1",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
         },
     },

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -389,18 +389,14 @@ local _ClassConfig = {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell) and mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
                 name = "Epic",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
         },
         ['Burn'] = {
@@ -436,13 +432,12 @@ local _ClassConfig = {
                 name = "Infusion of Thunder",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             { --10m reuse

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -263,7 +263,7 @@ local _ClassConfig = {
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
                 return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99))
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(Targeting.GetAutoTarget()) and mq.TLO.Me.PctAggro() > 99))
             end,
         },
         {
@@ -350,9 +350,9 @@ local _ClassConfig = {
             {
                 name = "Imitate Death",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99)
+                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
                         and not Core.IAmMA
                 end,
             },

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -1044,9 +1044,6 @@ local _ClassConfig = {
             {
                 name = "OoW_Chest",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0
-                end,
             },
             {
                 name = "Funeral Pyre",

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -821,14 +821,14 @@ local _ClassConfig = {
                 name = "Death Peace",
                 type = "AA",
                 cond = function(self, aaName)
-                    return not Casting.IAmFeigning() and Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < 75
+                    return not Casting.IAmFeigning() and mq.TLO.Me.PctHPs() < 75
                 end,
             },
             {
                 name = "Harm Shield",
                 type = "AA",
                 cond = function(self, aaName)
-                    return not Casting.IAmFeigning() and Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() >= 75
+                    return not Casting.IAmFeigning() and mq.TLO.Me.PctHPs() >= 75
                 end,
             },
             {
@@ -848,14 +848,14 @@ local _ClassConfig = {
                 name = "Scent of Thule",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "ScentDebuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -919,12 +919,10 @@ local _ClassConfig = {
             {
                 name = "DichoSpell",
                 type = "Spell",
-                cond = function(self, _) return true end,
             },
             {
                 name = "SwarmPet",
                 type = "Spell",
-                cond = function(self, _) return true end,
             },
             {
                 name = "SnareDot",
@@ -1095,20 +1093,16 @@ local _ClassConfig = {
             {
                 name = "Companion's Fury",
                 type = "AA",
-                cond = function(self, aaName) return Casting.AAReady(aaName) end,
             },
             {
                 name = "Rise of Bones",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, aaName, target)
+                    return Casting.SelfBuffAACheck(aaName) and Targeting.IsNamed(target)
                 end,
             },
             {
@@ -1197,7 +1191,7 @@ local _ClassConfig = {
                 name = "Death Bloom",
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.SongActiveByName(mq.TLO.AltAbility(aaName).Spell.RankName()) end,
-                cond = function(self, aaName) return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('DeathBloomPercent') end,
+                cond = function(self, aaName) return mq.TLO.Me.PctMana() < Config:GetSetting('DeathBloomPercent') end,
             },
         },
         ['PetSummon'] = { --TODO: Double check these lists to ensure someone leveling doesn't have to change options to keep pets current at lower levels
@@ -1247,14 +1241,14 @@ local _ClassConfig = {
                 name = "Aegis of Kildrukaun",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
                 name = "Fortify Companion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -788,8 +788,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not mq.TLO.Group() then return false end
-                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt') and
-                        Casting.AAReady(aaName)
+                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt')
                 end,
             },
             {
@@ -797,15 +796,14 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not mq.TLO.Group() then return false end
-                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt') and
-                        Casting.AAReady(aaName)
+                    return mq.TLO.Group.Injured(Config:GetSetting('GroupHealPoint'))() > Config:GetSetting('GroupInjureCnt')
                 end,
             },
             {
                 name = "Lay on Hands",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
+                    return Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
                 end,
             },
         },
@@ -872,50 +870,38 @@ return {
             {
                 name = "Valorous Rage",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Inquisitor's Judgment",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Thunder of Karana",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoNuke')
-                end,
             },
             {
                 name = "Group Armor of The Inquisitor",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Undeadburn",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.ActiveDisc.ID() and Casting.TargetedDiscReady(discSpell)
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "Righteousstrike",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.ActiveDisc.ID() and Casting.TargetedDiscReady(discSpell)
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "Healproc",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not Core.IsTanking() and Casting.SpellReady(spell)
+                    return not Core.IsTanking()
                 end,
             },
         },
@@ -949,7 +935,7 @@ return {
                 name = "Shield Flash",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < Config:GetSetting('FlashHP')
+                    return mq.TLO.Me.PctHPs() < Config:GetSetting('FlashHP')
                 end,
             },
             {
@@ -957,8 +943,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -966,8 +951,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -975,8 +959,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -984,15 +967,14 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return Core.IsModeActive('Tank') and
-                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and
-                        mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())() and not mq.TLO.Me.ActiveDisc.ID()
+                        (mq.TLO.SpawnCount("NPC radius 60 zradius 50")() > 2 or Targeting.IsNamed(target)) and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "meleemit",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return Casting.DiscReady(discSpell) and not (discSpell.Level() < 108 and mq.TLO.Me.ActiveDisc.ID())
+                    return not ((discSpell.Level() or 0) < 108 and mq.TLO.Me.ActiveDisc.ID())
                 end,
             },
             {
@@ -1015,21 +997,21 @@ return {
                 name = "Hallowed Lodestar",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetXTHaterCount() > 2
+                    return Targeting.GetXTHaterCount() > 2
                 end,
             },
             {
                 name = "Beacon of the Righteous",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetXTHaterCount() > 2
+                    return Targeting.GetXTHaterCount() > 2
                 end,
             },
             {
                 name = "Heroic Leap",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.GetXTHaterCount() > 2
+                    return Targeting.GetXTHaterCount() > 2
                 end,
             },
             {
@@ -1037,120 +1019,95 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     return (mq.TLO.Me.AltAbility(aaName).Rank() or 0) > 7 and not Casting.BuffActiveByName("Knight's Yaulp") and
-                        Targeting.GetTargetDistance() < 30 and Casting.AAReady(aaName)
+                        Targeting.GetTargetDistance() < 30
                 end,
             },
             {
                 name = "Taunt",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetDistance() < 30
+                cond = function(self, abilityName, target)
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and target.ID() > 0 and Targeting.GetTargetDistance(target) < 30
                 end,
             },
             {
                 name = "Bash",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target) and
-                        (Core.ShieldEquipped() or Casting.CanUseAA("2 Hand Bash"))
+                    return Core.ShieldEquipped() or Casting.CanUseAA("2 Hand Bash")
                 end,
             },
             {
                 name = "Disarm",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Challengetaunt",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and not Casting.TargetHasBuff(spell)
+                    return not Casting.TargetHasBuff(spell)
                 end,
             },
             {
                 name = "StunTimer4",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "StunTimer5",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "LessonStun",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "CrushTimer5",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "CrushTimer6",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Armor of the Inquisitor",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Healtaunt",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Lowaggronuke",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Dicho",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "AntiUndeadNuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
                 name = "Vanquish The Fallen",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
@@ -1166,29 +1123,23 @@ return {
             {
                 name = "Bash",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Disarm",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Marr's Gift",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() <= 60
+                    return mq.TLO.Me.PctMana() <= 60
                 end,
             },
             {
                 name = "Dicho",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= 35
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) <= 35
                 end,
             },
             {
@@ -1219,49 +1170,46 @@ return {
                 name = "AntiUndeadNuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
                 name = "Reverseds",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.TargetHasBuff(spell) and Config:GetSetting('DoReverseDS')
+                    return Casting.TargetHasBuff(spell) and Config:GetSetting('DoReverseDS')
                 end,
             },
             {
                 name = "Lowaggronuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Config:GetSetting('DoNuke')
+                    return Config:GetSetting('DoNuke')
                 end,
             },
             {
                 name = "CrushTimer6",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Config:GetSetting('DoNuke') and (mq.TLO.Me.SecondaryPctAggro() or 0) > 60
+                    return Config:GetSetting('DoNuke') and (mq.TLO.Me.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
                 name = "HealNuke",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Vanquish The Fallen",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
+                    return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
             {
                 name = "Disruptive Persecution",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.AltAbility(aaName).Rank() >= 3 and not Casting.BuffActiveByName("Knight's Yaulp")
+                    return mq.TLO.Me.AltAbility(aaName).Rank() >= 3 and not Casting.BuffActiveByName("Knight's Yaulp")
                 end,
             },
             {
@@ -1278,7 +1226,7 @@ return {
                 name = "aurabuff1",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and not Casting.AuraActiveByName(spell.RankName.Name()) and mq.TLO.Me.PctEndurance() > 10
+                    return not Casting.AuraActiveByName(spell.RankName.Name()) and mq.TLO.Me.PctEndurance() > 10
                 end,
             },
             {
@@ -1292,14 +1240,14 @@ return {
                 name = "ArmorSelfBuff",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "FuryProc",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1307,42 +1255,42 @@ return {
                 type = "Spell",
                 cond = function(self, spell) --use this always until we have a Fury proc, and optionally after that, up until the point that Fury is rolled into DPU
                     if (mq.TLO.Me.AltAbility("Divine Protector's Unity").Rank() or 0) > 1 or (self:GetResolvedActionMapItem("FuryProc") and not Config:GetSetting('DoUndeadProc')) then return false end
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "Remorse",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "Piety",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return not self.ClassConfig.HelperFunctions.castDPU(self) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "Preservation",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
+                    return Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
                 end,
             },
             {
                 name = "TempHP",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
+                    return Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
                 end,
             },
             {
                 name = "Incoming",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
+                    return Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
                 end,
             },
             {
@@ -1368,7 +1316,7 @@ return {
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.ID()) end,
                 cond = function(self, spell)
                     if Config:GetSetting('AegoSymbol') ~= 1 then return false end
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1377,7 +1325,7 @@ return {
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.ID()) end,
                 cond = function(self, spell)
                     if Config:GetSetting('AegoSymbol') ~= 2 then return false end
-                    return Casting.SpellReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1385,7 +1333,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSalvation') then return false end
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -10,7 +10,7 @@ return {
     ['ModeChecks']        = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
         IsHealing = function() return true end,
-        IsCuring = function() return Config:GetSetting('DoCures') end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.AAReady("Radiant Cure") end,
         IsRezing = function() return (Config:GetSetting('DoBattleRez') and not Core.IsTanking()) or Targeting.GetXTHaterCount() == 0 end,
         --Disabling tank battle rez is not optional to prevent settings in different areas and to avoid causing more potential deaths
     },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -1108,12 +1108,12 @@ return {
                     return Targeting.TargetBodyIs(mq.TLO.Target, "Undead")
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },
@@ -1207,12 +1207,12 @@ return {
                     return mq.TLO.Me.AltAbility(aaName).Rank() >= 3 and not Casting.BuffActiveByName("Knight's Yaulp")
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Config:GetSetting('DoChestClick') and item() and item.Spell.Stacks() and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },
@@ -1293,8 +1293,8 @@ return {
                 type = "Item",
                 active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
                 cond = function(self)
-                    return Config:GetSetting('SummonArrows') and mq.TLO.Me.Level() > 89 and mq.TLO.FindItemCount("Ethereal Arrow")() < 101 and
-                        mq.TLO.Me.ItemReady("Huntsman's Ethereal Quiver")()
+                    if not Config:GetSetting('SummonArrows') then return false end
+                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
                 end,
             },
         },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -863,8 +863,8 @@ return {
                 name = "Spire of Chivalry",
                 type = "AA",
                 cond = function(self, aaName)
-                    return mq.TLO.Me.Level() < 80 and Casting.AAReady(aaName) and not Casting.SongActiveByName('Group Armor of the Inquisitor') and
-                        not Casting.SongActiveByName('Armor of the Inquisitor') and not Casting.BuffActiveByName('Spire of Chivalry')
+                    return mq.TLO.Me.Level() < 80 and not Casting.SongActiveByName('Group Armor of the Inquisitor') and not Casting.SongActiveByName('Armor of the Inquisitor') and
+                        not Casting.BuffActiveByName('Spire of Chivalry')
                 end,
             },
             {
@@ -981,16 +981,14 @@ return {
                 name = "TotLightHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
                 name = "BurstHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
@@ -1146,24 +1144,21 @@ return {
                 name = "TotLightHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
                 name = "BurstHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('TotHealPoint')
                 end,
             },
             {
                 name = "DebuffNuke",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and
-                        ((Targeting.TargetBodyIs(mq.TLO.Target, "Undead") or mq.TLO.Me.Level() >= 96) and not Casting.TargetHasBuff(spell) and Config:GetSetting('DoNuke'))
+                    return ((Targeting.TargetBodyIs(mq.TLO.Target, "Undead") or mq.TLO.Me.Level() >= 96) and not Casting.TargetHasBuff(spell) and Config:GetSetting('DoNuke'))
                 end,
             },
             {

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -1483,7 +1483,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },

--- a/class_configs/Project Lazarus/rog_class_config.lua
+++ b/class_configs/Project Lazarus/rog_class_config.lua
@@ -290,57 +290,45 @@ return {
                 name = "Frenzied",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Twisted",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Executioner",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "EdgeDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Rogue's Fury",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Pinpoint",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "MarkDisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Spire of the Rake",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = mq.TLO.Me.Inventory("Chest").Name(),
@@ -354,54 +342,39 @@ return {
             {
                 name = "PoisonBlade",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Dicho",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Shadow's Flanking",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Rake's Rampage",
                 type = "AA",
                 cond = function(self, aaName)
-                    local speedDisc = self:GetResolvedActionMapItem("Speed")
                     if not Config:GetSetting("DoAEDamage") then return false end
-                    return Casting.AAReady(aaName) and self.ClassConfig.HelperFunctions.AETargetCheck(self)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(self)
                 end,
             },
             {
                 name = "Focused Rake's Rampage",
                 type = "AA",
                 cond = function(self, aaName)
-                    if Config:GetSetting("DoAEDamage") then return false end
-                    return Casting.AAReady(aaName)
+                    return not Config:GetSetting("DoAEDamage")
                 end,
             },
             {
                 name = "Phantom",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -419,28 +392,28 @@ return {
                 name = "Knifeplay",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "AspDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "ProcBuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -448,7 +421,7 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAlliance') then return false end
-                    return Casting.TargetedDiscReady(discSpell) and not Casting.TargetHasBuffByName(discSpell.Trigger(1))
+                    return not Casting.TargetHasBuffByName(discSpell.Trigger(1))
                 end,
             },
             {
@@ -464,7 +437,7 @@ return {
                 name = "Assassin's Premonition",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Casting.BurnCheck()
+                    return Casting.BurnCheck()
                 end,
             },
         },
@@ -473,72 +446,49 @@ return {
                 name = "Backstab",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    if not Casting.CanUseAA("Chaotic Stab") and not mq.TLO.Stick.Behind() then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
+                    return Casting.CanUseAA("Chaotic Stab") or mq.TLO.Stick.Behind()
                 end,
             },
             {
                 name = "Carve",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "SecretBlade",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "FellStrike",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Jugular",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Twisted Shank",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Puncture",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "DaggerThrow",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             { --Check ToT to ensure we are not boosting the hate generation of someone we shouldn't be
                 name = "HateDebuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and mq.TLO.Me.TargetOfTarget.ID() == (mq.TLO.Group.MainTank.ID() or Core.GetMainAssistId())
+                    return mq.TLO.Me.TargetOfTarget.ID() == (mq.TLO.Group.MainTank.ID() or Core.GetMainAssistId())
                 end,
             },
             {
                 name = "Intimidation",
                 type = "Ability",
                 cond = function(self, abilityName)
-                    if (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) < 2 then return false end
-                    return mq.TLO.Me.AbilityReady(abilityName)()
+                    return (mq.TLO.Me.AltAbility("Intimidation").Rank() or 0) > 1
                 end,
             },
         },
@@ -547,7 +497,7 @@ return {
                 name = "Escape",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.IHaveAggro(100)
+                    return Targeting.IHaveAggro(100)
                 end,
             },
             {
@@ -555,15 +505,12 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoVetAA') then return false end
-                    return mq.TLO.Me.PctHPs() < 35 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.PctHPs() < 35
                 end,
             },
             {
                 name = "Tumble",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Coating",
@@ -578,7 +525,7 @@ return {
                 name = "CADisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Targeting.IHaveAggro(100)
+                    return Targeting.IHaveAggro(100)
                 end,
             },
         },
@@ -587,7 +534,7 @@ return {
                 name = "ThiefBuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.SelfBuffCheck(discSpell) and Casting.DiscReady(discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
                 end,
             },
             {
@@ -595,14 +542,14 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if self:GetResolvedActionMapItem("CombatEndRegen") then return false end
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {

--- a/class_configs/Project Lazarus/rog_class_config.lua
+++ b/class_configs/Project Lazarus/rog_class_config.lua
@@ -253,7 +253,7 @@ return {
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
                 return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(mq.TLO.Target) and mq.TLO.Me.PctAggro() > 99))
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Targeting.IsNamed(Targeting.GetAutoTarget()) and mq.TLO.Me.PctAggro() > 99))
             end,
         },
         {

--- a/class_configs/Project Lazarus/rog_class_config.lua
+++ b/class_configs/Project Lazarus/rog_class_config.lua
@@ -330,13 +330,12 @@ return {
                 name = "Spire of the Rake",
                 type = "AA",
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -384,8 +383,7 @@ return {
                 type = "Item",
                 cond = function(self, itemName)
                     if Config:GetSetting('UseEpic') == 1 then return false end
-                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck())) and mq.TLO.FindItem(itemName)() and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck()))
                 end,
             },
             {
@@ -515,10 +513,9 @@ return {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell) and mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -858,7 +858,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if Config:GetSetting('ProcChoice') ~= 1 then return false end
                     --SelfBuffAACheck does not work for this specific AA, it returns a strange spell in the stacking check
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -869,7 +869,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if Config:GetSetting('ProcChoice') ~= 2 then return false end
                     --SelfBuffAACheck does not work for this specific AA, it returns a strange spell in the stacking check
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1355,9 +1355,9 @@ local _ClassConfig = {
                 name = "Epic",
                 type = "Item",
                 tooltip = Tooltips.Epic,
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and
-                        (self.ClassConfig.HelperFunctions.LeechCheck(self) or Targeting.IsNamed(mq.TLO.Target))
+                        (self.ClassConfig.HelperFunctions.LeechCheck(self) or Targeting.IsNamed(target))
                 end,
             },
             {
@@ -1629,9 +1629,9 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("Shield").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("Shield").Active() then return false end
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("Shield") end,
             },
@@ -1641,10 +1641,10 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("2Hand").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("2Hand").Active() then return false end
                     return mq.TLO.Me.PctHPs() >= Config:GetSetting('Equip2Hand') and mq.TLO.Me.ActiveDisc.Name() ~= "Deflection Discipline" and
-                        (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000 and not (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                        (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000 and not (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("2Hand") end,
             },

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -838,18 +838,16 @@ local _ClassConfig = {
             {
                 name = "EndRegen",
                 type = "Disc",
-                tooltip = Tooltips.EndRegen,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.Level() < 106 and mq.TLO.Me.PctEndurance() < 15
+                    if self:GetResolvedActionMapItem("CombatEndRegen") then return false end
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
-            --If these tables were combined, errors could occur... there is no other good way I can think of to ensure a timer 13 ability that can be used in combat is scribed.
             {
                 name = "CombatEndRegen",
                 type = "Disc",
-                tooltip = Tooltips.CombatEndRegen,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.Level() > 105 and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -958,7 +956,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Skin,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 60
+                    return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 60
                 end,
             },
             {
@@ -968,7 +966,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
                     if not Config:GetSetting('DoTempHP') or not Casting.GemReady(spell) then return false end
-                    return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 45
+                    return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 45
                 end,
             },
             {
@@ -977,7 +975,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.HealBurn,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 30
+                    return Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 30
                 end,
             },
             {
@@ -1031,7 +1029,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return mq.TLO.Me.Pet.ID() > 0 end,
                 cond = function(self, spell)
                     if mq.TLO.Me.Pet.ID() ~= 0 or not Config:GetSetting('DoPet') then return false end
-                    return Casting.SpellReady(spell) and Casting.ReagentCheck(spell)
+                    return Casting.ReagentCheck(spell)
                 end,
             },
         },
@@ -1042,14 +1040,14 @@ local _ClassConfig = {
                 tooltip = Tooltips.PetHaste,
                 active_cond = function(self, spell) return mq.TLO.Me.PetBuff(spell.RankName) ~= nil end,
                 cond = function(self, spell)
-                    return Casting.SpellReady(spell) and Casting.SelfBuffPetCheck(spell)
+                    return Casting.SelfBuffPetCheck(spell)
                 end,
             },
             {
                 name = "Fortify Companion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },
@@ -1062,8 +1060,8 @@ local _ClassConfig = {
                 name = "Armor of Experience",
                 type = "AA",
                 tooltip = Tooltips.ArmorofExperience,
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
+                cond = function(self)
+                    return mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
                 end,
             },
             --Note that on named we may already have a mantle/carapace running already, could make this remove other discs, but meh, Shield Flash still a thing.
@@ -1077,7 +1075,7 @@ local _ClassConfig = {
                     end
                 end,
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell) and
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID() and
                         (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000
                 end,
             },
@@ -1090,16 +1088,16 @@ local _ClassConfig = {
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() ~= "Deflection Discipline"
+                cond = function(self)
+                    return mq.TLO.Me.ActiveDisc.Name() ~= "Deflection Discipline"
                 end,
             },
             {
                 name = "LeechCurse",
                 type = "Disc",
                 tooltip = Tooltips.LeechCurse,
-                cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell)
+                cond = function(self)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             --Influence is in an odd place with Carapace. Usage is very subjective and may be more nuanced than automation can support. Placed here as an alternative to Carapace in low health situations to get you topped back off again for tanks. Should be used in burn for non-tanks (adding non-tank stuff is TODO)
@@ -1107,16 +1105,16 @@ local _ClassConfig = {
                 name = "InfluenceDisc",
                 type = "Disc",
                 tooltip = Tooltips.InfluenceDisc,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID() and Core.IsTanking()
+                cond = function(self)
+                    return not mq.TLO.Me.ActiveDisc.ID() and Core.IsTanking()
                 end,
             },
             {
                 name = "Carapace",
                 type = "Disc",
                 tooltip = Tooltips.Carapace,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                cond = function(self)
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -1132,8 +1130,8 @@ local _ClassConfig = {
                 name = "Mantle",
                 type = "Disc",
                 tooltip = Tooltips.Mantle,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                cond = function(self)
+                    return not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             --if we made it this far let's reset our dicho/dire and hope for the best!
@@ -1141,9 +1139,6 @@ local _ClassConfig = {
                 name = "Forceful Rejuvenation",
                 type = "AA",
                 tooltip = Tooltips.ForcefulRejuv,
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ['HateTools'] = {
@@ -1153,7 +1148,7 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.AgelessEnmity,
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.GetTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
+                    return Targeting.GetAutoTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
                 end,
             },
             --used to jumpstart hatred on named from the outset and prevent early rips from burns
@@ -1161,8 +1156,8 @@ local _ClassConfig = {
                 name = "Acrimony",
                 type = "Disc",
                 tooltip = Tooltips.Acrimony,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, discSpell, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             --used to reinforce hatred on named
@@ -1172,81 +1167,80 @@ local _ClassConfig = {
                 tooltip = Tooltips.VeilofDarkness,
                 cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
+                    return Targeting.IsNamed(target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
                 end,
             },
             {
                 name = "AETaunt",
                 type = "Spell",
                 tooltip = Tooltips.AETaunt,
-                cond = function(self, spell)
+                cond = function(self)
                     if Config:GetSetting('AETauntSpell') == 1 then return false end
-                    return Casting.SpellReady(spell) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
                 name = "Explosion of Hatred",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfHatred,
-                cond = function(self, aaName, target)
+                cond = function(self)
                     if not Config:GetSetting('AETauntAA') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
                 name = "Explosion of Spite",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfSpite,
-                cond = function(self, aaName)
+                cond = function(self)
                     if not Config:GetSetting('AETauntAA') then return false end
-                    return Casting.AAReady(aaName) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
                 name = "Projection of Doom",
                 type = "AA",
                 tooltip = Tooltips.ProjectionofDoom,
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
+                    return Targeting.IsNamed(target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
                 end,
             },
             {
                 name = "Taunt",
                 type = "Ability",
                 tooltip = Tooltips.Taunt,
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetID() > 0 and
-                        Targeting.GetTargetDistance() < 30
+                cond = function(self)
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetID() > 0
                 end,
             },
             {
                 name = "Terror",
                 type = "Spell",
                 tooltip = Tooltips.Terror,
-                cond = function(self, spell, target)
+                cond = function(self)
                     if Config:GetSetting('DoTerror') == 1 then return false end
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
+                    return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
                 name = "Terror2",
                 type = "Spell",
                 tooltip = Tooltips.Terror,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if Config:GetSetting('DoTerror') == 1 then return false end
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.SpellLoaded(spell) and Casting.TargetedSpellReady(spell, target.ID()) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
+                    return Casting.SpellLoaded(spell) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
                 name = "ForPower",
                 type = "Spell",
                 tooltip = Tooltips.ForPower,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoForPower') then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1254,41 +1248,30 @@ local _ClassConfig = {
             {
                 name = "Visage of Death",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Crimson",
                 type = "Disc",
                 tooltip = Tooltips.Crimson,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
             {
                 name = "Harm Touch",
                 type = "AA",
                 tooltip = Tooltips.HarmTouch,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Thought Leech",
                 type = "AA",
                 tooltip = Tooltips.ThoughtLeech,
-                cond = function(self, aaName, target)
-                    if Config:GetSetting('DoThoughtLeech') == 1 then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                cond = function(self)
+                    return Config:GetSetting('DoThoughtLeech') ~= 1
                 end,
             },
             {
@@ -1296,56 +1279,46 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
-                    if Config:GetSetting('DoLeechTouch') == 1 then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID())
+                    return Config:GetSetting('DoLeechTouch') ~= 1
                 end,
             },
             {
                 name = "Spire of the Reavers",
                 type = "AA",
                 tooltip = Tooltips.SpireoftheReavers,
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Chattering Bones",
                 type = "AA",
                 tooltip = Tooltips.ChatteringBones,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "T`Vyl's Resolve",
                 type = "AA",
                 tooltip = Tooltips.Tvyls,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "SpiteStrike",
                 type = "Disc",
                 tooltip = Tooltips.SpikeStrike,
-                cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                cond = function(self)
+                    return not Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "UnholyAura",
                 type = "Disc",
                 tooltip = Tooltips.UnholyAura,
-                cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                cond = function(self)
+                    return not Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
                 name = "InfluenceDisc",
                 type = "Disc",
                 tooltip = Tooltips.InfluenceDisc,
-                cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.ID()
+                cond = function(self)
+                    return not Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },
@@ -1354,8 +1327,8 @@ local _ClassConfig = {
                 name = "Encroaching Darkness",
                 tooltip = Tooltips.EncroachingDarkness,
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                cond = function(self, aaName)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1364,7 +1337,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.SnareDot,
                 cond = function(self, spell, target)
                     if Casting.CanUseAA("Encroaching Darkness") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell) and Targeting.GetTargetPctHPs(target) < 50
+                    return Casting.DetSpellCheck(spell) and Targeting.GetAutoTargetPctHPs() < 50
                 end,
             },
         },
@@ -1374,7 +1347,8 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.MeleeMit,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not (discSpell.Level() < 108 and mq.TLO.Me.ActiveDisc.ID())
+                    if not Core.IsTanking() then return false end
+                    return not ((discSpell.Level() or 0) < 108 and mq.TLO.Me.ActiveDisc.ID())
                 end,
             },
             {
@@ -1398,45 +1372,45 @@ local _ClassConfig = {
                 name = "Carapace",
                 type = "Disc",
                 tooltip = Tooltips.Carapace,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
                 name = "Mantle",
                 type = "Disc",
                 tooltip = Tooltips.Mantle,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
                 name = "Guardian",
                 type = "Disc",
                 tooltip = Tooltips.Guardian,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
                 name = "UnholyAura",
                 type = "Disc",
                 tooltip = Tooltips.UnholyAura,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and
-                        (Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                cond = function(self, discSpell, target)
+                    if not Core.IsTanking() then return false end
+                    return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
                 end,
             },
             {
                 name = "Purity of Death",
                 type = "AA",
                 tooltip = Tooltips.PurityofDeath,
-                cond = function(self, aaName)
+                cond = function(self)
                     ---@diagnostic disable-next-line: undefined-field
-                    return mq.TLO.Me.TotalCounters() > 0 and Casting.AAReady(aaName)
+                    return mq.TLO.Me.TotalCounters() > 0
                 end,
             },
         },
@@ -1448,7 +1422,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoLeechTouch') == 2 then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and mq.TLO.Me.PctHPs() < 25
+                    return mq.TLO.Me.PctHPs() < 25
                 end,
             },
             --the trick with the next two is to find a sweet spot between using discs and long term CD abilities (we want these to trigger so those don't need to) and using them needlessly (which isn't much of a damage increase). Trying to get it dialed in for a good default value.
@@ -1456,10 +1430,10 @@ local _ClassConfig = {
                 name = "Dicho",
                 type = "Spell",
                 tooltip = Tooltips.Dicho,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoDicho') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
+                    return Casting.GemReady(spell) and
                         (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDicho')))
                 end,
             },
@@ -1470,7 +1444,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDireTap') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
+                    return Casting.GemReady(spell) and
                         (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDireTap')))
                 end,
             },
@@ -1478,9 +1452,9 @@ local _ClassConfig = {
                 name = "LifeTap",
                 type = "Spell",
                 tooltip = Tooltips.LifeTap,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
+                    return Casting.GemReady(spell) and
                         (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
                 end,
             },
@@ -1488,9 +1462,9 @@ local _ClassConfig = {
                 name = "AELifeTap", --conditions on this may require further tuning, right now it does not respect the start tap settings
                 type = "Spell",
                 tooltip = Tooltips.AELifeTap,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) or not spell or not spell() then return false end
-                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.SpellStacksOnMe(spell.Trigger) and Casting.TargetedSpellReady(spell, target.ID()) and
+                    return Casting.GemReady(spell) and not mq.TLO.Me.Buff(spell.Trigger())() and Casting.SpellStacksOnMe(spell.Trigger) and
                         self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
@@ -1498,17 +1472,17 @@ local _ClassConfig = {
                 name = "ReflexStrike",
                 type = "Disc",
                 tooltip = Tooltips.ReflexStrike,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                cond = function(self)
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {
                 name = "LifeTap2",
                 type = "Spell",
                 tooltip = Tooltips.LifeTap,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.TargetedSpellReady(spell, target.ID()) and
+                    return Casting.GemReady(spell) and
                         (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
                 end,
             },
@@ -1518,47 +1492,35 @@ local _ClassConfig = {
                 name = "ReflexStrike",
                 type = "Disc",
                 tooltip = Tooltips.ReflexStrike,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and (mq.TLO.Group.Injured(80)() or 0) > 2
+                cond = function(self)
+                    return (mq.TLO.Group.Injured(80)() or 0) > 2
                 end,
             },
             {
                 name = "CombatEndRegen",
                 type = "Disc",
                 tooltip = Tooltips.CombatEndRegen,
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                cond = function(self)
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
                 name = "Vicious Bite of Chaos",
                 type = "AA",
                 tooltip = Tooltips.ViciousBiteOfChaos,
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Unbridled Strike of Fear",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Blade",
                 type = "Disc",
                 tooltip = Tooltips.Blade,
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "Gift of the Quick Spear",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Thought Leech",
@@ -1566,25 +1528,21 @@ local _ClassConfig = {
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoThoughtLeech') == 2 then return false end
-                    return mq.TLO.Me.PctMana() < 10 and Casting.TargetedAAReady(aaName, target.ID())
+                    return mq.TLO.Me.PctMana() < 10
                 end,
             },
             {
                 name = "Bash",
                 type = "Ability",
                 -- tooltip = Tooltips.Bash,
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target) and
-                        (Core.ShieldEquipped() or Casting.CanUseAA("2 Hand Bash"))
+                cond = function(self)
+                    return (Core.ShieldEquipped() or Casting.CanUseAA("2 Hand Bash"))
                 end,
             },
             {
                 name = "Slam",
                 type = "Ability",
                 tooltip = Tooltips.Slam,
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
         },
         ['Combat'] = {
@@ -1592,18 +1550,18 @@ local _ClassConfig = {
                 name = "BondTap",
                 type = "Spell",
                 tooltip = Tooltips.BondTap,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoBondTap') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
                 name = "AESpearNuke",
                 type = "Spell",
                 tooltip = Tooltips.SpearNuke,
-                cond = function(self, spell, target)
+                cond = function(self)
                     if not (Config:GetSetting('DoAESpearNuke') and Config:GetSetting('DoAEDamage')) then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1611,25 +1569,25 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.AESpearNuke,
                 cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID()) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
                 name = "PoisonDot",
                 type = "Spell",
                 tooltip = Tooltips.PoisonDot,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoPoisonDot') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
                 name = "CorruptionDot",
                 type = "Spell",
                 tooltip = Tooltips.PoisonDot,
-                cond = function(self, spell, target)
+                cond = function(self, spell)
                     if not Config:GetSetting('DoCorruptionDot') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1638,15 +1596,15 @@ local _ClassConfig = {
                 tooltip = Tooltips.DireDot,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDireDot') then return false end
-                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
                 name = "BiteTap",
                 type = "Spell",
                 tooltip = Tooltips.BiteTap,
-                cond = function(self, spell, target) --no mana check here because this returns half the mana cost to the entire group. can adjust later as needed.
-                    return Casting.TargetedSpellReady(spell, target.ID()) and mq.TLO.Me.PctHPs() <= Config:GetSetting('StartLifeTap')
+                cond = function(self) --no mana check here because this returns half the mana cost to the entire group. can adjust later as needed.
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('StartLifeTap')
                 end,
             },
             {
@@ -1655,7 +1613,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAC,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoACTap') or not spell or not spell() then return false end
-                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.TargetedSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Trigger())()
                 end,
             },
             {
@@ -1664,7 +1622,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAtk,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAtkTap') or not spell or not spell() then return false end
-                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.TargetedSpellReady(spell, target.ID())
+                    return not mq.TLO.Me.Buff(spell.Trigger())()
                 end,
             },
         },

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -114,6 +114,10 @@ local _ClassConfig = {
             "Heartstiller's Mail Chestguard",
             "Duskbringer's Plate Chestguard of the Hateful",
         },
+        ['Coating'] = {
+            "Spirit Drinker's Coating",
+            "Blood Drinker's Coating",
+        },
     },
     ['AbilitySets']     = {
         ['Mantle'] = {
@@ -998,16 +1002,12 @@ local _ClassConfig = {
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
-            {
-                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "None" end,
+            { --Charm Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "CharmClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return item() and Casting.TargetHasBuff(item.Spell, mq.TLO.Me)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return Config:GetSetting('DoCharmClick') and item() and Casting.SelfBuffCheck(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoCharmClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1118,12 +1118,11 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end, --stops errors in rotation window when slot is empty
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -1356,8 +1355,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName, target)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and
-                        (self.ClassConfig.HelperFunctions.LeechCheck(self) or Targeting.IsNamed(target))
+                    return self.ClassConfig.HelperFunctions.LeechCheck(self) or Targeting.IsNamed(target)
                 end,
             },
             {
@@ -1365,7 +1363,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.OoW_BP,
                 cond = function(self, itemName)
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and self.ClassConfig.HelperFunctions.LeechCheck(self)
+                    return self.ClassConfig.HelperFunctions.LeechCheck(self)
                 end,
             },
             {
@@ -1393,6 +1391,14 @@ local _ClassConfig = {
                 cond = function(self, discSpell, target)
                     if not Core.IsTanking() then return false end
                     return not mq.TLO.Me.ActiveDisc.ID() and (Targeting.IsNamed(target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                end,
+            },
+            {
+                name = "Coating",
+                type = "Item",
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoCoating') then return false end
+                    return Casting.ItemSpellCheck(itemName, target) and self.ClassConfig.HelperFunctions.LeechCheck(self)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -808,10 +808,10 @@ local _ClassConfig = {
         { --Offensive actions to temporarily boost damage dealt
             name = 'Burn',
             state = 1,
-            steps = 1,
+            steps = 2,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
+                return combat_state == "Combat" and Casting.BurnCheck() and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyStart')
             end,
         },
         { --Non-spell actions that can be used during/between casts
@@ -1210,8 +1210,8 @@ local _ClassConfig = {
                 name = "Taunt",
                 type = "Ability",
                 tooltip = Tooltips.Taunt,
-                cond = function(self)
-                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetID() > 0
+                cond = function(self, abilityName, target)
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and target.ID() > 0 and Targeting.GetTargetDistance(target) < 30
                 end,
             },
             {
@@ -1433,8 +1433,7 @@ local _ClassConfig = {
                 cond = function(self, spell)
                     if not Config:GetSetting('DoDicho') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.GemReady(spell) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDicho')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDicho')))
                 end,
             },
             {
@@ -1444,8 +1443,7 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDireTap') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.GemReady(spell) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDireTap')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartDireTap')))
                 end,
             },
             {
@@ -1454,8 +1452,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LifeTap,
                 cond = function(self, spell)
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.GemReady(spell) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
                 end,
             },
             {
@@ -1464,7 +1461,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.AELifeTap,
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) or not spell or not spell() then return false end
-                    return Casting.GemReady(spell) and not mq.TLO.Me.Buff(spell.Trigger())() and Casting.SpellStacksOnMe(spell.Trigger) and
+                    return not mq.TLO.Me.Buff(spell.Trigger())() and Casting.SpellStacksOnMe(spell.Trigger) and
                         self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
@@ -1482,8 +1479,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LifeTap,
                 cond = function(self, spell)
                     local myHP = mq.TLO.Me.PctHPs()
-                    return Casting.GemReady(spell) and
-                        (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
+                    return (myHP <= Config:GetSetting('EmergencyStart') or ((Casting.HaveManaToNuke() or Casting.BurnCheck()) and myHP <= Config:GetSetting('StartLifeTap')))
                 end,
             },
         },

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -826,9 +826,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
             { --if we hit this we need intervention back ASAP
                 name = "Forceful Rejuvenation",
@@ -862,9 +859,6 @@ local _ClassConfig = {
             {
                 name = "VP2Hammer",
                 type = "Item",
-                cond = function(self, itemName)
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
-                end,
             },
         },
     },
@@ -1139,8 +1133,7 @@ local _ClassConfig = {
                 type = "Item",
                 cond = function(self, itemName)
                     if Config:GetSetting('UseEpic') == 1 then return false end
-                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck())) and mq.TLO.FindItem(itemName)() and
-                        mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return (Config:GetSetting('UseEpic') == 3 or (Config:GetSetting('UseEpic') == 2 and Casting.BurnCheck()))
                 end,
             },
             {

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -747,21 +747,19 @@ local _ClassConfig = {
                 name = "Call of the Ancients",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.AAReady(aaName) and (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
+                    return (target.PctHPs() or 999) < Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "RecklessHeal1",
                 type = "Spell",
-                cond = function(self, spell, target) return Casting.TargetedSpellReady(spell, target.ID(), true) end,
             },
             {
                 name = "GroupRenewalHoT",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') or not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                        and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -770,44 +768,34 @@ local _ClassConfig = {
                 name = "InterventionHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.GemReady(spell) and
-                        Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "Soothsayer's Intervention",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.TargetedAAReady(aaName, target.ID(), true)
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
                 name = "RecourseHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "AESpiritualHeal",
                 type = "Spell",
-                cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
-                end,
             },
             {
                 name = "Call of the Ancients",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "GroupRenewalHoT",
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -816,36 +804,24 @@ local _ClassConfig = {
                 name = "Ancestral Guard",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (target.ID() or 0) == mq.TLO.Me.ID() and Casting.AAReady(aaName)
+                    return (target.ID() or 0) == mq.TLO.Me.ID()
                 end,
             },
             {
                 name = "InterventionHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "Soothsayer's Intervention",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
             {
                 name = "Union of Spirits",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID(), true)
-                end,
             },
             { --The stuff above is down, lets make mainhealpoint chonkier.
                 name = "Spiritual Blessing",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -857,46 +833,31 @@ local _ClassConfig = {
             { --if we hit this we need intervention back ASAP
                 name = "Forceful Rejuvenation",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
         },
         ["MainHealPoint"] = {
             {
                 name = "RecourseHeal",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "AESpiritualHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (target.ID() or 0) == Core.GetMainAssistId() and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Targeting.TargetIsMA(target)
                 end,
             },
             {
                 name = "RecklessHeal1",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "RecklessHeal2",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "RecklessHeal3",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.TargetedSpellReady(spell, target.ID(), true)
-                end,
             },
             {
                 name = "VP2Hammer",
@@ -1036,8 +997,7 @@ local _ClassConfig = {
                 type = "Spell",
                 retries = 0,
                 cond = function(self, spell)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
-                        not Casting.SongActiveByName("Healing Twincast")
+                    return not Casting.SongActiveByName("Healing Twincast")
                 end,
             },
         },
@@ -1046,7 +1006,7 @@ local _ClassConfig = {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1054,7 +1014,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetResolvedActionMapItem('DichoSpell') then return false end
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1062,51 +1022,38 @@ local _ClassConfig = {
             {
                 name = "Fleeting Spirit",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Ancestral Aid",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Spire of Ancestors",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Focus of Arcanum",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, aaName, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             {
                 name = "Spirit Call",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Rabid Bear",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
+                    return Config:GetSetting('DoMelee') and mq.TLO.Me.Combat()
                 end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -1116,8 +1063,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEMalo') then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1125,8 +1071,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAEMalo') or Casting.CanUseAA("Wind of Malosinete") then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.TargetedSpellReady(spell, target.ID()) and
-                        Casting.DetSpellCheck(spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AEMaloCount') and Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1134,7 +1079,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTMalo') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1142,7 +1087,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoSTMalo') or Casting.CanUseAA("Malosinete") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1152,8 +1097,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAESlow') then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.TargetedAAReady(aaName, target.ID()) and
-                        Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1161,8 +1105,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAESlow') or Casting.CanUseAA("Tigir's Insect Swarm") then return false end
-                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.TargetedSpellReady(spell, target.ID()) and
-                        Casting.DetSpellCheck(spell)
+                    return Targeting.GetXTHaterCount() >= Config:GetSetting('AESlowCount') and Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1170,7 +1113,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSTSlow') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -1178,7 +1121,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoSTSlow') or Casting.CanUseAA("Turgur's Swarm") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
             {
@@ -1186,7 +1129,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not (Config:GetSetting('DoDiseaseSlow') and Config:GetSetting('DoSTSlow')) or Casting.CanUseAA("Turgur's Swarm") then return false end
-                    return Casting.TargetedSpellReady(spell, target.ID()) and Casting.DetSpellCheck(spell)
+                    return Casting.DetSpellCheck(spell)
                 end,
             },
         },
@@ -1205,8 +1148,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.GemReady(spell) and Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and
-                        Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1214,7 +1156,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1222,7 +1164,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1230,7 +1172,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if (Core.IsModeActive("Heal") and (Core.GetResolvedActionMapItem('CurseDot2') or not Config:GetSetting('DoHealDPS'))) then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1238,7 +1180,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if (Core.IsModeActive("Heal") and (Core.GetResolvedActionMapItem('ChaoticDot') or not Config:GetSetting('DoHealDPS'))) then return false end
-                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1246,7 +1188,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Core.IsModeActive("Hybrid") then return false end
-                    return Targeting.IsNamed(mq.TLO.Target) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Targeting.IsNamed(target) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1254,7 +1196,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Core.IsModeActive("Hybrid") or Core.GetResolvedActionMapItem('AfflictionDot') then return false end
-                    return Targeting.IsNamed(mq.TLO.Target) and Casting.DotSpellCheck(spell) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Targeting.IsNamed(target) and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1263,8 +1205,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, aaName)
                     if not (Config:GetSetting('DoAACanni') and Config:GetSetting('DoCombatCanni')) then return false end
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and
-                        mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
             {
@@ -1273,8 +1214,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
-                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
-                        mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
             {
@@ -1291,7 +1231,7 @@ local _ClassConfig = {
                 name = "FastPoisonNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1299,7 +1239,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and Core.GetResolvedActionMapItem('FastPoisonNuke') then return false end
-                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
             {
@@ -1307,7 +1247,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetResolvedActionMapItem('PoisonNuke') then return false end
-                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return not Casting.DotSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck())
                 end,
             },
         },
@@ -1331,17 +1271,14 @@ local _ClassConfig = {
                 name = "Cannibalization",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Config:GetSetting('DoAACanni') and Casting.AAReady(aaName) and
-                        mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and
-                        mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
+                    return Config:GetSetting('DoAACanni') and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
             {
                 name = "CanniSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Config:GetSetting('DoSpellCanni') and Casting.GemReady(spell) and
-                        mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
+                    return Config:GetSetting('DoSpellCanni') and Casting.GemReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -1384,7 +1321,7 @@ local _ClassConfig = {
                 name = "Fortify Companion",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell) and Casting.AAReady(aaName)
+                    return Casting.SelfBuffPetCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
         },
@@ -1439,8 +1376,8 @@ local _ClassConfig = {
                 name = "Spirit Guardian",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.AAReady(aaName) and Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
+                    if not Targeting.TargetIsMA(target) then return false end
+                    return Casting.GroupBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell, target)
                 end,
             },
             {
@@ -1545,7 +1482,7 @@ local _ClassConfig = {
                 active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoGroupShrink') then return false end
-                    return target.Height() > 2.2 and Casting.TargetedAAReady(aaName, target.ID())
+                    return target.Height() > 2.2
                 end,
             },
             {
@@ -1554,7 +1491,7 @@ local _ClassConfig = {
                 active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoGroupShrink') or Casting.CanUseAA("Group Shrink") then return false end
-                    return target.Height() > 2.2 and Casting.TargetedAAReady(aaName, target.ID())
+                    return target.Height() > 2.2
                 end,
             },
             {
@@ -1563,7 +1500,7 @@ local _ClassConfig = {
                 active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoGroupShrink') or Casting.CanUseAA("Group Shrink") or Casting.CanUseAA("Shrink") then return false end
-                    return target.Height() > 2.2 and Casting.TargetedSpellReady(spell, target.ID())
+                    return target.Height() > 2.2
                 end,
             },
             {

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -385,7 +385,7 @@ local _ClassConfig = {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctEndurance() < 75
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -431,21 +431,24 @@ local _ClassConfig = {
             {
                 name = "Brace for Impact",
                 type = "AA",
+                cond = function(self, aaName, target)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
             },
             {
                 name = "HealHateAE",
                 type = "Disc",
-                cond = function(self, discSpell)
+                cond = function(self, discSpell, target)
                     if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and Casting.GroupBuffCheck(discSpell, target)
                 end,
             },
             {
                 name = "HealHateSingle",
                 type = "Disc",
-                cond = function(self, discSpell)
+                cond = function(self, discSpell, target)
                     if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and Casting.GroupBuffCheck(discSpell, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -431,9 +431,6 @@ local _ClassConfig = {
             {
                 name = "Brace for Impact",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "HealHateAE",
@@ -524,53 +521,46 @@ local _ClassConfig = {
             {
                 name = "Projection of Fury",
                 type = "AA",
-                cond = function(self, aaName)
+                cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.AAReady(aaName) and Targeting.IsNamed(mq.TLO.Target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
+                    return Targeting.IsNamed(target) and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
                 end,
             },
             {
                 name = "Taunt",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and Targeting.GetTargetID() > 0 and
-                        Targeting.GetTargetDistance() < 30
+                cond = function(self, abilityName, target)
+                    return mq.TLO.Me.TargetOfTarget.ID() ~= mq.TLO.Me.ID() and target.ID() > 0 and Targeting.GetTargetDistance(target) < 30
                 end,
             },
             {
                 name = "AbsorbTaunt",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "AEBlades",
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAEDamage') then return false end
-                    return Casting.TargetedDiscReady(discSpell) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
                 name = "AddHate1",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Casting.DetSpellCheck(discSpell)
+                    return Casting.DetSpellCheck(discSpell)
                 end,
             },
             {
                 name = "AddHate2",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "AgroPet",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, discSpell, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             -- { --this appears to have incredibly limited usage and the line was discontinued
@@ -589,58 +579,45 @@ local _ClassConfig = {
                 name = "Armor of Experience",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Casting.AAReady(aaName) and mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
+                    return mq.TLO.Me.PctHPs() < 25 and Config:GetSetting('DoVetAA')
                 end,
             },
             {
                 name = "Fortitude",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and Casting.DiscReady(discSpell) and
-                        not Casting.SongActiveByName("Flash of Anger") and not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not Casting.SongActiveByName("Flash of Anger") and
+                        not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
                 end,
             },
             {
                 name = "Flash",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.ActiveDisc.Name() ~= "Fortitude Discipline" and
-                        not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
+                    return not mq.TLO.Me.ActiveDisc.Name() ~= "Fortitude Discipline" and not Casting.BuffActiveByID(mq.TLO.AltAbility("Blade Guardian").Spell.Base(1)())
                 end,
             },
             {
                 name = "Warlord's Tenacity",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Warlord's Resurgence",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "RuneShield",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell)
-                end,
             },
             {
                 name = "Mark of the Mage Hunter",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             { --here for use in emergencies regarldless of ability staggering below
                 name = "StandDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
+                    return Core.IsTanking() and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
                 end,
             },
         },
@@ -651,9 +628,9 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("Shield").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("Shield").Active() then return false end
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("Shield") end,
             },
@@ -663,9 +640,9 @@ local _ClassConfig = {
                 active_cond = function(self, target)
                     return mq.TLO.Me.Bandolier("DW").Active()
                 end,
-                cond = function(self)
+                cond = function(self, target)
                     if mq.TLO.Me.Bandolier("DW").Active() then return false end
-                    return mq.TLO.Me.PctHPs() >= Config:GetSetting('EquipDW') and not (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('NamedShieldLock'))
+                    return mq.TLO.Me.PctHPs() >= Config:GetSetting('EquipDW') and not (Targeting.IsNamed(target) and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("DW") end,
             },
@@ -677,7 +654,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local itemSpell = mq.TLO.Me.Inventory("Chest").Spell()
-                    return Casting.DiscReady(discSpell) and not (itemSpell and mq.TLO.Me.Buff(itemSpell)())
+                    return not (itemSpell and mq.TLO.Me.Buff(itemSpell)())
                 end,
             },
             { --shares effect with Dicho Shield
@@ -695,7 +672,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local absorbDisc = Core.GetResolvedActionMapItem('AbsorbDisc')
-                    return Casting.DiscReady(discSpell) and not mq.TLO.Me.Song(absorbDisc)() and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
+                    return not mq.TLO.Me.Song(absorbDisc)() and self.ClassConfig.HelperFunctions.DiscOverwriteCheck(self)
                 end,
             },
             { --offset from StandDisc for automation flow/coverage
@@ -703,7 +680,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     local standDisc = self:GetResolvedActionMapItem('StandDisc')
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName()
+                    return mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName()
                 end,
             },
             { --shares effect with StandDisc and Warlord's Bravery, offset from AbsorbDisc for automation flow/coverage
@@ -722,8 +699,7 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     local absorbDisc = Core.GetResolvedActionMapItem('AbsorbDisc')
                     local standDisc = Core.GetResolvedActionMapItem('StandDisc')
-                    return Casting.AAReady(aaName) and mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName() and
-                        mq.TLO.Me.Song(absorbDisc)() and not Casting.BuffActiveByName("Guardian's Boon") and
+                    return mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName() and mq.TLO.Me.Song(absorbDisc)() and not Casting.BuffActiveByName("Guardian's Boon") and
                         not Casting.BuffActiveByName("Guardian's Bravery")
                 end,
             },
@@ -756,73 +732,61 @@ local _ClassConfig = {
             {
                 name = "Spire of the Warlord",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Imperator's Command",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Onslaught",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return not Core.IsTanking() and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "MightyStrike",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return not Core.IsTanking() and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "OffensiveDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not Core.IsTanking() and Casting.DiscReady(discSpell) and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
+                    return not Core.IsTanking() and self.ClassConfig.HelperFunctions.BurnDiscCheck(self)
                 end,
             },
             {
                 name = "Vehement Rage",
                 type = "AA",
                 cond = function(self, aaName)
-                    return not Core.IsTanking() and Casting.AAReady(aaName)
+                    return not Core.IsTanking()
                 end,
             },
             {
                 name = "Rage of Rallos Zek",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Casting.AAReady(aaName)
-                end,
             },
             {
                 name = "Warlord's Fury",
                 type = "AA",
                 cond = function(self, aaName, target)
                     local dichoShield = Core.GetResolvedActionMapItem('DichoShield')
-                    return Core.IsTanking() and Casting.TargetedAAReady(aaName, target.ID()) and not mq.TLO.Me.Buff(dichoShield)
+                    return Core.IsTanking() and not mq.TLO.Me.Buff(dichoShield)
                 end,
             },
             {
                 name = "War Sheol's Heroic Blade",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "SelfBuffAE",
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking()
                 end,
             },
             {
@@ -830,29 +794,28 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "TongueDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Resplendent Glory",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Core.IsTanking() and Casting.AAReady(aaName)
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoVetAA') then return false end
-                    return Casting.AAReady(aaName)
+                    return Config:GetSetting('DoVetAA')
                 end,
             },
         },
@@ -860,15 +823,12 @@ local _ClassConfig = {
             {
                 name = "ShieldHit",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell)
-                end,
             },
             {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 15
+                    return mq.TLO.Me.PctEndurance() < 15
                 end,
             },
             {
@@ -876,7 +836,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoBattleLeap') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and not Casting.SongActiveByName(aaName) and not Casting.SongActiveByName('Group Bestial Alignment')
+                    return not Casting.SongActiveByName(aaName) and not Casting.SongActiveByName('Group Bestial Alignment')
                         ---@diagnostic disable-next-line: undefined-field --Defs are not updated with HeadWet
                         and not mq.TLO.Me.HeadWet() --Stops Leap from launching us above the water's surface
                 end,
@@ -885,22 +845,19 @@ local _ClassConfig = {
                 name = "Gut Punch",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Core.IsTanking() and Casting.TargetedAAReady(aaName, target.ID())
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Knee Strike",
                 type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID())
-                end,
             },
             {
                 name = "Rampage",
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting("DoAEDamage") then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and self.ClassConfig.HelperFunctions.AETargetCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETargetCheck(true)
                 end,
             },
             {
@@ -908,7 +865,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSnare') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
+                    return Casting.DetSpellCheck(mq.TLO.Me.AltAbility(aaName).Spell)
                 end,
             },
             {
@@ -916,29 +873,23 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting("DoPress") then return false end
-                    return Core.IsTanking() and Casting.TargetedAAReady(aaName, target.ID())
+                    return Core.IsTanking()
                 end,
             },
             {
                 name = "Bash",
                 type = "Ability",
                 cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target) and Core.ShieldEquipped()
+                    return Core.ShieldEquipped()
                 end,
             },
             {
                 name = "Slam",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             {
                 name = "Kick",
                 type = "Ability",
-                cond = function(self, abilityName, target)
-                    return mq.TLO.Me.AbilityReady(abilityName)() and Casting.AbilityRangeCheck(target)
-                end,
             },
             -- { --todo:homework
             --     name = "Disarm",
@@ -952,9 +903,7 @@ local _ClassConfig = {
                 name = "StrikeDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and
-                        Targeting.GetTargetDistance() < Targeting.GetTargetMaxRangeTo() and
-                        Targeting.GetTargetPctHPs() <= 20
+                    return Targeting.GetTargetDistance() < Targeting.GetTargetMaxRangeTo() and Targeting.GetTargetPctHPs() <= 20
                 end,
             },
             {
@@ -964,7 +913,7 @@ local _ClassConfig = {
                     return mq.TLO.Me.ActiveDisc.ID() == discSpell.ID()
                 end,
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
         },
@@ -1224,6 +1173,5 @@ local _ClassConfig = {
         },
     },
 }
-
 
 return _ClassConfig

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -465,16 +465,12 @@ local _ClassConfig = {
                     return Casting.SelfBuffAACheck(aaName) and not Casting.SongActiveByName(aaName)
                 end,
             },
-            {
-                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "None" end,
+            { --Charm Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "CharmClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return item() and Casting.TargetHasBuff(item.Spell, mq.TLO.Me)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Charm")
-                    return Config:GetSetting('DoCharmClick') and item() and Casting.SelfBuffCheck(item.Spell) and item.TimerReady() == 0
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoCharmClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             {
@@ -482,8 +478,8 @@ local _ClassConfig = {
                 type = "Item",
                 active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
                 cond = function(self)
-                    return Config:GetSetting('SummonArrows') and mq.TLO.Me.Level() > 89 and mq.TLO.FindItemCount("Ethereal Arrow")() < 101 and
-                        mq.TLO.Me.ItemReady("Huntsman's Ethereal Quiver")()
+                    if not Config:GetSetting('SummonArrows') then return false end
+                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
                 end,
             },
         },
@@ -660,14 +656,13 @@ local _ClassConfig = {
                     return not (itemSpell and mq.TLO.Me.Buff(itemSpell)())
                 end,
             },
-            { --shares effect with Dicho Shield
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --shares effect with Dicho Shield --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                cond = function(self)
-                    if not Config:GetSetting('DoChestClick') then return false end
-                    local item = mq.TLO.Me.Inventory("Chest")
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
                     local dichoShield = Core.GetResolvedActionMapItem('DichoShield')
-                    return item() and item.TimerReady() == 0 and Casting.SpellStacksOnMe(item.Spell) and not mq.TLO.Me.Buff(dichoShield)
+                    return not mq.TLO.Me.Buff(dichoShield) and Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             { --shares effect with OoW Chest and Warlord's Bravery, offset from AbsorbDisc for automation flow/coverage
@@ -692,8 +687,7 @@ local _ClassConfig = {
                 cond = function(self, itemName)
                     local absorbDisc = Core.GetResolvedActionMapItem('AbsorbDisc')
                     local standDisc = Core.GetResolvedActionMapItem('StandDisc')
-                    return mq.TLO.FindItemCount(itemName)() ~= 0 and mq.TLO.FindItem(itemName).TimerReady() == 0 and mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName() and
-                        not mq.TLO.Me.Song(absorbDisc)()
+                    return mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName() and not mq.TLO.Me.Song(absorbDisc)()
                 end,
             },
             { --See above entries for notes
@@ -716,18 +710,16 @@ local _ClassConfig = {
             {
                 name = "Coating",
                 type = "Item",
-                cond = function(self, itemName)
+                cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    local item = mq.TLO.FindItem(itemName)
-                    return item() and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                    return Casting.ItemSpellCheck(itemName, target)
                 end,
             },
             { --incredibly weak at high level, but low opportunity cost for use and optional
                 name = "Epic",
                 type = "Item",
                 cond = function(self, itemName)
-                    if not Config:GetSetting('DoEpic') then return false end
-                    return mq.TLO.FindItem(itemName).TimerReady() == 0
+                    return Config:GetSetting('DoEpic')
                 end,
             },
         },

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -357,7 +357,7 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 --need to look at rotation and decide if it should fire during emergencies. leaning towards no
                 return combat_state == "Combat" and Core.IsTanking() and (mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') or
-                    Targeting.IsNamed(mq.TLO.Target) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
+                    Targeting.IsNamed(Targeting.GetAutoTarget()) or self.ClassConfig.HelperFunctions.DefensiveDiscCheck(true))
             end,
         },
         { --Offensive actions to temporarily boost damage dealt
@@ -385,7 +385,7 @@ local _ClassConfig = {
                 name = "EndRegen",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and mq.TLO.Me.PctEndurance() < 75
+                    return mq.TLO.Me.PctEndurance() < 75
                 end,
             },
             {
@@ -395,7 +395,7 @@ local _ClassConfig = {
                     return Casting.AuraActiveByName(discSpell.RankName.Name())
                 end,
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.Aura(1).ID() and Casting.DiscReady(discSpell)
+                    return not mq.TLO.Me.Aura(1).ID()
                 end,
             },
             {
@@ -405,7 +405,7 @@ local _ClassConfig = {
                     return Casting.SongActive(discSpell)
                 end,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not Casting.SongActive(discSpell)
+                    return not Casting.SongActive(discSpell)
                 end,
             },
             {
@@ -415,7 +415,7 @@ local _ClassConfig = {
                     return Casting.SongActive(discSpell)
                 end,
                 cond = function(self, discSpell)
-                    return Casting.DiscReady(discSpell) and not Casting.SongActive(discSpell)
+                    return not Casting.SongActive(discSpell)
                 end,
             },
             {
@@ -425,7 +425,7 @@ local _ClassConfig = {
                     return mq.TLO.Me.ActiveDisc.ID() == discSpell.ID()
                 end,
                 cond = function(self, discSpell)
-                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID() and Casting.DiscReady(discSpell)
+                    return Core.IsTanking() and not mq.TLO.Me.ActiveDisc.ID()
                 end,
             },
             {
@@ -437,7 +437,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell) and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
                 end,
             },
             {
@@ -445,7 +445,7 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell)
                     if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.DiscReady(discSpell) and not Casting.BuffActiveByID(discSpell.ID())
+                    return Core.IsTanking() and not Casting.BuffActiveByID(discSpell.ID())
                 end,
             },
             {
@@ -490,15 +490,15 @@ local _ClassConfig = {
                 name = "Ageless Enmity",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.GetTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
+                    return Targeting.GetTargetPctHPs() < 90 and mq.TLO.Me.PctAggro() < 100
                 end,
             },
             --used to jumpstart hatred on named from the outset and prevent early rips from burns
             {
                 name = "Attention",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.TargetedDiscReady(discSpell) and Targeting.IsNamed(mq.TLO.Target)
+                cond = function(self, discSpell, target)
+                    return Targeting.IsNamed(target)
                 end,
             },
             --used to reinforce hatred after it is initially established
@@ -507,7 +507,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     ---@diagnostic disable-next-line: undefined-field
-                    return Casting.TargetedAAReady(aaName, target.ID()) and Targeting.GetTargetPctHPs() < 90 and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
+                    return Targeting.GetTargetPctHPs() < 90 and (mq.TLO.Target.SecondaryPctAggro() or 0) > 70
                 end,
             },
             {
@@ -515,7 +515,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     --if not Config:GetSetting('AETauntAA') then return false end
-                    return Casting.TargetedAAReady(aaName, target.ID()) and self.ClassConfig.HelperFunctions.AETauntCheck(true)
+                    return self.ClassConfig.HelperFunctions.AETauntCheck(true)
                 end,
             },
             {
@@ -567,7 +567,7 @@ local _ClassConfig = {
             --     name = "AERoar",
             --     type = "Disc",
             --     cond = function(self, discSpell)
-            --         return Core.IsModeActive("Tank") and Casting.DiscReady(discSpell) and Targeting.GetXTHaterCount() >= Config:GetSetting('BurnMobCount') and
+            --         return Core.IsModeActive("Tank") and Targeting.GetXTHaterCount() >= Config:GetSetting('BurnMobCount') and
             --             Config:GetSetting('DoAEAgro')
             --     end,
             -- },

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -1121,17 +1121,12 @@ return {
                     return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and (mq.TLO.Me.GemTimer(spell.RankName.Name())() or -1) == 0
                 end,
             },
-            {
-                name = mq.TLO.Me.Inventory("Chest").Name(),
+            { --Chest Click, name function stops errors in rotation window when slot is empty
+                name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
-                active_cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    return Casting.BuffActive(item.Spell)
-                end,
-                cond = function(self)
-                    local item = mq.TLO.Me.Inventory("Chest")
-                    if not Config:GetSetting('DoChestClick') or not item or not item() then return false end
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and item.TimerReady() == 0 and Casting.SelfBuffCheck(item.Spell)
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoChestClick') or not Casting.ItemHasClicky(itemName) then return false end
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.ItemSpellCheck(itemName, target)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -6,9 +6,9 @@
 local mq        = require('mq')
 local Config    = require('utils.config')
 local Modules   = require("utils.modules")
-local Comms     = require("utils.comms")
 local Targeting = require("utils.targeting")
 local Casting   = require("utils.casting")
+local Comms     = require("utils.comms")
 
 return {
     _version         = "1.0 - Project Lazarus",
@@ -31,13 +31,14 @@ return {
     },
     ['AbilitySets']  = {
         ['AllianceSpell'] = {
-            "Malarian Mantle",
+            "Frostbound Covariance",
             "Frostbound Conjunction",
             "Frostbound Coalition",
             "Frostbound Covenant",
             "Frostbound Alliance",
         },
         ['DichoSpell'] = {
+            "Reciprocal Fire",
             "Ecliptic Fire",
             "Composite Fire",
             "Dissident Fire",
@@ -152,6 +153,7 @@ return {
         },
         ['VortexNuke'] = {
             -- NOTE: ${Spell[${VortexNuke}].ResistType} can be used to determine which resist type is getting debuffed
+            "Chromospheric Vortex",
             "Shadebright Vortex",
             "Thaumaturgic Vortex",
             "Stormjolt Vortex",
@@ -341,6 +343,7 @@ return {
             "Musing Gambit",
             "Quiescent Gambit",
             "Bucolic Gambit",
+            "Contemplative Gambit",
         },
         ['PetSpell'] = {
             "Kindleheart's Pyroblade",
@@ -601,7 +604,7 @@ return {
 
 
                     for _, port in ipairs(evacSpells) do
-                        if me.Class.Name() == 'Wizard' and me.Level()>= 57 and port == 'Evacuate' then
+                        if me.Class.Name() == 'Wizard' and me.Level() >= 57 and port == 'Evacuate' then
                             portName = port
                             break
                         elseif me.Class.Name() == 'Wizard' and me.Level() >= 18 and port == 'Lesser Evacuate' then
@@ -764,7 +767,7 @@ return {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.AAReady("Harvest of Druzzil")
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {
@@ -844,7 +847,7 @@ return {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.AAReady("Harvest of Druzzil")
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {
@@ -859,23 +862,14 @@ return {
             {
                 name = "Force of Ice",
                 type = "AA",
-                cond = function(self)
-                    return Casting.AAReady("Force of Ice")
-                end,
             },
             {
                 name = "Force of Will",
                 type = "AA",
-                cond = function(self)
-                    return Casting.AAReady("Force of Will")
-                end,
             },
             {
                 name = "Force of Flame",
                 type = "AA",
-                cond = function(self)
-                    return Casting.AAReady("Force of Flame")
-                end,
             },
         },
         ['Gift of Mana'] = {
@@ -1117,7 +1111,7 @@ return {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 cond = function(self)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct') and Casting.AAReady("Harvest of Druzzil")
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
             },
             {

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -750,7 +750,7 @@ return {
                 name = "Improved Twincast",
                 type = "AA",
                 cond = function(self)
-                    return not Casting.BuffActiveByName("Twincast")
+                    return not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {
@@ -961,7 +961,7 @@ return {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return not Casting.DetGambitCheck() and mq.TLO.Me.Buff("Twincast").ID() == 0 and not Casting.BuffActiveByName("Improved Twincast")
+                    return not Casting.DetGambitCheck() and not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
             {

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1812,7 +1812,7 @@ function Casting.AbilityReady(abilityName, target)
 end
 
 function Casting.ItemReady(itemName)
-    if not mq.TLO.FindItem("=" .. itemName)() then return false end
+    if not mq.TLO.FindItem("=" .. itemName).Clicky() then return false end
 
     local ready = mq.TLO.Me.ItemReady(itemName)()
 

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1803,7 +1803,7 @@ function Casting.AbilityReady(abilityName, target)
     if not target or not target() then return false end
 
     local ready = mq.TLO.Me.AbilityReady(abilityName)()
-    local inRange = Targeting.GetTargetDistance(target) <= Targeting.GetTargetMaxRangeTo(target)
+    local inRange = Targeting.GetTargetDistance(target) <= Targeting.GetTargetMaxRangeTo(target) or abilityName:lower() == "taunt"
 
     Logger.log_super_verbose("AbilityReady for  %s: Ready(%s), In-Range(%s)", abilityName, Strings.BoolToColorString(ready),
         Strings.BoolToColorString(inRange))

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -322,16 +322,12 @@ function Casting.SelfBuffAACheck(aaName)
     local triggerNotActive = not Casting.BuffActiveByID(mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1).ID())
     local auraNotActive = not mq.TLO.Me.Aura(tostring(mq.TLO.Spell(aaName).RankName())).ID()
     local stacks = Casting.SpellStacksOnMe(mq.TLO.Spell(mq.TLO.Me.AltAbility(aaName).Spell.RankName.Name()))
-    --local triggerStacks = (not mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1).ID() or mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1).ID() == 0 or mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1).Stacks())
-    -- trigger is already checked in SpellStacksOnMe, testing.
 
     Logger.log_verbose("SelfBuffAACheck(%s) buffNotActive(%s) triggerNotActive(%s) auraNotActive(%s) stacks(%s)", aaName, -- triggerStacks(%s)
         Strings.BoolToColorString(buffNotActive),
         Strings.BoolToColorString(triggerNotActive),
         Strings.BoolToColorString(auraNotActive),
         Strings.BoolToColorString(stacks))
-    --Strings.BoolToColorString(triggerStacks))
-
 
     return buffNotActive and triggerNotActive and auraNotActive and stacks -- and triggerStacks
 end
@@ -1025,6 +1021,7 @@ function Casting.UseAbility(abilityName)
     Core.DoCmd("/doability %s", abilityName)
     mq.delay(8, function() return not me.AbilityReady(abilityName) end)
     Logger.log_debug("Using Ability \ao =>> \ag %s \ao <<=", abilityName)
+    return true
 end
 
 --- Uses a discipline spell on a specified target.
@@ -1812,6 +1809,18 @@ function Casting.AbilityReady(abilityName, target)
     if not ready then return false end
 
     return Targeting.GetTargetDistance(target) <= Targeting.GetTargetMaxRangeTo(target) or abilityName:lower() == "taunt"
+end
+
+function Casting.ItemReady(itemName)
+    if not mq.TLO.FindItem("=" .. itemName)() then return false end
+
+    local ready = mq.TLO.Me.ItemReady(itemName)()
+
+    Logger.log_verbose("ItemReady for  %s: Ready(%s)", itemName, Strings.BoolToColorString(ready))
+
+    if not ready then return false end
+
+    return true
 end
 
 return Casting

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1792,7 +1792,7 @@ function Casting.AAReady(aaName)
     local ready = me.AltAbilityReady(aaName)()
     local aaSpell = me.AltAbility(aaName).Spell
 
-    Logger.log_verbose("AAReady for AA %s (aaSpell: %s, %d): Ready(%s).", aaName, aaSpell.Name(), aaSpell.ID(), Strings.BoolToColorString(ready))
+    Logger.log_verbose("AAReady for AA %s (aaSpell: %s, %d): Ready(%s).", aaName, (aaSpell.Name() or "None"), (aaSpell.ID() or 0), Strings.BoolToColorString(ready))
 
     return Casting.CastCheck(aaSpell)
 end

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1721,7 +1721,7 @@ function Casting.CastCheck(spell, bAllowMove)
     local manaCheck = (Config.Globals.InMedState and (me.CurrentMana() - (2 * me.ManaRegen())) or me.CurrentMana()) >= spell.Mana()
     local endCheck = (Config.Globals.InMedState and (me.CurrentEndurance() - (2 * me.EnduranceRegen())) or me.CurrentEndurance()) >= spell.EnduranceCost()
     ---@diagnostic disable-next-line: undefined-field -- Feared is a valid data member
-    local controlCheck = not (me.Stunned() or me.Feared() or me.Charmed())
+    local controlCheck = not (me.Stunned() or me.Feared() or me.Charmed() or me.Mezzed())
 
     Logger.log_verbose("CastCheck for %s (%d): CastingCheck(%s), MovingCheck(%s), ManaCheck(%s), EndCheck(%s), ControlCheck(%s)", spell.Name(), spell.ID(),
         Strings.BoolToColorString(castingCheck), Strings.BoolToColorString(movingCheck), Strings.BoolToColorString(manaCheck), Strings.BoolToColorString(endCheck),

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1794,6 +1794,8 @@ function Casting.AAReady(aaName)
 
     Logger.log_verbose("AAReady for AA %s (aaSpell: %s, %d): Ready(%s).", aaName, (aaSpell.Name() or "None"), (aaSpell.ID() or 0), Strings.BoolToColorString(ready))
 
+    if not ready then return false end
+
     return Casting.CastCheck(aaSpell)
 end
 
@@ -1804,12 +1806,12 @@ function Casting.AbilityReady(abilityName, target)
     if not target or not target() then return false end
 
     local ready = mq.TLO.Me.AbilityReady(abilityName)()
-    local inRange = Targeting.GetTargetDistance(target) <= Targeting.GetTargetMaxRangeTo(target) or abilityName:lower() == "taunt"
 
-    Logger.log_verbose("AbilityReady for  %s: Ready(%s), In-Range(%s)", abilityName, Strings.BoolToColorString(ready),
-        Strings.BoolToColorString(inRange))
+    Logger.log_verbose("AbilityReady for  %s: Ready(%s)", abilityName, Strings.BoolToColorString(ready))
 
-    return ready and inRange
+    if not ready then return false end
+
+    return Targeting.GetTargetDistance(target) <= Targeting.GetTargetMaxRangeTo(target) or abilityName:lower() == "taunt"
 end
 
 return Casting

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -298,7 +298,7 @@ end
 --- @return boolean Returns true if the DoT spell can fire, false otherwise.
 function Casting.DotSpellCheck(spell)
     if not spell or not spell() then return false end
-    local named = Targeting.IsNamed(mq.TLO.Target)
+    local named = Targeting.IsNamed(Targeting.GetAutoTarget())
     local targethp = Targeting.GetTargetPctHPs()
 
     return not Casting.TargetHasBuff(spell) and Casting.SpellStacksOnTarget(spell) and
@@ -1435,7 +1435,7 @@ end
 function Casting.BurnCheck()
     local settings = Config:GetSettings()
     local autoBurn = settings.BurnAuto and
-        ((Targeting.GetXTHaterCount() >= settings.BurnMobCount) or (Targeting.IsNamed(mq.TLO.Target) and settings.BurnNamed))
+        ((Targeting.GetXTHaterCount() >= settings.BurnMobCount) or (Targeting.IsNamed(Targeting.GetAutoTarget()) and settings.BurnNamed))
     local alwaysBurn = (settings.BurnAlways and settings.BurnAuto)
     local forcedBurn = Targeting.ForceBurnTargetID > 0 and Targeting.ForceBurnTargetID == mq.TLO.Target.ID()
 
@@ -1687,7 +1687,7 @@ end
 --- @return boolean True if the target matches the Con requirements for debuffing.
 function Casting.DebuffConCheck()
     local conLevel = (Config.Constants.ConColorsNameToId[mq.TLO.Target.ConColor() or "Grey"] or 0)
-    return conLevel >= Config:GetSetting('DebuffMinCon') or (Targeting.IsNamed(mq.TLO.Target) and Config:GetSetting('DebuffNamedAlways'))
+    return conLevel >= Config:GetSetting('DebuffMinCon') or (Targeting.IsNamed(Targeting.GetAutoTarget()) and Config:GetSetting('DebuffNamedAlways'))
 end
 
 --- Determines whether the utility should shrink.

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -151,7 +151,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if not songSpell or not songSpell() then return false end
 
-        if Casting.SongReady(songSpell) then
+        if Casting.SongReady(songSpell, bAllowMem) then
             ret = Casting.UseSong(songSpell.RankName(), targetId, bAllowMem, entry.retries)
         end
         Logger.log_verbose("Trying to sing %s - %s :: %s", entry.name, songSpell.RankName(),

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -166,7 +166,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
         if Casting.DiscReady(discSpell) then
             ret = Casting.UseDisc(discSpell, targetId)
         end
-        Logger.log_verbose("Trying to perform %s - %s :: %s", entry.name, discSpell.RankName(),
+        Logger.log_verbose("Trying to do %s - %s :: %s", entry.name, discSpell.RankName(),
             ret and "\agSuccess" or "\arFailed!")
     end
 

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -440,4 +440,9 @@ function Targeting.SetForceBurn(targetId)
         Targeting.ForceBurnTargetID)
 end
 
+function Targeting.TargetIsMA(target)
+    if not target or not target() then return false end
+    return target.ID() == Core.GetMainAssistId()
+end
+
 return Targeting


### PR DESCRIPTION
Commit message should give greater details.


Refactoring XReady functions, TargetedXReady functions, Target Checks, etc.
Baking Ready checks into rotation checks where they don't already exist

I am trying to simplify and make this code more cohesive, more readable, with less repeated checks.

I am also attempting to make the configs easier to digest for the amateur.

On the performance end, I am cutting out quite a bit of duplicate checks; there may be spaces for more. I am, however, also introducing some checks that weren't there before.

The overall philosophy behind these checks is to never fail a usespell unless something drastically changes.

Once we commit to using the ability, we move on to the next rotation, and when that fails in the UseX for whatever reason, it is often suboptimal.

In edge cases, it can even dangerous (for example: We need a bigheal, but commit to using a heal that is on long cooldown... now, that fails, and we are in the mainheal rotation and use a lesser ability. Meanwhile, the AA in the big heal table immediately below it could've been used, and given the health the tank needed).