### PR TITLE
GemReady function

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -1213,7 +1213,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoTempHP') then return false end
-                    return Targeting.TargetClassIs("WAR", target) and Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Targeting.TargetClassIs("WAR", target) and Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {

--- a/class_configs/Alpha (Live)/wiz_class_config.lua
+++ b/class_configs/Alpha (Live)/wiz_class_config.lua
@@ -724,7 +724,7 @@ return {
             name = 'DPS(PBAELowLevel)',
             state = 1,
             steps = 1,
-            load_cond = function() return Core.IsModeActive('PBAELowLevel') and mq.TLO.Me.Level() < 71 end,
+            load_cond = function() return Core.IsModeActive('PBAE(LowLevel)') and mq.TLO.Me.Level() < 71 end,
             doFullRotation = true,
             targetId = function(self) return mq.TLO.Target.ID() == Config.Globals.AutoTargetID and { Config.Globals.AutoTargetID, } or {} end,
             cond = function(self, combat_state)
@@ -1150,28 +1150,28 @@ return {
                 name = "PBTimer4",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "FireJyll",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "IceJyll",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
                 name = "MagicJyll",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and Casting.HaveManaToNuke() and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
         },
@@ -1282,7 +1282,7 @@ return {
             spells = {
                 { name = "FireClaw", },
                 { name = "WildNuke", },
-                { name = "PBTimer4",  cond = function() return Core.IsModeActive('PBAELowLevel') and mq.TLO.Me.Level() < 71 end, },
+                { name = "PBTimer4",  cond = function() return Core.IsModeActive('PBAE(LowLevel)') and mq.TLO.Me.Level() < 71 end, },
                 { name = "StunSpell", cond = function() return Config:GetSetting('DoStun') end, },
             },
         },
@@ -1290,7 +1290,7 @@ return {
             gem = 4,
             spells = {
                 { name = "FireEtherealNuke", },
-                { name = "FireJyll",         cond = function() return Core.IsModeActive('PBAELowLevel') and mq.TLO.Me.Level() < 71 end, },
+                { name = "FireJyll",         cond = function() return Core.IsModeActive('PBAE(LowLevel)') and mq.TLO.Me.Level() < 71 end, },
                 { name = "FireRain",         cond = function() return Config:GetSetting('DoRain') and Config:GetSetting('ElementChoice') == 1 end, },
                 { name = "IceRain",          cond = function() return Config:GetSetting('DoRain') and Config:GetSetting('ElementChoice') == 2 end, },
                 { name = "EvacSpell", },
@@ -1301,7 +1301,7 @@ return {
             gem = 5,
             spells = {
                 { name = "IceEtherealNuke", },
-                { name = "IceJyll",         cond = function() return Core.IsModeActive('PBAELowLevel') and mq.TLO.Me.Level() < 71 end, },
+                { name = "IceJyll",         cond = function() return Core.IsModeActive('PBAE(LowLevel)') and mq.TLO.Me.Level() < 71 end, },
                 { name = "JoltSpell", },
             },
         },
@@ -1309,7 +1309,7 @@ return {
             gem = 6,
             spells = {
                 { name = "CloudburstNuke", },
-                { name = "MagicJyll",      cond = function() return Core.IsModeActive('PBAELowLevel') and mq.TLO.Me.Level() < 71 end, },
+                { name = "MagicJyll",      cond = function() return Core.IsModeActive('PBAE(LowLevel)') and mq.TLO.Me.Level() < 71 end, },
                 { name = "SnareSpell",     cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
             },
         },

--- a/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
+++ b/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
@@ -1220,7 +1220,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoTempHP') then return false end
-                    return Targeting.TargetClassIs("WAR", target) and Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Targeting.TargetClassIs("WAR", target) and Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -1241,7 +1241,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     -- Make sure this is gemmed due to long refresh, and only use the single target versions on classes that need it.
-                    if (spell and spell() and ((spell.TargetType() or ""):lower() ~= "group v2")) and (not Casting.CastReady(spell.RankName)
+                    if (spell and spell() and ((spell.TargetType() or ""):lower() ~= "group v2")) and (not Casting.GemReady(spell)
                             or not Config.Constants.RGMelee:contains(target.Class.ShortName())) then
                         return false
                     end

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -780,7 +780,7 @@ local _ClassConfig = {
                 name = "DichoHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
                         (mq.TLO.Group.Injured(Config:GetSetting('BigHealPoint'))() or 0) >= Config:GetSetting('GroupInjureCnt')
                 end,
             },
@@ -795,7 +795,7 @@ local _ClassConfig = {
                 name = "GroupFastHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
@@ -809,7 +809,7 @@ local _ClassConfig = {
                 name = "GroupHealCure",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
@@ -824,7 +824,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -833,7 +833,7 @@ local _ClassConfig = {
                 name = "ClutchHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Targeting.GetTargetPctHPs() < 35
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Targeting.GetTargetPctHPs() < 35
                 end,
             },
             {
@@ -847,7 +847,7 @@ local _ClassConfig = {
                 name = "DichoHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and target.ID() == Core.GetMainAssistId
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and target.ID() == Core.GetMainAssistId
                 end,
             },
             {
@@ -950,7 +950,7 @@ local _ClassConfig = {
                 name = "GroupHealNoCure",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
@@ -958,7 +958,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -988,42 +988,42 @@ local _ClassConfig = {
                 name = "HealNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "HealNuke2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "RemedyHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
                 name = "Renewal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
                 name = "Renewal2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
                 name = "Renewal3",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
@@ -1031,14 +1031,14 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
         },
@@ -1065,7 +1065,7 @@ local _ClassConfig = {
                 name = "RemedyHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
@@ -1073,14 +1073,14 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
         },
@@ -1173,7 +1173,7 @@ local _ClassConfig = {
                 name = "ReverseDS",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1181,7 +1181,7 @@ local _ClassConfig = {
                 type = "Spell",
                 allowDead = true,
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1272,7 +1272,7 @@ local _ClassConfig = {
                 retries = 0,
                 cond = function(self, spell)
                     if not Config:GetSetting('DoTwinHeal') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
                         not Casting.SongActiveByName("Healing Twincast")
                 end,
             },
@@ -1281,7 +1281,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealStun') or ((spell.Level() or 0) > 85 and Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint')) then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and
+                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and
                         Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
@@ -1290,7 +1290,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-                    return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1298,7 +1298,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-                    return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1306,7 +1306,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-                    return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1323,7 +1323,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if Casting.CanUseAA("Yaulp") then return false end
-                    return Casting.CastReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.GemReady(spell) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1332,7 +1332,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if (mq.TLO.Me.Level() < 101 and not Casting.DetGOMCheck()) then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
+                    return Casting.GemReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
                 end,
             },
             {
@@ -1340,7 +1340,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoLLStun') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff() and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1356,7 +1356,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoUndeadNuke') or not Targeting.TargetBodyIs(target, "Undead") then return false end
-                    return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1364,7 +1364,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoMagicNuke') then return false end
-                    return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
         },
@@ -1490,7 +1490,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDivineBuff') or target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },
         },

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -1068,7 +1068,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     --NDT will not be cast or memorized if it isn't already on the bar due to a very long refresh time
-                    if not Config:GetSetting('DoNDTBuff') or not Casting.CastReady(spell.RankName) then return false end
+                    if not Config:GetSetting('DoNDTBuff') or not Casting.GemReady(spell) then return false end
                     --Single target versions of the spell will only be used on Melee, group versions will be cast if they are missing from any groupmember
                     if (spell and spell() and ((spell.TargetType() or ""):lower() ~= "group v2"))
                         and not Config.Constants.RGMelee:contains(target.Class.ShortName()) then

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -1003,7 +1003,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.TempHP,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
-                    if not Config:GetSetting('DoTempHP') or not Casting.CastReady(spell.RankName) then return false end
+                    if not Config:GetSetting('DoTempHP') or not Casting.GemReady(spell) then return false end
                     return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 45
                 end,
             },
@@ -1032,7 +1032,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.HateBuff,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell) end,
                 cond = function(self, spell)
-                    if not Config:GetSetting('DoHateBuff') or Casting.CanUseAA('Voice of Thule') or not Casting.CastReady(spell.RankName) then return false end
+                    if not Config:GetSetting('DoHateBuff') or Casting.CanUseAA('Voice of Thule') or not Casting.GemReady(spell) then return false end
                     return Casting.SelfBuffCheck(spell)
                 end,
             },

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -762,7 +762,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') or not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                         and Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -772,7 +772,7 @@ local _ClassConfig = {
                 name = "InterventionHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.CastReady(spell.RankName) and
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.GemReady(spell) and
                         Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
@@ -787,14 +787,14 @@ local _ClassConfig = {
                 name = "RecourseHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
                 name = "AESpiritualHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
@@ -818,7 +818,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -835,7 +835,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
@@ -1039,7 +1039,7 @@ local _ClassConfig = {
                 type = "Spell",
                 retries = 0,
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
                         not Casting.SongActiveByName("Healing Twincast")
                 end,
             },
@@ -1049,7 +1049,7 @@ local _ClassConfig = {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1057,7 +1057,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetResolvedActionMapItem('DichoSpell') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1208,7 +1208,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and
+                    return Casting.GemReady(spell) and Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and
                         Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
@@ -1276,7 +1276,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
-                    return Casting.CastReady(spell.RankName()) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -1343,7 +1343,7 @@ local _ClassConfig = {
                 name = "CanniSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Config:GetSetting('DoSpellCanni') and Casting.CastReady(spell.RankName()) and
+                    return Config:GetSetting('DoSpellCanni') and Casting.GemReady(spell) and
                         mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
@@ -1446,7 +1446,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoTempHP') then return false end
-                    return Targeting.TargetClassIs("WAR", target) and Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Targeting.TargetClassIs("WAR", target) and Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1474,7 +1474,7 @@ local _ClassConfig = {
                 name = "LowLvlAtkBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return mq.TLO.Me.Level() < 86 and Config.Constants.RGMelee:contains(target.Class.ShortName()) and Casting.CastReady(spell.RankName) and
+                    return mq.TLO.Me.Level() < 86 and Config.Constants.RGMelee:contains(target.Class.ShortName()) and Casting.GemReady(spell) and
                         Casting.GroupBuffCheck(spell, target)
                 end,
             },

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -1229,7 +1229,7 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     -- Make sure this is gemmed due to long refresh, and only use the single target versions on classes that need it.
-                    if (spell and spell() and ((spell.TargetType() or ""):lower() ~= "group v2")) and (not Casting.CastReady(spell.RankName)
+                    if (spell and spell() and ((spell.TargetType() or ""):lower() ~= "group v2")) and (not Casting.GemReady(spell)
                             or not Config.Constants.RGMelee:contains(target.Class.ShortName())) then
                         return false
                     end

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -783,7 +783,7 @@ local _ClassConfig = {
                 name = "DichoHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
                         (mq.TLO.Group.Injured(Config:GetSetting('BigHealPoint'))() or 0) >= Config:GetSetting('GroupInjureCnt')
                 end,
             },
@@ -798,7 +798,7 @@ local _ClassConfig = {
                 name = "GroupFastHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
@@ -812,7 +812,7 @@ local _ClassConfig = {
                 name = "GroupHealCure",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
@@ -827,7 +827,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -836,7 +836,7 @@ local _ClassConfig = {
                 name = "ClutchHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Targeting.GetTargetPctHPs() < 35
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Targeting.GetTargetPctHPs() < 35
                 end,
             },
             {
@@ -850,7 +850,7 @@ local _ClassConfig = {
             --     name = "DichoHeal",
             --     type = "Spell",
             --     cond = function(self, spell, target)
-            --         return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and target.ID() == Core.GetMainAssistId
+            --         return Casting.GemReady(spell) and Casting.SpellReady(spell) and target.ID() == Core.GetMainAssistId
             --     end,
             -- },
             {
@@ -975,7 +975,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') or (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -989,7 +989,7 @@ local _ClassConfig = {
                 name = "GroupHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
         },
@@ -1005,42 +1005,42 @@ local _ClassConfig = {
                 name = "HealNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "HealNuke2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and mq.TLO.Me.CombatState():lower() == "combat"
                 end,
             },
             {
                 name = "RemedyHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
                 name = "Renewal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
                 name = "Renewal2",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
                 name = "Renewal3",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
@@ -1048,14 +1048,14 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
         },
@@ -1064,7 +1064,7 @@ local _ClassConfig = {
                 name = "RemedyHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
@@ -1072,14 +1072,14 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "HealingLight",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
         },
@@ -1172,7 +1172,7 @@ local _ClassConfig = {
                 name = "ReverseDS",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1180,7 +1180,7 @@ local _ClassConfig = {
                 type = "Spell",
                 allowDead = true,
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1264,7 +1264,7 @@ local _ClassConfig = {
             --     retries = 0,
             --     cond = function(self, spell)
             --         if not Config:GetSetting('DoTwinHeal') then return false end
-            --         return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and
+            --         return Casting.GemReady(spell) and Casting.SpellReady(spell) and
             --             not Casting.SongActiveByName("Healing Twincast")
             --     end,
             -- },
@@ -1273,7 +1273,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealStun') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and
+                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and
                         Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
@@ -1282,7 +1282,7 @@ local _ClassConfig = {
             --     type = "Spell",
             --     cond = function(self, spell, target)
             --         if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-            --         return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+            --         return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
             --     end,
             -- },
             -- {
@@ -1290,7 +1290,7 @@ local _ClassConfig = {
             --     type = "Spell",
             --     cond = function(self, spell, target)
             --         if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-            --         return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+            --         return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
             --     end,
             -- },
             -- {
@@ -1298,7 +1298,7 @@ local _ClassConfig = {
             --     type = "Spell",
             --     cond = function(self, spell, target)
             --         if Core.GetMainAssistPctHPs() > Config:GetSetting('LightHealPoint') then return false end
-            --         return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+            --         return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
             --     end,
             -- },
             {
@@ -1315,7 +1315,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if Casting.CanUseAA("Yaulp") then return false end
-                    return Casting.CastReady(spell) and Casting.SelfBuffCheck(spell)
+                    return Casting.GemReady(spell) and Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1324,7 +1324,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if (mq.TLO.Me.Level() < 101 and not Casting.DetGOMCheck()) then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
+                    return Casting.GemReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 15
                 end,
             },
             {
@@ -1332,7 +1332,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoLLStun') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff() and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and Casting.DetSpellCheck(spell) and Casting.HaveManaToDebuff() and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1348,7 +1348,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoUndeadNuke') or not Targeting.TargetBodyIs(target, "Undead") then return false end
-                    return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
             {
@@ -1356,7 +1356,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoMagicNuke') then return false end
-                    return Casting.CastReady(spell.RankName) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
+                    return Casting.GemReady(spell) and (Casting.HaveManaToNuke() or Casting.BurnCheck()) and Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
         },
@@ -1484,7 +1484,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoDivineBuff') or target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -1082,7 +1082,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     --NDT will not be cast or memorized if it isn't already on the bar due to a very long refresh time
-                    if not Config:GetSetting('DoNDTBuff') or not Casting.CastReady(spell.RankName) then return false end
+                    if not Config:GetSetting('DoNDTBuff') or not Casting.GemReady(spell) then return false end
                     --Single target versions of the spell will only be used on Melee, group versions will be cast if they are missing from any groupmember
                     if (spell and spell() and ((spell.TargetType() or ""):lower() ~= "group v2"))
                         and not Config.Constants.RGMelee:contains(target.Class.ShortName()) then

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -967,7 +967,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.TempHP,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell.RankName.ID()) end,
                 cond = function(self, spell)
-                    if not Config:GetSetting('DoTempHP') or not Casting.CastReady(spell.RankName) then return false end
+                    if not Config:GetSetting('DoTempHP') or not Casting.GemReady(spell) then return false end
                     return Casting.SpellReady(spell) and Casting.SpellStacksOnMe(spell.RankName) and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 45
                 end,
             },
@@ -996,7 +996,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.HateBuff,
                 active_cond = function(self, spell) return Casting.BuffActiveByID(spell) end,
                 cond = function(self, spell)
-                    if not Config:GetSetting('DoHateBuff') or Casting.CanUseAA('Voice of Thule') or not Casting.CastReady(spell.RankName) then return false end
+                    if not Config:GetSetting('DoHateBuff') or Casting.CanUseAA('Voice of Thule') or not Casting.GemReady(spell) then return false end
                     return Casting.SelfBuffCheck(spell)
                 end,
             },

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -760,7 +760,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') or not Targeting.GroupedWithTarget(target) then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                         and Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -770,7 +770,7 @@ local _ClassConfig = {
                 name = "InterventionHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.CastReady(spell.RankName) and
+                    return (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') and Casting.GemReady(spell) and
                         Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
@@ -785,14 +785,14 @@ local _ClassConfig = {
                 name = "RecourseHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
                 name = "AESpiritualHeal",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell)
                 end,
             },
             {
@@ -807,7 +807,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoHealOverTime') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -823,7 +823,7 @@ local _ClassConfig = {
                 name = "InterventionHeal",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.TargetedSpellReady(spell, target.ID(), true)
+                    return Casting.GemReady(spell) and Casting.TargetedSpellReady(spell, target.ID(), true)
                 end,
             },
             {
@@ -1036,7 +1036,7 @@ local _ClassConfig = {
                 type = "Spell",
                 retries = 0,
                 cond = function(self, spell)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and
                         not Casting.SongActiveByName("Healing Twincast")
                 end,
             },
@@ -1046,7 +1046,7 @@ local _ClassConfig = {
                 name = "DichoSpell",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1054,7 +1054,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.GetResolvedActionMapItem('DichoSpell') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1205,7 +1205,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
-                    return Casting.CastReady(spell.RankName) and Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and
+                    return Casting.GemReady(spell) and Casting.DotSpellCheck(spell) and (Casting.DotHaveManaToNuke() or Casting.BurnCheck()) and
                         Casting.TargetedSpellReady(spell, target.ID())
                 end,
             },
@@ -1273,7 +1273,7 @@ local _ClassConfig = {
                 allowDead = true,
                 cond = function(self, spell)
                     if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
-                    return Casting.CastReady(spell.RankName()) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
+                    return Casting.GemReady(spell) and Casting.SpellReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -1340,7 +1340,7 @@ local _ClassConfig = {
                 name = "CanniSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Config:GetSetting('DoSpellCanni') and Casting.CastReady(spell.RankName()) and
+                    return Config:GetSetting('DoSpellCanni') and Casting.GemReady(spell) and
                         mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
@@ -1448,7 +1448,7 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoTempHP') then return false end
-                    return Targeting.TargetClassIs("WAR", target) and Casting.CastReady(spell.RankName) and Casting.GroupBuffCheck(spell, target)
+                    return Targeting.TargetClassIs("WAR", target) and Casting.GemReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1476,7 +1476,7 @@ local _ClassConfig = {
                 name = "LowLvlAtkBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return mq.TLO.Me.Level() < 86 and Config.Constants.RGMelee:contains(target.Class.ShortName()) and Casting.CastReady(spell.RankName) and
+                    return mq.TLO.Me.Level() < 86 and Config.Constants.RGMelee:contains(target.Class.ShortName()) and Casting.GemReady(spell) and
                         Casting.GroupBuffCheck(spell, target)
                 end,
             },

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1747,4 +1747,9 @@ function Casting.AbilityRangeCheck(target)
     return Targeting.GetTargetDistance(target) <= Targeting.GetTargetMaxRangeTo(target)
 end
 
+function Casting.GemReady(spell) -- split from CastReady so we don't have to pass RankName in class configs. If we change SpellReady, we break custom configs
+    if not spell or not spell() then return false end
+    return mq.TLO.Me.SpellReady(spell.RankName.Name())()
+end
+
 return Casting


### PR DESCRIPTION
* Simplified Gem Timer checks in Class Configs
* * Removed CastReady helper function calls from class configs in favor of GemReady, which does not require passing RankName.
* * These changes are backwards-compatible (custom config users can contine to use CastReady).