### PR TITLE
Emu Rez Changes (Cleric Prototype)

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -1407,24 +1407,20 @@ local _ClassConfig = {
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
             local rezAction = false
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
-                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew"), true) then
-                    rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell("Incarnate Anew", corpseId, true, true)
                 end
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
             end
 
             return rezAction

--- a/class_configs/Alpha (Live)/nec_class_config.lua
+++ b/class_configs/Alpha (Live)/nec_class_config.lua
@@ -1168,19 +1168,9 @@ local _ClassConfig = {
         end,
 
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.OkayToBuff() then
-                Targeting.SetTarget(corpseId)
-
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
-                if Casting.AAReady("Convergence") and mq.TLO.FindItemCount(mq.TLO.AltAbility("Convergence").Spell.ReagentID(1)())() > 0 then
-                    return Casting.UseAA("Convergence", corpseId, true, 1)
+            if Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat" then
+                if Casting.AAReady("Convergence") and Casting.ReagentCheck(mq.TLO.Me.AltAbility("Convergence").Spell) then
+                    return Casting.OkayToRez(corpseId) and Casting.UseAA("Convergence", corpseId, true, 1)
                 end
             end
         end,

--- a/class_configs/Alpha (Live)/pal_class_config.lua
+++ b/class_configs/Alpha (Live)/pal_class_config.lua
@@ -728,16 +728,12 @@ local _ClassConfig = {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
-                rezAction = Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
+                rezAction = okayToRez and Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
             elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell, true) then
-                rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
+                rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
             end
 
             return rezAction

--- a/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
+++ b/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
@@ -1325,18 +1325,19 @@ local _ClassConfig = {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
-                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(rezSpell, true) then
-                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end
 

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -675,28 +675,24 @@ local _ClassConfig = {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = self.ResolvedActionMap['RezSpell']
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
-                    rezAction = Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId) or false
                 end
             end
 
             if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
-                    rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true) or false
                 elseif Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
                 elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
-                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true) or false
                 end
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
             end
 
             return rezAction

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -679,19 +679,19 @@ local _ClassConfig = {
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
-                    rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId) or false
+                    rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
             end
 
             if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
-                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true) or false
+                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
                 elseif Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
-                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true) or false
+                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end
 

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1587,24 +1587,20 @@ local _ClassConfig = {
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
             local rezAction = false
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
-                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew"), true) then
-                    rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell("Incarnate Anew", corpseId, true, true)
                 end
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
             end
 
             return rezAction

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -1190,19 +1190,9 @@ local _ClassConfig = {
         end,
 
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.OkayToBuff() then
-                Targeting.SetTarget(corpseId)
-
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
-                if Casting.AAReady("Convergence") and mq.TLO.FindItemCount(mq.TLO.AltAbility("Convergence").Spell.ReagentID(1)())() > 0 then
-                    return Casting.UseAA("Convergence", corpseId, true, 1)
+            if Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat" then
+                if Casting.AAReady("Convergence") and Casting.ReagentCheck(mq.TLO.Me.AltAbility("Convergence").Spell) then
+                    return Casting.OkayToRez(corpseId) and Casting.UseAA("Convergence", corpseId, true, 1)
                 end
             end
         end,

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -726,16 +726,12 @@ return {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
-                rezAction = Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
+                rezAction = okayToRez and Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
             elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell, true) then
-                rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
+                rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
             end
 
             return rezAction

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -680,24 +680,20 @@ local _ClassConfig = {
     ['HelperFunctions']   = {
         DoRez = function(self, corpseId)
             local rezAction = false
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
-                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(mq.TLO.Spell("Incarnate Anew"), true) then
-                    rezAction = Casting.UseSpell("Incarnate Anew", corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell("Incarnate Anew", corpseId, true, true)
                 end
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
             end
 
             return rezAction

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -685,28 +685,24 @@ local _ClassConfig = {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = self.ResolvedActionMap['RezSpell']
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
-                    rezAction = Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId) or false
                 end
             end
 
             if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
-                    rezAction = Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true) or false
                 elseif Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
                 elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
-                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true) or false
                 end
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
             end
 
             return rezAction

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -689,19 +689,19 @@ local _ClassConfig = {
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
-                    rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId) or false
+                    rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
             end
 
             if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
-                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true) or false
+                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
                 elseif Casting.AAReady("Blessing of Resurrection") then
-                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1) or false
+                    rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
-                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true) or false
+                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end
 

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -1660,24 +1660,20 @@ local _ClassConfig = {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
-                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(rezSpell, true) then
-                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
             end
 
             return rezAction

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -1255,19 +1255,9 @@ local _ClassConfig = {
         end,
 
         DoRez = function(self, corpseId)
-            if Config:GetSetting('DoBattleRez') or Casting.OkayToBuff() then
-                Targeting.SetTarget(corpseId)
-
-                local target = mq.TLO.Target
-
-                if not target or not target() then return false end
-
-                if mq.TLO.Target.Distance() > 25 then
-                    Core.DoCmd("/corpse")
-                end
-
-                if Casting.AAReady("Convergence") and mq.TLO.FindItemCount(mq.TLO.AltAbility("Convergence").Spell.ReagentID(1)())() > 0 then
-                    return Casting.UseAA("Convergence", corpseId, true, 1)
+            if Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat" then
+                if Casting.AAReady("Convergence") and Casting.ReagentCheck(mq.TLO.Me.AltAbility("Convergence").Spell) then
+                    return Casting.OkayToRez(corpseId) and Casting.UseAA("Convergence", corpseId, true, 1)
                 end
             end
         end,

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -721,16 +721,12 @@ return {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if (Config:GetSetting('DoBattleRez') or mq.TLO.Me.CombatState():lower() ~= "combat") and Casting.AAReady("Gift of Resurrection") then
-                rezAction = Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
+                rezAction = okayToRez and Casting.UseAA("Gift of Resurrection", corpseId, true, 1)
             elseif not Casting.CanUseAA("Gift of Resurrection") and mq.TLO.Me.CombatState():lower() ~= "combat" and Casting.SpellReady(rezSpell, true) then
-                rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
+                rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
             end
 
             return rezAction

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -678,24 +678,20 @@ local _ClassConfig = {
         DoRez = function(self, corpseId)
             local rezAction = false
             local rezSpell = Core.GetResolvedActionMapItem('RezSpell')
+            local okayToRez = Casting.OkayToRez(corpseId)
 
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if mq.TLO.FindItem("Staff of Forbidden Rites")() and mq.TLO.Me.ItemReady("Staff of Forbidden Rites")() then
-                    rezAction = Casting.UseItem("Staff of Forbidden Rites", corpseId)
+                    rezAction = okayToRez and Casting.UseItem("Staff of Forbidden Rites", corpseId)
                 elseif Casting.AAReady("Call of the Wild") and corpseId ~= mq.TLO.Me.ID() then
-                    rezAction = Casting.UseAA("Call of the Wild", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Call of the Wild", corpseId, true, 1)
                 end
             elseif mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
                 if Casting.AAReady("Rejuvenation of Spirit") then
-                    rezAction = Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
+                    rezAction = okayToRez and Casting.UseAA("Rejuvenation of Spirit", corpseId, true, 1)
                 elseif not Casting.CanUseAA("Rejuvenation of Spirit") and Casting.SpellReady(rezSpell, true) then
-                    rezAction = Casting.UseSpell(rezSpell, corpseId, true, true)
+                    rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
-            end
-
-            if rezAction and mq.TLO.Spawn(corpseId).Distance3D() > 25 then
-                Targeting.SetTarget(corpseId)
-                Core.DoCmd("/corpse")
             end
 
             return rezAction

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -39,6 +39,8 @@ Config.Globals.CastResult            = 0
 Config.Globals.BuildType             = mq.TLO.MacroQuest.BuildName()
 Config.Globals.Minimized             = false
 Config.Globals.LastUsedSpell         = "None"
+Config.Globals.CorpseConned          = false
+Config.Globals.RezzedCorpses         = {}
 
 -- Constants
 Config.Constants                     = {}

--- a/utils/event_handlers.lua
+++ b/utils/event_handlers.lua
@@ -10,6 +10,7 @@ local Logger      = require("utils.logger")
 local Movement    = require("utils.movement")
 local ClassLoader = require('utils.classloader')
 
+
 -- [ CANT SEE HANDLERS ] --
 
 mq.event("CantSee", "You cannot see your target.", function()
@@ -459,3 +460,19 @@ mq.event('PersonaEquipLoad', "You successfully loaded your #*# equipment set.", 
     end
 end)
 -- [ END CLASS CHANGE EVENT HANDLERS ] --
+
+-- [ EMU REZ HANDLERS] --
+mq.event('CorpseConned', "This corpse will decay#*#.", function()
+    if Core.OnEMU and Modules:ExecModule("Class", "IsRezing") then
+        Logger.log_verbose("Corpse /con message received for rez checks.")
+        Config.Globals.CorpseConned = true
+    end
+end)
+
+mq.event('AlreadyRezzed', "This corpse has already accepted a resurrection.", function()
+    if Core.OnEMU and Modules:ExecModule("Class", "IsRezing") then
+        Logger.log_verbose("Already rezzed corpse detected, we will ignore this corpse for now.")
+        table.insert(Config.Globals.RezzedCorpses, mq.TLO.Target.ID()) --target.id returns 0 if no target
+    end
+end)
+-- [ END EMU REZ HANDLERS] --


### PR DESCRIPTION
***UPDATE: All DoRez functions now converted to use this system.***

On Emu, corpses persist past resurrection. Because of this, if the corpse isn't looted in a timely manner, we can find ourselves in a loop of a healer casting a rez every few seconds, and the target chain-accepting due to mq2rez settings.

Any corpse that has already been rezzed will indicate so when conned.

This update addresses the issue like so:

* During FooCheckAndRez, we will check to ensure the corpse ID is not on a table of already rezzed corpses.
* * If it is, we abort. If it is not...

* We will start to execute our DoRez function.
* * If a valid rez ability for combat state is not available, we abort. If it is...

* We will make a check to see if we are on Emu.
* * If not, we will summon the corpse (if it isn't already nearby) and use the Rez action. If we are...

* We will target the corpse and perform a /con.
* * This will use an event handler to determine a con has been performed (keyed off of the decay time message)
* * Once we detect the con has gone through, we will check for the presence of the "already rezzed" message.
* * If that message is NOT found, we will summon the corpse (if it isn't already nearby) and use the Rez action. If it IS found...

* We will add the corpseId to the exclusion table and move on.

* During subsequent rez checks in the class givetime, the event detection and exclusion table will be reset once we detect no PC corpses within half-again the range of our normal corpse checks (150 and 100, respectively).

* These functions have no networking capability; each healer will maintain and update their own exclusion tables independently. This at most will cost us a couple of targets/cons, in return for safety and simplicity.

I am absolutely not sure this is the best way to do this, and I would like to make sure that there isn't a smarter thing to do (for one step or the entire process).

Fixes #525