### PR TITLE
Paladin Heal Rotations (Thanks Redfrog!)

### DIFF
--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -743,72 +743,76 @@ return {
     },
     ['HealRotationOrder'] = {
         {
+            name = 'GroupHealPoint',
+            state = 1,
+            steps = 1,
+            cond = function(self, target) return Targeting.GroupHealsNeeded() end,
+        },
+        {
             name = 'MainHealPoint',
             state = 1,
             steps = 1,
             cond = function(self, target) return Targeting.MainHealsNeeded(target) end,
         },
-        {
-            name = 'LightHealPoint',
-            state = 1,
-            steps = 1,
-            cond = function(self, target) return Targeting.LightHealsNeeded(target) end,
-        },
     },
     ['HealRotations']     = {
-        ["LightHealPoint"] = {
-            {
-                name = "LightHeal",
-                type = "Spell",
-                cond = function(self, _) return true end,
-            },
-        },
-        ["MainHealPoint"] = {
-            {
-                name = "WaveHeal",
-                type = "Spell",
-                cond = function(self, _)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
-                end,
-            },
-            {
-                name = "WaveHeal2",
-                type = "Spell",
-                cond = function(self, _)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
-                end,
-            },
-            {
-                name = "Aurora",
-                type = "Spell",
-                cond = function(self, _)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
-                end,
-            },
+        ["GroupHealPoint"] = {
             {
                 name = "Gift of Life",
                 type = "AA",
-                cond = function(self, aaName)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.BigGroupHealsNeeded()
                 end,
             },
             {
                 name = "Hand of Piety",
                 type = "AA",
-                cond = function(self, aaName)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.BigGroupHealsNeeded()
                 end,
             },
             {
+                name = "WaveHeal",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
+                end,
+            },
+            {
+                name = "Aurora",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
+                end,
+            },
+            {
+                name = "WaveHeal2",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
+                end,
+            },
+        },
+        ["MainHealPoint"] = {
+            {
                 name = "Lay on Hands",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
+                end,
+            },
+            {
+                name = "Hand of Piety",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.BigHealsNeeded(target) and Targeting.TargetIsMyself(target)
+                end,
+            },
+            {
+                name = "LightHeal",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
                 end,
             },
         },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -738,72 +738,76 @@ return {
     },
     ['HealRotationOrder'] = {
         {
+            name = 'GroupHealPoint',
+            state = 1,
+            steps = 1,
+            cond = function(self, target) return Targeting.GroupHealsNeeded() end,
+        },
+        {
             name = 'MainHealPoint',
             state = 1,
             steps = 1,
             cond = function(self, target) return Targeting.MainHealsNeeded(target) end,
         },
-        {
-            name = 'LightHealPoint',
-            state = 1,
-            steps = 1,
-            cond = function(self, target) return Targeting.LightHealsNeeded(target) end,
-        },
     },
     ['HealRotations']     = {
-        ["LightHealPoint"] = {
-            {
-                name = "LightHeal",
-                type = "Spell",
-                cond = function(self, _) return true end,
-            },
-        },
-        ["MainHealPoint"] = {
-            {
-                name = "WaveHeal",
-                type = "Spell",
-                cond = function(self, _)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
-                end,
-            },
-            {
-                name = "WaveHeal2",
-                type = "Spell",
-                cond = function(self, _)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
-                end,
-            },
-            {
-                name = "Aurora",
-                type = "Spell",
-                cond = function(self, _)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
-                end,
-            },
+        ["GroupHealPoint"] = {
             {
                 name = "Gift of Life",
                 type = "AA",
-                cond = function(self, aaName)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.BigGroupHealsNeeded()
                 end,
             },
             {
                 name = "Hand of Piety",
                 type = "AA",
-                cond = function(self, aaName)
-                    if not mq.TLO.Group() then return false end
-                    return Targeting.GroupHealsNeeded()
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.BigGroupHealsNeeded()
                 end,
             },
             {
+                name = "WaveHeal",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
+                end,
+            },
+            {
+                name = "Aurora",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
+                end,
+            },
+            {
+                name = "WaveHeal2",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
+                end,
+            },
+        },
+        ["MainHealPoint"] = {
+            {
                 name = "Lay on Hands",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.GetTargetPctHPs() < Config:GetSetting('LayHandsPct')
+                end,
+            },
+            {
+                name = "Hand of Piety",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.BigHealsNeeded(target) and Targeting.TargetIsMyself(target)
+                end,
+            },
+            {
+                name = "LightHeal",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
                 end,
             },
         },

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -471,7 +471,7 @@ function Combat.FindBestAutoTargetCheck()
 
     -- our MA out of group has a valid target for us.
     if Config:GetSetting('AssistOutside') then
-        local queryResult = DanNet.query(Config.Globals.MainAssist, "Target.ID", 0)
+        local queryResult = DanNet.query(Config.Globals.MainAssist, "Target.ID", 1000)
 
         if queryResult then
             local assistTarget = mq.TLO.Spawn(queryResult)


### PR DESCRIPTION
* Adjusted Paladin Heal Rotations  (Live and Laz) to better reflect modern defaults and code.
* * Eliminated Light Heal Rotation
* * * "LightHeal" has been moved to the Main Heal rotation.
* * Added Group Heal Rotation and shuffled abilities as appropriate.