### PR TITLE
fix: classes loading, feat: AlwaysGlobal setting

### DIFF
--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -293,8 +293,8 @@ function Module:GiveTime(combat_state)
 		return
 	end
 
-	local deadCount = mq.TLO.SpawnCount(string.format('npccorpse radius %s zradius 50', 100))()
-	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius %d zradius 50", mq.TLO.Me.CleanName(), 100))()
+	local deadCount = mq.TLO.SpawnCount("npccorpse radius 100 zradius 50")()
+	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Me.CleanName()))()
 	if myCorpseCount > 0 then deadCount = deadCount + 1 end
 
 	if self.Actor == nil then self:LootMessageHandler() end

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -294,6 +294,8 @@ function Module:GiveTime(combat_state)
 	end
 
 	local deadCount = mq.TLO.SpawnCount(string.format('npccorpse radius %s zradius 50', 100))()
+	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius %d zradius 50", mq.TLO.Me.CleanName(), 100))()
+	if myCorpseCount > 0 then deadCount = deadCount + 1 end
 
 	if self.Actor == nil then self:LootMessageHandler() end
 	-- send actors message to loot


### PR DESCRIPTION
added always global setting
turning this on will duplicate your new items into Global Rules

this will happen when looting and when acknowledging the new items list.

fixed quest items not populating class designations properly