### PR TITLE
Aura Fixes (Thanks RYN227 and Lidori!)

### DIFF
--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -1367,9 +1367,9 @@ local _ClassConfig = {
             {
                 name = "Spirit Mastery",
                 type = "AA",
-                pre_activate = function(self, spell) --remove the old aura if we just purchased the AA, otherwise we will be spammed because of no focus.
+                pre_activate = function(self, aaName) --remove the old aura if we just purchased the AA, otherwise we will be spammed because of no focus.
                     ---@diagnostic disable-next-line: undefined-field
-                    if mq.TLO.Me.Aura(1)() then mq.TLO.Me.Aura(1).Remove() end
+                    if not Casting.AuraActiveByName("Aura of Pious Divinity") then mq.TLO.Me.Aura(1).Remove() end
                 end,
                 cond = function(self, aaName)
                     return not Casting.AuraActiveByName("Aura of Pious Divinity")

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -107,18 +107,13 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
         end
     end
 
-    -- Run pre-activates
-    if entry.pre_activate then
-        Logger.log_verbose("Running pre-activate for %s.", entry.name)
-        entry.pre_activate(caller, Rotation.GetEntryConditionArg(resolvedActionMap, entry))
-    end
-
     if entry.type:lower() == "item" then
         --Allow us to pass entry names directly for items in addition to Action Map tables
         local itemName = resolvedActionMap[entry.name]
         if not itemName then itemName = entry.name end
 
         if Casting.ItemReady(itemName) then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Casting.UseItem(itemName, targetId)
         end
         Logger.log_verbose("Trying to use item %s :: %s", itemName, ret and "\agSuccess" or "\arFailed!")
@@ -131,6 +126,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
         if not itemName or itemName:len() == 0 then return false end
 
         if Casting.ItemReady(itemName) then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Casting.UseItem(itemName, targetId)
         end
         Logger.log_verbose("Trying to use clickyitem %s :: %s", itemName, ret and "\agSuccess" or "\arFailed!")
@@ -142,6 +138,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
         if not spell or not spell() then return false end
 
         if Casting.SpellReady(spell, bAllowMem) then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Casting.UseSpell(spell.RankName(), targetId, bAllowMem, entry.allowDead, entry.overrideWaitForGlobalCooldown, entry.retries)
         end
         Logger.log_verbose("(Spell) Trying to use %s - %s :: %s", entry.name, spell.RankName(), ret and "\agSuccess" or "\arFailed!")
@@ -153,6 +150,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
         if not songSpell or not songSpell() then return false end
 
         if Casting.SongReady(songSpell, bAllowMem) then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Casting.UseSong(songSpell.RankName(), targetId, bAllowMem, entry.retries)
         end
         Logger.log_verbose("(Song) Trying to use %s - %s :: %s", entry.name, songSpell.RankName(), ret and "\agSuccess" or "\arFailed!")
@@ -164,6 +162,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
         if not discSpell then return false end
 
         if Casting.DiscReady(discSpell) then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Casting.UseDisc(discSpell, targetId)
         end
         Logger.log_verbose("(Disc) Trying to use %s - %s :: %s", entry.name, discSpell.RankName(), ret and "\agSuccess" or "\arFailed!")
@@ -171,6 +170,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
     if entry.type:lower() == "aa" then
         if Casting.AAReady(entry.name) then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Casting.UseAA(entry.name, targetId, entry.allowDead, entry.retries)
         end
         Logger.log_verbose("(AA) Trying to use %s :: %s", entry.name, ret and "\agSuccess" or "\arFailed!")
@@ -178,6 +178,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
     if entry.type:lower() == "ability" then
         if Casting.AbilityReady(entry.name, mq.TLO.Spawn(targetId)) then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Casting.UseAbility(entry.name)
         end
         Logger.log_verbose("(Ability) Trying to use %s :: %s", entry.name, ret and "\agSuccess" or "\arFailed!")
@@ -185,6 +186,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
     if entry.type:lower() == "customfunc" then
         if entry.custom_func then
+            Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret = Core.SafeCallFunc(string.format("Custom Func Entry: %s", entry.name), entry.custom_func, caller, targetId)
         end
         Logger.log_verbose("(Custom Function) Calling %s", entry.name, ret and "\agSuccess" or "\arFailed!")
@@ -522,6 +524,13 @@ function Rotation.FindAllMissingSpells(abilitySets, highestOnly)
     end
 
     return missingSpellList
+end
+
+function Rotation.RunPreActivate(caller, resolvedActionMap, entry)
+    if entry.pre_activate then
+        Logger.log_verbose("Running pre-activate for %s.", entry.name)
+        entry.pre_activate(caller, Rotation.GetEntryConditionArg(resolvedActionMap, entry))
+    end
 end
 
 return Rotation


### PR DESCRIPTION
* [CLR - Laz] Fix for undesired aura removal causing a spam condition in some situations.

* [rotation] Entry Pre-Activation functions will no longer be executed until the very last step before an action's use.
* * This fixes a possible aura spam condition with the Laz Enchanter.