### PR TITLE
Tank MoveBack Update

### DIFF
--- a/modules/class.lua
+++ b/modules/class.lua
@@ -899,12 +899,11 @@ function Module:GiveTime(combat_state)
 
         for i = 1, xtCount do
             local xtSpawn = mq.TLO.Me.XTarget(i)
-            if xtSpawn and xtSpawn() and xtSpawn.ID() > 0 and not xtSpawn.Dead() and (math.ceil(xtSpawn.PctHPs() or 0)) > 0 and math.abs((mq.TLO.Me.Heading.Degrees() - (xtSpawn.Heading.Degrees() or 0))) < 100 then
+            if xtSpawn and xtSpawn.ID() > 0 and not xtSpawn.Dead() and (math.ceil(xtSpawn.PctHPs() or 0)) > 0 and ((xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater") or Targeting.ForceCombat) and math.abs((mq.TLO.Me.Heading.Degrees() - (xtSpawn.Heading.Degrees() or 0))) < 100 then
                 Logger.log_debug("\arXT(%s) is behind us! \atTaking evasive maneuvers! \awMyHeader(\am%d\aw) ThierHeading(\am%d\aw)", xtSpawn.DisplayName() or "",
-                    mq.TLO.Me.Heading.Degrees(),
-                    (xtSpawn.Heading.Degrees() or 0))
+                    mq.TLO.Me.Heading.Degrees(), (xtSpawn.Heading.Degrees() or 0))
                 Core.DoCmd("/stick moveback %d", Config:GetSetting('MovebackDistance'))
-                mq.delay(500)
+                -- mq.delay(500) I don't see the need for a delay here, tanks could still be using AA/discs/etc while moving. Rotation checks for movement are very tight now. Going to test. Algar 3/17/25
             end
         end
     end


### PR DESCRIPTION
* Adjusted xtarget-based moveback when we detect an xthater behind us.
* * Removed the delay after we issue this command, as this should (speculatively) no longer be required due to the current movement checks embedded in rotations.