### PR TITLE
Laz - Mind Crystal Update

### DIFF
--- a/modules/class.lua
+++ b/modules/class.lua
@@ -787,7 +787,16 @@ function Module:RunCounterRotation()
     end
 end
 
-function Module:DoCombatClickies()
+function Module:DoCombatClickies() --TODO: Find out why normal clickies are in movement module. Split clickies into bene/detr/self-heals or something.
+    -- I plan on breaking clickies out further to allow things like horn, other healing clickies to be used, that the user will select... alternative is a modrod like table to check. This is "interim" implementation.
+    if Core.OnLaz() and mq.TLO.Me.PctHPs() <= (Config:GetSetting('EmergencyStart', true) and Config:GetSetting('EmergencyStart') or 45) then
+        local crystal = mq.TLO.FindItem("Sanguine Mind Crystal")()
+        if (mq.TLO.FindItem(crystal or "None").Timer.TotalSeconds() or -1) == 0 then
+            Logger.log_verbose("Low Health Detected, using our mind crystal!")
+            Casting.UseItem(mq.TLO.FindItem("Sanguine Mind Crystal")() or "None", mq.TLO.Me.ID())
+        end
+    end
+
     if not Config:GetSetting('UseCombatClickies') then return end
 
     -- make sure we are safe to use clickies


### PR DESCRIPTION
* [ENC] Mind Crystal Improvements:
* * Added entry for Sanguine Mind Crystal.
* * Checks for crystals needed will now include the entire group.
* * Added the ability to adjust the ms delay before an /autoinv is issued to the group after summon (similar to MAG).
* * * Please note that /autoinv can fail on PCs taking certain other actions, and your enchanter isn't to blame for this.

* [All] Added initial support for Sanguine Crystal use.
* * Crystals will be used in-combat, when we detect health under your class-specific Emergency Start settings (with 45% as a fallback for classes who don't currently have the setting).

As a note, Mind Crystals were added to be used under the same conditions as ModRods in a previous update.