### PR TITLE
brings up to current

### DIFF
--- a/lib/lootnscoot/init.lua
+++ b/lib/lootnscoot/init.lua
@@ -2771,6 +2771,7 @@ function LNS.checkLore(itemName, itemLink, decision, countHave, isLore)
         return decision, true
     end
     if countHave > 0 then
+        Logger.Warn(LNS.guiLoot.console, "Item is \ayLORE\ax and I \arHAVE\ax it. Ignoring.")
         return 'Ignore', false
     end
     local ret = decision

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -285,6 +285,7 @@ end
 
 function Module:GiveTime(combat_state)
 	if not Config:GetSetting('DoLoot') or not Config:GetSetting('LootCorpses') then return end
+	if Config.Globals.PauseMain then return end
 
 	if not Core.OkayToNotHeal() or mq.TLO.Me.Invis() or Casting.IAmFeigning() then return end
 

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -79,7 +79,7 @@ function Casting.LocalBuffCheck(spellId, checkPet)
         return false
     end
 
-    if not (checkPet and me.Pet.Buff(spellName) or me.FindBuff("id " .. spellId)()) then
+    if not (checkPet and me.Pet.Buff(spellName)() or me.FindBuff("id " .. spellId)()) then
         Logger.log_verbose("LocalBuffCheck: %s(ID:%d) not found, let's check for triggers.", spellName, spellId)
         local numEffects = mq.TLO.Spell(spellId).NumEffects()
         local triggerCount = 0
@@ -90,7 +90,7 @@ function Casting.LocalBuffCheck(spellId, checkPet)
             if triggerSpell and triggerSpell() and triggerSpell.ID() > 0 then
                 local triggerName = triggerSpell.Name()
                 local triggerID = triggerSpell.ID()
-                if not (checkPet and me.Pet.Buff(triggerName) or me.FindBuff("id " .. triggerID)()) then
+                if not (checkPet and me.Pet.Buff(triggerName)() or me.FindBuff("id " .. triggerID)()) then
                     Logger.log_verbose("LocalBuffCheck: %s(ID:%d) not found, checking stacking.", triggerName, triggerID)
                     if triggerSpell.Stacks() then
                         Logger.log_verbose("LocalBuffCheck: %s(ID:%d) seems to stack, let's do it!", triggerName, triggerID)


### PR DESCRIPTION
Casting check
should no longer run to loot mid cast.

Corpse Check adjusted now checks for exact name when searching for player corpse. this should prevent selecting wrong corpse when multiple PC's start with the same name ex. Derple Derplemag Derpleclr

bank changes and some other fixes. 
the bank tradeskills flag will no longer auto flag items to bank

Instead it will be checked when issuing the bank command.

When banking:
check rules and if its 'Bank' toss it into the bank
if the rule is not Global or Personal then check if the item is a TS item, and if we have Bank TS enabled.
if both are true then bank it.

this way we don't have rules flip flopping from this setting. and it still serves a purpose for items without overrides in global or personal rules tables.

This still allows you to manually set items to Bank and it will follow that rule.
