### PR TITLE
Laz Config Update

### DIFF
--- a/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
+++ b/class_configs/Alpha (Project Lazarus)/dru_class_config.lua
@@ -483,17 +483,6 @@ local _ClassConfig = {
         ['TwincastSpell'] = {
             "Twincast",
         },
-        ['TwinHealNuke'] = {
-            -- Druid Twincast
-            "Sundew Blessing",
-            "Sunrise Blessing",
-            "Sunbreeze Blessing",
-            "Sunbeam Blessing",
-            "Sunfire Blessing",
-            "Sunflash Blessing",
-            "Sunrake Blessing",
-            "Sunwarmth Blessing",
-        },
         ['IceNuke'] = {
             --Ice Nuke
             "Ice",
@@ -856,16 +845,6 @@ local _ClassConfig = {
                     Casting.BurnCheck() and Core.OkayToNotHeal()
             end,
         },
-        -- {
-        --     name = 'TwinHeal',
-        --     state = 1,
-        --     steps = 1,
-        --     load_cond = function(self) return Config:GetSetting('DoTwinHeal') and self:GetResolvedActionMapItem('TwinHealNuke') end,
-        --     targetId = function(self) return { Core.GetMainAssistId(), } end,
-        --     cond = function(self, combat_state)
-        --         return combat_state == "Combat" and Core.OkayToNotHeal()
-        --     end,
-        -- },
         {
             name = 'HealDPS(1-70)',
             state = 1,
@@ -968,29 +947,15 @@ local _ClassConfig = {
                 end,
             },
         },
-        -- ['TwinHeal'] = {
-        --     {
-        --         name = "TwinHealNuke",
-        --         type = "Spell",
-        --         retries = 0,
-        --         cond = function(self) return not Casting.IHaveBuff("Healing Twincast") end,
-        --     },
-        -- },
         ['RoDebuff'] = {
-            {
-                name = "Blessing of Ro",
+            { -- Ro Debuff AA, will use the first(best) available
+                name_func = function(self)
+                    return Casting.GetBestAA({ "Blessing of Ro", "Hand of Ro", })
+                end,
                 type = "AA",
                 cond = function(self, aaName, target)
                     local aaSpell = Casting.GetAASpell(aaName)
                     return Casting.DetAACheck(aaName) and Casting.ReagentCheck(aaSpell and aaSpell.Trigger(1) or aaName)
-                end,
-            },
-            {
-                name = "Hand of Ro",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if Casting.CanUseAA("Blessing of Ro") then return false end
-                    return Casting.DetAACheck(aaName)
                 end,
             },
             {
@@ -1258,7 +1223,6 @@ local _ClassConfig = {
             gem = 8,
             spells = {
 
-                { name = "TwinHealNuke",        cond = function(self) return Config:GetSetting("DoTwinHeal") end, },
                 { name = "GroupCure",           cond = function(self) return true end, },
                 { name = "TempHPBuff",          cond = function(self) return Config:GetSetting('DoTempHP') end, },
                 { name = "ReptileCombatInnate", cond = function(self) return true end, },
@@ -1419,15 +1383,6 @@ local _ClassConfig = {
             FAQ = "Why do I see orphaned settings?",
             Answer = "To avoid deletion of settings when moving between configs, our beta or experimental configs keep placeholders for live settings\n" ..
                 "These tabs or settings will be removed if and when the config is made the default.",
-        },
-        ['DoTwinHeal']   = {
-            DisplayName = "Cast Twin Heal Nuke",
-            Category = "Spells and Abilities",
-            Tooltip = "Use Twin Heal Nuke Spells",
-            RequiresLoadoutChange = true,
-            Default = true,
-            FAQ = "I have Twincastig AA, can I use it?",
-            Answer = "Yes, you can enable [DoTwinHeal] to use Twin Heal Nuke spells.",
         },
         ['DoHPBuff']     = {
             DisplayName = "Group HP Buff",

--- a/class_configs/Beta (Project Lazarus)/enc_class_config.lua
+++ b/class_configs/Beta (Project Lazarus)/enc_class_config.lua
@@ -923,18 +923,12 @@ local _ClassConfig = {
                 active_cond = function(self, aaName) return Casting.IHaveBuff(aaName) end,
                 cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) end,
             },
-            {
-                name = "Mana Draw",
+            { -- Mana Restore AA, will use the first(best) available
+                name_func = function(self)
+                    return Casting.GetBestAA({ "Mana Draw", "Gather Mana", })
+                end,
                 type = "AA",
                 cond = function(self, aaName) return mq.TLO.Me.PctMana() < 30 end,
-            },
-            {
-                name = "Gather Mana",
-                type = "AA",
-                cond = function(self, aaName)
-                    if Casting.CanUseAA("Mana Draw") then return false end
-                    return mq.TLO.Me.PctMana() < 30
-                end,
             },
             {
                 name = "Auroria Mastery",

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -1455,21 +1455,14 @@ local _ClassConfig = {
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
-            {
-                name = "Group Shrink",
+            { --Shrink AA, will use first(best) available
+                name_func = function(self)
+                    return Casting.GetBestAA({ "Group Shrink", "Shrink", })
+                end,
                 type = "AA",
                 active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoGroupShrink') then return false end
-                    return target.Height() > 2.2
-                end,
-            },
-            {
-                name = "Shrink",
-                type = "AA",
-                active_cond = function(self) return mq.TLO.Me.Height() < 2 end,
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoGroupShrink') or Casting.CanUseAA("Group Shrink") then return false end
                     return target.Height() > 2.2
                 end,
             },

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1701,41 +1701,13 @@ _ClassConfig      = {
             },
         },
         ['Summon ModRods'] = {
-            {
-                name = "Large Modulation Shard",
+            { -- Mod Rod AA, will use the first(best) one found.
+                name_func = function(self)
+                    return Casting.GetBestAA({ "Large Modulation Shard", "Medium Modulation Shard", "Small Modulation Shard", })
+                end,
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) then return false end
-                    local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
-                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
-                        (mq.TLO.Cursor.ID() or 0) == 0
-                end,
-                post_activate = function(self, aaName, success)
-                    if success then
-                        Core.SafeCallFunc("Autoinventory", self.ClassConfig.HelperFunctions.HandleItemSummon, self, aaName, "group")
-                    end
-                end,
-            },
-            {
-                name = "Medium Modulation Shard",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) or Casting.CanUseAA("Large Modulation Shard") then return false end
-                    local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
-                    return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
-                        (mq.TLO.Cursor.ID() or 0) == 0
-                end,
-                post_activate = function(self, aaName, success)
-                    if success then
-                        Core.SafeCallFunc("Autoinventory", self.ClassConfig.HelperFunctions.HandleItemSummon, self, aaName, "group")
-                    end
-                end,
-            },
-            {
-                name = "Small Modulation Shard",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) or Casting.CanUseAA("Medium Modulation Shard") then return false end
+                    if not Config:GetSetting('SummonModRods') then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
                     return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -1041,17 +1041,9 @@ return {
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
-            { --Familiar AA, will use them in order of preference (Kera > Ro's > Imp.)
+            { --Familiar AA, will use the first(best) one found
                 name_func = function(self)
-                    local ret = "None"
-                    local famAA = { "Kerafyrm's Prismatic Familiar", "Ro's Flaming Familiar", "Improved Familiar", }
-                    for _, abil in ipairs(famAA) do
-                        if Casting.CanUseAA(abil) then
-                            ret = abil
-                            break
-                        end
-                    end
-                    return ret
+                    return Casting.GetBestAA({ "Kerafyrm's Prismatic Familiar", "Ro's Flaming Familiar", "Improved Familiar", })
                 end,
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.IHaveBuff(aaName) end,

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1620,6 +1620,22 @@ function Casting.AutoMed()
     end
 end
 
+--- Retrieves the first available purchased AA in a list.
+--- @param aaList table The list of AA to check.
+--- @return string The name of the selected AA (or "None" if no ability was found).
+function Casting.GetBestAA(aaList)
+    if not aaList or type(aaList) ~= "table" then return "None" end
+
+    local ret = "None"
+    for _, abil in ipairs(aaList) do
+        if Casting.CanUseAA(abil) then
+            ret = abil
+            break
+        end
+    end
+    return ret
+end
+
 --- Function to execute use of modrods.
 function Casting.ClickModRod()
     local me = mq.TLO.Me


### PR DESCRIPTION
Cleaned up entry list and rotation window on some classes by creating a helper function to iterate over a list of AA to choose the best available (Laz has many tiered AA's that share timers).
* * The dynamic names assigned to these entries will update on loadout scan (inc. mode change) or settings save.