### PR TITLE
AutoMed update

### DIFF
--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1621,7 +1621,8 @@ function Casting.AutoMed()
         end
     end
 
-    if not me.Sitting() and forcesit then
+    -- if we aren't sitting, see if we were already medding and we got interrupted, or if our checks above say we should start medding
+    if not me.Sitting() and (Config.Globals.InMedState or forcesit) then
         Config.Globals.InMedState = true
         Logger.log_debug("Forcing sit - all conditions met.")
         me.Sit()


### PR DESCRIPTION
We should now return to our seats if we perform an action while already meditating and have yet to reach our "stop" percentages (even when we are now above the "start" percentages).