### PR TITLE
Laz AE Update

### DIFF
--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -880,6 +880,7 @@ _ClassConfig      = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
+                if not Config:GetSetting('DoAEDamage') then return false end
                 return combat_state == "Combat" and self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('PBAETargetCnt'), true)
             end,
         },

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -365,6 +365,7 @@ return {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
+                if not Config:GetSetting('DoAEDamage') then return false end
                 return combat_state == "Combat" and self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('PBAETargetCnt'), true)
             end,
         },


### PR DESCRIPTION
Fixed the fact that MAG and WIZ ae rotations were not fully respecting the DoAEDamage setting (which is designed to be a top-level quick toggle without changing spell loadout, etc).