### PR TITLE
Rez Update

### DIFF
--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -679,20 +679,23 @@ local _ClassConfig = {
             local rezSpell = self.ResolvedActionMap['RezSpell']
             local okayToRez = Casting.OkayToRez(corpseId)
 
+            if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
+                if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
+                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
+                end
+            end
+
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
                     rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
                     rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
-            end
-
-            if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
-                if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
-                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
-                elseif Casting.AAReady("Blessing of Resurrection") then
+            else
+                if Casting.AAReady("Blessing of Resurrection") then
                     rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
-                elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
+                end
+                if not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
                     rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -689,20 +689,23 @@ local _ClassConfig = {
             local rezSpell = self.ResolvedActionMap['RezSpell']
             local okayToRez = Casting.OkayToRez(corpseId)
 
+            if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
+                if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
+                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
+                end
+            end
+
             if mq.TLO.Me.CombatState():lower() == "combat" and Config:GetSetting('DoBattleRez') then
                 if Casting.AAReady("Blessing of Resurrection") then
                     rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
                 elseif mq.TLO.FindItem("Water Sprinkler of Nem Ankh")() and mq.TLO.Me.ItemReady("Water Sprinkler of Nem Ankh")() then
                     rezAction = okayToRez and Casting.UseItem("Water Sprinkler of Nem Ankh", corpseId)
                 end
-            end
-
-            if mq.TLO.Me.CombatState():lower() == ("active" or "resting") then
-                if mq.TLO.SpawnCount("pccorpse radius 80 zradius 30")() > 2 and Casting.SpellReady(mq.TLO.Spell("Larger Reviviscence"), true) then
-                    rezAction = okayToRez and Casting.UseSpell("Larger Reviviscence", corpseId, true, true)
-                elseif Casting.AAReady("Blessing of Resurrection") then
+            else
+                if Casting.AAReady("Blessing of Resurrection") then
                     rezAction = okayToRez and Casting.UseAA("Blessing of Resurrection", corpseId, true, 1)
-                elseif not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
+                end
+                if not Casting.CanUseAA("Blessing of Resurrection") and Casting.SpellReady(rezSpell, true) then
                     rezAction = okayToRez and Casting.UseSpell(rezSpell, corpseId, true, true)
                 end
             end

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -457,8 +457,10 @@ function Casting.OkayToRez(corpseId)
             mq.delay(20)
             maxWait = maxWait - 20
             if maxWait <= 0 then
-                Logger.log_debug("\atEmuOkayToRez(): Checked corpse ID %d, but did not receive a con message. Aborting.", corpseId or 0)
-                return false
+                Logger.log_info(
+                    "\atEmuOkayToRez(): \arWarning! \atChecked corpse ID %d, but did not receive a con message. Allowing the check to proceed, but a spam condition is possible.",
+                    corpseId or 0)
+                --return false -- issues with combat rezzes, testing. 4/5/25 Algar
             end
         end
         mq.doevents('AlreadyRezzed')


### PR DESCRIPTION
* When a /con message isn't received on emu, we will now warn the player but allow the "already rezzed" check to continue to prevent possible conflict with combat rezzing.

* Corrected an issue where a cleric may not use appropriate rez actions if in the "debuffed" combat state.