### PR TITLE
Buff Gem Use Update

### DIFF
--- a/utils/config.lua
+++ b/utils/config.lua
@@ -139,6 +139,8 @@ for i, v in ipairs(Config.Constants.ConColors) do Config.Constants.ConColorsName
 
 Config.Constants.Spires = { "First", "Second", "Third", }
 
+Config.Constants.LastGemRemem = { "Do Nothing", "Mem Previous Spell", "Mem Loadout Spell", }
+
 -- Defaults
 Config.DefaultConfig = {
 
@@ -922,15 +924,22 @@ Config.DefaultConfig = {
         FAQ = "Why am I not standing up from Feign Death when it fails?",
         Answer = "You can set the [StandFailedFD] option to true to automatically stand up if you fail to Feign Death.",
     },
-    ['RememLastSlot']        = {
-        DisplayName = "Mem After Buff:",
+    ['LastGemRemem']         = {
+        DisplayName = "Remem After Buff:",
         Category = "Spells/Abils",
         Index = 6,
-        Tooltip = "Re-memorize the spell on the last gem after we use that gem to buff.",
-        Default = true,
+        Tooltip = "Choose what do with the last gem slot after we use it to buff:\n" ..
+            "Do Nothing: Use the slot as needed for buffs, but don't rememorize anything.\n" ..
+            "Remem Previous Spell: Rememorize the spell that was in the slot before buffing, if there was one.\n" ..
+            "Remem Loadout Spell: Rememorize the spell from the current loadout, if there is one.",
+        Default = 3,
+        Min = 1,
+        Max = #Config.Constants.LastGemRemem,
+        Type = "Combo",
+        ComboOptions = Config.Constants.LastGemRemem,
         ConfigType = "Advanced",
-        FAQ = "Why am I constantly rememorizing spells in the last slot?",
-        Answer = "You can disable the Re-Mem After Buff option to stop this behavior.",
+        FAQ = "Why am I constantly rememorizing buffs in the last slot?",
+        Answer = "You can control how and what we will remem in the last gem after buffing on the Spells/Abils options tab.",
     },
     ['IgnoreLevelCheck']     = {
         DisplayName = "Ignore Spell Level Checks",

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -5,6 +5,7 @@ local Logger     = require("utils.logger")
 local Casting    = require("utils.casting")
 local Strings    = require("utils.strings")
 local Targeting  = require("utils.targeting")
+local Modules    = require("utils.modules")
 
 local Rotation   = { _version = '1.0', _name = "Rotation", _author = 'Derple', }
 Rotation.__index = Rotation
@@ -261,6 +262,7 @@ end
 --- @return number, boolean
 function Rotation.Run(caller, rotationTable, targetId, resolvedActionMap, steps, start_step, bAllowMem, bDoFullRotation, fnRotationCond)
     local oldSpellInSlot = mq.TLO.Me.Gem(Casting.UseGem)
+    local loadoutSpell   = (Modules.ModuleList.Class.SpellLoadOut[Casting.UseGem] and Modules.ModuleList.Class.SpellLoadOut[Casting.UseGem].spell)
     local stepsThisTime  = 0
     local lastStepIdx    = 0
     local anySuccess     = false
@@ -328,9 +330,14 @@ function Rotation.Run(caller, rotationTable, targetId, resolvedActionMap, steps,
         end
     end
 
-    if Config:GetSetting('RememLastSlot') and Targeting.GetXTHaterCount() == 0 and oldSpellInSlot() and mq.TLO.Me.Gem(Casting.UseGem)() ~= oldSpellInSlot.Name() then
-        Logger.log_debug("\ayRestoring %s in slot %d", oldSpellInSlot, Casting.UseGem)
-        Casting.MemorizeSpell(Casting.UseGem, oldSpellInSlot.Name(), false, 15000)
+    if Targeting.GetXTHaterCount() == 0 then -- no magic numbers, just 4 u bb
+        if Config.Constants.LastGemRemem[Config:GetSetting('LastGemRemem')] == "Mem Previous Spell" and oldSpellInSlot() and mq.TLO.Me.Gem(Casting.UseGem)() ~= oldSpellInSlot.Name() then
+            Logger.log_debug("\ayRestoring %s in slot %d", oldSpellInSlot, Casting.UseGem)
+            Casting.MemorizeSpell(Casting.UseGem, oldSpellInSlot.Name(), false, 15000)
+        elseif Config.Constants.LastGemRemem[Config:GetSetting('LastGemRemem')] == "Mem Loadout Spell" and loadoutSpell and mq.TLO.Me.Gem(Casting.UseGem)() ~= loadoutSpell.RankName() then
+            Logger.log_debug("\ayRestoring %s in slot %d", loadoutSpell.RankName(), Casting.UseGem)
+            Casting.MemorizeSpell(Casting.UseGem, loadoutSpell.RankName(), false, 15000)
+        end
     end
 
     -- Move to the next step


### PR DESCRIPTION
Expanded support for spell memorization after the last gem is used for buffs:
* New options are "Mem Loadout Spell" (default), "Mem Previous Spell" (default old behavior), and "Do Nothing". Please see the tooltip in game for more details. This option can be found in the main config options on the Spells/Abils tab.