### PR TITLE
Live TwinHeal Update

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -866,7 +866,7 @@ local _ClassConfig = {
             state = 1,
             steps = 1,
             load_cond = function(self) return Config:GetSetting('DoTwinHeal') and self:GetResolvedActionMapItem('TwinHealNuke') end,
-            targetId = function(self) return { Core.GetMainAssistId(), } end,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Core.OkayToNotHeal()
             end,
@@ -1057,9 +1057,15 @@ local _ClassConfig = {
         ['TwinHeal'] = {
             {
                 name = "TwinHealNuke",
-                type = "Spell",
-                retries = 0,
-                cond = function(self) return not Casting.IHaveBuff("Healing Twincast") end,
+                type = "CustomFunc",
+                cond = function(self, spell, target)
+                    if Casting.IHaveBuff("Healing Twincast") then return false end
+                    return Casting.SpellReady(spell, false)
+                end,
+                custom_func = function(self)
+                    local twinHeal = Core.GetResolvedActionMapItem("TwinHealNuke")
+                    Casting.UseSpell(twinHeal.RankName(), Core.GetMainAssistId(), false, false, false, 0)
+                end,
             },
         },
         ['Debuff'] = {

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -949,10 +949,11 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Twin Heal',
+            name = 'TwinHeal',
             state = 1,
             steps = 1,
-            targetId = function(self) return { Core.GetMainAssistId(), } end,
+            load_cond = function(self) return Config:GetSetting('DoTwinHeal') and self:GetResolvedActionMapItem('TwinHealNuke') end,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Config:GetSetting('DoTwinHeal') and Core.IsHealing() and
                     Targeting.GetTargetPctHPs() <= Config:GetSetting('AutoAssistAt')
@@ -1152,12 +1153,18 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ['Twin Heal'] = {
+        ['TwinHeal'] = {
             {
                 name = "TwinHealNuke",
-                type = "Spell",
-                retries = 0,
-                cond = function(self, spell) return not Casting.IHaveBuff("Healing Twincast") end,
+                type = "CustomFunc",
+                cond = function(self, spell, target)
+                    if Casting.IHaveBuff("Healing Twincast") then return false end
+                    return Casting.SpellReady(spell, false)
+                end,
+                custom_func = function(self)
+                    local twinHeal = Core.GetResolvedActionMapItem("TwinHealNuke")
+                    Casting.UseSpell(twinHeal.RankName(), Core.GetMainAssistId(), false, false, false, 0)
+                end,
             },
         },
         ['Debuff'] = {

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -966,7 +966,7 @@ local _ClassConfig = {
             state = 1,
             steps = 1,
             load_cond = function(self) return Config:GetSetting('DoTwinHeal') and self:GetResolvedActionMapItem('TwinHealNuke') end,
-            targetId = function(self) return { Core.GetMainAssistId(), } end,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
             end,
@@ -977,10 +977,14 @@ local _ClassConfig = {
         ['TwinHeal'] = {
             {
                 name = "TwinHealNuke",
-                type = "Spell",
-                retries = 0,
-                cond = function(self, spell)
-                    return not Casting.IHaveBuff("Healing Twincast")
+                type = "CustomFunc",
+                cond = function(self, spell, target)
+                    if Casting.IHaveBuff("Healing Twincast") then return false end
+                    return Casting.SpellReady(spell, false)
+                end,
+                custom_func = function(self)
+                    local twinHeal = Core.GetResolvedActionMapItem("TwinHealNuke")
+                    Casting.UseSpell(twinHeal.RankName(), Core.GetMainAssistId(), false, false, false, 0)
                 end,
             },
         },


### PR DESCRIPTION
Refactored DRU/SHM Twinheal nukes to use a custom function so the autotarget can remain the rotation target.