### PR TITLE
Remove HoT spell from normal heal list

### DIFF
--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -73,7 +73,6 @@ local _ClassConfig = {
             "Light Healing",
             "Healing",
             "Greater Healing",
-            "Celestial Health",
             "Superior Healing",
             "Healing Light",
             "Divine Light",

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -60,7 +60,6 @@ local _ClassConfig = {
             "Light Healing",
             "Healing",
             "Greater Healing",
-            "Celestial Health",
             "Superior Healing",
             "Healing Light",
             "Divine Light",

--- a/extras/contributors.lua
+++ b/extras/contributors.lua
@@ -10,4 +10,5 @@ return {
     "Grimmier",
     "cannonballdex",
     "RobbanEQ",
+    "mackal",
 }


### PR DESCRIPTION
This was erroneously added as a normal heal I guess. It's in HoT section as well.