### PR TITLE
Fix rogue PreEnage check

### DIFF
--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -605,13 +605,13 @@ return {
 
             Logger.log_debug("\ayPreEngage(): Testing Opener ability = %s", openerAbility or "None")
 
-            if openerAbility and mq.TLO.Me.CombatAbilityReady(openerAbility)() and mq.TLO.Me.AbilityReady("Hide")() and Config:GetSetting("DoOpener") and mq.TLO.Me.Invis() then
+            if openerAbility and mq.TLO.Me.CombatAbilityReady(openerAbility)() and not mq.TLO.Me.AbilityReady("Hide")() and mq.TLO.Me.AbilityTimer("Hide")() < 6000 and Config:GetSetting("DoOpener") and mq.TLO.Me.Invis() then
                 Casting.UseDisc(openerAbility, target)
                 Logger.log_debug("\agPreEngage(): Using Opener ability = %s", openerAbility or "None")
             else
-                Logger.log_debug("\arPreEngage(): NOT using Opener ability = %s, DoOpener = %s, Hide Ready = %s, Invis = %s", openerAbility or "None",
+                Logger.log_debug("\arPreEngage(): NOT using Opener ability = %s, DoOpener = %s, Hide Ready = %s, Hide Timer = %d, Invis = %s", openerAbility or "None",
                     Strings.BoolToColorString(Config:GetSetting("DoOpener")), Strings.BoolToColorString(mq.TLO.Me.AbilityReady("Hide")()),
-                    Strings.BoolToColorString(mq.TLO.Me.Invis()))
+                    mq.TLO.Me.AbilityTimer("Hide")(), Strings.BoolToColorString(mq.TLO.Me.Invis()))
             end
         end,
         BurnDiscCheck = function(self)


### PR DESCRIPTION
Sneak Attack type discs can be used after 4 seconds of being hidden. AbilityReady will return false in these cases (even after 10 second reuse). We can check AbilityTimer (reuse is 10 seconds) to see how long it has been since we've gone hidden.


I doubt live has changed the timer since I parsed it years ago to implement on EQEmu.