### PR TITLE
Fix DRU RunSpeed error spam

### DIFF
--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1253,7 +1253,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     local bookSpell = self:GetResolvedActionMapItem('MoveSpells')
                     local aaSpell = Casting.GetAASpell(aaName)
-                    if not Config:GetSetting('DoRunSpeed') or (bookSpell and bookSpell.Level() or 999) > (aaSpell.Level() or 0) then return false end
+                    if not Config:GetSetting('DoRunSpeed') or (bookSpell and bookSpell.Level() or 999) > (aaSpell ~= "None" and aaSpell.Level() or 0) then return false end
 
                     return Casting.GroupBuffAACheck(aaName, target)
                 end,


### PR DESCRIPTION
I was getting an error messages here at lower levels without the AA.

Note: the GetAASpell does return "None" here instead of nil or something

I haven't been able to test this with the AA, but I don't see why it shouldn't work