### PR TITLE
Bard Adjustments (#663)

### DIFF
--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -1193,7 +1193,7 @@ local _ClassConfig = {
                 name = "CrescendoSong",
                 type = "Song",
                 cond = function(self, songSpell)
-                    if not Config:GetSetting('UseCrescendo') then return false end
+                    if not Config:GetSetting('UseCrescendo') or (mq.TLO.Me.GemTimer(songSpell.RankName())() or -1) > 0 then return false end
                     local pct = Config:GetSetting('GroupManaPct')
                     return (mq.TLO.Group.LowMana(pct)() or -1) >= Config:GetSetting('GroupManaCt')
                 end,

--- a/modules/mez.lua
+++ b/modules/mez.lua
@@ -760,7 +760,7 @@ function Module:ProcessMezList()
                         if self.settings.DoAEMez and not mq.TLO.Target.Mezzed() and mq.TLO.Me.GroupAssistTarget.ID() ~= id then
                             --lets make sure we didn't have more mobs dogpile on, making an AE mez more appropriate
                             local aeMezSpell = self:GetAEMezSpell()
-                            if aeMezSpell and aeMezSpell() and Targeting.GetXTHaterCount() >= self.settings.MezAECount and ((mq.TLO.Me.GemTimer(aeMezSpell.RankName())() or -1 == 0) or (self.settings.DoAAMez and mq.TLO.Me.AltAbilityReady("Beam of Slumber"))) then
+                            if aeMezSpell and aeMezSpell() and Targeting.GetXTHaterCount() >= self.settings.MezAECount and ((mq.TLO.Me.GemTimer(aeMezSpell.RankName())() or -1) == 0 or (self.settings.DoAAMez and mq.TLO.Me.AltAbilityReady("Beam of Slumber"))) then
                                 Logger.log_debug("High number of targets, let's check if AE Mez is needed again before we start singles.")
                                 self:AEMezCheck()
                             end
@@ -793,7 +793,7 @@ end
 function Module:DoMez()
     local mezSpell = self:GetMezSpell()
     local aeMezSpell = self:GetAEMezSpell()
-    if aeMezSpell and aeMezSpell() and Targeting.GetXTHaterCount() >= self.settings.MezAECount and ((mq.TLO.Me.GemTimer(aeMezSpell.RankName())() or -1 == 0) or (self.settings.DoAAMez and mq.TLO.Me.AltAbilityReady("Beam of Slumber"))) then
+    if aeMezSpell and aeMezSpell() and Targeting.GetXTHaterCount() >= self.settings.MezAECount and ((mq.TLO.Me.GemTimer(aeMezSpell.RankName())() or -1) == 0 or (self.settings.DoAAMez and mq.TLO.Me.AltAbilityReady("Beam of Slumber"))) then
         self:AEMezCheck()
     end
 


### PR DESCRIPTION
* Bard Adjustments

* Fixed an issue in which discs, aa and items would not always properly report ready for a Bard.

* We will now properly ignore Crescendo if the gem is in cooldown.

* Speculative fix for occasionally locking gems when an Insult is cancelled at precisely the wrong moment.

A previous version of these notes mentioned using items or discs while singing; at this time, that is not the case.