### PR TITLE
Casting, Config Updates

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -1067,7 +1067,7 @@ local _ClassConfig = {
                 type = "CustomFunc",
                 cond = function(self, spell, target)
                     if Casting.IHaveBuff("Healing Twincast") then return false end
-                    return Casting.SpellReady(spell, false)
+                    return Casting.CastReady(spell)
                 end,
                 custom_func = function(self)
                     local twinHeal = Core.GetResolvedActionMapItem("TwinHealNuke")

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1165,7 +1165,7 @@ local _ClassConfig = {
                 type = "CustomFunc",
                 cond = function(self, spell, target)
                     if Casting.IHaveBuff("Healing Twincast") then return false end
-                    return Casting.SpellReady(spell, false)
+                    return Casting.CastReady(spell)
                 end,
                 custom_func = function(self)
                     local twinHeal = Core.GetResolvedActionMapItem("TwinHealNuke")

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -1090,12 +1090,10 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    --NDT will not be cast or memorized if it isn't already on the bar due to a very long refresh time
-                    if not Config:GetSetting('DoNDTBuff') or not Casting.CastReady(spell) then return false end
                     --Single target versions of the spell will only be used on Melee, group versions will be cast if they are missing from any groupmember
-                    if (spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target) then return false end
+                    if not Config:GetSetting('DoNDTBuff') or ((spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target)) then return false end
 
-                    return Casting.GroupBuffCheck(spell, target)
+                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -1104,7 +1102,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoProcBuff') or not Targeting.TargetIsACaster(target) then return false end
-                    return Casting.GroupBuffCheck(spell, target)
+                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -818,13 +818,13 @@ local _ClassConfig = {
             name  = 'LowLevelHealPoint', -- Fastheal
             state = 1,
             steps = 1,
-            cond  = function(self, target) return mq.TLO.Me.Level() >= 89 and Targeting.MainHealsNeeded(Core.GetMainAssistSpawn()) end,
+            cond  = function(self, target) return mq.TLO.Me.Level() <= 89 and Targeting.TargetIsMA(target) and Targeting.MainHealsNeeded(target) end,
         },
         {
-            name = 'MainHealPoint', -- Heal
+            name = 'MainHealPoint',
             state = 1,
             steps = 1,
-            cond = function(self, target) return Targeting.MainHealsNeeded(Core.GetMainAssistSpawn()) end,
+            cond = function(self, target) return Targeting.TargetIsMA(target) and Targeting.MainHealsNeeded(target) end,
         },
         {
             name = 'GroupHealPoint', -- TotHeal

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -985,7 +985,7 @@ local _ClassConfig = {
                 type = "CustomFunc",
                 cond = function(self, spell, target)
                     if Casting.IHaveBuff("Healing Twincast") then return false end
-                    return Casting.SpellReady(spell, false)
+                    return Casting.CastReady(spell)
                 end,
                 custom_func = function(self)
                     local twinHeal = Core.GetResolvedActionMapItem("TwinHealNuke")

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -609,12 +609,10 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    --NDT will not be cast or memorized if it isn't already on the bar due to a very long refresh time
-                    if not Config:GetSetting('DoNDTBuff') or not Casting.CastReady(spell) then return false end
                     --Single target versions of the spell will only be used on Melee, group versions will be cast if they are missing from any groupmember
-                    if (spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target) then return false end
+                    if not Config:GetSetting('DoNDTBuff') or ((spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target)) then return false end
 
-                    return Casting.GroupBuffCheck(spell, target)
+                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
@@ -623,7 +621,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoProcBuff') or not Targeting.TargetIsACaster(target) then return false end
-                    return Casting.SpellReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -815,16 +815,10 @@ local _ClassConfig = {
     -- These will run in order and exit after the first valid spell to cast
     ['HealRotationOrder'] = {
         {
-            name  = 'LowLevelHealPoint', -- Fastheal
+            name = 'MainHealPoint',
             state = 1,
             steps = 1,
-            cond  = function(self, target) return mq.TLO.Me.Level() >= 89 and Targeting.HPInMainHealRange(Core.GetMainAssistSpawn()) end,
-        },
-        {
-            name = 'MainHealPoint', -- Heal
-            state = 1,
-            steps = 1,
-            cond = function(self, target) return Targeting.HPInMainHealRange(Core.GetMainAssistSpawn()) end,
+            cond = function(self, target) return Targeting.TargetIsMA(target) and Targeting.MainHealsNeeded(target) end,
         },
         {
             name = 'GroupHealPoint', -- TotHeal
@@ -834,7 +828,7 @@ local _ClassConfig = {
         },
     },
     ['HealRotations']     = {
-        ["LowLevelHealPoint"] = {
+        ["MainHealPoint"] = {
             {
                 name = "Fastheal",
                 type = "Spell",
@@ -842,9 +836,6 @@ local _ClassConfig = {
                     return Config:GetSetting('DoHeals')
                 end,
             },
-
-        },
-        ["MainHealPoint"] = {
             {
                 name = "Heal",
                 type = "Spell",


### PR DESCRIPTION
* Bard item/aa/disc ready checks will no longer fail while they are singing if the cast time is instant.

* Speculative fix for Insults occasionally causing stuck bard gems.

* Standardized logging level in use functions for spells/AA/discs/songs/items.

* Various Classes: Corrected ready checks for long recast spells (thanks mackal!)

* RNG: Fix for healing rotation functions (thanks sputnik!)