### PR TITLE
Minor Updates

### DIFF
--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -685,7 +685,7 @@ local _ClassConfig = {
                 name = "Fundament: Second Spire of Enchantment",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (mq.TLO.Group.LowMana(30)() + (mq.TLO.Me.PctMana() < 30 and 1 or 0)) > 1
+                    return ((mq.TLO.Group.LowMana(30)() or 0) + (mq.TLO.Me.PctMana() < 30 and 1 or 0)) > 1
                 end,
             },
             {

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -817,6 +817,17 @@ local _ClassConfig = {
                     return Targeting.IsNamed(target) and (Casting.CanUseAA("Cascading Theft of Defense") and not Casting.IHaveBuff("Cascading Theft of Defense"))
                 end,
             },
+            {
+                name = "Skin",
+                type = "Spell",
+                tooltip = Tooltips.Skin,
+                cond = function(self, spell, target)
+                    if not Core.IsTanking() or not Targeting.IsNamed(target) then return false end
+                    return Casting.SelfBuffCheck(spell)
+                        --laz specific deconflict
+                        and not Casting.IHaveBuff("Necrotic Pustules")
+                end,
+            },
         },
         ['Snare'] = {
             {

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -63,6 +63,19 @@ Module.DefaultConfig     = {
 		Answer =
 		"If you turn on Respect Med State in the Group Watch options, your looter will remain medding until those thresholds are reached.\nIf Stand When Done is not enabled, the looter may continue to sit after those thresholds are reached.",
 	},
+	['LootingTimeout']                         = {
+		DisplayName = "Looting Timeout",
+		Category = "Loot N Scoot",
+		Index = 5,
+		Tooltip = "The length of time in seconds that RGMercs will allow LNS to process loot actions in a single check.",
+		Default = 5,
+		Min = 1,
+		Max = 10,
+		FAQ = "Why do my guys take too long to loot, or sometimes miss corpses?",
+		Answer =
+			"While RGMercs doesn't necessary control what LNS is doing, exactly, we do have a timeout setting that dictates how long we will allow it to do it before re-checking for other actions. \n" ..
+			"You can adjust this advanced setting in the Loot options. Please note, if no other actions are required by mercs, we will simply allow LNS to continue.",
+	},
 	[string.format("%s_Popped", Module._name)] = {
 		DisplayName = Module._name .. " Popped",
 		Type = "Custom",
@@ -238,7 +251,7 @@ end
 function Module.DoLooting()
 	if not Module.TempSettings.Looting then return end
 
-	local maxWait = 5000
+	local maxWait = Config:GetSetting('LootingTimeout') * 1000
 	while Module.TempSettings.Looting do
 		if mq.TLO.Me.CombatState():lower() == "combat" and not Config:GetSetting('CombatLooting') then
 			Logger.log_debug("\ay[LOOT]: Aborting Actions due to combat!")

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -1430,7 +1430,7 @@ function Module:CheckGroupForPull(resourceResumePct, resourcePausePct, campData)
 
     for i, _ in ipairs(groupWatch) do
         local member = mq.TLO.Group.Member(i)
-        if groupWatch[i] and member and member.ID() > 0 then
+        if groupWatch[i] and member() and member.ID() > 0 then
             local resourcePct = self.TempSettings.PullState == PullStates.PULL_GROUPWATCH_WAIT and resourceResumePct or resourcePausePct
             if member.PctHPs() < resourcePct then
                 Comms.HandleAnnounce(string.format("%s is low on hp - Holding pulls!", member.CleanName()), Config:GetSetting('PullAnnounceGroup'), Config:GetSetting('PullAnnounce'))


### PR DESCRIPTION
* [pull] Fix for nil crash when Group Watch is enabled for non-existent party members (thanks mhoney71!)
* [ENC-Laz] Fix for spire check when not in a group.
* [SHD-Laz] We will now refresh the skin buff as needed if in combat with a named mob.
* [loot] Exposed the maximum amount of time we will allow LNS to process corpse looting in one iteration as a setting. (Default: 5 seconds, the original hardcoded value).