### PR TITLE
Casting Fix

### DIFF
--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -225,13 +225,6 @@ local _ClassConfig = {
             "Blade of Vesagran",
             "Prismatic Dragon Blade",
         },
-        ['Dreadstone'] = {
-            "Possessed Dreadstone Minstrel's Rapier",
-        },
-        ['SymphonyOfBattle'] = {
-            "Rapier of Somber Notes",
-            "Songblade of the Eternal",
-        },
         ['Coating'] = {
             "Spirit Drinker's Coating",
             "Blood Drinker's Coating",
@@ -890,7 +883,7 @@ local _ClassConfig = {
         {
             name = 'Burn',
             state = 1,
-            steps = 1,
+            steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.BurnCheck()
@@ -935,12 +928,12 @@ local _ClassConfig = {
                 type = "AA",
             },
             {
-                name = "Song of Stone",
-                type = "AA",
-            },
-            {
                 name = "ThousandBlades",
                 type = "Disc",
+            },
+            {
+                name = "Song of Stone",
+                type = "AA",
             },
             {
                 name = "Flurry of Notes",
@@ -994,14 +987,6 @@ local _ClassConfig = {
                 type = "Song",
                 cond = function(self, songSpell)
                     return Config:GetSetting('DoDispel') and mq.TLO.Target.Beneficial() ~= nil
-                end,
-            },
-            {
-                name = "Dreadstone",
-                type = "Item",
-                cond = function(self, itemName, target)
-                    if not Config:GetSetting('UseDreadstone') then return false end
-                    return Casting.DetItemCheck(itemName, target)
                 end,
             },
         },
@@ -1356,14 +1341,6 @@ local _ClassConfig = {
                 end,
                 cond = function(self, songSpell)
                     return not Casting.AuraActiveByName(songSpell.BaseName()) and Config:GetSetting('UseAura') == 2
-                end,
-            },
-            {
-                name = "SymphonyOfBattle",
-                type = "Item",
-                cond = function(self, itemName, target)
-                    if not Config:GetSetting('UseSoBItems') then return false end
-                    return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
             {
@@ -1956,26 +1933,6 @@ local _ClassConfig = {
             FAQ = "What is a Chest Click?",
             Answer = "Most Chest slot items after level 75ish have a clickable effect.\n" ..
                 "BRD is set to use theirs during burns, so long as the item equipped has a clicky effect.",
-        },
-        ['UseSoBItems']         = {
-            DisplayName = "Symph. of Battle",
-            Category = "Equipment",
-            Index = 3,
-            Tooltip = "Click your Symphony of Battle items.",
-            Default = false,
-            ConfigType = "Advanced",
-            FAQ = "What is Symphony of Battle?",
-            Answer = "Symphony of Battle is a clicky group haste effect found on Rapier of Somber Notes or Songblade of the Eternal.",
-        },
-        ['UseDreadstone']       = {
-            DisplayName = "Dreadstone",
-            Category = "Equipment",
-            Index = 4,
-            Tooltip = "Use your Dreadstone when able.",
-            Default = false,
-            ConfigType = "Advanced",
-            FAQ = "What does the Dreadstone option control?",
-            Answer = "Possessed Dreadstone Minstrel's Rapier is a clicky 55% slow item rewarded by the quest \"The Depths of Fear\".",
         },
         ['DoCoating']           = {
             DisplayName = "Use Coating",

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -855,6 +855,9 @@ local _ClassConfig = {
             {
                 name = "RecklessHeal2",
                 type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.SpellLoaded(spell)
+                end,
             },
             {
                 name = "RecklessHeal3",
@@ -1205,7 +1208,7 @@ local _ClassConfig = {
                 type = "Spell",
                 allowDead = true,
                 cond = function(self, spell)
-                    if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
+                    if not Casting.CastReady(spell) or not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
                     return mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -1214,7 +1217,7 @@ local _ClassConfig = {
                 type = "Spell",
                 allowDead = true,
                 cond = function(self, spell, target)
-                    if not Casting.CanUseAA("Luminary's Synergy") or not Config:GetSetting('DoHealOverTime') then return false end
+                    if not Casting.CanUseAA("Luminary's Synergy") or not Config:GetSetting('DoHealOverTime') or not Casting.CastReady(spell) then return false end
                     return Targeting.MobHasLowHP and spell.RankName.Stacks() and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 30
                 end,
             },
@@ -1271,8 +1274,8 @@ local _ClassConfig = {
                 name = "CanniSpell",
                 type = "Spell",
                 cond = function(self, spell)
-                    return Config:GetSetting('DoSpellCanni') and Casting.CastReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
-                        mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
+                    if not Config:GetSetting('DoSpellCanni') or not Casting.CastReady(spell) then return false end
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
             {
@@ -1287,7 +1290,7 @@ local _ClassConfig = {
                 name = "GroupRenewalHoT",
                 type = "Spell",
                 cond = function(self, spell)
-                    if not Casting.CanUseAA("Luminary's Synergy") or not Config:GetSetting('DoHealOverTime') then return false end
+                    if not Casting.CanUseAA("Luminary's Synergy") or not Config:GetSetting('DoHealOverTime') or not Casting.CastReady(spell) then return false end
                     return spell.RankName.Stacks() and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 30
                 end,
             },
@@ -1759,7 +1762,7 @@ local _ClassConfig = {
             Tooltip = "Select the Combat Mode for this Toon",
             Type = "Custom",
             RequiresLoadoutChange = true,
-            Default = 2,
+            Default = 1,
             Min = 1,
             Max = 2,
             FAQ = "What do the different Modes do?",

--- a/utils/event_handlers.lua
+++ b/utils/event_handlers.lua
@@ -142,7 +142,7 @@ local function tooFarHandler()
                 if Combat.OkToEngage(target.ID() or 0) then
                     Core.DoCmd("/squelch /face fast")
 
-                    if Targeting.GetTargetDistance() < (10 and target.MaxRangeTo()) then --not sure if this is necessary or still happening since we changed distance to use 3D.
+                    if Targeting.GetTargetDistance() < (10 and (target.MaxRangeTo() or 10)) then --not sure if this is necessary or still happening since we changed distance to use 3D.
                         Logger.log_debug("Too Far from Target (%s [%d]). Possible flyer detected. Moving back 10.", target.CleanName() or "", target.ID() or 0)
                         Core.DoCmd("/stick 10 moveback uw")
                     else


### PR DESCRIPTION
* Fixed a bug in AA checks that was causing some AA to be bypassed once a cast has started. (Thanks guest01!)

* Further adjusted bard singing check to better handle song cancellation.

* [BRD(Live] - Removed support for Dreadstone/SoB items. These can now be used on the clickies tab if desired.

* [SHM(Live] - Corrected a case in which certain spells would be memorized at inopportune times in hybrid mode (thanks guest01!)

* Added a nil safety in a target range check for the too far handlers. (thanks Coldblooded!)