### PR TITLE
Loot module update

### DIFF
--- a/lib/lootnscoot/lib/Write.lua
+++ b/lib/lootnscoot/lib/Write.lua
@@ -39,6 +39,17 @@ local function GetColorEnd()
     return ''
 end
 
+local function FormatTableOutput(message)
+    local output = ''
+    for k, v in pairs(message) do
+        if output ~= '' then
+            output = output .. '\n\t\t'
+        end
+        output = string.format("%s \ao%s\ax: \at%s\ax", output, k, tostring(v))
+    end
+    return output
+end
+
 local function GetCallerString()
     if Write.loglevels[Write.loglevel:lower()].level > Write.callstringlevel then
         return ''
@@ -83,11 +94,7 @@ function Write.Debug(console, message, ...)
         Output('debug', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('debug', console, dbgMessage)
+        Output('debug', console, FormatTableOutput(message))
     end
 end
 
@@ -106,6 +113,7 @@ function Write.Info(console, message, ...)
             dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
         end
         Output('info', console, dbgMessage)
+        -- Output('info', console, FormatTableOutput(message))        local dbgMessage = ''
     end
 end
 
@@ -119,11 +127,7 @@ function Write.Warn(console, message, ...)
         Output('warn', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('warn', console, dbgMessage)
+        Output('warn', console, FormatTableOutput(message))
     end
 end
 
@@ -137,11 +141,7 @@ function Write.Error(console, message, ...)
         Output('error', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('error', console, dbgMessage)
+        Output('error', console, FormatTableOutput(message))
     end
 end
 
@@ -152,14 +152,10 @@ function Write.Fatal(console, message, ...)
     if type(message) == 'string' then
         if (... ~= nil) then message = string.format(message, ...) end
 
-        Output('error', console, message)
+        Output('fatal', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('error', console, dbgMessage)
+        Output('fatal', console, FormatTableOutput(message))
     end
     Terminate()
 end

--- a/lib/lootnscoot/lib/Write.lua
+++ b/lib/lootnscoot/lib/Write.lua
@@ -43,9 +43,10 @@ local function FormatTableOutput(message)
     local output = ''
     for k, v in pairs(message) do
         if output ~= '' then
-            output = output .. '\n\t\t'
+            --     output = output .. '\n\t\t'
+            -- end
+            output = string.format("%s \ao%s\ax: \at%s\ax", output, k, tostring(v))
         end
-        output = string.format("%s \ao%s\ax: \at%s\ax", output, k, tostring(v))
     end
     return output
 end

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -1,33 +1,37 @@
 -- Sample Basic Class Module
-local mq                 = require('mq')
-local Config             = require('utils.config')
-local Core               = require("utils.core")
-local Casting            = require("utils.casting")
-local Ui                 = require("utils.ui")
-local Comms              = require("utils.comms")
-local Strings            = require("utils.strings")
-local Logger             = require("utils.logger")
-local Files              = require("utils.files")
-local Actors             = require("actors")
-local Set                = require("mq.Set")
-local Icons              = require('mq.ICONS')
-local LootnScootPath     = string.format("%s/lootnscoot/init.lua", mq.luaDir)
-local bundleScriptPath   = string.format("rgmercs/lib/lootnscoot")
-local LootScript         = "lootnscoot"
-local hasLootnScoot      = Files.file_exists(LootnScootPath)
-local url                = "https://www.redguides.com/community/resources/lootnscoot-for-emu.2675/"
+local mq                                = require('mq')
+local Config                            = require('utils.config')
+local Core                              = require("utils.core")
+local Casting                           = require("utils.casting")
+local Ui                                = require("utils.ui")
+local Comms                             = require("utils.comms")
+local Strings                           = require("utils.strings")
+local Logger                            = require("utils.logger")
+local Files                             = require("utils.files")
+local Actors                            = require("actors")
+local Set                               = require("mq.Set")
+local Icons                             = require('mq.ICONS')
+local LootnScootPath                    = string.format("%s/lootnscoot/init.lua", mq.luaDir)
+local bundleScriptPath                  = string.format("rgmercs/lib/lootnscoot")
+local LootScript                        = "lootnscoot"
+local hasLootnScoot                     = Files.file_exists(LootnScootPath)
+local url                               = "https://www.redguides.com/community/resources/lootnscoot-for-emu.2675/"
 
-local Module             = { _version = '0.1a', _name = "Loot", _author = 'Derple, Grimmier, Aquietone (lootnscoot lua)', }
-Module.__index           = Module
-Module.settings          = {}
-Module.DefaultCategories = {}
-Module.ModuleLoaded      = false
-Module.TempSettings      = {}
+local Module                            = { _version = '0.1a', _name = "Loot", _author = 'Derple, Grimmier, Aquietone (lootnscoot lua)', }
+Module.__index                          = Module
+Module.settings                         = {}
+Module.DefaultCategories                = {}
+Module.ModuleLoaded                     = false
+Module.TempSettings                     = {}
+Module.TempSettings.CorpsesToIgnore     = {}
+Module.TempSettings.LootMyCorpse        = false
+Module.TempSettings.IgnoreMyNearCorpses = false
+Module.TempSettings.CombatLooting       = false
 
-Module.FAQ               = {}
-Module.ClassFAQ          = {}
+Module.FAQ                              = {}
+Module.ClassFAQ                         = {}
 
-Module.DefaultConfig     = {
+Module.DefaultConfig                    = {
 	['UseBundled']                             = {
 		DisplayName = "Use Bundled LootNScoot",
 		Category = "Loot N Scoot",
@@ -55,36 +59,36 @@ Module.DefaultConfig     = {
 		FAQ = "I have LootNScoot loaded, why am I not looting?",
 		Answer = "Ensure you have enabled Loot Corpses, and note that Combat Looting is the setting that controls looting while in combat.",
 	},
-	['CombatLooting']                          = {
-		DisplayName = "Combat Looting",
-		Category = "Loot N Scoot",
-		Index = 4,
-		Tooltip = "Enables looting during combat.",
-		Default = false,
-		FAQ = "How do i make sure my guys are looting during combat?, incase I die or something.",
-		Answer = "You can enable [CombatLooting] to loot during combat, I recommend only having one or 2 characters do this and NOT THE MA!!.",
-	},
-	['LNSLootMyCorpse']                        = {
-		DisplayName = "Loot My Corpse",
-		Category = "Loot N Scoot",
-		Index = 5,
-		Tooltip = "Enable LootNScoot to loot your corpse.",
-		Default = false,
-		FAQ = "Why do my guys not loot my corpse?",
-		Answer =
-			"RGMercs will only loot your corpse if you have this setting enabled. If you have a corpse that is outside of the radius, it will not be looted.\n" ..
-			"You can adjust this advanced setting in the Loot options.",
-	},
-	['IgnoreNearbyCorpses']                    = {
-		DisplayName = "Ignore Nearby Corpses",
-		Category = "Loot N Scoot",
-		Index = 6,
-		Tooltip = "Ignore My Corpses that are within the radius of your character.",
-		Default = false,
-		FAQ = "Why do my guys not loot corpses that are close to them?",
-		Answer =
-		"You probably have one of your own corpses nearby, enable [IgnoreNearbyCorpses] to ignore your own corpses that are within the radius of your character.",
-	},
+	-- ['CombatLooting']                          = {
+	-- 	DisplayName = "Combat Looting",
+	-- 	Category = "Loot N Scoot",
+	-- 	Index = 4,
+	-- 	Tooltip = "Enables looting during combat.",
+	-- 	Default = false,
+	-- 	FAQ = "How do i make sure my guys are looting during combat?, incase I die or something.",
+	-- 	Answer = "You can enable [CombatLooting] to loot during combat, I recommend only having one or 2 characters do this and NOT THE MA!!.",
+	-- },
+	-- ['LNSLootMyCorpse']                        = {
+	-- 	DisplayName = "Loot My Corpse",
+	-- 	Category = "Loot N Scoot",
+	-- 	Index = 5,
+	-- 	Tooltip = "Enable LootNScoot to loot your corpse.",
+	-- 	Default = false,
+	-- 	FAQ = "Why do my guys not loot my corpse?",
+	-- 	Answer =
+	-- 		"RGMercs will only loot your corpse if you have this setting enabled. If you have a corpse that is outside of the radius, it will not be looted.\n" ..
+	-- 		"You can adjust this advanced setting in the Loot options.",
+	-- },
+	-- ['IgnoreNearbyCorpses']                    = {
+	-- 	DisplayName = "Ignore Nearby Corpses",
+	-- 	Category = "Loot N Scoot",
+	-- 	Index = 6,
+	-- 	Tooltip = "Ignore My Corpses that are within the radius of your character.",
+	-- 	Default = false,
+	-- 	FAQ = "Why do my guys not loot corpses that are close to them?",
+	-- 	Answer =
+	-- 	"You probably have one of your own corpses nearby, enable [IgnoreNearbyCorpses] to ignore your own corpses that are within the radius of your character.",
+	-- },
 	['LootRespectMedState']                    = {
 		DisplayName = "Respect Med State",
 		Category = "Loot N Scoot",
@@ -132,7 +136,7 @@ Module.DefaultConfig     = {
 	},
 }
 
-Module.FAQ               = {
+Module.FAQ                              = {
 	[1] = {
 		Questions = "How can I set the same settings on all of my characters?",
 		Answer =
@@ -150,11 +154,11 @@ Module.FAQ               = {
 	},
 }
 
-Module.CommandHandlers   = {
+Module.CommandHandlers                  = {
 
 }
 
-Module.DefaultCategories = Set.new({})
+Module.DefaultCategories                = Set.new({})
 for k, v in pairs(Module.DefaultConfig or {}) do
 	if v.Type ~= "Custom" then
 		Module.DefaultCategories:add(v.Category)
@@ -199,40 +203,19 @@ function Module:SaveSettings(doBroadcast)
 				Core.DoCmd("/lua run %s directed rgmercs %s", scriptName, scriptName)
 			end
 
-			if self.TempSettings.LastCombatSetting == nil then
-				self.TempSettings.LastCombatSetting = Config:GetSetting('CombatLooting')
-			end
-
 			if self.TempSettings.LastRadiusSetting == nil then
 				self.TempSettings.LastRadiusSetting = Config:GetSetting('CorpseRadius')
 			end
 
-			if self.TempSettings.LastLootMyCorpseSetting == nil then
-				self.TempSettings.LastLootMyCorpseSetting = Config:GetSetting('LNSLootMyCorpse')
-			end
-
-			if self.TempSettings.LastIgnoreNearbyCorpsesSetting == nil then
-				self.TempSettings.LastIgnoreNearbyCorpsesSetting = Config:GetSetting('IgnoreNearbyCorpses')
-			end
-
-			if (self.TempSettings.LastCombatSetting ~= Config:GetSetting('CombatLooting') or
-					self.TempSettings.LastRadiusSetting ~= Config:GetSetting('CorpseRadius') or
-					self.TempSettings.LastLootMyCorpseSetting ~= Config:GetSetting('LNSLootMyCorpse') or
-					self.TempSettings.LastIgnoreNearbyCorpsesSetting ~= Config:GetSetting('IgnoreNearbyCorpses')) then
-				self.TempSettings.LastCombatSetting = Config:GetSetting('CombatLooting')
+			if self.TempSettings.LastRadiusSetting ~= Config:GetSetting('CorpseRadius') then
 				self.TempSettings.LastRadiusSetting = Config:GetSetting('CorpseRadius')
-				self.TempSettings.LastLootMyCorpseSetting = Config:GetSetting('LNSLootMyCorpse')
-				self.TempSettings.LastIgnoreNearbyCorpsesSetting = Config:GetSetting('IgnoreNearbyCorpses')
 
 				if mq.gettime() - (self.TempSettings.LastSent or 0) > 500 then
 					self.Actor:send({ mailbox = 'lootnscoot', script = scriptName, },
 						{
 							who = Config.Globals.CurLoadedChar,
 							directions = 'setsetting_directed',
-							CombatLooting = Config:GetSetting('CombatLooting'),
 							CorpseRadius = Config:GetSetting('CorpseRadius'),
-							LootMyCorpse = Config:GetSetting('LNSLootMyCorpse'),
-							IgnoreNearby = Config:GetSetting('IgnoreNearbyCorpses'),
 						})
 					self.TempSettings.LastSent = mq.gettime()
 				end
@@ -306,8 +289,7 @@ function Module:Init()
 			local lnsRunning = mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING'
 			if lnsRunning then
 				Core.DoCmd("/lns quit")
-				mq.delay(1) -- give it a moment to stop
-				mq.delay(3000, function() return mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' end)
+				mq.delay(1000, function() return not mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' end)
 			end
 
 			if not hasLootnScoot and not Config:GetSetting('UseBundled') then
@@ -317,8 +299,7 @@ function Module:Init()
 			local scriptName = Config:GetSetting('UseBundled') and bundleScriptPath or LootScript
 
 			Core.DoCmd("/lua run %s directed rgmercs %s", scriptName, scriptName)
-			mq.delay(1) -- give it a moment to start
-			mq.delay(1000, function() return mq.TLO.Lua.Script(scriptName).Status() ~= 'RUNNING' end)
+			mq.delay(3000, function() return mq.TLO.Lua.Script(scriptName).Status() ~= 'RUNNING' end)
 
 			self.Actor:send({ mailbox = 'lootnscoot', script = scriptName, },
 				{ who = Config.Globals.CurLoadedChar, directions = 'getsettings_directed', })
@@ -369,21 +350,21 @@ end
 function Module:DoLooting(combat_state)
 	if not self.TempSettings.Looting then return end
 
-	local maxWait = Config:GetSetting('LootingTimeout') * 1000
+	local maxWait = Config:GetSetting('LootingTimeout')
 	while self.TempSettings.Looting do
 		if combat_state == "Combat" and not Config:GetSetting('CombatLooting') then
-			Logger.log_debug("\ay[LOOT]: Aborting Actions due to combat!")
+			Logger.log_warn("\ay[LOOT]: Aborting Actions due to \arCombat!")
 			if mq.TLO.Window('LootWnd').Open() then mq.TLO.Window('LootWnd').DoClose() end
 			self.TempSettings.Looting = false
 			break
 		end
 
-		mq.delay(20, function() return not self.TempSettings.Looting end)
+		-- changed time check and shotend the delay so event checks can happen more frequently
+		mq.delay(1)
 
-		maxWait = maxWait - 20
-
-		if maxWait <= 0 then
-			Logger.log_debug("\ay[LOOT]: Aborting Actions due to timeout.")
+		if os.clock() - (self.TempSettings.LootCalledAt or 0) > maxWait and mq.TLO.Corpse() == 'FALSE' then
+			Logger.log_warn("\ay[LOOT]: \awLoot Actions\ar Timeout: \ay%s\aw seconds", maxWait)
+			if mq.TLO.Window('LootWnd').Open() then mq.TLO.Window('LootWnd').DoClose() end
 			self.TempSettings.Looting = false
 			break
 		end
@@ -401,10 +382,7 @@ function Module:LootMessageHandler()
 		local RadiusSetting = mail.CorpseRadius or 0
 		local LootMyCorpse = mail.LootMyCorpse
 		local IgnoreNearbyCorpses = mail.IgnoreNearby
-		local currCombatSetting = Config:GetSetting('CombatLooting')
 		local currRadiusSetting = Config:GetSetting('CorpseRadius')
-		local currLootMyCorpse = Config:GetSetting('LNSLootMyCorpse')
-		local currIgnoreNearbyCorpses = Config:GetSetting('IgnoreNearbyCorpses')
 		local needSave = false
 
 		if mail.Bundle ~= nil and who ~= Config.Globals.CurLoadedChar then
@@ -418,32 +396,40 @@ function Module:LootMessageHandler()
 
 		if who ~= Config.Globals.CurLoadedChar then return end
 
+		self.TempSettings.CorpsesToIgnore = mail.CorpsesToIgnore ~= nil and mail.CorpsesToIgnore or {}
+
 		if subject == 'done_looting' or subject == 'done_processing' then
-			Logger.log_verbose("\ay[LOOT]: \atFinishing Looting: \agResuming")
 			self.TempSettings.Looting = false
 		elseif subject == 'processing' then
 			Logger.log_verbose("\ay[LOOT]: \atProcessing Loot Actions")
 			self.TempSettings.Looting = true
 		else
+			-- these settings and values are sent from LNS to help Mercs throttle the number of times we call LNS to loot. (prechecks)
 			if CombatLooting ~= nil then
-				if currCombatSetting ~= CombatLooting then
-					Config:SetSetting('CombatLooting', CombatLooting)
+				if self.TempSettings.CombatLooting ~= CombatLooting then
+					self.TempSettings.CombatLooting = CombatLooting
 					needSave = true
 				end
 			end
+
+			--[[ Radius is synced on both sides, so we aren't haveing mismatch issues where say mercs is higher than lns.
+				Should stop instances where we keep chain calling loot and exiting because LNS doesn't see a corpse in that range.]]
 			if (RadiusSetting or 0) > 0 and currRadiusSetting ~= RadiusSetting then
 				Config:SetSetting('CorpseRadius', RadiusSetting)
 				needSave = true
 			end
+
+			-- LootMyCorpse and IgnoreNearbyCorpses are sent from LNS to help Mercs throttle the number of times we call LNS to loot.
 			if LootMyCorpse ~= nil then
-				if currLootMyCorpse ~= LootMyCorpse then
-					Config:SetSetting('LNSLootMyCorpse', LootMyCorpse)
+				if self.TempSettings.LootMyCorpse ~= LootMyCorpse then
+					self.TempSettings.LootMyCorpse = LootMyCorpse
 					needSave = true
 				end
 			end
+
 			if IgnoreNearbyCorpses ~= nil then
-				if currIgnoreNearbyCorpses ~= IgnoreNearbyCorpses then
-					Config:SetSetting('IgnoreNearbyCorpses', IgnoreNearbyCorpses)
+				if self.TempSettings.IgnoreMyNearCorpses ~= IgnoreNearbyCorpses then
+					self.TempSettings.IgnoreMyNearCorpses = IgnoreNearbyCorpses
 					needSave = true
 				end
 			end
@@ -473,23 +459,58 @@ function Module:GiveTime(combat_state)
 		return
 	end
 
-	local deadCount = mq.TLO.SpawnCount(string.format("npccorpse radius %s zradius 50", Config:GetSetting('CorpseRadius') or 100))()
-	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse \"%s\" radius %s zradius 50", (mq.TLO.Me.CleanName() .. "'s corpse"), Config:GetSetting('CorpseRadius') or 100))()
-	if Config:GetSetting('LNSLootMyCorpse') and myCorpseCount > 0 then deadCount = deadCount + 1 end
+	if mq.TLO.Corpse() == 'TRUE' then
+		mq.TLO.Window('LootWnd').DoClose()
+		Logger.log_debug("\ay[LOOT]: \agLoot Window\ax is \arOpen\ax, \aoClosing it.")
+		return
+	end
+
+	local radiusCorpse = Config:GetSetting('CorpseRadius')
+
+	local deadCount = mq.TLO.SpawnCount(string.format("npccorpse radius %s zradius 50", radiusCorpse))()
+	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse \"%s\" radius %s zradius 50", (mq.TLO.Me.CleanName() .. "'s corpse"), radiusCorpse))()
+
+	-- check the already looted corpses list and if all corpses have been looted, skip the loot actions
+	if deadCount > 0 then
+		local found = true
+		for i = 1, deadCount do
+			local corpse = mq.TLO.NearestSpawn(string.format("%d, npccorpse radius %d zradius 50", i, radiusCorpse))
+			if corpse() then
+				if not self.TempSettings.CorpsesToIgnore[corpse.ID()] then
+					Logger.log_debug("\ay[LOOT]: \ax\at%s\ax Corpse has Not been Looted Yet, \ayPreparing to check corpse.", corpse.CleanName())
+					found = false
+					break
+				end
+			end
+		end
+		if found then
+			Logger.log_debug("\ay[LOOT]: \ax\atAll Corpses\ax have been \agChecked\ax, \aoSkipping Loot Actions.")
+			return
+		end
+	end
+
+	if self.TempSettings.LootMyCorpse and myCorpseCount > 0 then deadCount = deadCount + myCorpseCount end
+
+	--
+	if myCorpseCount > 0 and (not self.TempSettings.IgnoreMyNearCorpses and not self.TempSettings.LootMyCorpse) then
+		Logger.log_debug("\ay[LOOT]: \arYou have a corpse\ax, \aoSkipping Loot Actions.")
+		return
+	end
 
 	if self.Actor == nil then self:LootMessageHandler() end
 	-- send actors message to loot
-	if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then
+	if (combat_state ~= "Combat" or self.TempSettings.CombatLooting) and (deadCount > 0) then
 		if not self.TempSettings.Looting then
 			local scriptName = Config:GetSetting('UseBundled') and bundleScriptPath or LootScript
 			self.Actor:send({ mailbox = 'lootnscoot', script = scriptName, },
-				{ who = Config.Globals.CurLoadedChar, directions = 'doloot', })
+				{ who = Config.Globals.CurLoadedChar, directions = 'doloot', limit = 1, })
 			self.TempSettings.Looting = true
+			self.TempSettings.LootCalledAt = os.clock()
 		end
 	end
 
 	if self.TempSettings.Looting then
-		Logger.log_verbose("\ay[LOOT]: \aoPausing for \atLoot Actions")
+		Logger.log_verbose("\ay[LOOT]: \aoPausing for \atLoot Actions\aw, \aoCombat State\ax: [\at%s\ax]", combat_state)
 		self:DoLooting(combat_state)
 	end
 end

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -295,7 +295,7 @@ function Module:Init()
 	self:LootMessageHandler()
 
 	self:LoadSettings()
-	if not hasLootnScoot then
+	if not hasLootnScoot and not Config:GetSetting('UseBundled') then
 		Logger.log_error("\ay[LOOT]: \arLootNScoot is not installed, please install it to use this module.")
 	end
 	if not Core.OnEMU() then
@@ -310,7 +310,7 @@ function Module:Init()
 				mq.delay(3000, function() return mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' end)
 			end
 
-			if not hasLootnScoot then
+			if not hasLootnScoot and not Config:GetSetting('UseBundled') then
 				Config:SetSetting('UseBundled', true)
 			end
 
@@ -344,7 +344,7 @@ function Module:Render()
 		Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
 		ImGui.NewLine()
 	end
-	if hasLootnScoot then
+	if hasLootnScoot or Config:GetSetting('UseBundled') then
 		local pressed = false
 		if ImGui.CollapsingHeader("Config Options") then
 			self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -7,18 +7,20 @@ local Ui                 = require("utils.ui")
 local Comms              = require("utils.comms")
 local Strings            = require("utils.strings")
 local Logger             = require("utils.logger")
+local Files              = require("utils.files")
 local Actors             = require("actors")
 local Set                = require("mq.Set")
 local Icons              = require('mq.ICONS')
-local LootnScootPath     = string.format("\"%s/rgmercs/lib/lootnscoot\"", mq.luaDir)
-local LootScript         = "rgmercs/lib/lootnscoot"
-local sNameStripped      = string.gsub(mq.TLO.EverQuest.Server(), ' ', '_')
+local LootnScootPath     = string.format("%s/lootnscoot/init.lua", mq.luaDir)
+local bundleScriptPath   = string.format("rgmercs/lib/lootnscoot")
+local LootScript         = "lootnscoot"
+local hasLootnScoot      = Files.file_exists(LootnScootPath)
+local url                = "https://www.redguides.com/community/resources/lootnscoot-for-emu.2675/"
 
 local Module             = { _version = '0.1a', _name = "Loot", _author = 'Derple, Grimmier, Aquietone (lootnscoot lua)', }
 Module.__index           = Module
 Module.settings          = {}
 Module.DefaultCategories = {}
-
 Module.ModuleLoaded      = false
 Module.TempSettings      = {}
 
@@ -26,10 +28,19 @@ Module.FAQ               = {}
 Module.ClassFAQ          = {}
 
 Module.DefaultConfig     = {
+	['UseBundled']                             = {
+		DisplayName = "Use Bundled LootNScoot",
+		Category = "Loot N Scoot",
+		Index = 1,
+		Tooltip = "Use the bundled LootNScoot script instead of the one installed in your MQ Lua directory.",
+		Default = not hasLootnScoot,
+		FAQ = "What is this silver coin thing? How do I turn it off?",
+		Answer = "The silver coin is our integration of LootNScoot, looting automation for Emu. It can be disabled as you choose.",
+	},
 	['DoLoot']                                 = {
 		DisplayName = "Load LootNScoot",
 		Category = "Loot N Scoot",
-		Index = 1,
+		Index = 2,
 		Tooltip = "Load the integrated LootNScoot in directed mode. Turning this off will unload the looting script.",
 		Default = true,
 		FAQ = "What is this silver coin thing? How do I turn it off?",
@@ -38,7 +49,7 @@ Module.DefaultConfig     = {
 	['LootCorpses']                            = {
 		DisplayName = "Loot Corpses",
 		Category = "Loot N Scoot",
-		Index = 2,
+		Index = 3,
 		Tooltip = "Enable LootNScoot to loot corpses for you.",
 		Default = true,
 		FAQ = "I have LootNScoot loaded, why am I not looting?",
@@ -47,16 +58,37 @@ Module.DefaultConfig     = {
 	['CombatLooting']                          = {
 		DisplayName = "Combat Looting",
 		Category = "Loot N Scoot",
-		Index = 3,
+		Index = 4,
 		Tooltip = "Enables looting during combat.",
 		Default = false,
 		FAQ = "How do i make sure my guys are looting during combat?, incase I die or something.",
 		Answer = "You can enable [CombatLooting] to loot during combat, I recommend only having one or 2 characters do this and NOT THE MA!!.",
 	},
+	['LNSLootMyCorpse']                        = {
+		DisplayName = "Loot My Corpse",
+		Category = "Loot N Scoot",
+		Index = 5,
+		Tooltip = "Enable LootNScoot to loot your corpse.",
+		Default = false,
+		FAQ = "Why do my guys not loot my corpse?",
+		Answer =
+			"RGMercs will only loot your corpse if you have this setting enabled. If you have a corpse that is outside of the radius, it will not be looted.\n" ..
+			"You can adjust this advanced setting in the Loot options.",
+	},
+	['IgnoreNearbyCorpses']                    = {
+		DisplayName = "Ignore Nearby Corpses",
+		Category = "Loot N Scoot",
+		Index = 6,
+		Tooltip = "Ignore My Corpses that are within the radius of your character.",
+		Default = false,
+		FAQ = "Why do my guys not loot corpses that are close to them?",
+		Answer =
+		"You probably have one of your own corpses nearby, enable [IgnoreNearbyCorpses] to ignore your own corpses that are within the radius of your character.",
+	},
 	['LootRespectMedState']                    = {
 		DisplayName = "Respect Med State",
 		Category = "Loot N Scoot",
-		Index = 4,
+		Index = 7,
 		Tooltip = "Hold looting if you are currently meditating.",
 		Default = false,
 		FAQ = "Why is the PC sitting there and not medding?",
@@ -66,15 +98,28 @@ Module.DefaultConfig     = {
 	['LootingTimeout']                         = {
 		DisplayName = "Looting Timeout",
 		Category = "Loot N Scoot",
-		Index = 5,
+		Index = 8,
 		Tooltip = "The length of time in seconds that RGMercs will allow LNS to process loot actions in a single check.",
 		Default = 5,
 		Min = 1,
-		Max = 10,
+		Max = 60,
 		FAQ = "Why do my guys take too long to loot, or sometimes miss corpses?",
 		Answer =
 			"While RGMercs doesn't necessary control what LNS is doing, exactly, we do have a timeout setting that dictates how long we will allow it to do it before re-checking for other actions. \n" ..
 			"You can adjust this advanced setting in the Loot options. Please note, if no other actions are required by mercs, we will simply allow LNS to continue.",
+	},
+	['CorpseRadius']                           = {
+		DisplayName = "Loot Corpse Radius",
+		Category = "Loot N Scoot",
+		Index = 9,
+		Tooltip = "The radius we will check for corpses to loot in.",
+		Default = 100,
+		Min = 10,
+		Max = 500,
+		FAQ = "Why do my guys not loot corpses that are close to them?",
+		Answer =
+			"RGMercs will only loot corpses that are within the radius you set here. If you have a corpse that is outside of this radius, it will not be looted.\n" ..
+			"You can adjust this advanced setting in the Loot options.",
 	},
 	[string.format("%s_Popped", Module._name)] = {
 		DisplayName = Module._name .. " Popped",
@@ -90,17 +135,17 @@ Module.DefaultConfig     = {
 Module.FAQ               = {
 	[1] = {
 		Questions = "How can I set the same settings on all of my characters?",
-		Answer = "You can copy your Loot_Server_Name_CharName_CLASS.lua and rename them for the other characters.\n\n" ..
-			"Example: Loot_Project_Lazarus_Grimmier_CLR.lua\n\n" ..
-			"We may add an option at a later date to copy settings from one character to another directly.",
+		Answer =
+		"Inside the Settings section of the LootNScoot GUI you can edit any other character loaded on that PC directly or even clone one set to other characters for faster copying.",
 		Settings_Used = "DoLoot",
 	},
 	[2] = {
-		Question = "What is the difference between GlobalItem and NormalItem?",
+		Question = "What is the difference between Personal, Global, and Normal Rules?",
 		Answer =
-			"GlobalItem is a setting that will always be used for that item.\nNormalItem is a setting that will be used for that item unless it is set as a GlobalItem.\n" ..
-			"NormalItem settings are evaluated each time if you have [AlwaysEval] turned on, which can change your setting if the item no longer meets the criteria.\n" ..
-			"Setting an items as a GlobalItem will prevent it from being re-evaluated and always use the GlobalItem setting.",
+			"Personal Rules are settings that are only used for that character, and will not be used by any other character These Rules OVERRIDE all other rules!\n" ..
+			"Global is a setting that will always be used for that item.\nNormal is a setting that will be used for that item unless it is set as a Global or Personal Rule.\n" ..
+			"Normal settings are evaluated each time if you have [AlwaysEval] turned on, which can change your setting if the item no longer meets the criteria.\n" ..
+			"Setting an items as a Global will prevent it from being re-evaluated and always use the Global setting.",
 		Settings_Used = "GlobalLootOn",
 	},
 }
@@ -127,25 +172,73 @@ local function getConfigFileName()
 end
 
 function Module:SaveSettings(doBroadcast)
+	if not hasLootnScoot then Config:SetSetting('UseBundled', true) end
 	mq.pickle(getConfigFileName(), self.settings)
 	if self.SettingsLoaded then
+		local scriptName = Config:GetSetting('UseBundled') and bundleScriptPath or LootScript
+
 		if self.settings.DoLoot == true then
-			local lnsRunning = mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' or false
-			local localLNSRunning = mq.TLO.Lua.Script(LootScript).Status() == 'RUNNING' or false
-			if lnsRunning then
-				Core.DoCmd("/lua stop lootnscoot")
+			local LocalLNSRunning = false
+
+			if not self.Actor then self:LootMessageHandler() end
+
+			if self.TempSettings.LastScript ~= scriptName then
+				Logger.log_debug("\ay[LOOT]: \arStopping previous LootNScoot script: %s", self.TempSettings.LastScript)
+				Core.DoCmd("/lua stop %s", self.TempSettings.LastScript)
+
+				self.TempSettings.LastScript = scriptName
+
+				self.Actor:send({ mailbox = 'loot_module', script = 'rgmercs', },
+					{ Who = Config.Globals.CurLoadedChar, Bundle = Config:GetSetting('UseBundled'), })
 			end
 
-			if not localLNSRunning then
-				Core.DoCmd("/lua run %s directed rgmercs", LootnScootPath)
+			LocalLNSRunning = mq.TLO.Lua.Script(scriptName).Status() == 'RUNNING' or false
+
+			if not LocalLNSRunning then
+				Logger.log_debug("\ay[LOOT]: \agStarting LootNScoot script: %s", scriptName)
+				Core.DoCmd("/lua run %s directed rgmercs %s", scriptName, scriptName)
 			end
 
-			if not self.Actor then Module:LootMessageHandler() end
+			if self.TempSettings.LastCombatSetting == nil then
+				self.TempSettings.LastCombatSetting = Config:GetSetting('CombatLooting')
+			end
 
-			self.Actor:send({ mailbox = 'lootnscoot', script = LootScript, },
-				{ who = Config.Globals.CurLoadedChar, directions = 'combatlooting', CombatLooting = self.settings.CombatLooting, })
+			if self.TempSettings.LastRadiusSetting == nil then
+				self.TempSettings.LastRadiusSetting = Config:GetSetting('CorpseRadius')
+			end
+
+			if self.TempSettings.LastLootMyCorpseSetting == nil then
+				self.TempSettings.LastLootMyCorpseSetting = Config:GetSetting('LNSLootMyCorpse')
+			end
+
+			if self.TempSettings.LastIgnoreNearbyCorpsesSetting == nil then
+				self.TempSettings.LastIgnoreNearbyCorpsesSetting = Config:GetSetting('IgnoreNearbyCorpses')
+			end
+
+			if (self.TempSettings.LastCombatSetting ~= Config:GetSetting('CombatLooting') or
+					self.TempSettings.LastRadiusSetting ~= Config:GetSetting('CorpseRadius') or
+					self.TempSettings.LastLootMyCorpseSetting ~= Config:GetSetting('LNSLootMyCorpse') or
+					self.TempSettings.LastIgnoreNearbyCorpsesSetting ~= Config:GetSetting('IgnoreNearbyCorpses')) then
+				self.TempSettings.LastCombatSetting = Config:GetSetting('CombatLooting')
+				self.TempSettings.LastRadiusSetting = Config:GetSetting('CorpseRadius')
+				self.TempSettings.LastLootMyCorpseSetting = Config:GetSetting('LNSLootMyCorpse')
+				self.TempSettings.LastIgnoreNearbyCorpsesSetting = Config:GetSetting('IgnoreNearbyCorpses')
+
+				if mq.gettime() - (self.TempSettings.LastSent or 0) > 500 then
+					self.Actor:send({ mailbox = 'lootnscoot', script = scriptName, },
+						{
+							who = Config.Globals.CurLoadedChar,
+							directions = 'setsetting_directed',
+							CombatLooting = Config:GetSetting('CombatLooting'),
+							CorpseRadius = Config:GetSetting('CorpseRadius'),
+							LootMyCorpse = Config:GetSetting('LNSLootMyCorpse'),
+							IgnoreNearby = Config:GetSetting('IgnoreNearbyCorpses'),
+						})
+					self.TempSettings.LastSent = mq.gettime()
+				end
+			end
 		else
-			Core.DoCmd("/lua stop %s", LootnScootPath)
+			Core.DoCmd("/lua stop %s", scriptName)
 		end
 	end
 	if doBroadcast == true then
@@ -157,19 +250,22 @@ function Module:LoadSettings()
 	Logger.log_debug("\ay[LOOT]: \atLootnScoot EMU, Loot Module Loading Settings for: %s.",
 		Config.Globals.CurLoadedChar)
 	local settings_pickle_path = getConfigFileName()
-
+	local needsSave = false
 	local config, err = loadfile(settings_pickle_path)
 	if err or not config then
 		Logger.log_error("\ay[LOOT]: \aoUnable to load global settings file(%s), creating a new one!",
 			settings_pickle_path)
 		self.settings.MyCheckbox = false
-		self:SaveSettings(false)
+		needsSave = true
 	else
 		self.settings = config()
 	end
 
-	local needsSave = false
 	self.settings, needsSave = Config.ResolveDefaults(Module.DefaultConfig, self.settings)
+
+	if self.TempSettings.LastScript == nil then
+		self.TempSettings.LastScript = self.settings.UseBundled and bundleScriptPath or LootScript
+	end
 
 	Logger.log_debug("Settings Changes = %s", Strings.BoolToColorString(needsSave))
 	if needsSave then
@@ -196,8 +292,12 @@ function Module.New()
 end
 
 function Module:Init()
-	self:LoadSettings()
 	self:LootMessageHandler()
+
+	self:LoadSettings()
+	if not hasLootnScoot then
+		Logger.log_error("\ay[LOOT]: \arLootNScoot is not installed, please install it to use this module.")
+	end
 	if not Core.OnEMU() then
 		Logger.log_debug("\ay[LOOT]: \agWe are not on EMU unloading module. Build: %s",
 			mq.TLO.MacroQuest.BuildName())
@@ -205,12 +305,23 @@ function Module:Init()
 		if self.settings.DoLoot then
 			local lnsRunning = mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING'
 			if lnsRunning then
-				Core.DoCmd("/lua stop lootnscoot")
-				mq.delay(1000, function() return mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' end)
+				Core.DoCmd("/lns quit")
+				mq.delay(1) -- give it a moment to stop
+				mq.delay(3000, function() return mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' end)
 			end
-			Core.DoCmd("/lua run %s directed rgmercs", LootnScootPath)
-			self.Actor:send({ mailbox = 'lootnscoot', script = LootScript, },
-				{ who = Config.Globals.CurLoadedChar, directions = 'getcombatsetting', })
+
+			if not hasLootnScoot then
+				Config:SetSetting('UseBundled', true)
+			end
+
+			local scriptName = Config:GetSetting('UseBundled') and bundleScriptPath or LootScript
+
+			Core.DoCmd("/lua run %s directed rgmercs %s", scriptName, scriptName)
+			mq.delay(1) -- give it a moment to start
+			mq.delay(1000, function() return mq.TLO.Lua.Script(scriptName).Status() ~= 'RUNNING' end)
+
+			self.Actor:send({ mailbox = 'lootnscoot', script = scriptName, },
+				{ who = Config.Globals.CurLoadedChar, directions = 'getsettings_directed', })
 		end
 		self.TempSettings.Looting = false
 		--pass settings to lootnscoot lib
@@ -228,75 +339,130 @@ function Module:Render()
 	if not self.settings[self._name .. "_Popped"] then
 		if ImGui.SmallButton(Icons.MD_OPEN_IN_NEW) then
 			self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-			self:SaveSettings(false)
+			self.TempSettings.NeedSave = true
 		end
 		Ui.Tooltip(string.format("Pop the %s tab out into its own window.", self._name))
 		ImGui.NewLine()
 	end
-	local pressed = false
-	if ImGui.CollapsingHeader("Config Options") then
-		self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,
-			self.DefaultCategories)
+	if hasLootnScoot then
+		local pressed = false
+		if ImGui.CollapsingHeader("Config Options") then
+			self.settings, pressed, _ = Ui.RenderSettings(self.settings, self.DefaultConfig,
+				self.DefaultCategories)
+		end
 		if pressed then
-			self:SaveSettings(false)
+			self.TempSettings.NeedSave = true
+		end
+	else
+		ImGui.Text("Please install LootNScoot to use this module.")
+		if ImGui.Button("Copy Link to LootNScoot") then
+			ImGui.SetClipboardText(url)
 		end
 	end
 end
 
 function Module:Pop()
 	self.settings[self._name .. "_Popped"] = not self.settings[self._name .. "_Popped"]
-	self:SaveSettings(false)
+	self.TempSettings.NeedSave = true
 end
 
-function Module.DoLooting(combat_state)
-	if not Module.TempSettings.Looting then return end
+function Module:DoLooting(combat_state)
+	if not self.TempSettings.Looting then return end
 
 	local maxWait = Config:GetSetting('LootingTimeout') * 1000
-	while Module.TempSettings.Looting do
+	while self.TempSettings.Looting do
 		if combat_state == "Combat" and not Config:GetSetting('CombatLooting') then
 			Logger.log_debug("\ay[LOOT]: Aborting Actions due to combat!")
 			if mq.TLO.Window('LootWnd').Open() then mq.TLO.Window('LootWnd').DoClose() end
-			Module.TempSettings.Looting = false
+			self.TempSettings.Looting = false
 			break
 		end
 
-		mq.delay(20, function() return not Module.TempSettings.Looting end)
+		mq.delay(20, function() return not self.TempSettings.Looting end)
 
 		maxWait = maxWait - 20
 
 		if maxWait <= 0 then
 			Logger.log_debug("\ay[LOOT]: Aborting Actions due to timeout.")
-			Module.TempSettings.Looting = false
+			self.TempSettings.Looting = false
 			break
 		end
 		mq.doevents()
 	end
-	Logger.log_verbose("\ay[LOOT]: \atFinished or Aborted Looting: \agResuming")
+	Logger.log_verbose("\ay[LOOT]: \atFinished Looting: \agResuming")
 end
 
 function Module:LootMessageHandler()
 	self.Actor = Actors.register('loot_module', function(message)
-		local mail = message()
+		local mail = message() or {}
 		local subject = mail.Subject or ''
 		local who = mail.Who or ''
-		local CombatLooting = mail.CombatLooting or false
-		local currSetting = Config:GetSetting('CombatLooting')
+		local CombatLooting = mail.CombatLooting
+		local RadiusSetting = mail.CorpseRadius or 0
+		local LootMyCorpse = mail.LootMyCorpse
+		local IgnoreNearbyCorpses = mail.IgnoreNearby
+		local currCombatSetting = Config:GetSetting('CombatLooting')
+		local currRadiusSetting = Config:GetSetting('CorpseRadius')
+		local currLootMyCorpse = Config:GetSetting('LNSLootMyCorpse')
+		local currIgnoreNearbyCorpses = Config:GetSetting('IgnoreNearbyCorpses')
+		local needSave = false
+
+		if mail.Bundle ~= nil and who ~= Config.Globals.CurLoadedChar then
+			if mail.Bundle ~= Config:GetSetting('UseBundled') then
+				Logger.log_debug("\ay[LOOT]: \aoSetting UseBundled to %s", mail.Bundle and "\agOn" or "\arOff")
+				Config:SetSetting('UseBundled', mail.Bundle)
+				-- Core.DoCmd("/lns quit")
+				needSave = true
+			end
+		end
 
 		if who ~= Config.Globals.CurLoadedChar then return end
 
-		if currSetting ~= CombatLooting then
-			Config:SetSetting('CombatLooting', CombatLooting)
+		if subject == 'done_looting' or subject == 'done_processing' then
+			Logger.log_verbose("\ay[LOOT]: \atFinishing Looting: \agResuming")
+			self.TempSettings.Looting = false
+		elseif subject == 'processing' then
+			Logger.log_verbose("\ay[LOOT]: \atProcessing Loot Actions")
+			self.TempSettings.Looting = true
+		else
+			if CombatLooting ~= nil then
+				if currCombatSetting ~= CombatLooting then
+					Config:SetSetting('CombatLooting', CombatLooting)
+					needSave = true
+				end
+			end
+			if (RadiusSetting or 0) > 0 and currRadiusSetting ~= RadiusSetting then
+				Config:SetSetting('CorpseRadius', RadiusSetting)
+				needSave = true
+			end
+			if LootMyCorpse ~= nil then
+				if currLootMyCorpse ~= LootMyCorpse then
+					Config:SetSetting('LNSLootMyCorpse', LootMyCorpse)
+					needSave = true
+				end
+			end
+			if IgnoreNearbyCorpses ~= nil then
+				if currIgnoreNearbyCorpses ~= IgnoreNearbyCorpses then
+					Config:SetSetting('IgnoreNearbyCorpses', IgnoreNearbyCorpses)
+					needSave = true
+				end
+			end
 		end
 
-		if subject == ('done_looting' or 'done_processing') then
-			Module.TempSettings.Looting = false
-		elseif subject == 'processing' then
-			Module.TempSettings.Looting = true
+		if needSave then
+			Logger.log_debug("\ay[LOOT]: \agUpdating Loot Settings for %s", Config.Globals.CurLoadedChar)
+			self.TempSettings.NeedSave = true
 		end
 	end)
 end
 
 function Module:GiveTime(combat_state)
+	if self.TempSettings.NeedSave then
+		self:SaveSettings(false)
+		self.TempSettings.NeedSave = false
+		Logger.log_debug("\ay[LOOT]: \agSettings Saved for %s", Config.Globals.CurLoadedChar)
+	end
+
 	if not Config:GetSetting('DoLoot') or not Config:GetSetting('LootCorpses') then return end
 	if Config.Globals.PauseMain then return end
 
@@ -307,15 +473,16 @@ function Module:GiveTime(combat_state)
 		return
 	end
 
-	local deadCount = mq.TLO.SpawnCount("npccorpse radius 100 zradius 50")()
-	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Me.CleanName()))()
-	if myCorpseCount > 0 then deadCount = deadCount + 1 end
+	local deadCount = mq.TLO.SpawnCount(string.format("npccorpse radius %s zradius 50", Config:GetSetting('CorpseRadius') or 100))()
+	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse \"%s\" radius %s zradius 50", (mq.TLO.Me.CleanName() .. "'s corpse"), Config:GetSetting('CorpseRadius') or 100))()
+	if Config:GetSetting('LNSLootMyCorpse') and myCorpseCount > 0 then deadCount = deadCount + 1 end
 
 	if self.Actor == nil then self:LootMessageHandler() end
 	-- send actors message to loot
 	if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then
 		if not self.TempSettings.Looting then
-			self.Actor:send({ mailbox = 'lootnscoot', script = 'rgmercs/lib/lootnscoot', },
+			local scriptName = Config:GetSetting('UseBundled') and bundleScriptPath or LootScript
+			self.Actor:send({ mailbox = 'lootnscoot', script = scriptName, },
 				{ who = Config.Globals.CurLoadedChar, directions = 'doloot', })
 			self.TempSettings.Looting = true
 		end
@@ -323,7 +490,7 @@ function Module:GiveTime(combat_state)
 
 	if self.TempSettings.Looting then
 		Logger.log_verbose("\ay[LOOT]: \aoPausing for \atLoot Actions")
-		Module.DoLooting(combat_state)
+		self:DoLooting(combat_state)
 	end
 end
 
@@ -378,7 +545,8 @@ end
 
 function Module:Shutdown()
 	Logger.log_debug("\ay[LOOT]: \axEMU Loot Module Unloaded.")
-	Core.DoCmd("/lua stop %s", LootnScootPath)
+	local scriptName = Config:GetSetting('UseBundled') and bundleScriptPath or LootScript
+	Core.DoCmd("/lua stop %s", scriptName)
 end
 
 return Module


### PR DESCRIPTION
* Added more settings to the window (shared back and forth with LNS)
* you can toggle between bundled lns and standalone lns

In the Future this means LNS can be unbundled from RGMercs and save on maintaining 2 versions

LNS Update

* Added New setting `IgnoreMyNearCorpses` for those servers where you keep your gear on death.
* Added `SafeZones` see Settings panel We will NOT try to loot if in a `SafeZone`.
* Added Tooltips to the settings
* Added a button to the GUI to toggle Debug spam
* Another pass on directed mode.
* Another pass on loot rule checks (hopefully this fixes the occasional looting of `NoDrop` by the wrong class, looking good so far in testing)
* Performance pass on Actors messaging to cut down on how often messages are sent trimming duplicate sending.

Directed Mode Adjustments

* Added 3rd argument when launching for the scripts location (default `YourScriptName/lib/lootnscoot`) you can also just pass `lootnscoot` to have your script call LNS from its native install if it exists.
  * `/lua run ScriptPath directed DirectorName ScriptPath` where:
    * `ScriptPath` is `lootnscoot` for the standalone as arguments 1 and 3 or your bundled path.  If bundled and not specified in the 3rd argument then it defaults to  `DirectorName/lib/lootnscoot` 
    * `DirectorName` is the name of your script you are calling this from (name of folder in the lua dir)
   * If loading the default lootnscoot you should always add the 3rd field `lootnscoot`.
  * example from RGMercs Lua: In this example we also allow the user to choose which to load if they have LNS installed and the bundled version.
 ```
local Files                             = require('mq.Utils') -- has file exists function
local hasLootnScoot      = Files.File.Exists(string.format("%s/lootnscoot/init.lua", mq.luaDir)) -- check if they have lootnscoot installed
local bundleScriptPath   = string.format("rgmercs/lib/lootnscoot") -- set the bundled path
local LootScript         = "lootnscoot" -- default lootnscoot script name ie `/lua/lootnscoot` foldername
local scriptName = (Config:GetSetting('UseBundled') and hasLootnScoot) and bundleScriptPath or LootScript
mq.cmdf("/lua run %s directed rgmercs %s", scriptName, scriptName) -- call the script, by passing the 3rd argument we can use this in Actors mailbox addressing to refine the correct mailbox.
-- If you leave the 3rd one blank we will default to `DirectorName/lib/lootnscoot` if loading the default lootnscoot you should always add the 3rd field.
```
  * This should make it easier to maintain LNS in a script that is bundling it, by allowing  you to not have to bundle it
  * Saves on maintaining a copy every time LNS is updated.
* Added some more settings to be passed over actors to the `DirectingScript` so you can toggle them from both GUI's if you wanted.
