### PR TITLE
BST/WIZ (Laz)

### DIFF
--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -498,7 +498,7 @@ return {
                 name = "BloodDot",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') then return false end
+                    if not Config:GetSetting('DoDot') or (Config:GetSetting('DotNamedOnly') and not Targeting.IsNamed(target)) then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
@@ -506,7 +506,7 @@ return {
                 name = "EndemicDot",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') then return false end
+                    if not Config:GetSetting('DoDot') or (Config:GetSetting('DotNamedOnly') and not Targeting.IsNamed(target)) then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
@@ -602,7 +602,7 @@ return {
                 cond = function(self, spell, target)
                     -- Only use the single target versions on classes that need it
                     if (spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target) then return false end
-                    return Casting.GroupBuffCheck(spell, target)
+                    return Casting.GroupBuffCheck(spell, target) and not Casting.TargetHasBuff("Brell's Vibrant Barricade", target, true)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -446,35 +446,13 @@ return {
                 type = "AA",
             },
             {
-                name = "Volatile Mana Blaze",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoManaBurn') or mq.TLO.Me.PctAggro() > 70 then return false end
-                    return not Casting.TargetHasBuff(aaName) and Casting.HaveManaToNuke()
+                name_func = function(self)
+                    return Casting.GetFirstAA({ "Volatile Mana Blaze", "Mana Blaze", "Mana Blast", "Mana Burn", })
                 end,
-            },
-            {
-                name = "Mana Blaze",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoManaBurn') or mq.TLO.Me.PctAggro() > 70 then return false end
-                    return not Casting.TargetHasBuff(aaName) and Casting.HaveManaToNuke()
-                end,
-            },
-            {
-                name = "Mana Blast",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoManaBurn') or mq.TLO.Me.PctAggro() > 70 then return false end
-                    return not Casting.TargetHasBuff(aaName) and Casting.HaveManaToNuke()
-                end,
-            },
-            {
-                name = "Mana Burn",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoManaBurn') or mq.TLO.Me.PctAggro() > 70 then return false end
-                    return not Casting.TargetHasBuff(aaName) and Casting.HaveManaToNuke()
+                    if not Config:GetSetting('DoManaBurn') then return false end
+                    return Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() < 70 and Casting.HaveManaToNuke() and not mq.TLO.Target.FindBuff("detspa 350")()
                 end,
             },
             {
@@ -950,7 +928,7 @@ return {
             DisplayName = "Use Mana Burn AA",
             Category = "Damage",
             Index = 2,
-            Tooltip = "Enable usage of Mana Burn",
+            Tooltip = "Enable usage of the Mana Burn series of AA.",
             Default = true,
             FAQ = "Can I use Mana Burn?",
             Answer = "Yes, you can enable [DoManaBurn] to use Mana Burn when it is available.",


### PR DESCRIPTION
[BST-Laz]
* We will now respect the setting to DoT only named.
* Hardcoded workaround for improper stacking reporting for Spiritual Vitality. 

[WIZ-Laz]
* Consolidated all Mana Burn style AA and limited their use to named.