### PR TITLE
Casting, Laz Adjustments

### DIFF
--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -491,7 +491,15 @@ return {
                 type = "AA",
                 cond = function(self, aaName)
                     if not Config:GetSetting('DoParagon') then return false end
-                    return (mq.TLO.Group.LowMana(Config:GetSetting('ParaPct'))() or -1) > 0
+                    return Casting.GroupLowManaCount(Config:GetSetting('ParaPct')) > 0
+                end,
+            },
+            {
+                name = "Tome of Nife's Mercy",
+                type = "Item",
+                load_cond = function(self) return mq.TLO.FindItem("=Tome of Nife's Mercy")() end,
+                cond = function(self, itemName, target)
+                    return Casting.GroupLowManaCount(Config:GetSetting('ParaPct')) > 1
                 end,
             },
             {
@@ -809,7 +817,7 @@ return {
             Category = "Mana Mgmt.",
             Index = 2,
             Tooltip = "Minimum mana % before we use Paragon of Spirit.",
-            Default = 80,
+            Default = 50,
             Min = 1,
             Max = 99,
             ConfigType = "Advanced",

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -697,7 +697,15 @@ local _ClassConfig = {
                 name = "Fundament: Second Spire of Enchantment",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return ((mq.TLO.Group.LowMana(30)() or 0) + (mq.TLO.Me.PctMana() < 30 and 1 or 0)) > 1
+                    return Casting.GroupLowManaCount(30) > 1
+                end,
+            },
+            {
+                name = "Tome of Nife's Mercy",
+                type = "Item",
+                load_cond = function(self) return mq.TLO.FindItem("=Tome of Nife's Mercy")() end,
+                cond = function(self, itemName, target)
+                    return Casting.GroupLowManaCount(50) > 1
                 end,
             },
             {

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -696,6 +696,11 @@ return {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
+            {
+                name = "Forsaken Fungus Covered Scale Tunic",
+                type = "Item",
+                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
+            },
             { --Note that on named we may already have a defensive disc running already, could make this remove other discs, but we have other options.
                 name = "BlockDisc",
                 type = "Disc",
@@ -959,6 +964,14 @@ return {
             {
                 name = "Slam",
                 type = "Ability",
+            },
+            {
+                name = "Forsaken Fungus Covered Scale Tunic",
+                type = "Item",
+                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
+                cond = function(self, itemName, target)
+                    return mq.TLO.Me.PctMana() < 30 or mq.TLO.Me.PctEndurance() < 30
+                end,
             },
         },
         ['Weapon Management'] = {

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -5,7 +5,6 @@
 
 local mq        = require('mq')
 local Config    = require('utils.config')
-local Modules   = require("utils.modules")
 local Targeting = require("utils.targeting")
 local Casting   = require("utils.casting")
 local Core      = require("utils.core")
@@ -541,6 +540,14 @@ return {
                 load_cond = function(self) return not Casting.CanUseAA("Harvest of Druzzil") end,
                 allowDead = true,
                 cond = function(self)
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct')
+                end,
+            },
+            {
+                name = "Forsaken Fungus Covered Scale Tunic",
+                type = "Item",
+                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
+                cond = function(self, itemName, target)
                     return mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct')
                 end,
             },

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1030,7 +1030,7 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, overrideWa
 
         Casting.ActionPrep()
 
-        retryCount = retryCount or 3
+        retryCount = retryCount or 2
 
         if targetId > 0 then
             Targeting.SetTarget(targetId, true)
@@ -1320,7 +1320,7 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
         Targeting.SetTarget(targetId, true)
     end
 
-    retryCount = retryCount or 3
+    retryCount = retryCount or 2
     local cmd = string.format("/alt act %d", aaAbility.ID())
 
     Logger.log_debug("\ayUseAA():Activating AA: '%s' [t: %dms]", cmd, aaAbility.Spell.MyCastTime())
@@ -1752,6 +1752,24 @@ function Casting.ClickModRod()
             return
         end
     end
+
+    --- Function to tally up the players who have mana under the passed percent. Accounts for the fact that LowMana does not include the pc on emu.
+    function GroupLowManaCount(percent)
+        local count = mq.TLO.Group.LowMana(percent or 50)() or 0
+        if Core.OnEMU() then
+            count = count + (mq.TLO.Me.PctMana() < (percent or 50) and 1 or 0)
+        end
+        return count
+    end
+end
+
+--- Function to tally up the players who have mana under the passed percent. Accounts for the fact that LowMana does not include the pc on emu.
+function Casting.GroupLowManaCount(percent)
+    local count = mq.TLO.Group.LowMana(percent or 50)() or 0
+    if Core.OnEMU() then
+        count = count + (mq.TLO.Me.PctMana() < (percent or 50) and 1 or 0)
+    end
+    return count
 end
 
 return Casting


### PR DESCRIPTION
[casting]
* The default retrycount for spells and abilities has been lowered to two (from three).

[Laz Adjustments]
* Added Tome of Nife's Mercy entries for classes that can use it. The item will not show in rotations unless you have a copy; loadout rescan will be required if you acquire one mid-playsession.
* Added helper function for LowManaCount that accounts for the PC not reporting his own low mana in the Group.LowMana check on emu.
* Rolled out basic support for Forsaken Fungus Covered Scale Tunic for a couple of classes. WIP.