### PR TITLE
Group Check Fix / DRU(Laz) item add

### DIFF
--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -542,6 +542,14 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Forsaken Elder Spiritist's Gauntlets",
+                type = "Item",
+                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Elder Spiritist's Gauntlets")() end,
+                cond = function(self, itemName, target)
+                    return Casting.DotItemCheck(itemName, target)
+                end,
+            },
+            {
                 name = "SwarmDot",
                 type = "Spell",
                 load_cond = function() return Config:GetSetting('DoSwarmDot') end,

--- a/utils/strings.lua
+++ b/utils/strings.lua
@@ -1,3 +1,5 @@
+local Logger    = require("utils.logger")
+
 local Strings   = { _version = '1.0', _name = "Strings", _author = 'Derple', }
 Strings.__index = Strings
 
@@ -72,6 +74,7 @@ end
 --- @return string: "true" if the boolean is true, "false" otherwise.
 function Strings.BoolToString(b)
     if type(b) ~= "boolean" then
+        Logger.log_error("%s is not a boolean value!", b)
         return "\ayNOT A BOOL\ax"
     end
 
@@ -84,6 +87,7 @@ end
 --- @return string: The color string corresponding to the boolean value.
 function Strings.BoolToColorString(b)
     if type(b) ~= "boolean" then
+        Logger.log_error("%s is not a boolean value!", b)
         return "\ayNOT A BOOL\ax"
     end
 

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -445,7 +445,7 @@ end
 --- Checks if the target is in the same group.
 function Targeting.GroupedWithTarget(target)
     local targetName = target.CleanName() or "None"
-    return mq.TLO.Group.Member(targetName)()
+    return mq.TLO.Group.Member(targetName)() and true or false
 end
 
 function Targeting.SetForceBurn(targetId)


### PR DESCRIPTION
* Fix for checking if a target is grouped with you not properly returning a true/false value.
* Added error logging to boolto(color)string to help detect further issues.

* [DRU-Laz] Added entry for seb gloves.