### PR TITLE
LNS Loot Module Update

### DIFF
--- a/utils/core.lua
+++ b/utils/core.lua
@@ -273,4 +273,8 @@ function Core.SetPetHold()
     Modules:ExecModule("Class", "SetPetHold")
 end
 
+function Core.GetChaseTarget()
+    return Modules:ExecModule("Movement", "GetChaseTarget")
+end
+
 return Core


### PR DESCRIPTION
* Added a check for chase target distance that can be used to abort or stop new looting actions. (Default: 300).