### PR TITLE
Pet Heal Adjustment

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -772,7 +772,7 @@ local _ClassConfig = {
             name  = 'BigHealPoint',
             state = 1,
             steps = 1,
-            cond  = function(self, target) return Targeting.BigHealsNeeded(target) end,
+            cond  = function(self, target) return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target) end,
         },
         {
             name = 'GroupHealPoint',

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -767,7 +767,7 @@ local _ClassConfig = {
             steps = 1,
             load_cond = function() return mq.TLO.Me.Level() > 76 end,
             cond = function(self, target)
-                return Targeting.BigHealsNeeded(target)
+                return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target)
             end,
         },
         { -- Level 59-76
@@ -776,7 +776,7 @@ local _ClassConfig = {
             steps = 1,
             load_cond = function() return mq.TLO.Me.Level() > 58 and mq.TLO.Me.Level() < 77 end,
             cond = function(self, target)
-                return Targeting.BigHealsNeeded(target)
+                return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target)
             end,
         },
         { -- Level 101+

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -867,7 +867,7 @@ local _ClassConfig = {
             name  = 'BigHealPoint',
             state = 1,
             steps = 1,
-            cond  = function(self, target) return Targeting.BigHealsNeeded(target) end,
+            cond  = function(self, target) return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target) end,
         },
         {
             name = 'GroupHealPoint',

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -2006,6 +2006,19 @@ _ClassConfig      = {
             FAQ = "I want to make sure my pet is always Heirloomed, how do I do that?",
             Answer = "You can use the [DoPetHeirlooms] feature to summon pet Heirlooms.",
         },
+        ['DoPetHealSpell'] = {
+            DisplayName = "Pet Heal Spell",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "General Healing",
+            Index = 101,
+            Tooltip = "Mem and cast your Pet Heal spell. AA Pet Heals are always used in emergencies.",
+            Default = true,
+            RequiresLoadoutChange = true,
+            FAQ = "My Pet Keeps Dying, What Can I Do?",
+            Answer = "Make sure you have [DoPetHealSpell] enabled.\n" ..
+                "If your pet is still dying, consider using [PetHealPct] to adjust the pet heal threshold.",
+        },
         ['PetHealPct']     = {
             DisplayName = "Pet Heal %",
             Group = "Abilities",

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -778,7 +778,7 @@ local _ClassConfig = {
             state = 1,
             steps = 1,
             load_cond = function() return mq.TLO.Me.Level() > 64 end,
-            cond = function(self, target) return Targeting.BigHealsNeeded(target) end,
+            cond = function(self, target) return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target) end,
         },
         {
             name = 'MainHealPoint',

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -867,7 +867,7 @@ return {
         },
         --Pets
         ['DoPetHealSpell'] = {
-            DisplayName = "Do Pet Heals",
+            DisplayName = "Pet Heal Spell",
             Group = "Abilities",
             Header = "Recovery",
             Category = "General Healing",

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -382,7 +382,7 @@ local _ClassConfig = {
             state = 1,
             steps = 1,
             cond = function(self, target)
-                return Targeting.BigHealsNeeded(target)
+                return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target)
             end,
         },
         {

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -340,7 +340,7 @@ local _ClassConfig = {
             name  = 'BigHealPoint',
             state = 1,
             steps = 1,
-            cond  = function(self, target) return Targeting.BigHealsNeeded(target) end,
+            cond  = function(self, target) return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target) end,
         },
         {
             name = 'GroupHealPoint',

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -395,7 +395,7 @@ return {
             state = 1,
             steps = 1,
             cond = function(self, target)
-                return Targeting.BigHealsNeeded(target)
+                return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target)
             end,
         },
         {

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -422,7 +422,7 @@ local _ClassConfig = {
             name = 'BigHealPoint',
             state = 1,
             steps = 1,
-            cond = function(self, target) return Targeting.BigHealsNeeded(target) end,
+            cond = function(self, target) return Targeting.BigHealsNeeded(target) and not Targeting.TargetIsType("pet", target) end,
         },
         {
             name = 'MainHealPoint',

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -932,7 +932,7 @@ function Combat.FindWorstHurtXT(minHPs)
         local healTarget = mq.TLO.Me.XTarget(i)
 
         if healTarget and healTarget() and Targeting.TargetIsType("pc", healTarget) then
-            if not healTarget.Dead() and healTarget.PctHPs() < worstPct then
+            if not healTarget.Dead() and (healTarget.PctHPs() or 101) < worstPct then
                 Logger.log_verbose("\aySo far %s is the worst off.", healTarget.DisplayName())
                 worstPct = healTarget.PctHPs()
                 worstId = healTarget.ID()

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1391,11 +1391,11 @@ Config.DefaultConfig = {
         Header = "Recovery",
         Category = "General Healing",
         Index = 1,
-        Tooltip = "Treat pets as valid targets for PC healing rotations. Please note that many pet classes may use their pet heal abilities even with this off.",
-        Default = false,
+        Tooltip = "Allow pets to be targeted in PC healing rotations.\n" ..
+            "Note that CLR/DRU/PAL/SHM will reserve \"Big Heal\" rotations for PCs.\n" ..
+            "Further note that many abilities that heal the PC's own pet do not check this setting and are handled seperately.",
+        Default = true,
         ConfigType = "Advanced",
-        FAQ = "Why am I not healing pets?",
-        Answer = "You can set the [DoPetHeals] option to true to heal pets in your group.",
     },
     ['BreakInvisForHealing'] = {
         DisplayName = "Break Invis",


### PR DESCRIPTION
* Default class configs for healers (inc. PAL)  have been adjusted to no longer use "big heal" rotations on pets (if pet healing is enabled in the first place).
* * Hybrid and pet class healing has not been adjusted.

* Made minor adjustments to pet heal settings and tooltips for clarity.