### PR TITLE
Server-Specific Default Clickies

### DIFF
--- a/class_configs/Alpha (Live)/pal_class_config.lua
+++ b/class_configs/Alpha (Live)/pal_class_config.lua
@@ -1113,15 +1113,6 @@ local _ClassConfig = {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
-            {
-                name = "Huntsman's Ethereal Quiver",
-                type = "Item",
-                active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
-                cond = function(self)
-                    if not Config:GetSetting('SummonArrows') then return false end
-                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
-                end,
-            },
         },
         ['GroupBuff'] = {
             --These intentionally only check the tank so he isn't constantly switching targets to check stacking/pausing to rebuff others with single target spells. Considering removing or splitting single target versions of buffs.
@@ -1974,17 +1965,6 @@ local _ClassConfig = {
             Default = true,
             FAQ = "Why does my SHD switch to a Shield on puny gray named?",
             Answer = "The Shield on Named option doesn't check levels, so feel free to disable this setting (or Bandolier swapping entirely) if you are farming fodder.",
-        },
-        ['SummonArrows']      = {
-            DisplayName = "Use Huntsman's Quiver",
-            Group = "Items",
-            Header = "Clickies",
-            Category = "Class Config Clickies",
-            Index = 104,
-            Tooltip = "Summon arrows with your Huntsman's Ethereal Quiver (Level 90+)",
-            Default = false,
-            FAQ = "How do I summon arrows?",
-            Answer = "If you are at least level 90, keep a Huntsman's Ethereal Quiver in your inventory and enable its use in the options.",
         },
         --ORPHANED PLACEHOLDERS
         ['DoNuke']            = {

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -1327,15 +1327,6 @@ return {
                     return Casting.SelfBuffCheck(spell) and Core.IsModeActive("Tank")
                 end,
             },
-            {
-                name = "Huntsman's Ethereal Quiver",
-                type = "Item",
-                active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
-                cond = function(self)
-                    if not Config:GetSetting('SummonArrows') then return false end
-                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
-                end,
-            },
         },
         ['GroupBuff'] = {
             {
@@ -1615,16 +1606,6 @@ return {
             Default = true,
             FAQ = "Why am I not casting Reverse DS?",
             Answer = "Make sure you have the [DoReverseDS] setting enabled.",
-        },
-        ['SummonArrows'] = {
-            DisplayName = "Use Huntsman's Quiver",
-            Group = "Items",
-            Header = "Clickies",
-            Category = "Class Config Clickies",
-            Tooltip = "Summon arrows with your Huntsman's Ethereal Quiver (Level 90+)",
-            Default = false,
-            FAQ = "How do I summon arrows?",
-            Answer = "If you are at least level 90, keep a Huntsman's Ethereal Quiver in your inventory and enable its use in the options.",
         },
         ['DoBrells']     = {
             DisplayName = "Do Brells",

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -1089,15 +1089,6 @@ local _ClassConfig = {
                     return Casting.SelfBuffAACheck(aaName)
                 end,
             },
-            {
-                name = "Huntsman's Ethereal Quiver",
-                type = "Item",
-                active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
-                cond = function(self)
-                    if not Config:GetSetting('SummonArrows') then return false end
-                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
-                end,
-            },
         },
         ['PetSummon'] = {
             {
@@ -2780,17 +2771,6 @@ local _ClassConfig = {
             Default = true,
             FAQ = "Why does my SHD switch to a Shield on puny gray named?",
             Answer = "The Shield on Named option doesn't check levels, so feel free to disable this setting (or Bandolier swapping entirely) if you are farming fodder.",
-        },
-        ['SummonArrows']      = {
-            DisplayName = "Use Huntsman's Quiver",
-            Group = "Items",
-            Header = "Clickies",
-            Category = "Class Config Clickies",
-            Index = 104,
-            Tooltip = "Summon arrows with your Huntsman's Ethereal Quiver (Level 90+)",
-            Default = false,
-            FAQ = "How do I summon arrows?",
-            Answer = "If you are at least level 90, keep a Huntsman's Ethereal Quiver in your inventory and enable its use in the options.",
         },
     },
 }

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -476,15 +476,6 @@ local _ClassConfig = {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
-            {
-                name = "Huntsman's Ethereal Quiver",
-                type = "Item",
-                active_cond = function(self) return mq.TLO.FindItemCount("Ethereal Arrow")() > 100 end,
-                cond = function(self)
-                    if not Config:GetSetting('SummonArrows') then return false end
-                    return mq.TLO.FindItemCount("Ethereal Arrow")() < 101
-                end,
-            },
         },
         ['HateTools'] = {
             --used when we've lost hatred after it is initially established
@@ -1192,17 +1183,6 @@ local _ClassConfig = {
             Default = false,
             FAQ = "How do I use my Epic Weapon?",
             Answer = "Enable Do Epic to click your Epic Weapon.",
-        },
-        ['SummonArrows']     = {
-            DisplayName = "Use Huntsman's Quiver",
-            Group = "Items",
-            Header = "Clickies",
-            Category = "Class Config Clickies",
-            Index = 105,
-            Tooltip = "Summon arrows with your Huntsman's Ethereal Quiver (Level 90+)",
-            Default = false,
-            FAQ = "How do I summon arrows?",
-            Answer = "If you are at least level 90, keep a Huntsman's Ethereal Quiver in your inventory and enable its use in the options.",
         },
     },
 }

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1557,14 +1557,6 @@ _ClassConfig      = {
                     return false
                 end,
             },
-            {
-                name = "Forsaken Fungus Covered Scale Tunic",
-                type = "Item",
-                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
-                cond = function(self, itemName, target)
-                    return mq.TLO.Me.PctMana() < 40 or mq.TLO.Me.PctHPs() < 40
-                end,
-            },
         },
         ['DPS(PBAE)'] = {
             {

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -348,17 +348,6 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'OrbMAHeal',
-            state = 1,
-            steps = 1,
-            load_cond = function() return Config:GetSetting('DoMAOrbHeal') end,
-            targetId = function(self) return { Core.GetMainAssistId(), } or {} end,
-            cond = function(self, combat_state)
-                if not mq.TLO.FindItem("=Orb of Shadows")() or mq.TLO.FindItem("=Orb of Souls")() then return false end
-                return combat_state == "Combat" and Targeting.BigHealsNeeded(Core.GetMainAssistSpawn())
-            end,
-        },
-        {
             name = 'Scent(Terris)',
             state = 1,
             steps = 1,
@@ -514,14 +503,6 @@ local _ClassConfig = {
             },
         },
         ['CombatBuff']      = {
-            {
-                name = "Forsaken Fungus Covered Scale Tunic",
-                type = "Item",
-                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
-                cond = function(self, itemName, target)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('DeathBloomPercent') or mq.TLO.Me.PctHPs() < 40
-                end,
-            },
             {
                 name = "Death Bloom",
                 type = "AA",
@@ -908,18 +889,6 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['OrbMAHeal']       = {
-            {
-                name = "Orb of Shadows",
-                type = "Item",
-                load_cond = function(self) return mq.TLO.Me.Book("Shadow Orb")() end,
-            },
-            {
-                name = "Orb of Souls",
-                type = "Item",
-                load_cond = function(self) return not mq.TLO.Me.Book("Shadow Orb")() end,
-            },
-        },
     },
     ['HelperFunctions'] = {
         CancelLich = function(self)
@@ -1290,18 +1259,6 @@ local _ClassConfig = {
             Category = "Direct",
             Index = 103,
             Tooltip = "Use your Orb nuke to summon more Soul/Shadow orbs when needed.",
-            RequiresLoadoutChange = true,
-            Default = true,
-            FAQ = "How can I use my Lifetap?",
-            Answer = "You can enable the Lifetap line on the Combat tab of your Class options.",
-        },
-        ['DoMAOrbHeal']       = {
-            DisplayName = "Heal MA with Orbs",
-            Group = "Items",
-            Header = "Clickies",
-            Category = "Class Config Clickies",
-            Index = 102,
-            Tooltip = "Use the your Orb of Shadows on the MA when their health is low.",
             RequiresLoadoutChange = true,
             Default = true,
             FAQ = "How can I use my Lifetap?",

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -775,11 +775,6 @@ return {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
-            {
-                name = "Forsaken Fungus Covered Scale Tunic",
-                type = "Item",
-                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
-            },
             { --Note that on named we may already have a defensive disc running already, could make this remove other discs, but we have other options.
                 name = "BlockDisc",
                 type = "Disc",
@@ -1050,14 +1045,6 @@ return {
             {
                 name = "Slam",
                 type = "Ability",
-            },
-            {
-                name = "Forsaken Fungus Covered Scale Tunic",
-                type = "Item",
-                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
-                cond = function(self, itemName, target)
-                    return mq.TLO.Me.PctMana() < 30 or mq.TLO.Me.PctEndurance() < 30
-                end,
             },
         },
         ['Weapon Management'] = {

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -530,14 +530,6 @@ return {
         ['CombatBuff'] =
         {
             {
-                name = "Forsaken Fungus Covered Scale Tunic",
-                type = "Item",
-                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fungus Covered Scale Tunic")() end,
-                cond = function(self, itemName, target)
-                    return mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct') or mq.TLO.Me.PctHPs() < 40
-                end,
-            },
-            {
                 name = "Harvest of Druzzil",
                 type = "AA",
                 load_cond = function(self) return Casting.CanUseAA("Harvest of Druzzil") end,


### PR DESCRIPTION
Project Lazarus users: We are replacing some hardcoded "heal clicky" support and you should have a look at these update notes.

* Added support for server/environment-specific default recommended clickies on the clickies tab:
* * These clickies will be present on load for new users.
* * Current users can add these clickies any time through a button in the UI.
* * Live/Test clickies are a WIP and feedback is requested.
* * Laz clickies include Orb of Shadows, Sanguine Mind Crystals, and the Forsaken Fungus Covered Scale Tunic.

* Removed the above clickies from hardcoded positions in default class configs.

* Removed Huntsman's quiver from default live configs.