### PR TITLE
Targeting Adjustments

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -259,10 +259,10 @@ local function RGInit(...)
     printf("\aw\awVersion \ag%s \aw(\at%s\aw)", Config._version, Config._subVersion)
     printf("\aw\awBy \ag%s", Config._author)
     printf("\aw****************************")
-    -- keep these for easy editing/additon later
-    printf("\agOur Assist System has been revamped! See our recent forum post or commit messages.")
+    -- keep these for easy editing/addition later
+    --  printf("\agThe new options panel is live! See our recent forum post or commit messages.")
     printf("\awPlease visit us on the RG forums for the most recent news and updates.")
-    printf("\aw use \ag /rg \aw for a list of commands")
+    printf("\aw Use \ag /rgl \aw or check our options panel for a list of commands.")
 
     -- store initial positioning data.
     initPctComplete = 90

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -358,7 +358,7 @@ function Module:LoadSettings()
     local settings = {}
     local firstSaveRequired = false
 
-    Logger.log_info("\ar%s\ao Core Module Loading Settings for: %s.", Config.Globals.CurLoadedClass,
+    Logger.log_debug("\ar%s\ao Core Module Loading Settings for: %s.", Config.Globals.CurLoadedClass,
         Config.Globals.CurLoadedChar)
     Logger.log_info("\ayUsing Class Config by: \at%s\ay (\am%s\ay)", self.ClassConfig._author,
         self.ClassConfig._version)

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -793,7 +793,7 @@ function Module:LoadSettings()
 
     Config:RegisterModuleSettings(self._name, settings, self.DefaultConfig, self.FAQ, firstSaveRequired)
 
-    Logger.log_info("\awClicky Module: \atLoaded \ag%d\at Clickies", #settings.Clickies or 0)
+    Logger.log_debug("\awClicky Module: \atLoaded \ag%d\at Clickies", #settings.Clickies or 0)
 end
 
 function Module.New()

--- a/utils/classloader.lua
+++ b/utils/classloader.lua
@@ -34,7 +34,7 @@ end
 ---@param class string # EQ Class ShortName
 function ClassLoader.load(class)
     local classConfigFile, customConfig = ClassLoader.getClassConfigFileName(class)
-    Logger.log_info("Loading Base Config:\n\ag%s", classConfigFile)
+    Logger.log_debug("Loading Base Config:\n\ag%s", classConfigFile)
 
     if Files.file_exists(classConfigFile) then
         local config, err = loadfile(classConfigFile)

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -515,19 +515,21 @@ function Combat.FindBestAutoTarget(validateFn)
     Logger.log_verbose("FindTarget(): FoundTargetID(%d), myTargetId(%d)", Config.Globals.AutoTargetID or 0,
         mq.TLO.Target.ID())
 
-    local autoTargetId = Config.Globals.AutoTargetID
-    if autoTargetId > 0 and (validateFn and validateFn(autoTargetId)) then
-        if mq.TLO.Target.ID() ~= autoTargetId then
-            Targeting.SetTarget(autoTargetId)
-        end
+    if Config:GetSetting('DoAutoTarget') then -- don't adjust target if autotargeting is off
+        local autoTargetId = Config.Globals.AutoTargetID
+        if autoTargetId > 0 and (validateFn and validateFn(autoTargetId)) then
+            if mq.TLO.Target.ID() ~= autoTargetId then
+                Targeting.SetTarget(autoTargetId)
+            end
 
-        -- For Assist Lists, this ensures we correctly and quickly receive health percent to assist in a timely manner
-        -- For Emu, this helps correct for emu xtarget bugs
-        -- Second dead check because targets were ocasionally dying between the validateFn and this check
-        if Config:GetSetting('UseAssistList') or Core.OnEMU() then
-            if mq.TLO.Spawn(autoTargetId)() and not mq.TLO.Spawn(autoTargetId).Dead() and not Targeting.IsSpawnXTHater(autoTargetId) then
-                Targeting.AddXTByID(1, Config.Globals.AutoTargetID)
-                Logger.log_verbose("FindTarget(): FoundTargetID(%d) not on xt list, adding.", autoTargetId or 0)
+            -- For Assist Lists, this ensures we correctly and quickly receive health percent to assist in a timely manner
+            -- For Emu, this helps correct for emu xtarget bugs
+            -- Second dead check because targets were ocasionally dying between the validateFn and this check
+            if Config:GetSetting('UseAssistList') or Core.OnEMU() then
+                if mq.TLO.Spawn(autoTargetId)() and not mq.TLO.Spawn(autoTargetId).Dead() and not Targeting.IsSpawnXTHater(autoTargetId) then
+                    Targeting.AddXTByID(1, Config.Globals.AutoTargetID)
+                    Logger.log_verbose("FindTarget(): FoundTargetID(%d) not on xt list, adding.", autoTargetId or 0)
+                end
             end
         end
     end

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -176,6 +176,16 @@ Config.FAQ                         = {
         Answer = "  Announcments are used to broadcast the selected options to the DanNet channel. The Group Announce optios will output the announcement to /gsay.",
         Settings_Used = "",
     },
+    [2] = {
+        Question = "I want to manually control my driver and choose my own targets. What do I need to adjust?",
+        Answer = "The following settings may require adjustment to drive yourself:\n\n" ..
+            "Targeting:\nAuto Target (controls scanning for combat targets and changing targets to them).\n\n" ..
+            "Assisting:\nAuto Engage (controls navigating to targets, sticking, and using melee if enabled).\n\n" ..
+            "Positioning:\nFace Target In Combat (Mercs will still assume you are facing properly for abilities that require it!)\n\n" ..
+            "Mercs will still manage the action, and we should return to the target you had if needed after a heal, buff, item use, etc. You can pause mercs to take full control." ..
+            "These settings and interactions have been recently adjusted, and feedback is requested if you see something not quite right!",
+        Settings_Used = "",
+    },
 }
 -- Defaults
 Config.DefaultConfig               = {
@@ -649,7 +659,8 @@ Config.DefaultConfig               = {
         Header = "Targeting",
         Category = "Targeting Behavior",
         Index = 1,
-        Tooltip = "Allow RGMercs to automatically change your target. This applies to combat, healing, and most other actions.",
+        Tooltip =
+        "MA: Allow RGMercs to scan for and assign targets in combat.\nNon-MA: Allow RGMercs to adjust your target to the MA-provided autotarget.\nTarget changes to use spells/songs/AA/items will occur, but you will return to your original target after doing so.",
         Default = true,
         ConfigType = "Advanced",
     },
@@ -659,7 +670,7 @@ Config.DefaultConfig               = {
         Header = "Targeting",
         Category = "Targeting Behavior",
         Index = 2,
-        Tooltip = "Don't change combat targets when the MA does.",
+        Tooltip = "Don't change combat targets when the MA changes its Mercs autotarget. Stay on the original enemy.",
         Default = false,
         ConfigType = "Advanced",
     },
@@ -2241,7 +2252,7 @@ function Config:RegisterModuleSettings(module, settings, defaultSettings, faq, f
 
     self.TempSettings.lastModuleRegisteredTime = os.time()
 
-    Logger.log_info("\agModule %s - registered settings!", module)
+    Logger.log_debug("\agModule %s - registered settings!", module)
 end
 
 function Config:RequestPeerConfigs(peer)

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -30,12 +30,10 @@ function Targeting.SetTarget(targetId, ignoreBuffPopulation)
 
     if targetId == mq.TLO.Target.ID() then return end
     Logger.log_debug("SetTarget(): Setting Target: %d (buffPopWait: %d)", targetId, ignoreBuffPopulation and 0 or maxWaitBuffs)
-    if Config:GetSetting('DoAutoTarget') then
-        if Targeting.GetTargetID() ~= targetId then
-            mq.TLO.Spawn(targetId).DoTarget()
-            mq.delay(10, function() return mq.TLO.Target.ID() == targetId end)
-            mq.delay(maxWaitBuffs, function() return ignoreBuffPopulation or (mq.TLO.Target() and mq.TLO.Target.BuffsPopulated()) end)
-        end
+    if Targeting.GetTargetID() ~= targetId then
+        mq.TLO.Spawn(targetId).DoTarget()
+        mq.delay(10, function() return mq.TLO.Target.ID() == targetId end)
+        mq.delay(maxWaitBuffs, function() return ignoreBuffPopulation or (mq.TLO.Target() and mq.TLO.Target.BuffsPopulated()) end)
     end
     Logger.log_debug("SetTarget(): Set Target to: %d (buffsPopulated: %s)", targetId, Strings.BoolToColorString(mq.TLO.Target.BuffsPopulated()))
 end


### PR DESCRIPTION
* All major actions should now return the user to their previous target.
* The Auto Targeting setting now only toggles whether we scan for/and or change to the combat autotarget (and no longer controls near all of our targeting).