### PR TITLE
Pull Fix, SHD(EQM) Update

### DIFF
--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -205,7 +205,7 @@ local _ClassConfig = {
             "Leech Soul", -- EQM Custom
             "Touch of Inruku",
             "Touch of Innoruuk",
-            --"Touch of Volatis", -- Drain Soul buffed on Lazarus and is superior to this.
+            "Touch of Volatis",
             "Drain Soul",
             "Drain Spirit",
             "Spirit Tap",
@@ -220,7 +220,7 @@ local _ClassConfig = {
             "Leech Soul", -- EQM Custom
             "Touch of Inruku",
             "Touch of Innoruuk",
-            --"Touch of Volatis", -- Drain Soul buffed on Lazarus and is superior to this.
+            "Touch of Volatis",
             "Drain Soul",
             "Drain Spirit",
             "Spirit Tap",

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -1270,7 +1270,7 @@ function Module:DeleteMobFromList(list, idx)
 
     -- if we are pulling start over.
     if Config:GetSetting('DoPull') then
-        Core.DoCmd("/multiline ; /rgl set DoPull false ; /timed 10 /rgl set DoPull true")
+        self.TempSettings.PullListUpdated = true
     end
 end
 


### PR DESCRIPTION
* [pull] The hunt start position will no longer be reset when we remove a mob from the pull allow/deny lists.

* [SHD - EQM] Re-added Touch of Volantis (was disabled from Laz config).