### PR TITLE
Targeting/Auto Attack improvements

### DIFF
--- a/class_configs/HiddenForest/clr_class_config.lua
+++ b/class_configs/HiddenForest/clr_class_config.lua
@@ -663,7 +663,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoGroupElixir') end,
                 cond = function(self, spell)
                     if not Config:GetSetting('GroupElixirUptime') then return false end
-                    return spell.RankName.Stacks() and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 6
+                    return spell.RankName.Stacks() and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 6
                 end,
             },
             {

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -692,6 +692,17 @@ Config.DefaultConfig               = {
         Default = true,
         ConfigType = "Advanced",
     },
+    ['StopAttackForPCs']     = {
+        DisplayName = "Stop Attack for PCs",
+        Group = "Combat",
+        Header = "Targeting",
+        Category = "Targeting Behavior",
+        Index = 4,
+        Tooltip = "Ensure that auto attack is turned off before targeting a PC to use a spell, song, AA, or item. May be required if PvP is enabled by flag, zone, or server.",
+        Default = false,
+        ConfigType = "Advanced",
+    },
+
     ['ScanNamedPriority']    = {
         DisplayName = "Scan Priority:",
         Group = "Combat",


### PR DESCRIPTION
* Expanded functionality for turning off auto-attack before targeting PCs.
* * The "Stop Attack For PCs" setting (default: false) now controls all relevant sections of code.