### PR TITLE
Bard Adjustments, Rotation UI

### DIFF
--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -313,13 +313,23 @@ local _ClassConfig = {
     },
     ['RotationOrder']   = {
         {
+            name = 'Enduring Breath',
+            state = 1,
+            steps = 1,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            load_cond = function(self) return Config:GetSetting('UseEndBreath') and Core.GetResolvedActionMapItem('EndBreathSong') end,
+            cond = function(self, combat_state)
+                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')
+            end,
+        },
+        {
             name = 'Melody',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and not (Config:GetSetting('BardRespectMedState') and Config.Globals.InMedState)
+                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and not Config.Globals.InMedState
             end,
         },
         {
@@ -328,7 +338,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and not mq.TLO.Me.Invis() and not (Config:GetSetting('BardRespectMedState') and Config.Globals.InMedState)
+                return combat_state == "Downtime" and not mq.TLO.Me.Invis()
             end,
         },
         {
@@ -569,15 +579,16 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Melody'] = {
+        ['Enduring Breath'] = {
             {
                 name = "EndBreathSong",
                 type = "Song",
                 cond = function(self, songSpell)
-                    if not (Config:GetSetting('UseEndBreath') and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')) then return false end
                     return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
+        },
+        ['Melody'] = {
             {
                 name = "AriaSong",
                 type = "Song",
@@ -661,6 +672,7 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, aaName)
                     if not Config:GetSetting('UseRunBuff') then return false end
                     --refresh slightly before expiry for better uptime
@@ -671,8 +683,9 @@ local _ClassConfig = {
                 name = "RunBuff",
                 type = "Song",
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and not Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, songSpell)
-                    if Casting.CanUseAA("Selo's Sonata") or not Config:GetSetting('UseRunBuff') then return false end
+                    if Config.Globals.InMedState then return false end
                     return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
@@ -686,14 +699,6 @@ local _ClassConfig = {
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseAura') then return false end
                     return not Casting.AuraActiveByName(songSpell.BaseName())
-                end,
-            },
-            {
-                name = "EndBreathSong",
-                type = "Song",
-                cond = function(self, songSpell)
-                    if not (Config:GetSetting('UseEndBreath') and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')) then return false end
-                    return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
         },
@@ -773,7 +778,7 @@ local _ClassConfig = {
         },
     },
     ['DefaultConfig']   = {
-        ['Mode']                = {
+        ['Mode']            = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -786,7 +791,7 @@ local _ClassConfig = {
             Answer = "Currently Bards only have one general mode. More modes may be added in the future.",
         },
         -- Buffs
-        ['UseRunBuff']          = {
+        ['UseRunBuff']      = {
             DisplayName = "Use RunSpeed Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -798,7 +803,7 @@ local _ClassConfig = {
             FAQ = "Why am I slowing down in combat?",
             Answer = "Runspeed songs, if selected, are only sung in the downtime rotation. Higher level bards will have longer durations.",
         },
-        ['UseEndBreath']        = {
+        ['UseEndBreath']    = {
             DisplayName = "Use Enduring Breath",
             Group = "Abilities",
             Header = "Buffs",
@@ -809,7 +814,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
         },
-        ['UseAura']             = {
+        ['UseAura']         = {
             DisplayName = "Use Aura",
             Group = "Abilities",
             Header = "Buffs",
@@ -821,7 +826,7 @@ local _ClassConfig = {
             FAQ = "My bard is spam casting aura, what do I do?",
             Answer = "We have code to prevent this, but if it has slipped the cracks, check what aura you have active in your window (Shift+A by default). You may need to clear it.",
         },
-        ['UseAmp']              = {
+        ['UseAmp']          = {
             DisplayName = "Use Amp",
             Group = "Abilities",
             Header = "Buffs",
@@ -835,7 +840,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['SpireChoice']         = {
+        ['SpireChoice']     = {
             DisplayName = "Spire Choice:",
             Group = "Abilities",
             Header = "Buffs",
@@ -853,7 +858,7 @@ local _ClassConfig = {
         },
 
         -- Debuffs
-        ['DoSTSlow']            = {
+        ['DoSTSlow']        = {
             DisplayName = "Use Slow (ST)",
             Group = "Abilities",
             Header = "Debuffs",
@@ -863,7 +868,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoAESlow']            = {
+        ['DoAESlow']        = {
             DisplayName = "Use Slow (AE)",
             Group = "Abilities",
             Header = "Debuffs",
@@ -873,7 +878,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoResistDebuff']      = {
+        ['DoResistDebuff']  = {
             DisplayName = "Use Resist Debuff",
             Group = "Abilities",
             Header = "Debuffs",
@@ -883,7 +888,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoDispel']            = {
+        ['DoDispel']        = {
             DisplayName = "Use Dispel",
             Group = "Abilities",
             Header = "Debuffs",
@@ -895,7 +900,7 @@ local _ClassConfig = {
         },
 
         -- Defensive
-        ['UseResist']           = {
+        ['UseResist']       = {
             DisplayName = "Use Resist Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -909,7 +914,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseSpellAbsorb']      = {
+        ['UseSpellAbsorb']  = {
             DisplayName = "Use Spell Absorb",
             Group = "Abilities",
             Header = "Buffs",
@@ -920,7 +925,7 @@ local _ClassConfig = {
             FAQ = "When is the Spell Damage Absorb/Shield used?",
             Answer = "This song is used during burns.",
         },
-        ['UseFading']           = {
+        ['UseFading']       = {
             DisplayName = "Use Combat Escape",
             Group = "Abilities",
             Header = "Utility",
@@ -933,7 +938,7 @@ local _ClassConfig = {
             Answer = "When Use Combat Escape is enabled, Fading Memories will be used when the Bard has any unwanted aggro.\n" ..
                 "This helps the common issue of bards gaining aggro from singing before a tank has the chance to secure it.",
         },
-        ['EmergencyStart']      = {
+        ['EmergencyStart']  = {
             DisplayName = "Emergency HP%",
             Group = "Abilities",
             Header = "Utility",
@@ -947,7 +952,7 @@ local _ClassConfig = {
         },
 
         -- Healing
-        ['RegenSong']           = {
+        ['RegenSong']       = {
             DisplayName = "Regen Song Choice:",
             Group = "Abilities",
             Header = "Recovery",
@@ -964,7 +969,7 @@ local _ClassConfig = {
             Answer = "At low level, the regen songs are spaced broadly, and wallow back and forth before settling on providing both resources.\n" ..
                 "Endurance is eventually added as well.",
         },
-        ['UseRegen']            = {
+        ['UseRegen']        = {
             DisplayName = "Regen Song Use:",
             Group = "Abilities",
             Header = "Recovery",
@@ -977,7 +982,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 4,
         },
-        ['GroupManaPct']        = {
+        ['GroupManaPct']    = {
             DisplayName = "Group Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -989,7 +994,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['GroupManaCt']         = {
+        ['GroupManaCt']     = {
             DisplayName = "Group Mana Count",
             Group = "Abilities",
             Header = "Recovery",
@@ -1001,7 +1006,7 @@ local _ClassConfig = {
             Max = 6,
             ConfigType = "Advanced",
         },
-        ['UseCure']             = {
+        ['UseCure']         = {
             DisplayName = "Cure Ailments",
             Group = "Abilities",
             Header = "Recovery",
@@ -1011,19 +1016,9 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['BardRespectMedState'] = {
-            DisplayName = "Bard: Respect Med Settings",
-            Group = "Movement",
-            Header = "Meditation",
-            Category = "Med Rules",
-            Index = 101,
-            Tooltip = "Allows the bard to meditate.\nPlease note that this comes at the cost of disabling all normal downtime actions while meditating.",
-            Default = false,
-            ConfigType = "Advanced",
-        },
 
         -- Instruments
-        ['SwapInstruments']     = {
+        ['SwapInstruments'] = {
             DisplayName = "Auto Swap Instruments",
             Index = 101,
             Group = "Items",
@@ -1033,7 +1028,7 @@ local _ClassConfig = {
             Default = false,
 
         },
-        ['UseBandolier']        = {
+        ['UseBandolier']    = {
             DisplayName = "Use Bandolier",
             Index = 102,
             Group = "Items",
@@ -1042,7 +1037,7 @@ local _ClassConfig = {
             Tooltip = "Auto swap instruments using bandolier if avail, valid names (wind, drum, brass, string or main), if a bandolier is missing we will direct swap instead.",
             Default = true,
         },
-        ['Offhand']             = {
+        ['Offhand']         = {
             DisplayName = "Offhand",
             Index = 103,
             Group = "Items",
@@ -1053,7 +1048,7 @@ local _ClassConfig = {
 
             Default = "",
         },
-        ['BrassInst']           = {
+        ['BrassInst']       = {
             DisplayName = "Brass Instrument",
             Index = 104,
             Group = "Items",
@@ -1063,7 +1058,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['WindInst']            = {
+        ['WindInst']        = {
             DisplayName = "Wind Instrument",
             Index = 105,
             Group = "Items",
@@ -1073,7 +1068,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['PercInst']            = {
+        ['PercInst']        = {
             DisplayName = "Percussion Instrument",
             Index = 106,
             Group = "Items",
@@ -1083,7 +1078,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['StringedInst']        = {
+        ['StringedInst']    = {
             DisplayName = "Stringed Instrument",
             Index = 107,
             Group = "Items",
@@ -1095,7 +1090,7 @@ local _ClassConfig = {
         },
 
         -- Offensive
-        ['UseAria']             = {
+        ['UseAria']         = {
             DisplayName = "Use Aria",
             Group = "Abilities",
             Header = "Buffs",
@@ -1109,7 +1104,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseMarch']            = {
+        ['UseMarch']        = {
             DisplayName = "Use War March",
             Group = "Abilities",
             Header = "Buffs",
@@ -1123,7 +1118,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseProcSong']         = {
+        ['UseProcSong']     = {
             DisplayName = "Use Group Proc",
             Group = "Abilities",
             Header = "Buffs",
@@ -1137,7 +1132,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseArcane']           = {
+        ['UseArcane']       = {
             DisplayName = "Use Arcane Line",
             Group = "Abilities",
             Header = "Buffs",
@@ -1151,7 +1146,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseEpic']             = {
+        ['UseEpic']         = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -1164,7 +1159,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 3,
         },
-        ['UseFireDots']         = {
+        ['UseFireDots']     = {
             DisplayName = "Use Fire Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1174,7 +1169,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UseIceDots']          = {
+        ['UseIceDots']      = {
             DisplayName = "Use Ice Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1184,7 +1179,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UsePoisonDots']       = {
+        ['UsePoisonDots']   = {
             DisplayName = "Use Poison Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1194,7 +1189,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UseDiseaseDots']      = {
+        ['UseDiseaseDots']  = {
             DisplayName = "Use Disease Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1205,7 +1200,7 @@ local _ClassConfig = {
             Default = false,
 
         },
-        ['UseJonthan']          = {
+        ['UseJonthan']      = {
             DisplayName = "Use Jonthan",
             Group = "Abilities",
             Header = "Buffs",
@@ -1220,7 +1215,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
         },
-        ['UseShout']            = {
+        ['UseShout']        = {
             DisplayName = "Use Vain. Shout",
             Group = "Abilities",
             Header = "Damage",
@@ -1231,7 +1226,7 @@ local _ClassConfig = {
         },
 
         -- Song Duration Adjustment
-        ['RefreshDT']           = {
+        ['RefreshDT']       = {
             DisplayName = "Downtime Threshold",
             Group = "Abilities",
             Header = "Common",
@@ -1247,7 +1242,7 @@ local _ClassConfig = {
             Answer = "You may need to adjust your Downtime Threshold value downward at lower levels/song durations.\n" ..
                 "This needs to be carefully tailored towards your song line-up.",
         },
-        ['RefreshCombat']       = {
+        ['RefreshCombat']   = {
             DisplayName = "Combat Threshold",
             Group = "Abilities",
             Header = "Common",
@@ -1271,6 +1266,14 @@ local _ClassConfig = {
                 "  Up until level 65, it should work quite well, but may need some clickies managed on the clickies tab.\n\n" ..
                 "  After level 65, expect performance to degrade somewhat as not all EQMight custom spells or items are added, and some Laz-specific entries may remain.\n\n" ..
                 "  Community effort and feedback are required for robust, resilient class configs, and PRs are highly encouraged!",
+            Settings_Used = "",
+        },
+        [2] = {
+            Question = "How does Bard meditation function?",
+            Answer = "Bards can elect to med using the same settings as other classes. If a bard begins to med, they will stop singing any songs in the Melody rotation.\n\n" ..
+                "  Using the default class configs, the combat rotations will still be used. Thus, there is generally little or no support for in-combat meditation for Bard.\n\n" ..
+                "  The 'Stand When Done' med setting will ensure that a bard begins to sing again as soon as they reach the med stop threshold.\n\n" ..
+                "  Note that the Enduring Breath song, if enabled (and needed), does not respect meditation settings, for the safety of your group.",
             Settings_Used = "",
         },
     },

--- a/class_configs/HiddenForest/brd_class_config.lua
+++ b/class_configs/HiddenForest/brd_class_config.lua
@@ -310,13 +310,23 @@ local _ClassConfig = {
     },
     ['RotationOrder']   = {
         {
+            name = 'Enduring Breath',
+            state = 1,
+            steps = 1,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            load_cond = function(self) return Config:GetSetting('UseEndBreath') and Core.GetResolvedActionMapItem('EndBreathSong') end,
+            cond = function(self, combat_state)
+                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')
+            end,
+        },
+        {
             name = 'Melody',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and not (Config:GetSetting('BardRespectMedState') and Config.Globals.InMedState)
+                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and not Config.Globals.InMedState
             end,
         },
         {
@@ -325,7 +335,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and not mq.TLO.Me.Invis() and not (Config:GetSetting('BardRespectMedState') and Config.Globals.InMedState)
+                return combat_state == "Downtime" and not mq.TLO.Me.Invis()
             end,
         },
         {
@@ -563,15 +573,16 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Melody'] = {
+        ['Enduring Breath'] = {
             {
                 name = "EndBreathSong",
                 type = "Song",
                 cond = function(self, songSpell)
-                    if not (Config:GetSetting('UseEndBreath') and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')) then return false end
                     return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
+        },
+        ['Melody'] = {
             {
                 name = "AriaSong",
                 type = "Song",
@@ -655,6 +666,7 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, aaName)
                     if not Config:GetSetting('UseRunBuff') then return false end
                     --refresh slightly before expiry for better uptime
@@ -665,8 +677,9 @@ local _ClassConfig = {
                 name = "RunBuff",
                 type = "Song",
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and not Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, songSpell)
-                    if Casting.CanUseAA("Selo's Sonata") or not Config:GetSetting('UseRunBuff') then return false end
+                    if Config.Globals.InMedState then return false end
                     return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
@@ -680,14 +693,6 @@ local _ClassConfig = {
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseAura') then return false end
                     return not Casting.AuraActiveByName(songSpell.BaseName())
-                end,
-            },
-            {
-                name = "EndBreathSong",
-                type = "Song",
-                cond = function(self, songSpell)
-                    if not (Config:GetSetting('UseEndBreath') and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')) then return false end
-                    return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
         },
@@ -848,7 +853,7 @@ local _ClassConfig = {
 
 
         -- Debuffs
-        ['DoSTSlow']            = {
+        ['DoSTSlow']        = {
             DisplayName = "Use Slow (ST)",
             Group = "Abilities",
             Header = "Debuffs",
@@ -858,7 +863,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoAESlow']            = {
+        ['DoAESlow']        = {
             DisplayName = "Use Slow (AE)",
             Group = "Abilities",
             Header = "Debuffs",
@@ -868,7 +873,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoResistDebuff']      = {
+        ['DoResistDebuff']  = {
             DisplayName = "Use Resist Debuff",
             Group = "Abilities",
             Header = "Debuffs",
@@ -878,7 +883,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoDispel']            = {
+        ['DoDispel']        = {
             DisplayName = "Use Dispel",
             Group = "Abilities",
             Header = "Debuffs",
@@ -890,7 +895,7 @@ local _ClassConfig = {
         },
 
         -- Defensive
-        ['UseResist']           = {
+        ['UseResist']       = {
             DisplayName = "Use Resist Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -904,7 +909,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseSpellAbsorb']      = {
+        ['UseSpellAbsorb']  = {
             DisplayName = "Use Spell Absorb",
             Group = "Abilities",
             Header = "Buffs",
@@ -915,7 +920,7 @@ local _ClassConfig = {
             FAQ = "When is the Spell Damage Absorb/Shield used?",
             Answer = "This song is used during burns.",
         },
-        ['UseFading']           = {
+        ['UseFading']       = {
             DisplayName = "Use Combat Escape",
             Group = "Abilities",
             Header = "Utility",
@@ -928,7 +933,7 @@ local _ClassConfig = {
             Answer = "When Use Combat Escape is enabled, Fading Memories will be used when the Bard has any unwanted aggro.\n" ..
                 "This helps the common issue of bards gaining aggro from singing before a tank has the chance to secure it.",
         },
-        ['EmergencyStart']      = {
+        ['EmergencyStart']  = {
             DisplayName = "Emergency HP%",
             Group = "Abilities",
             Header = "Utility",
@@ -942,7 +947,7 @@ local _ClassConfig = {
         },
 
         -- Healing
-        ['RegenSong']           = {
+        ['RegenSong']       = {
             DisplayName = "Regen Song Choice:",
             Group = "Abilities",
             Header = "Recovery",
@@ -959,7 +964,7 @@ local _ClassConfig = {
             Answer = "At low level, the regen songs are spaced broadly, and wallow back and forth before settling on providing both resources.\n" ..
                 "Endurance is eventually added as well.",
         },
-        ['UseRegen']            = {
+        ['UseRegen']        = {
             DisplayName = "Regen Song Use:",
             Group = "Abilities",
             Header = "Recovery",
@@ -972,7 +977,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 4,
         },
-        ['GroupManaPct']        = {
+        ['GroupManaPct']    = {
             DisplayName = "Group Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -984,7 +989,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['GroupManaCt']         = {
+        ['GroupManaCt']     = {
             DisplayName = "Group Mana Count",
             Group = "Abilities",
             Header = "Recovery",
@@ -996,7 +1001,7 @@ local _ClassConfig = {
             Max = 6,
             ConfigType = "Advanced",
         },
-        ['UseCure']             = {
+        ['UseCure']         = {
             DisplayName = "Cure Ailments",
             Group = "Abilities",
             Header = "Recovery",
@@ -1006,19 +1011,9 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['BardRespectMedState'] = {
-            DisplayName = "Bard: Respect Med Settings",
-            Group = "Movement",
-            Header = "Meditation",
-            Category = "Med Rules",
-            Index = 101,
-            Tooltip = "Allows the bard to meditate.\nPlease note that this comes at the cost of disabling all normal downtime actions while meditating.",
-            Default = false,
-            ConfigType = "Advanced",
-        },
 
         -- Instruments
-        ['SwapInstruments']     = {
+        ['SwapInstruments'] = {
             DisplayName = "Auto Swap Instruments",
             Index = 101,
             Group = "Items",
@@ -1028,7 +1023,7 @@ local _ClassConfig = {
             Default = false,
 
         },
-        ['UseBandolier']        = {
+        ['UseBandolier']    = {
             DisplayName = "Use Bandolier",
             Index = 102,
             Group = "Items",
@@ -1037,7 +1032,7 @@ local _ClassConfig = {
             Tooltip = "Auto swap instruments using bandolier if avail, valid names (wind, drum, brass, string or main), if a bandolier is missing we will direct swap instead.",
             Default = true,
         },
-        ['Offhand']             = {
+        ['Offhand']         = {
             DisplayName = "Offhand",
             Index = 103,
             Group = "Items",
@@ -1048,7 +1043,7 @@ local _ClassConfig = {
 
             Default = "",
         },
-        ['BrassInst']           = {
+        ['BrassInst']       = {
             DisplayName = "Brass Instrument",
             Index = 104,
             Group = "Items",
@@ -1058,7 +1053,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['WindInst']            = {
+        ['WindInst']        = {
             DisplayName = "Wind Instrument",
             Index = 105,
             Group = "Items",
@@ -1068,7 +1063,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['PercInst']            = {
+        ['PercInst']        = {
             DisplayName = "Percussion Instrument",
             Index = 106,
             Group = "Items",
@@ -1078,7 +1073,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['StringedInst']        = {
+        ['StringedInst']    = {
             DisplayName = "Stringed Instrument",
             Index = 107,
             Group = "Items",
@@ -1090,7 +1085,7 @@ local _ClassConfig = {
         },
 
         -- Offensive
-        ['UseAria']             = {
+        ['UseAria']         = {
             DisplayName = "Use Aria",
             Group = "Abilities",
             Header = "Buffs",
@@ -1104,7 +1099,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseMarch']            = {
+        ['UseMarch']        = {
             DisplayName = "Use War March",
             Group = "Abilities",
             Header = "Buffs",
@@ -1118,7 +1113,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseProcSong']         = {
+        ['UseProcSong']     = {
             DisplayName = "Use Group Proc",
             Group = "Abilities",
             Header = "Buffs",
@@ -1132,7 +1127,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseArcane']           = {
+        ['UseArcane']       = {
             DisplayName = "Use Arcane Line",
             Group = "Abilities",
             Header = "Buffs",
@@ -1146,7 +1141,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseEpic']             = {
+        ['UseEpic']         = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -1159,7 +1154,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 3,
         },
-        ['UseFireDots']         = {
+        ['UseFireDots']     = {
             DisplayName = "Use Fire Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1169,7 +1164,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UseIceDots']          = {
+        ['UseIceDots']      = {
             DisplayName = "Use Ice Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1179,7 +1174,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UsePoisonDots']       = {
+        ['UsePoisonDots']   = {
             DisplayName = "Use Poison Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1189,7 +1184,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UseDiseaseDots']      = {
+        ['UseDiseaseDots']  = {
             DisplayName = "Use Disease Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1200,7 +1195,7 @@ local _ClassConfig = {
             Default = false,
 
         },
-        ['UseJonthan']          = {
+        ['UseJonthan']      = {
             DisplayName = "Use Jonthan",
             Group = "Abilities",
             Header = "Buffs",
@@ -1215,7 +1210,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
         },
-        ['UseShout']            = {
+        ['UseShout']        = {
             DisplayName = "Use Vain. Shout",
             Group = "Abilities",
             Header = "Damage",
@@ -1226,7 +1221,7 @@ local _ClassConfig = {
         },
 
         -- Song Duration Adjustment
-        ['RefreshDT']           = {
+        ['RefreshDT']       = {
             DisplayName = "Downtime Threshold",
             Group = "Abilities",
             Header = "Common",
@@ -1242,7 +1237,7 @@ local _ClassConfig = {
             Answer = "You may need to adjust your Downtime Threshold value downward at lower levels/song durations.\n" ..
                 "This needs to be carefully tailored towards your song line-up.",
         },
-        ['RefreshCombat']       = {
+        ['RefreshCombat']   = {
             DisplayName = "Combat Threshold",
             Group = "Abilities",
             Header = "Common",
@@ -1266,6 +1261,14 @@ local _ClassConfig = {
                 "  Up until the end of T2 progression, it should work quite well, but may need some clickies managed on the clickies tab.\n\n" ..
                 "  After that, expect performance to degrade somewhat as not all THF custom spells or items are added, and some Laz-specific entries may remain.\n\n" ..
                 "  Community effort and feedback are required for robust, resilient class configs, and PRs are highly encouraged!",
+            Settings_Used = "",
+        },
+        [2] = {
+            Question = "How does Bard meditation function?",
+            Answer = "Bards can elect to med using the same settings as other classes. If a bard begins to med, they will stop singing any songs in the Melody rotation.\n\n" ..
+                "  Using the default class configs, the combat rotations will still be used. Thus, there is generally little or no support for in-combat meditation for Bard.\n\n" ..
+                "  The 'Stand When Done' med setting will ensure that a bard begins to sing again as soon as they reach the med stop threshold.\n\n" ..
+                "  Note that the Enduring Breath song, if enabled (and needed), does not respect meditation settings, for the safety of your group.",
             Settings_Used = "",
         },
     },

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -310,13 +310,23 @@ local _ClassConfig = {
     },
     ['RotationOrder']   = {
         {
+            name = 'Enduring Breath',
+            state = 1,
+            steps = 1,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            load_cond = function(self) return Config:GetSetting('UseEndBreath') and Core.GetResolvedActionMapItem('EndBreathSong') end,
+            cond = function(self, combat_state)
+                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')
+            end,
+        },
+        {
             name = 'Melody',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and not (Config:GetSetting('BardRespectMedState') and Config.Globals.InMedState)
+                return not (combat_state == "Downtime" and mq.TLO.Me.Invis()) and not Config.Globals.InMedState
             end,
         },
         {
@@ -325,7 +335,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and not mq.TLO.Me.Invis() and not (Config:GetSetting('BardRespectMedState') and Config.Globals.InMedState)
+                return combat_state == "Downtime" and not mq.TLO.Me.Invis()
             end,
         },
         {
@@ -567,15 +577,16 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Melody'] = {
+        ['Enduring Breath'] = {
             {
                 name = "EndBreathSong",
                 type = "Song",
                 cond = function(self, songSpell)
-                    if not (Config:GetSetting('UseEndBreath') and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')) then return false end
                     return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
+        },
+        ['Melody'] = {
             {
                 name = "AriaSong",
                 type = "Song",
@@ -659,6 +670,7 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, aaName)
                     if not Config:GetSetting('UseRunBuff') then return false end
                     --refresh slightly before expiry for better uptime
@@ -669,8 +681,9 @@ local _ClassConfig = {
                 name = "RunBuff",
                 type = "Song",
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and not Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, songSpell)
-                    if Casting.CanUseAA("Selo's Sonata") or not Config:GetSetting('UseRunBuff') then return false end
+                    if Config.Globals.InMedState then return false end
                     return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
@@ -684,14 +697,6 @@ local _ClassConfig = {
                 cond = function(self, songSpell)
                     if not Config:GetSetting('UseAura') then return false end
                     return not Casting.AuraActiveByName(songSpell.BaseName())
-                end,
-            },
-            {
-                name = "EndBreathSong",
-                type = "Song",
-                cond = function(self, songSpell)
-                    if not (Config:GetSetting('UseEndBreath') and (mq.TLO.Me.FeetWet() or mq.TLO.Zone.ShortName() == 'thegrey')) then return false end
-                    return self.ClassConfig.HelperFunctions.RefreshBuffSong(songSpell)
                 end,
             },
         },
@@ -786,7 +791,7 @@ local _ClassConfig = {
         },
     },
     ['DefaultConfig']   = {
-        ['Mode']                = {
+        ['Mode']            = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -799,7 +804,7 @@ local _ClassConfig = {
             Answer = "Currently Bards only have one general mode. More modes may be added in the future.",
         },
         -- Buffs
-        ['UseRunBuff']          = {
+        ['UseRunBuff']      = {
             DisplayName = "Use RunSpeed Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -811,7 +816,7 @@ local _ClassConfig = {
             FAQ = "Why am I slowing down in combat?",
             Answer = "Runspeed songs, if selected, are only sung in the downtime rotation. Higher level bards will have longer durations.",
         },
-        ['UseEndBreath']        = {
+        ['UseEndBreath']    = {
             DisplayName = "Use Enduring Breath",
             Group = "Abilities",
             Header = "Buffs",
@@ -822,7 +827,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
         },
-        ['UseAura']             = {
+        ['UseAura']         = {
             DisplayName = "Use Aura",
             Group = "Abilities",
             Header = "Buffs",
@@ -834,7 +839,7 @@ local _ClassConfig = {
             FAQ = "My bard is spam casting aura, what do I do?",
             Answer = "We have code to prevent this, but if it has slipped the cracks, check what aura you have active in your window (Shift+A by default). You may need to clear it.",
         },
-        ['UseAmp']              = {
+        ['UseAmp']          = {
             DisplayName = "Use Amp",
             Group = "Abilities",
             Header = "Buffs",
@@ -848,7 +853,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['SpireChoice']         = {
+        ['SpireChoice']     = {
             DisplayName = "Spire Choice:",
             Group = "Abilities",
             Header = "Buffs",
@@ -864,7 +869,7 @@ local _ClassConfig = {
             Min = 1,
             Max = #Config.Constants.SpireChoices,
         },
-        ['DoVetAA']             = {
+        ['DoVetAA']         = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -877,7 +882,7 @@ local _ClassConfig = {
         },
 
         -- Debuffs
-        ['DoSTSlow']            = {
+        ['DoSTSlow']        = {
             DisplayName = "Use Slow (ST)",
             Group = "Abilities",
             Header = "Debuffs",
@@ -887,7 +892,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoAESlow']            = {
+        ['DoAESlow']        = {
             DisplayName = "Use Slow (AE)",
             Group = "Abilities",
             Header = "Debuffs",
@@ -897,7 +902,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoResistDebuff']      = {
+        ['DoResistDebuff']  = {
             DisplayName = "Use Resist Debuff",
             Group = "Abilities",
             Header = "Debuffs",
@@ -907,7 +912,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoDispel']            = {
+        ['DoDispel']        = {
             DisplayName = "Use Dispel",
             Group = "Abilities",
             Header = "Debuffs",
@@ -919,7 +924,7 @@ local _ClassConfig = {
         },
 
         -- Defensive
-        ['UseResist']           = {
+        ['UseResist']       = {
             DisplayName = "Use Resist Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -933,7 +938,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseSpellAbsorb']      = {
+        ['UseSpellAbsorb']  = {
             DisplayName = "Use Spell Absorb",
             Group = "Abilities",
             Header = "Buffs",
@@ -944,7 +949,7 @@ local _ClassConfig = {
             FAQ = "When is the Spell Damage Absorb/Shield used?",
             Answer = "This song is used during burns.",
         },
-        ['UseFading']           = {
+        ['UseFading']       = {
             DisplayName = "Use Combat Escape",
             Group = "Abilities",
             Header = "Utility",
@@ -957,7 +962,7 @@ local _ClassConfig = {
             Answer = "When Use Combat Escape is enabled, Fading Memories will be used when the Bard has any unwanted aggro.\n" ..
                 "This helps the common issue of bards gaining aggro from singing before a tank has the chance to secure it.",
         },
-        ['DoCoating']           = {
+        ['DoCoating']       = {
             DisplayName = "Use Coating",
             Group = "Items",
             Header = "Clickies",
@@ -967,7 +972,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['EmergencyStart']      = {
+        ['EmergencyStart']  = {
             DisplayName = "Emergency HP%",
             Group = "Abilities",
             Header = "Utility",
@@ -981,7 +986,7 @@ local _ClassConfig = {
         },
 
         -- Healing
-        ['RegenSong']           = {
+        ['RegenSong']       = {
             DisplayName = "Regen Song Choice:",
             Group = "Abilities",
             Header = "Recovery",
@@ -998,7 +1003,7 @@ local _ClassConfig = {
             Answer = "At low level, the regen songs are spaced broadly, and wallow back and forth before settling on providing both resources.\n" ..
                 "Endurance is eventually added as well.",
         },
-        ['UseRegen']            = {
+        ['UseRegen']        = {
             DisplayName = "Regen Song Use:",
             Group = "Abilities",
             Header = "Recovery",
@@ -1011,7 +1016,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 4,
         },
-        ['GroupManaPct']        = {
+        ['GroupManaPct']    = {
             DisplayName = "Group Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1023,7 +1028,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['GroupManaCt']         = {
+        ['GroupManaCt']     = {
             DisplayName = "Group Mana Count",
             Group = "Abilities",
             Header = "Recovery",
@@ -1035,7 +1040,7 @@ local _ClassConfig = {
             Max = 6,
             ConfigType = "Advanced",
         },
-        ['UseCure']             = {
+        ['UseCure']         = {
             DisplayName = "Cure Ailments",
             Group = "Abilities",
             Header = "Recovery",
@@ -1045,19 +1050,9 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['BardRespectMedState'] = {
-            DisplayName = "Bard: Respect Med Settings",
-            Group = "Movement",
-            Header = "Meditation",
-            Category = "Med Rules",
-            Index = 101,
-            Tooltip = "Allows the bard to meditate.\nPlease note that this comes at the cost of disabling all normal downtime actions while meditating.",
-            Default = false,
-            ConfigType = "Advanced",
-        },
 
         -- Instruments
-        ['SwapInstruments']     = {
+        ['SwapInstruments'] = {
             DisplayName = "Auto Swap Instruments",
             Index = 101,
             Group = "Items",
@@ -1067,7 +1062,7 @@ local _ClassConfig = {
             Default = false,
 
         },
-        ['UseBandolier']        = {
+        ['UseBandolier']    = {
             DisplayName = "Use Bandolier",
             Index = 102,
             Group = "Items",
@@ -1076,7 +1071,7 @@ local _ClassConfig = {
             Tooltip = "Auto swap instruments using bandolier if avail, valid names (wind, drum, brass, string or main), if a bandolier is missing we will direct swap instead.",
             Default = true,
         },
-        ['Offhand']             = {
+        ['Offhand']         = {
             DisplayName = "Offhand",
             Index = 103,
             Group = "Items",
@@ -1087,7 +1082,7 @@ local _ClassConfig = {
 
             Default = "",
         },
-        ['BrassInst']           = {
+        ['BrassInst']       = {
             DisplayName = "Brass Instrument",
             Index = 104,
             Group = "Items",
@@ -1097,7 +1092,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['WindInst']            = {
+        ['WindInst']        = {
             DisplayName = "Wind Instrument",
             Index = 105,
             Group = "Items",
@@ -1107,7 +1102,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['PercInst']            = {
+        ['PercInst']        = {
             DisplayName = "Percussion Instrument",
             Index = 106,
             Group = "Items",
@@ -1117,7 +1112,7 @@ local _ClassConfig = {
             Type = "ClickyItem",
             Default = "",
         },
-        ['StringedInst']        = {
+        ['StringedInst']    = {
             DisplayName = "Stringed Instrument",
             Index = 107,
             Group = "Items",
@@ -1129,7 +1124,7 @@ local _ClassConfig = {
         },
 
         -- Offensive
-        ['UseAria']             = {
+        ['UseAria']         = {
             DisplayName = "Use Aria",
             Group = "Abilities",
             Header = "Buffs",
@@ -1143,7 +1138,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseMarch']            = {
+        ['UseMarch']        = {
             DisplayName = "Use War March",
             Group = "Abilities",
             Header = "Buffs",
@@ -1157,7 +1152,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseProcSong']         = {
+        ['UseProcSong']     = {
             DisplayName = "Use Group Proc",
             Group = "Abilities",
             Header = "Buffs",
@@ -1171,7 +1166,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseArcane']           = {
+        ['UseArcane']       = {
             DisplayName = "Use Arcane Line",
             Group = "Abilities",
             Header = "Buffs",
@@ -1185,7 +1180,7 @@ local _ClassConfig = {
             Max = 4,
             RequiresLoadoutChange = true,
         },
-        ['UseEpic']             = {
+        ['UseEpic']         = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -1198,7 +1193,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 3,
         },
-        ['UseFireDots']         = {
+        ['UseFireDots']     = {
             DisplayName = "Use Fire Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1208,7 +1203,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UseIceDots']          = {
+        ['UseIceDots']      = {
             DisplayName = "Use Ice Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1218,7 +1213,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UsePoisonDots']       = {
+        ['UsePoisonDots']   = {
             DisplayName = "Use Poison Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1228,7 +1223,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['UseDiseaseDots']      = {
+        ['UseDiseaseDots']  = {
             DisplayName = "Use Disease Dots",
             Group = "Abilities",
             Header = "Damage",
@@ -1239,7 +1234,7 @@ local _ClassConfig = {
             Default = false,
 
         },
-        ['UseJonthan']          = {
+        ['UseJonthan']      = {
             DisplayName = "Use Jonthan",
             Group = "Abilities",
             Header = "Buffs",
@@ -1254,7 +1249,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
         },
-        ['UseShout']            = {
+        ['UseShout']        = {
             DisplayName = "Use Vain. Shout",
             Group = "Abilities",
             Header = "Damage",
@@ -1265,7 +1260,7 @@ local _ClassConfig = {
         },
 
         -- Song Duration Adjustment
-        ['RefreshDT']           = {
+        ['RefreshDT']       = {
             DisplayName = "Downtime Threshold",
             Group = "Abilities",
             Header = "Common",
@@ -1281,7 +1276,7 @@ local _ClassConfig = {
             Answer = "You may need to adjust your Downtime Threshold value downward at lower levels/song durations.\n" ..
                 "This needs to be carefully tailored towards your song line-up.",
         },
-        ['RefreshCombat']       = {
+        ['RefreshCombat']   = {
             DisplayName = "Combat Threshold",
             Group = "Abilities",
             Header = "Common",
@@ -1306,6 +1301,14 @@ local _ClassConfig = {
                 "  Clickies that aren't already included should be managed via the clickies tab, or by customizing the config to add them directly.\n" ..
                 "  Additionally, those wishing more fine-tune control for specific encounters or raids should customize this config to their preference. \n\n" ..
                 "  Community effort and feedback are required for robust, resilient class configs, and PRs are highly encouraged!",
+            Settings_Used = "",
+        },
+        [2] = {
+            Question = "How does Bard meditation function?",
+            Answer = "Bards can elect to med using the same settings as other classes. If a bard begins to med, they will stop singing any songs in the Melody rotation.\n\n" ..
+                "  Using the default class configs, the combat rotations will still be used. Thus, there is generally little or no support for in-combat meditation for Bard.\n\n" ..
+                "  The 'Stand When Done' med setting will ensure that a bard begins to sing again as soon as they reach the med stop threshold.\n\n" ..
+                "  Note that the Enduring Breath song, if enabled (and needed), does not respect meditation settings, for the safety of your group.",
             Settings_Used = "",
         },
     },

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1655,8 +1655,6 @@ function Casting.AutoMed()
     local me = mq.TLO.Me
     if Config:GetSetting('DoMed') == 1 then return end
 
-    if Core.MyClassIs("BRD") and me.Level() > 5 and not Config:GetSetting('BardRespectMedState', true) then return end
-
     if me.Mount.ID() and not mq.TLO.Zone.Indoor() then
         Logger.log_verbose("Sit check returning early due to mount.")
         return

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -430,10 +430,10 @@ Config.DefaultConfig               = {
         Header = "Meditation",
         Category = "Med Rules",
         Index = 1,
-        Tooltip = "Choose if/when to meditate.",
+        Tooltip = "Choose if/when to meditate.\nMay interfere with bard songs (refer to FAQ for 'Bard Meditation').",
         Type = "Combo",
         ComboOptions = { 'Off', 'Out of Combat', 'In and Out of Combat', },
-        Default = 2,
+        Default = Config.Globals.CurLoadedClass == "BRD" and 1 or 2,
         Min = 1,
         Max = 3,
         ConfigType = "Normal",
@@ -445,7 +445,7 @@ Config.DefaultConfig               = {
         Category = "Med Rules",
         Index = 2,
         Tooltip = "Force a stand to end meditation when thresholds are reached.",
-        Default = false,
+        Default = Config.Globals.CurLoadedClass == "BRD",
     },
     ['AfterCombatMedDelay']  = {
         DisplayName = "After Combat Med Delay",
@@ -504,7 +504,7 @@ Config.DefaultConfig               = {
         Tooltip = "Cease attempts to meditate when at or under this HP percentage.",
         Default = 90,
         Min = 1,
-        Max = 99,
+        Max = 100,
         ConfigType = "Advanced",
     },
     ['ManaMedPct']           = {
@@ -528,7 +528,7 @@ Config.DefaultConfig               = {
         Tooltip = "Cease attempts to meditate when at or under this Mana percentage.",
         Default = 90,
         Min = 1,
-        Max = 99,
+        Max = 100,
         ConfigType = "Advanced",
     },
     ['EndMedPct']            = {
@@ -552,7 +552,7 @@ Config.DefaultConfig               = {
         Tooltip = "Cease attempts to meditate when at or under this HP percentage.",
         Default = 90,
         Min = 1,
-        Max = 99,
+        Max = 100,
         ConfigType = "Advanced",
     },
 

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -412,25 +412,25 @@ function Ui.RenderRotationTableKey()
     if ImGui.BeginTable("Rotation_keys", 2, ImGuiTableFlags.Borders) then
         ImGui.TableNextColumn()
         ImGui.PushStyleColor(ImGuiCol.Text, 0.03, 1.0, 0.3, 1.0)
-        ImGui.Text(Icons.FA_SMILE_O .. ": Active")
+        ImGui.Text(Icons.FA_SMILE_O .. ": Effect is Active")
 
         ImGui.PopStyleColor()
         ImGui.TableNextColumn()
 
         ImGui.PushStyleColor(ImGuiCol.Text, 0.03, 1.0, 0.3, 1.0)
-        ImGui.Text(Icons.MD_CHECK .. ": Will Cast (Conditions Met)")
+        ImGui.Text(Icons.MD_CHECK .. ": Cast Occured (Conditions Met)")
 
         ImGui.PopStyleColor()
         ImGui.TableNextColumn()
 
         ImGui.PushStyleColor(ImGuiCol.Text, 1.0, 0.3, 0.3, 1.0)
-        ImGui.Text(Icons.FA_EXCLAMATION .. ": Cannot Cast")
+        ImGui.Text(Icons.FA_EXCLAMATION .. ": Didn't Cast (Conditions Not Met)")
 
         ImGui.PopStyleColor()
         ImGui.TableNextColumn()
 
         ImGui.PushStyleColor(ImGuiCol.Text, 0.3, 1.0, 1.0, 1.0)
-        ImGui.Text(Icons.MD_CHECK .. ": Will Cast (No Conditions)")
+        ImGui.Text(Icons.MD_CHECK .. ": No Conditions to Check")
 
         ImGui.PopStyleColor()
         ImGui.EndTable()


### PR DESCRIPTION
Bard (All Configs):
* Removed the bard-specific med setting, bards will now use the same logic as other classes.
* * Please refer to the in-game FAQ for "Bard Meditation" (searchable).
* * By default, meditation is disabled for bard, and the "Stand When Done" setting is enabled. However, existing users may need to adjust these settings.

* Moved Enduring Breath to its own rotation.

* Leveraged load conditions for some rotations and entries.

Rotation UI :
Clarified the meaning of the icons used for entry cast status. In a previous change, the UI was adjusted to only display the last cast attempt for each entry.