### PR TITLE
Combat Logic Improvements

### DIFF
--- a/modules/class.lua
+++ b/modules/class.lua
@@ -1530,7 +1530,7 @@ function Module:GiveTime(combat_state)
 
         for i = 1, xtCount do
             local xtSpawn = mq.TLO.Me.XTarget(i)
-            if xtSpawn and xtSpawn.ID() > 0 and not xtSpawn.Dead() and not xtSpawn.Fleeing() and (math.ceil(xtSpawn.PctHPs() or 0)) > 0 and ((xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater") or Targeting.ForceCombat) and Config.Constants.RGNotMezzedAnims:contains(xtSpawn.Animation()) and math.abs((mq.TLO.Me.Heading.Degrees() - (xtSpawn.Heading.Degrees() or 0))) < 100 then
+            if xtSpawn and xtSpawn.ID() > 0 and not xtSpawn.Dead() and not xtSpawn.Fleeing() and (math.ceil(xtSpawn.PctHPs() or 0)) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Config.Globals.ForceCombatID) and Config.Constants.RGNotMezzedAnims:contains(xtSpawn.Animation()) and math.abs((mq.TLO.Me.Heading.Degrees() - (xtSpawn.Heading.Degrees() or 0))) < 100 then
                 Logger.log_debug("\arXT(%s) is behind us! \atTaking evasive maneuvers! \awMyHeader(\am%d\aw) ThierHeading(\am%d\aw)", xtSpawn.DisplayName() or "",
                     mq.TLO.Me.Heading.Degrees(), (xtSpawn.Heading.Degrees() or 0))
                 if os.clock() - Movement:GetLastStickTimer() < 0.5 then

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -1660,61 +1660,61 @@ function Module:GetPullableSpawns()
         if not spawn() or spawn.ID() == 0 then return false end
         if not spawn.Targetable() then return false end
         if spawn.Type() ~= "NPC" and spawn.Type() ~= "NPCPET" then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aois type %s not an NPC or NPCPET -- Skipping", spawn.CleanName(), spawn.ID(),
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aois type %s not an NPC or NPCPET -- Skipping", spawn.CleanName(), spawn.ID(),
                 spawn.Type())
             return false
         end
 
         if spawn.Master.Type() == 'PC' then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aois Charmed Pet -- Skipping", spawn.CleanName(), spawn.ID())
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aois Charmed Pet -- Skipping", spawn.CleanName(), spawn.ID())
             return false
         end
 
         if Targeting.IsTempPet(spawn) then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aois Temp or Swarm Pet -- Skipping", spawn.CleanName(), spawn.ID())
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aois Temp or Swarm Pet -- Skipping", spawn.CleanName(), spawn.ID())
             return false
         end
 
         if self:IsPullMode("Chain") then
             if Targeting.IsSpawnXTHater(spawn.ID()) then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aoAlready on XTarget -- Skipping", spawn.CleanName(), spawn.ID())
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aoAlready on XTarget -- Skipping", spawn.CleanName(), spawn.ID())
                 return false
             end
         end
 
         if self:HaveList("PullAllowList") then
             if self:IsMobInList("PullAllowList", spawn.CleanName(), true) == false then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \ar -> Not Found in Allow List!", spawn.CleanName(), spawn.ID())
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \ar -> Not Found in Allow List!", spawn.CleanName(), spawn.ID())
                 return false
             end
         elseif self:HaveList("PullDenyList") then
             if self:IsMobInList("PullDenyList", spawn.CleanName(), false) == true then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \ar -> Found in Deny List!", spawn.CleanName(), spawn.ID())
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \ar -> Found in Deny List!", spawn.CleanName(), spawn.ID())
                 return false
             end
         end
 
         for _, ignoredMob in ipairs(self.TempSettings.PullIgnoreTargets) do
             if spawn.ID() == ignoredMob.ID() then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \ar -> Found in Ignore List!", spawn.CleanName(), spawn.ID())
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \ar -> Found in Ignore List!", spawn.CleanName(), spawn.ID())
                 return false
             end
         end
 
         if spawn.FeetWet() and not Config:GetSetting('PullMobsInWater') then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \agIgnoring mob in water", spawn.CleanName(), spawn.ID())
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \agIgnoring mob in water", spawn.CleanName(), spawn.ID())
             return false
         end
 
         -- Level Checks
         if Config:GetSetting('UsePullLevels') then
             if spawn.Level() < Config:GetSetting('PullMinLevel') then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aoLevel too low - %d", spawn.CleanName(), spawn.ID(),
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aoLevel too low - %d", spawn.CleanName(), spawn.ID(),
                     spawn.Level())
                 return false
             end
             if spawn.Level() > Config:GetSetting('PullMaxLevel') then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aoLevel too high - %d", spawn.CleanName(), spawn.ID(),
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aoLevel too high - %d", spawn.CleanName(), spawn.ID(),
                     spawn.Level())
                 return false
             end
@@ -1722,7 +1722,7 @@ function Module:GetPullableSpawns()
             -- check cons.
             local conLevel = Config.Constants.ConColorsNameToId[spawn.ConColor()]
             if conLevel > Config:GetSetting('PullMaxCon') or conLevel < Config:GetSetting('PullMinCon') then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw)  - Ignoring mob due to con color. Min = %d, Max = %d, Mob = %d (%s)",
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw)  - Ignoring mob due to con color. Min = %d, Max = %d, Mob = %d (%s)",
                     spawn.CleanName(), spawn.ID(),
                     Config:GetSetting('PullMinCon'),
                     Config:GetSetting('PullMaxCon'), conLevel, spawn.ConColor())
@@ -1731,7 +1731,7 @@ function Module:GetPullableSpawns()
             -- check max level difference
             local maxLvl = mq.TLO.Me.Level() + Config:GetSetting('MaxLevelDiff')
             if spawn.Level() > maxLvl then
-                Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw)  - Ignoring mob due to max level difference. Max Level = %d, Mob = %d",
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw)  - Ignoring mob due to max level difference. Max Level = %d, Mob = %d",
                     spawn.CleanName(), spawn.ID(), maxLvl, spawn.Level())
                 return false
             end
@@ -1749,7 +1749,7 @@ function Module:GetPullableSpawns()
 
         -- do distance checks.
         if math.abs(spawn.Z() - checkZ) > Config:GetSetting('PullZRadius') then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aoZDistance too far - %d > %d", spawn.CleanName(), spawn.ID(),
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aoZDistance too far - %d > %d", spawn.CleanName(), spawn.ID(),
                 math.abs(spawn.Z() - checkZ),
                 Config:GetSetting('PullZRadius'))
             return false
@@ -1758,7 +1758,7 @@ function Module:GetPullableSpawns()
         local distSqr = Math.GetDistanceSquared(spawn.X(), spawn.Y(), checkX, checkY)
 
         if distSqr > pullRadiusSqr then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aoDistance too far - distSq(%d) > pullRadiusSq(%d)",
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aoDistance too far - distSq(%d) > pullRadiusSq(%d)",
                 spawn.CleanName(), spawn.ID(), distSqr,
                 pullRadiusSqr)
             return false
@@ -1775,18 +1775,18 @@ function Module:GetPullableSpawns()
         end
 
         if not canPath or navDist > maxPathRange then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \aoPath check failed - dist(%d) canPath(%s)", spawn.CleanName(),
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \aoPath check failed - dist(%d) canPath(%s)", spawn.CleanName(),
                 spawn.ID(), navDist, Strings.BoolToColorString(canPath))
             return false
         end
 
         if Config:GetSetting('SafeTargeting') and Targeting.IsSpawnFightingStranger(spawn, 500) then
-            Logger.log_verbose("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \ar mob is fighting a stranger and safe targeting is enabled!",
+            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \ar mob is fighting a stranger and safe targeting is enabled!",
                 spawn.CleanName(), spawn.ID())
             return false
         end
 
-        Logger.log_debug("\atPULL::FindTarget \awFindTarget :: Spawn \am%s\aw (\at%d\aw) \agPotential Pull Added to List", spawn.CleanName(), spawn.ID())
+        Logger.log_debug("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \agPotential Pull Added to List", spawn.CleanName(), spawn.ID())
 
         metaDataCache[spawn.ID()] = { distance = navDist, }
 
@@ -1814,7 +1814,7 @@ function Module:FindTarget()
 
     if #pullTargets > 0 then
         local pullTarget = pullTargets[1]
-        Logger.log_info("\atPULL::FindTarget \agPulling %s [%d] with Distance: %d", pullTarget.CleanName(), pullTarget.ID(), metaData[pullTarget.ID()].distance)
+        Logger.log_info("\atPULL::FindPullTarget \agPulling %s [%d] with Distance: %d", pullTarget.CleanName(), pullTarget.ID(), metaData[pullTarget.ID()].distance)
         return pullTarget.ID()
     end
 

--- a/utils/comms.lua
+++ b/utils/comms.lua
@@ -57,31 +57,32 @@ function Comms.SendMessage(peer, module, event, data)
     Logger.log_debug("Sent Message: %s to:  %s event: %s", event, peer, Strings.TableToString(data or {}, 512))
 end
 
-function Comms.SendHeartbeat(assist, curState, curAutoTarget, chase)
+function Comms.SendHeartbeat(assist, curState, curAutoTarget, forceCombatId, chase)
     --if os.time() - Comms.LastHeartbeat < 1 then return end
     Comms.LastHeartbeat = os.time()
     Comms.BroadcastMessage("RGMercs", "Heartbeat", {
-        From       = Comms.GetPeerName(),
-        Zone       = mq.TLO.Zone.Name(),
-        X          = mq.TLO.Me.X(),
-        Y          = mq.TLO.Me.Y(),
-        Z          = mq.TLO.Me.Z(),
-        Poison     = tostring(mq.TLO.Me.Poisoned.ID()),
-        Disease    = tostring(mq.TLO.Me.Diseased.ID()),
-        Curse      = tostring(mq.TLO.Me.Cursed.ID()),
+        From          = Comms.GetPeerName(),
+        Zone          = mq.TLO.Zone.Name(),
+        X             = mq.TLO.Me.X(),
+        Y             = mq.TLO.Me.Y(),
+        Z             = mq.TLO.Me.Z(),
+        Poison        = tostring(mq.TLO.Me.Poisoned.ID()),
+        Disease       = tostring(mq.TLO.Me.Diseased.ID()),
+        Curse         = tostring(mq.TLO.Me.Cursed.ID()),
         ---@diagnostic disable-next-line: undefined-field
-        Mezzed     = tostring(mq.TLO.Me.Mezzed.ID()),
-        Corruption = tostring(mq.TLO.Me.Diseased.ID()),
-        Stunned    = mq.TLO.Me.Stunned(),
-        HPs        = mq.TLO.Me.PctHPs(),
-        Mana       = mq.TLO.Me.PctMana(),
-        Endurance  = mq.TLO.Me.PctEndurance(),
-        Target     = mq.TLO.Target.DisplayName() or "None",
-        TargetID   = mq.TLO.Target.ID() or 0,
-        AutoTarget = curAutoTarget,
-        Assist     = assist,
-        State      = curState,
-        Chase      = chase,
+        Mezzed        = tostring(mq.TLO.Me.Mezzed.ID()),
+        Corruption    = tostring(mq.TLO.Me.Diseased.ID()),
+        Stunned       = mq.TLO.Me.Stunned(),
+        HPs           = mq.TLO.Me.PctHPs(),
+        Mana          = mq.TLO.Me.PctMana(),
+        Endurance     = mq.TLO.Me.PctEndurance(),
+        Target        = mq.TLO.Target.DisplayName() or "None",
+        TargetID      = mq.TLO.Target.ID() or 0,
+        ForceCombatID = forceCombatId,
+        AutoTarget    = curAutoTarget,
+        Assist        = assist,
+        State         = curState,
+        Chase         = chase,
     })
 end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -48,6 +48,7 @@ Config.Globals.MainAssist                                = ""
 Config.Globals.ScriptDir                                 = ""
 Config.Globals.AutoTargetID                              = 0
 Config.Globals.ForceTargetID                             = 0
+Config.Globals.ForceCombatID                             = 0
 Config.Globals.LastPulledID                              = 0
 Config.Globals.SubmodulesLoaded                          = false
 Config.Globals.PauseMain                                 = false
@@ -188,6 +189,16 @@ Config.FAQ                         = {
             "Positioning:\nFace Target In Combat (Mercs will still assume you are facing properly for abilities that require it!)\n\n" ..
             "Mercs will still manage the action, and we should return to the target you had if needed after a heal, buff, item use, etc. You can pause mercs to take full control." ..
             "These settings and interactions have been recently adjusted, and feedback is requested if you see something not quite right!",
+        Settings_Used = "",
+    },
+    [3] = {
+        Question = "How do I force auto combat on a target that isn't aggressive or isn't hostile?",
+        Answer = "This is accomplished with the /rgl forcecombat <id?> command:\n\n" ..
+            "The command accepts a target ID, and will fall back to your current target's ID if one is not supplied.\n\n" ..
+            "When commanded, the MA will add the target to the first XT slot and immediately force target.\n\n" ..
+            "The force combat state will be broadcasted to peers via actors, and will allow the target to check as valid even when the 'Target Non-Aggressives' setting is disabled." ..
+            " Actors may need to be configured in MQ if all peers are not on the same PC. As an alternative, the setting above can be enabled temporarily.\n\n" ..
+            "Only one Force Combat target can be directed at a time, and the state will be cleared automatically. It can be cleared manually with the /rgl forcecombatclear command.",
         Settings_Used = "",
     },
 }
@@ -408,17 +419,6 @@ Config.DefaultConfig               = {
         Category = "Misc",
         Index = 1,
         Tooltip = "Instantly release to spawn point when you die.",
-        Default = false,
-        ConfigType = "Advanced",
-    },
-    ['ForceKillPet']         = { --Algarnote: I don't like this setting, I think I've fixed the issues... consider removal or a more elegant solution
-        DisplayName = "Force Kill Pet",
-        Group = "General",
-        Header = "Misc",
-        Category = "Misc",
-        Index = 2,
-        Tooltip =
-        "Force kill a peer's pet if found on xtarget after other means of correction have failed. Failsafe for buggy xtargeting on Emu servers. Please report if you need to use this setting!",
         Default = false,
         ConfigType = "Advanced",
     },
@@ -693,12 +693,23 @@ Config.DefaultConfig               = {
         Default = true,
         ConfigType = "Advanced",
     },
+    ['TargetNonAggressives'] = {
+        DisplayName = "Target Non-Aggressives",
+        Group = "Combat",
+        Header = "Targeting",
+        Category = "Targeting Behavior",
+        Index = 4,
+        Tooltip =
+        "Allow targeting of NPCs that are not aggressive (hostile) if they are targeted by our MA.\nNote: If combat has been forced on the target (by the MA via the forcecombat command), the target will also be allowed.",
+        Default = false,
+        ConfigType = "Advanced",
+    },
     ['StopAttackForPCs']     = {
         DisplayName = "Stop Attack for PCs",
         Group = "Combat",
         Header = "Targeting",
         Category = "Targeting Behavior",
-        Index = 4,
+        Index = 5,
         Tooltip = "Ensure that auto attack is turned off before targeting a PC to use a spell, song, AA, or item. May be required if PvP is enabled by flag, zone, or server.",
         Default = false,
         ConfigType = "Advanced",

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -201,6 +201,11 @@ function Core.GetMainAssistPctHPs()
         return groupMember.PctHPs() or 100
     end
 
+    local raidMember = mq.TLO.Raid.Member(Config.Globals.MainAssist)
+    if raidMember and raidMember() then
+        return raidMember.PctHPs() or 100
+    end
+
     local heartbeat = Config:GetPeerHeartbeatByName(Config.Globals.MainAssist)
     if heartbeat and heartbeat.Data and heartbeat.Data.HPs then
         local hpPct = tonumber(heartbeat.Data.HPs)

--- a/utils/event_handlers.lua
+++ b/utils/event_handlers.lua
@@ -16,7 +16,7 @@ local ClassLoader = require('utils.classloader')
 mq.event("CantSee", "You cannot see your target.", function()
     if Config.Globals.BackOffFlag then return end
     if Config.Globals.PauseMain then return end
-    if not Config:GetSetting('HandleCantSeeTarget') then
+    if not Config:GetSetting('HandleCantSeeTarget') or Targeting.GetXTHaterCount() == 0 then
         return
     end
     local target = mq.TLO.Target
@@ -70,7 +70,7 @@ end)
 -- [ TOO CLOSE HANDLERS] --
 
 mq.event("TooClose", "Your target is too close to use a ranged weapon!", function()
-    if not Config:GetSetting('HandleTooClose') then
+    if not Config:GetSetting('HandleTooClose') or Targeting.GetXTHaterCount() == 0 then
         Logger.log_debug("TooCloseHandler: Event Detected, but HandleTooClose is not enabled.")
         return
     end
@@ -119,7 +119,7 @@ end)
 -- [ TOO FAR HANDLERS ] --
 
 local function tooFarHandler()
-    if not Config:GetSetting('HandleTooFar') then
+    if not Config:GetSetting('HandleTooFar') or Targeting.GetXTHaterCount() == 0 then
         return
     end
     Logger.log_debug("tooFarHandler()")

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -255,7 +255,7 @@ function Ui.RenderForceTargetList(showPopout)
         local xtCount = mq.TLO.Me.XTarget() or 0
         for i = 1, xtCount do
             local xtarg = mq.TLO.Me.XTarget(i)
-            if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater") or Targeting.ForceCombat) then
+            if xtarg and xtarg.ID() > 0 and (xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater" or xtarg.ID() == Config.Globals.ForceCombatID) then
                 ImGui.TableNextColumn()
                 if (Targeting.GetAutoTarget().ID() or 0) == xtarg.ID() then
                     ImGui.TableSetBgColor(ImGuiTableBgTarget.RowBg0, Ui.GetConHighlightBySpawn(xtarg))


### PR DESCRIPTION
* Improved support for forcing combat on non-hostile targets.
* * The /rgl forcecombat command has been adjusted to accept an optional ID, with a fallback to the current target's ID.
* * Added /rgl forcecombatclear to remove the target manually if needed.
* * Please reference the (searchable!) in-game Command List and FAQs for a full explanation.

* Removed redundant checks from the engage logic.

* Fixed a bug preventing the proper function of Priority Healing.

* Adjusted pre-target validation. An autotarget will no longer be assigned until validated (for distance, health, hostility, etc).
* * As a result, using the assist list will no longer force every MA target change to be reflected in peer xtargets, eliminating some nuisances and edge-case bugs.

* Adjusted target validation. Tightened conditions around target engagement.

* Added protections to stop (non-MA) peers from engaging non-hostile targets. The "Target Non-Aggressives" setting (default: false) can be enabled to bypass these restrictions.

* Improved handling of xtarget use and reset.

* Eliminated a bug in which too far/can't see/too close event handlers could be fired out of combat.
* * This unfortunately removes the "feature" of turning auto-attack on for a driver to instantly close distances to a target. The '/rgl pulltarget' command or "Pull Target" UI button is my humble suggestion for an alternative.