### PR TITLE
EMU Configs and other minor updates

### DIFF
--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -499,16 +499,6 @@ local _ClassConfig = {
                 return combat_state == "Combat" and Core.OkayToNotHeal()
             end,
         },
-        {
-            name = 'ArcanumWeave',
-            state = 1,
-            steps = 1,
-            load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and Core.OkayToNotHeal() and not mq.TLO.Me.Buff("Focus of Arcanum")()
-            end,
-        },
     },
     ['Rotations']         = {
         ['DPS'] = {
@@ -863,29 +853,6 @@ local _ClassConfig = {
                 type = "Spell",
                 cond = function(self, spell)
                     return Casting.PetBuffCheck(spell)
-                end,
-            },
-        },
-        ['ArcanumWeave'] = {
-            {
-                name = "Empowered Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Enlightened Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Acute Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
         },
@@ -1325,16 +1292,6 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
-        },
-        ['DoArcanumWeave']    = {
-            DisplayName = "Weave Arcanums",
-            Group = "Abilities",
-            Header = "Buffs",
-            Category = "Self",
-            Index = 105,
-            Tooltip = "Weave Empowered/Enlighted/Acute Focus of Arcanum into your standard combat routine (Focus of Arcanum is saved for burns).",
-            RequiresLoadoutChange = true, --this setting is used as a load condition
-            Default = true,
         },
         ['KeepEvacMemmed']    = {
             DisplayName = "Memorize Evac",

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -974,16 +974,6 @@ _ClassConfig      = {
                 return downtime or combat
             end,
         },
-        {
-            name = 'ArcanumWeave',
-            state = 1,
-            steps = 1,
-            load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and not mq.TLO.Me.Buff("Focus of Arcanum")()
-            end,
-        },
     },
     -- Really the meat of this class.
     ['HelperFunctions']   = {
@@ -1777,29 +1767,6 @@ _ClassConfig      = {
                 end,
             },
         },
-        ['ArcanumWeave'] = {
-            {
-                name = "Empowered Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Enlightened Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Acute Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-        },
     },
     ['SpellList']         = {
         {
@@ -2089,16 +2056,6 @@ _ClassConfig      = {
             Min = 1,
             Max = 6,
             ConfigType = "Advanced",
-        },
-        ['DoArcanumWeave'] = {
-            DisplayName = "Weave Arcanums",
-            Group = "Abilities",
-            Header = "Buffs",
-            Category = "Self",
-            Index = 101,
-            Tooltip = "Weave Empowered/Enlighted/Acute Focus of Arcanum into your standard combat routine (Focus of Arcanum is saved for burns).",
-            RequiresLoadoutChange = true, --this setting is used as a load condition
-            Default = true,
         },
 
         --Damage (AE)

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -424,16 +424,6 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'ArcanumWeave',
-            state = 1,
-            steps = 1,
-            load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and not mq.TLO.Me.Buff("Focus of Arcanum")()
-            end,
-        },
-        {
             name = 'PetHealing',
             state = 1,
             steps = 1,
@@ -788,29 +778,6 @@ local _ClassConfig = {
                 name = "PetHealSpell",
                 type = "Spell",
                 load_cond = function(self) Config:GetSetting('DoPetHealSpell') end,
-            },
-        },
-        ['ArcanumWeave']    = {
-            {
-                name = "Empowered Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Enlightened Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Acute Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
             },
         },
         ['Downtime']        = {
@@ -1254,17 +1221,6 @@ local _ClassConfig = {
             Index = 101,
             Tooltip = "Use your Necrotic Pustules spell on the (non-SHD) MA.",
             RequiresLoadoutChange = true,
-            Default = true,
-            ConfigType = "Advanced",
-        },
-        ['DoArcanumWeave']    = {
-            DisplayName = "Weave Arcanums",
-            Group = "Abilities",
-            Header = "Buffs",
-            Category = "Self",
-            Index = 105,
-            Tooltip = "Weave Empowered/Enlighted/Acute Focus of Arcanum into your standard combat routine (Focus of Arcanum is saved for burns).",
-            RequiresLoadoutChange = true, --this setting is used as a load condition
             Default = true,
             ConfigType = "Advanced",
         },

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -710,6 +710,11 @@ local _ClassConfig = {
         },
         ['AEHateTools'] = {
             {
+                name = "Artifact of Dread Gaze",
+                type = "Item",
+                load_cond = function(self) return mq.TLO.FindItem("=Artifact of Dread Gaze")() end,
+            },
+            {
                 name = "Explosion of Hatred",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfHatred,
@@ -913,8 +918,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAC,
                 load_cond = function(self) return Config:GetSetting('DoACTap') end,
                 cond = function(self, spell, target)
-                    local triggerSpell = spell() and spell.Trigger()
-                    return triggerSpell and not Casting.IHaveBuff(triggerSpell)
+                    local triggerSpell = spell() and spell.RankName.Trigger()
+                    return triggerSpell and not mq.TLO.Me.Buff(triggerSpell)
                 end,
             },
             {
@@ -923,8 +928,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAtk,
                 load_cond = function(self) return Config:GetSetting('DoAtkTap') end,
                 cond = function(self, spell, target)
-                    local triggerSpell = spell() and spell.Trigger()
-                    return triggerSpell and not Casting.IHaveBuff(triggerSpell)
+                    local triggerSpell = spell() and spell.RankName.Trigger()
+                    return triggerSpell and not mq.TLO.Me.Buff(triggerSpell)
                 end,
             },
             {

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -594,17 +594,6 @@ local _ClassConfig = {
                     (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
             end,
         },
-        {
-            name = 'ArcanumWeave',
-            state = 1,
-            steps = 1,
-            load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and not mq.TLO.Me.Buff("Focus of Arcanum")() and
-                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
-            end,
-        },
 
     },
     ['Rotations']         = {
@@ -1046,29 +1035,6 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['ArcanumWeave'] = {
-            {
-                name = "Empowered Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Enlightened Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Acute Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-        },
     },
     -- New style spell list, gemless, priority-based. Will use the first set whose conditions are met.
     -- Conditions are not limited to modes. Virtually any helper function or TLO can be used. Example: Level-based lists.
@@ -1442,16 +1408,6 @@ local _ClassConfig = {
             Tooltip = "Do Haste Spells/AAs",
             Default = true,
             ConfigType = "Advanced",
-        },
-        ['DoArcanumWeave']    = {
-            DisplayName = "Weave Arcanums",
-            Group = "Abilities",
-            Header = "Buffs",
-            Category = "Self",
-            Index = 101,
-            Tooltip = "Weave Empowered/Enlighted/Acute Focus of Arcanum into your standard combat routine (Focus of Arcanum is saved for burns).",
-            RequiresLoadoutChange = true, --this setting is used as a load condition
-            Default = true,
         },
 
         -- Debuffs

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -387,16 +387,6 @@ return {
                 return combat_state == "Combat"
             end,
         },
-        {
-            name = 'ArcanumWeave',
-            state = 1,
-            steps = 1,
-            load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and not mq.TLO.Me.Buff("Focus of Arcanum")()
-            end,
-        },
     },
     ['Rotations']       = {
         ['Burn'] = {
@@ -726,29 +716,6 @@ return {
                 load_cond = function(self) return not Casting.CanUseAA("Harvest of Druzzil") end,
                 cond = function(self, spell)
                     return Casting.CastReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
-                end,
-            },
-        },
-        ['ArcanumWeave'] = {
-            {
-                name = "Empowered Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Enlightened Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Acute Focus of Arcanum",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
         },
@@ -1094,16 +1061,6 @@ return {
             Default = 60,
             Min = 1,
             Max = 99,
-        },
-        ['DoArcanumWeave']       = {
-            DisplayName = "Weave Arcanums",
-            Group = "Abilities",
-            Header = "Buffs",
-            Category = "Self",
-            Index = 101,
-            Tooltip = "Weave Empowered/Enlighted/Acute Focus of Arcanum into your standard combat routine (Focus of Arcanum is saved for burns).",
-            RequiresLoadoutChange = true, --this setting is used as a load condition
-            Default = true,
         },
     },
     ['ClassFAQ']        = {

--- a/class_configs/HiddenForest/shd_class_config.lua
+++ b/class_configs/HiddenForest/shd_class_config.lua
@@ -994,8 +994,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAC,
                 load_cond = function(self) return Config:GetSetting('DoACTap') end,
                 cond = function(self, spell, target)
-                    local triggerSpell = spell() and spell.Trigger()
-                    return triggerSpell and not Casting.IHaveBuff(triggerSpell)
+                    local triggerSpell = spell() and spell.RankName.Trigger()
+                    return triggerSpell and not mq.TLO.Me.Buff(triggerSpell)
                 end,
             },
             {
@@ -1004,8 +1004,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAtk,
                 load_cond = function(self) return Config:GetSetting('DoAtkTap') end,
                 cond = function(self, spell, target)
-                    local triggerSpell = spell() and spell.Trigger()
-                    return triggerSpell and not Casting.IHaveBuff(triggerSpell)
+                    local triggerSpell = spell() and spell.RankName.Trigger()
+                    return triggerSpell and not mq.TLO.Me.Buff(triggerSpell)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -978,8 +978,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAC,
                 load_cond = function(self) return Config:GetSetting('DoACTap') end,
                 cond = function(self, spell, target)
-                    local triggerSpell = spell() and spell.Trigger()
-                    return triggerSpell and not Casting.IHaveBuff(triggerSpell)
+                    local triggerSpell = spell() and spell.RankName.Trigger()
+                    return triggerSpell and not mq.TLO.Me.Buff(triggerSpell)
                 end,
             },
             {
@@ -988,8 +988,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAtk,
                 load_cond = function(self) return Config:GetSetting('DoAtkTap') end,
                 cond = function(self, spell, target)
-                    local triggerSpell = spell() and spell.Trigger()
-                    return triggerSpell and not Casting.IHaveBuff(triggerSpell)
+                    local triggerSpell = spell() and spell.RankName.Trigger()
+                    return triggerSpell and not mq.TLO.Me.Buff(triggerSpell)
                 end,
             },
             {

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -402,7 +402,6 @@ Module.LogicBlocks                      = {
         cond = function(self, target, hp, cnt)
             return (mq.TLO.Group.Injured(hp)() or 0) >= cnt
         end,
-        cond_targets = { 'Self', },
         tooltip = "Only use if [Count] group members are below [X] HP%.",
         render_header_text = function(self, cond)
             return string.format("%d group members are <= %d%% HP", cond.args[1] or 0, cond.args[2] or 100)

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -608,13 +608,12 @@ function Combat.OkToEngagePreValidateId(targetId)
             return true
         else
             local distanceCheck = Targeting.GetTargetDistance(target) < Config:GetSetting('AssistRange')
-            local assistHPCheck = Targeting.GetTargetPctHPs(target) <= Config:GetSetting('AutoAssistAt')
             local hostileCheck = Config:GetSetting('TargetNonAggressives') or target.Aggressive() or target.ID() == Config.Globals.ForceCombatID
 
-            Logger.log_verbose("OkToEngagePrevalidate check for %s(ID: %d) - DistanceCheck(%s), AssistHPCheck(%s), HostileCheck(%s)", targetName, targetId,
-                Strings.BoolToColorString(distanceCheck), Strings.BoolToColorString(assistHPCheck), Strings.BoolToColorString(hostileCheck))
+            Logger.log_verbose("OkToEngagePrevalidate check for %s(ID: %d) - DistanceCheck(%s), HostileCheck(%s)", targetName, targetId,
+                Strings.BoolToColorString(distanceCheck), Strings.BoolToColorString(hostileCheck))
 
-            return distanceCheck and assistHPCheck and hostileCheck
+            return distanceCheck and hostileCheck
         end
     end
 

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -25,7 +25,7 @@ end
 function Targeting.SetTarget(targetId, ignoreBuffPopulation)
     if targetId == 0 then return end
 
-    local maxWaitBuffs = ((mq.TLO.EverQuest.Ping() * 20) + 500)
+    local maxWaitBuffs = ((mq.TLO.EverQuest.Ping() * 2) + 500)
 
     if targetId == mq.TLO.Target.ID() then return end
     Logger.log_debug("SetTarget(): Setting Target: %d (buffPopWait: %d)", targetId, ignoreBuffPopulation and 0 or maxWaitBuffs)


### PR DESCRIPTION
EMU Config Updates
* [SHD - All EMU] Adjusted AC/Atk Tap conditions.
* [SHD- EQM] Added support for Dread Gaze artifact.
* [ENC - EQM] Adjusted NDT/Illusion Buffs
* [ALL - EQM] Removed remaining arcanum weave rotations/settings.

Minor Updates:
* Clickies: Removed unneeded condition target for group injured count.
* Combat: Removed HP check from  target prevalidation to give the fastest possible health update (via target).
* Targeting: Slightly adjusted max wait when waiting for buffs to populate.