### PR TITLE
Engage Check Improvements ; EQ Might Healer clickies

### DIFF
--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -92,6 +92,12 @@ local _ClassConfig = {
             "Fabled Blue Band of the Oak",
             "Blue Band of the Oak",
         },
+        ['Timer2HealItem'] = {
+            "Legendary Weighted Hammer of Conviction",
+            "Legendary Aged Shissar Apothic Staff",
+            "Weighted Hammer of Conviction",
+            "Aged Shissar Apothic Staff",
+        },
     },
     ['AbilitySets']       = {
         -- ['WardSelfBuff'] = {
@@ -471,11 +477,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "Legendary Aged Shissar Apothic Staff",
-                type = "Item",
-            },
-            {
-                name = "Weighted Hammer of Conviction",
+                name = "Timer2HealItem",
                 type = "Item",
             },
             { --This entry is for RemedyHeal until we learn a Renewal

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -82,6 +82,12 @@ local _ClassConfig = {
             "Fabled Blue Band of the Oak",
             "Blue Band of the Oak",
         },
+        ['Timer2HealItem'] = {
+            "Legendary Kelp-Covered Hammer",
+            "Legendary Aged Dragon Spine Staff",
+            "Kelp-Covered Hammer",
+            "Aged Dragon Spine Staff",
+        },
     },
     ['AbilitySets']       = {
         ['HealingAura'] = {
@@ -382,11 +388,7 @@ local _ClassConfig = {
                 type = "AA",
             },
             {
-                name = "Kelp-Covered Hammer",
-                type = "Item",
-            },
-            {
-                name = "Legendary Aged Dragon Spine Staff",
+                name = "Timer2HealItem",
                 type = "Item",
             },
             { --Let's make the mainheal autocrit since we have nothing better

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -84,6 +84,12 @@ local _ClassConfig = {
             "Fabled Blue Band of the Oak",
             "Blue Band of the Oak",
         },
+        ['Timer2HealItem'] = {
+            "Legendary Zun'Muram's Spear of Doom",
+            "Legendary Aged Hammer of the Dragonborn",
+            "Zun'Muram's Spear of Doom",
+            "Aged Hammer of the Dragonborn",
+        },
     },
     ['AbilitySets']       = {
         ["GroupFocusSpell"] = {
@@ -483,11 +489,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "Legendary Aged Hammer of the Dragonborn",
-                type = "Item",
-            },
-            {
-                name = "Zun'Muram's Spear of Doom",
+                name = "Timer2HealItem",
                 type = "Item",
             },
             {

--- a/init.lua
+++ b/init.lua
@@ -410,17 +410,17 @@ local function Main()
         Combat.FindBestAutoTarget(Combat.OkToEngagePreValidateId)
     end
 
+    if Combat.OkToEngage(Config.Globals.AutoTargetID) then
+        Combat.EngageTarget(Config.Globals.AutoTargetID)
+    else
+        if (Targeting.GetXTHaterCount(true) > 0 or mq.TLO.Me.Combat()) and Targeting.GetTargetID() ~= (Config:GetSetting('DoPull') and Config.Globals.LastPulledID or 0) and not (Core.IAmMA() and Targeting.IsSpawnXTHater(mq.TLO.Target.ID())) then
+            Logger.log_debug("\ayClearing Target because we are not OkToEngage() and we are in combat!")
+            Targeting.ClearTarget()
+        end
+    end
+
     -- Handles state for when we're in combat
     if curState == "Combat" then
-        if Combat.OkToEngage(Config.Globals.AutoTargetID) then
-            Combat.EngageTarget(Config.Globals.AutoTargetID)
-        else
-            if (Targeting.GetXTHaterCount(true) > 0 or mq.TLO.Me.Combat()) and Targeting.GetTargetID() ~= (Config:GetSetting('DoPull') and Config.Globals.LastPulledID or 0) and not (Core.IAmMA() and Targeting.IsSpawnXTHater(mq.TLO.Target.ID())) then
-                Logger.log_debug("\ayClearing Target because we are not OkToEngage() and we are in combat!")
-                Targeting.ClearTarget()
-            end
-        end
-
         if ((os.clock() - Config.Globals.LastPetCmd) > 2) then
             Config.Globals.LastPetCmd = os.clock()
             if ((Config:GetSetting('DoPet') or Config:GetSetting('CharmOn')) and mq.TLO.Pet.ID() ~= 0) and (Targeting.GetTargetPctHPs(Targeting.GetAutoTarget()) <= Config:GetSetting('PetEngagePct')) then

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -587,7 +587,15 @@ function Combat.OkToEngagePreValidateId(targetId)
     local target = mq.TLO.Spawn(targetId)
     local targetName = target.CleanName() or "Unknown"
 
-    if not target() or target.Dead() then return false end
+    if not target() then
+        Logger.log_verbose("\ayOkToEngagePrevalidate check - No Target Spawn --> Not Engaging")
+        return false
+    end
+
+    if target.Dead() then
+        Logger.log_verbose("\ayOkToEngagePrevalidate check for %s(ID: %d) - Target Spawn Dead --> Not Engaging", targetName, targetId)
+        return false
+    end
 
     local pcCheck = Targeting.TargetIsType("pc", target) or (Targeting.TargetIsType("pet", target) and Targeting.TargetIsType("pc", target.Master))
     local mercCheck = Targeting.TargetIsType("mercenary", target)
@@ -631,7 +639,20 @@ function Combat.OkToEngage(autoTargetId)
     local targetId = target.ID()
 
 
-    if not target() or target.Dead() then return false end
+    if not target() then
+        Logger.log_verbose("\ayOkToEngage check - No Target --> Not Engaging")
+        return false
+    end
+
+    if Targeting.GetTargetID() ~= autoTargetId then
+        Logger.log_verbose("\ayOkToEngage check for %s(ID: %d) - Target isn't the Auto Target, can't perform checks--> Not Engaging", targetName, targetId)
+        return false
+    end
+
+    if target.Dead() then
+        Logger.log_verbose("\ayOkToEngage check for %s(ID: %d) - Target Dead --> Not Engaging", targetName, targetId)
+        return false
+    end
 
     local pcCheck = Targeting.TargetIsType("pc", target) or (Targeting.TargetIsType("pet", target) and Targeting.TargetIsType("pc", target.Master))
     local mercCheck = Targeting.TargetIsType("mercenary", target)
@@ -660,13 +681,11 @@ function Combat.OkToEngage(autoTargetId)
             local distanceCheck = Targeting.GetTargetDistance() < Config:GetSetting('AssistRange')
             local assistHPCheck = Targeting.GetTargetPctHPs() <= Config:GetSetting('AutoAssistAt')
             local hostileCheck = Config:GetSetting('TargetNonAggressives') or target.Aggressive() or target.ID() == Config.Globals.ForceCombatID
-            local targetingCheck = Targeting.GetTargetID() == autoTargetId
 
-            Logger.log_verbose("OkToEngage check for %s(ID: %d) - DistanceCheck(%s), AssistHPCheck(%s), HostileCheck(%s), TargetCheck(%s)", targetName, targetId,
-                Strings.BoolToColorString(distanceCheck), Strings.BoolToColorString(assistHPCheck), Strings.BoolToColorString(hostileCheck),
-                Strings.BoolToColorString(targetingCheck))
+            Logger.log_verbose("OkToEngage check for %s(ID: %d) - DistanceCheck(%s), AssistHPCheck(%s), HostileCheck(%s)", targetName, targetId,
+                Strings.BoolToColorString(distanceCheck), Strings.BoolToColorString(assistHPCheck), Strings.BoolToColorString(hostileCheck))
 
-            return distanceCheck and assistHPCheck and hostileCheck and targetingCheck
+            return distanceCheck and assistHPCheck and hostileCheck
         end
     end
 


### PR DESCRIPTION
* Refactor of engage logic to improve handling of mobs going inactive/non-hostile.

* Refactor of engage checks to check target validity earlier and improve verbosity.

* EQM Healers: Consolidated clickies using timer 2 for heals into their own group.