### PR TITLE
Feign Death Adjustment/Fixes

### DIFF
--- a/class_configs/EQ Might/mnk_class_config.lua
+++ b/class_configs/EQ Might/mnk_class_config.lua
@@ -168,7 +168,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
-                        and not Core.IAmMA
+                        and not Core.IAmMA()
                 end,
             },
             {
@@ -176,7 +176,7 @@ local _ClassConfig = {
                 type = "Ability",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IAmMA
+                    return Targeting.IHaveAggro(80) and not Core.IAmMA()
                 end,
             },
             {

--- a/class_configs/HiddenForest/mnk_class_config.lua
+++ b/class_configs/HiddenForest/mnk_class_config.lua
@@ -162,7 +162,7 @@ local _ClassConfig = {
                 type = "Item",
                 cond = function(self, itemName, target)
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
-                        and not Core.IAmMA
+                        and not Core.IAmMA()
                 end,
             },
             {
@@ -171,7 +171,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
-                        and not Core.IAmMA
+                        and not Core.IAmMA()
                 end,
             },
             {
@@ -179,7 +179,7 @@ local _ClassConfig = {
                 type = "Ability",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IAmMA
+                    return Targeting.IHaveAggro(80) and not Core.IAmMA()
                 end,
             },
             {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -915,7 +915,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99) and not Core.IAmMA
+                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99) and not Core.IAmMA()
                 end,
             },
             {

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -353,7 +353,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
-                        and not Core.IAmMA
+                        and not Core.IAmMA()
                 end,
             },
             {
@@ -361,7 +361,7 @@ local _ClassConfig = {
                 type = "Ability",
                 cond = function(self, abilityName)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return Targeting.IHaveAggro(80) and not Core.IAmMA
+                    return Targeting.IHaveAggro(80) and not Core.IAmMA()
                 end,
             },
             {

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -164,7 +164,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Targeting.IsNamed(target) and mq.TLO.Me.PctAggro() > 99)
-                        and not Core.IAmMA
+                        and not Core.IAmMA()
                 end,
             },
             {
@@ -172,7 +172,7 @@ local _ClassConfig = {
                 type = "Ability",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IAmMA
+                    return Targeting.IHaveAggro(80) and not Core.IAmMA()
                 end,
             },
             {

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -86,7 +86,7 @@ function Combat.EngageTarget(autoTargetId)
 
     local target = mq.TLO.Target
 
-    if (mq.TLO.Me.Feigning() or mq.TLO.Me.State():lower() == "feign") and not Core.MyClassIs("mnk") and Config:GetSetting('AutoStandFD') then
+    if (mq.TLO.Me.Feigning() or mq.TLO.Me.State():lower() == "feign") and Config:GetSetting('AutoStandFD') then
         mq.TLO.Me.Stand()
     end
 


### PR DESCRIPTION
Fix for improper MA check.
Removed hardcoded check for standing from feign on Monk (this is already a user-configured option).