### PR TITLE
NEC Lich Adjustment, EQ Might Config Updates

### DIFF
--- a/class_configs/Alpha (Live)/nec_class_config.lua
+++ b/class_configs/Alpha (Live)/nec_class_config.lua
@@ -1303,11 +1303,11 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Tooltip = "Cancel Lich at Mana Pct [x]",
+            Tooltip = "Cancel your Lich spell when your mana has increased to this percentage. (Selecting 101 will disable canceling lich based on mana percent.)",
             RequiresLoadoutChange = false,
             Default = 100,
             Min = 1,
-            Max = 100,
+            Max = 101,
         },
         ['StartLichMana']     = {
             DisplayName = "Start Lich Mana",

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -963,6 +963,15 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Trinket of Suffocation",
+                type = "Item",
+                load_cond = function() return mq.TLO.Me.Level() >= 68 and mq.TLO.FindItem("=Trinket of Suffocation")() end,
+                cond = function(self, itemName, target)
+                    if Config:GetSetting('DotNamedOnly') and not Targeting.IsNamed(target) then return false end
+                    return Casting.DotItemCheck(itemName, target)
+                end,
+            },
+            {
                 name = "StrangleDot",
                 type = "Spell",
                 load_cond = function() return Config:GetSetting("DoStrangleDot") end,

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -267,9 +267,9 @@ _ClassConfig      = {
         ['SingleCotH'] = {
             "Call of the Hero",
         },
-        ['GroupCotH'] = {
-            "Call of the Harbinger",
-        },
+        -- ['GroupCotH'] = {
+        --     "Call of the Harbinger", -- does not appear to be added
+        -- },
         ['PBAE2'] = {
             "Scintillation",
         },
@@ -1089,8 +1089,8 @@ _ClassConfig      = {
                 { name = "MaloDebuff",       cond = function(self) return Config:GetSetting('DoMalo') and not Casting.CanUseAA("Malosinete") end, },
                 { name = "PetHealSpell",     cond = function(self) return Config:GetSetting('DoPetHealSpell') end, },
                 { name = "FireOrbSummon", },
-                { name = "GroupCotH", },
-                { name = "SingleCotH",       cond = function() return not Casting.CanUseAA('Call of the Hero') end, },
+                -- { name = "GroupCotH", },
+                { name = "SingleCotH", },
                 { name = "ManaRodSummon",    cond = function(self) return Config:GetSetting('SummonModRods') and not Casting.CanUseAA("Small Modulation Shard") end, },
                 { name = "FireShroud", },
                 { name = "LongDurDmgShield", },

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -569,6 +569,24 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Artifact of the Dread Pyre",
+                type = "Item",
+                load_cond = function() return mq.TLO.Me.Level() >= 68 and mq.TLO.Me.Level() < 70 and mq.TLO.FindItem("=Artifact of the Dread Pyre")() end,
+                cond = function(self, itemName, target)
+                    if Config:GetSetting('DotNamedOnly') and not Targeting.IsNamed(target) then return false end
+                    return Casting.DotItemCheck(itemName, target)
+                end,
+            },
+            {
+                name = "Trinket of Suffocation",
+                type = "Item",
+                load_cond = function() return mq.TLO.Me.Level() >= 68 and mq.TLO.FindItem("=Trinket of Suffocation")() end,
+                cond = function(self, itemName, target)
+                    if Config:GetSetting('DotNamedOnly') and not Targeting.IsNamed(target) then return false end
+                    return Casting.DotItemCheck(itemName, target)
+                end,
+            },
+            {
                 name = "PlagueDot",
                 type = "Spell",
                 cond = function(self, spell, target)
@@ -584,6 +602,13 @@ local _ClassConfig = {
             },
             {
                 name = "CurseDot2",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.DotSpellCheck(spell, target)
+                end,
+            },
+            {
+                name = "DurationTap",
                 type = "Spell",
                 cond = function(self, spell, target)
                     return Casting.DotSpellCheck(spell, target)
@@ -1101,11 +1126,11 @@ local _ClassConfig = {
             Header = "Buffs",
             Category = "Self",
             Index = 104,
-            Tooltip = "Cancel your Lich spell when your mana has increased to this percentage.",
+            Tooltip = "Cancel your Lich spell when your mana has increased to this percentage. (Selecting 101 will disable canceling lich based on mana percent.)",
             RequiresLoadoutChange = false,
             Default = 100,
             Min = 1,
-            Max = 100,
+            Max = 101,
         },
         ['DoOrbNuke']         = {
             DisplayName = "Summon Orbs",

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -11,7 +11,7 @@ local Core      = require("utils.core")
 local Logger    = require("utils.logger")
 
 return {
-    _version            = "2.0 - EQ Might (WIP)",
+    _version            = "2.1 - EQ Might (WIP)",
     _author             = "Derple, Algar",
     ['Modes']           = {
         'DPS',
@@ -31,20 +31,15 @@ return {
         },
     },
     ['AbilitySets']     = {
-        ['IceClaw'] = {
-            "Claw of Vox",
-            "Claw of Frost",
-        },
-        ['FireEtherealNuke'] = {
-            "Ether Flame",
-        },
-        ['ChaosNuke'] = {
-            "Chaos Flame",
-        },
+        -- ['IceClaw'] = {
+        --     "Claw of Vox",
+        --     "Claw of Frost",
+        -- },
         ['WildNuke'] = {
-            "Wildmagic Burst",
+            "Wildmagic Strike",
         },
         ['FireNuke'] = {
+            "Chaos Flame",
             "Spark of Fire",
             "Draught of Ro",
             "Draught of Fire",
@@ -55,7 +50,8 @@ return {
             "Shock of Fire",
         },
         ['BigFireNuke'] = { -- Level 51-70, Long Cast, Heavy Damage
-            -- "Ancient: Core Fire", --Ether Flame beats this soundly at the same level
+            "Ether Flame",
+            "Ancient: Core Fire",
             "Corona Flare", --67 on EQM
             "Ancient: Strike of Chaos",
             "White Fire",
@@ -64,7 +60,7 @@ return {
             "Sunstrike",
         },
         ['IceNuke'] = {
-            -- "Ancient: Spear of Gelaqua" -- Commented for now, because of the recast... considering, need to playtest.
+            "Ancient: Spear of Gelaqua",
             "Spark of Ice",
             "Black Ice",
             "Draught of E`ci",
@@ -90,14 +86,14 @@ return {
             "Garrison's Mighty Mana Shock",
             "Shock of Lightning",
         },
-        ['BigMagicNuke'] = { -- Level 60-68, High Cast Time/Damage
+        ['BigMagicNuke'] = { -- Level 60-70, High Cast Time/Damage
+            "Mana Weave",
             "Thundaka",
             "Shock of Magic",
             "Agnarr's Thunder",
             "Elnerick's Electrical Rending",
         },
         ['StunSpell'] = {
-            "Telakemara",
             "Telekara",
             "Telaka",
             "Telekin",
@@ -106,6 +102,7 @@ return {
             "Tishan's Clash",
         },
         ['SelfHPBuff'] = {
+            "Shield of the Crystalwing",
             "Ether Shield",
             "Shield of Maelin",
             "Shield of the Arcane",
@@ -124,6 +121,7 @@ return {
             "Minor Familiar",
         },
         ['SelfRune1'] = {
+            "Ether Ward",
             "Ether Skin",
             "Force Shield",
         },
@@ -132,17 +130,15 @@ return {
             "Nullify Magic",
             "Cancel Magic",
         },
-        ['TwincastSpell'] = {
-            "Twincast",
-        },
-        ['RootSpell'] = {
-            "Greater Fetter",
-            "Fetter",
-            "Paralyzing Earth",
-            "Immobilize",
-            "Instill",
-            "Root",
-        },
+        -- ['RootSpell'] = {
+        -- "Iceblock",
+        --     "Greater Fetter",
+        --     "Fetter",
+        --     "Paralyzing Earth",
+        --     "Immobilize",
+        --     "Instill",
+        --     "Root",
+        -- },
         ['SnareSpell'] = {
             "Atol's Spectral Shackles",
             "Bonds of Force",
@@ -155,11 +151,13 @@ return {
             "Harvest",
         },
         ['JoltSpell'] = {
+            "Concussive Blast",
             "Ancient: Greater Concussion",
             "Concussion",
         },
         -- Lure Spells
         -- ['IceLureNuke'] = {
+        -- "RimeLure",
         --     "Icebane",
         --     "Lure of Ice",
         --     "Lure of Frost",
@@ -197,6 +195,7 @@ return {
             "Icestrike",
         },
         ['FireRain'] = {
+            "Tears of the Betrayed",
             "Tears of the Sun",
             "Tears of Ro",
             "Tears of Solusek",
@@ -223,13 +222,14 @@ return {
         ['MagicJyll'] = {
             "Jyll's Static Pulse", -- Level 53
         },
-        ['ManaWeave'] = {
-            "Mana Weave",
-        },
         ['SwarmPet'] = {
             -- "Solist's Frozen Sword", -- Bugged, does not attack on Laz/Emu
             "Flaming Sword of Xuzl", --homework
         },
+        -- ['SpellWard'] = {
+        --     "Bulwark of Calrena",
+        --     "Defense of Calrena",
+        -- },
     },
     ['HelperFunctions'] = {
         --function to make sure we don't have non-hostiles in range before we use AE damage or non-taunt AE hate abilities
@@ -307,10 +307,10 @@ return {
             end,
         },
         {
-            name = 'DPS(Level70)',
+            name = 'WildNuke',
             state = 1,
             steps = 1,
-            load_cond = function() return mq.TLO.Me.Level() < 101 and mq.TLO.Me.Level() > 69 end,
+            load_cond = function() return Config:GetSetting('DoWildNuke') and Core.GetResolvedActionMapItem('WildNuke') end,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -322,10 +322,11 @@ return {
             name = 'DPS(Fire)',
             state = 1,
             steps = 1,
-            load_cond = function() return mq.TLO.Me.Level() < 70 and Config:GetSetting('ElementChoice') == 1 end,
+            load_cond = function() return Config:GetSetting('ElementChoice') == 1 or Config:GetSetting('KeepFireMemmed') end,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
+                if not Config:GetSetting('ElementChoice') == 1 then return false end
                 return combat_state == "Combat" and
                     not (Core.IsModeActive('PBAE') and self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('PBAETargetCnt'), true))
             end,
@@ -334,10 +335,11 @@ return {
             name = 'DPS(Ice)',
             state = 1,
             steps = 1,
-            load_cond = function() return mq.TLO.Me.Level() < 70 and Config:GetSetting('ElementChoice') == 2 end,
+            load_cond = function() return Config:GetSetting('ElementChoice') == 2 or Config:GetSetting('KeepIceMemmed') end,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
+                if not Config:GetSetting('ElementChoice') == 2 then return false end
                 return combat_state == "Combat" and
                     not (Core.IsModeActive('PBAE') and self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('PBAETargetCnt'), true))
             end,
@@ -346,10 +348,11 @@ return {
             name = 'DPS(Magic)',
             state = 1,
             steps = 1,
-            load_cond = function() return mq.TLO.Me.Level() < 70 and Config:GetSetting('ElementChoice') == 3 end,
+            load_cond = function() return Config:GetSetting('ElementChoice') == 2 or Config:GetSetting('KeepMagicMemmed') end,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
+                if not Config:GetSetting('ElementChoice') == 3 then return false end
                 return combat_state == "Combat" and
                     not (Core.IsModeActive('PBAE') and self.ClassConfig.HelperFunctions.AETargetCheck(Config:GetSetting('PBAETargetCnt'), true))
             end,
@@ -367,10 +370,10 @@ return {
             end,
         },
         {
-            name = 'Force of Will',
+            name = 'Weaves',
             state = 1,
             steps = 1,
-            load_cond = function() return Casting.CanUseAA("Force of Will") end,
+            load_cond = function() return Casting.CanUseAA("Force of Will") or Casting.CanUseAA("Lower Element") end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"
@@ -392,9 +395,6 @@ return {
             {
                 name = "Epic",
                 type = "Item",
-                cond = function(self)
-                    return not mq.TLO.Me.Buff("Twincast")()
-                end,
             },
             {
                 name = "OoW_Chest",
@@ -404,25 +404,12 @@ return {
                 name = "Focus of Arcanum",
                 type = "AA",
             },
-            {
-                name = "Fundament: Second Spire of Arcanum",
-                type = "AA",
-            },
-            {
-                name = "Fury of Ro",
-                type = "AA",
-            },
-            {
-                name = "Forsaken Sorceror's Shoes",
-                type = "Item",
-                load_cond = function(self) return mq.TLO.FindItem("=Forsaken Sorceror's Shoes")() end,
-            },
-            {
-                name = "Improved Twincast",
-                type = "AA",
-                cond = function(self)
-                    return not mq.TLO.Me.Buff("Twincast")()
+            { --Familiar AA, will use the correct element, and fallback to improved
+                name_func = function(self)
+                    local furyBuff = { "Fury of Ro", "Fury of Eci", "Fury of Druzzil", }
+                    return furyBuff[Config:GetSetting('ElementChoice')] or "Unknown Error"
                 end,
+                type = "AA",
             },
             { --Crit Chance AA, will use the first(best) one found
                 name_func = function(self)
@@ -451,6 +438,13 @@ return {
                 name = "Call of Xuzl",
                 type = "AA",
             },
+            {
+                name = "Ward of Destruction",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Config:GetSetting('DoAEDamage')
+                end,
+            },
         },
         ['Aggro Management'] =
         {
@@ -469,23 +463,8 @@ return {
                 end,
             },
             {
-                name = "A Hole in Space",
-                type = "AA",
-                cond = function(self)
-                    return Targeting.IHaveAggro(100)
-                end,
-            },
-            {
-                name = "Concussive Intuition",
-                type = "AA",
-                cond = function(self)
-                    return mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro')
-                end,
-            },
-            {
                 name = "JoltSpell",
                 type = "Spell",
-                load_cond = function(self) return not Casting.CanUseAA("Concussive Intuition") end,
                 cond = function(self)
                     return mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro')
                 end,
@@ -536,41 +515,38 @@ return {
                 end,
             },
         },
-        ['Force of Will'] = {
+        ['Weaves'] = {
+            {
+                name = "Lower Element",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Casting.DetAACheck(aaName)
+                end,
+            },
             {
                 name = "Force of Will",
                 type = "AA",
             },
         },
-        ['DPS(Level70)'] = {
-            {
-                name = "ManaWeave",
-                type = "Spell",
-                cond = function(self, spell, target)
-                    return not Casting.IHaveBuff("Weave of Power")
-                end,
-            },
-            {
-                name = "ChaosNuke",
-                type = "Spell",
-            },
+        ['WildNuke'] = {
             {
                 name = "WildNuke",
-                type = "Spell",
-            },
-            {
-                name = "Scepter of Incantations",
-                type = "Item",
-            },
-            {
-                name = "FireEtherealNuke",
                 type = "Spell",
             },
         },
         ['DPS(Fire)'] = {
             {
+                name = "Pyromancy",
+                type = "AA",
+                load_condtion = function(self) return Casting.CanUseAA("Pyromancy") end,
+                cond = function(self, aaName)
+                    return not mq.TLO.Me.Buff(aaName)()
+                end,
+            },
+            {
                 name = "FireRain",
                 type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoRain') end,
                 cond = function(self, spell, target)
                     if not self.ClassConfig.HelperFunctions.RainCheck(target) then return false end
                     return Targeting.AggroCheckOkay()
@@ -593,8 +569,17 @@ return {
         },
         ['DPS(Ice)'] = {
             {
+                name = "Cryomancy",
+                type = "AA",
+                load_condtion = function(self) return Casting.CanUseAA("Cryomancy") end,
+                cond = function(self, aaName)
+                    return not mq.TLO.Me.Buff(aaName)()
+                end,
+            },
+            {
                 name = "IceRain",
                 type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoRain') end,
                 cond = function(self, spell, target)
                     if not self.ClassConfig.HelperFunctions.RainCheck(target) then return false end
                     return Targeting.AggroCheckOkay()
@@ -616,6 +601,14 @@ return {
             },
         },
         ['DPS(Magic)'] = {
+            {
+                name = "Acromancy",
+                type = "AA",
+                load_condtion = function(self) return Casting.CanUseAA("Acromancy") end,
+                cond = function(self, aaName)
+                    return not mq.TLO.Me.Buff(aaName)()
+                end,
+            },
             {
                 name = "BigMagicNuke",
                 type = "Spell",
@@ -682,20 +675,28 @@ return {
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
-            { --Familiar AA, will use the first(best) one found
+            { --Familiar AA, will use the correct element, and fallback to improved
                 name_func = function(self)
-                    return Casting.GetFirstAA({ "Kerafyrm's Prismatic Familiar", "Ro's Flaming Familiar", "Improved Familiar", })
+                    local familiars = { "Ro's Flaming Familiar", "E'ci's Icy Familiar", "Druzzil's Mystical Familiar", }
+                    local currentFam = familiars[Config:GetSetting('ElementChoice')] or "Unknown Error"
+                    return Casting.CanUseAA(currentFam) and currentFam or "Improved Familiar"
                 end,
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.IHaveBuff(aaName) end,
+                pre_activate = function(self, aaName) -- remove the old familiar in case of stacking issues when switching elements
+                    if not mq.TLO.Me.Buff(aaName)() and mq.TLO.Me.Buff("Familiar")() then
+                        mq.TLO.Me.Buff("Familiar").Remove()
+                    end
+                end,
                 cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
+                    if not Casting.CanUseAA(aaName) then return false end
+                    return not mq.TLO.Me.Buff(aaName)()
                 end,
             },
             {
                 name = "FamiliarBuff",
                 type = "Spell",
-                load_cond = function(self) return not Casting.CanUseAA("Improved Familiar") end,
+                load_cond = function(self) return not Casting.CanUseAA("Improved Familiar") and not Casting.CanUseAA("Ro's Flaming Familiar") end, --in case someone skipped improved
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
                     return Casting.SelfBuffCheck(spell)
@@ -719,157 +720,30 @@ return {
             },
         },
     },
-    ['Spells']          = {
+    ['SpellList']       = { -- New style spell list, gemless, priority-based. Will use the first set whose conditions are met.
         {
-            gem = 1,
+            name = "Default Mode",
+            -- cond = function(self) return true end, --Code kept here for illustration, if there is no condition to check, this line is not required
             spells = {
-                { name = "ManaWeave", },
-                { name = "FireNuke",  cond = function() return Config:GetSetting('ElementChoice') == 1 end, },
-                { name = "IceNuke",   cond = function() return Config:GetSetting('ElementChoice') == 2 end, },
-                { name = "MagicNuke", cond = function() return Config:GetSetting('ElementChoice') == 3 end, },
-
-            },
-        },
-        {
-            gem = 2,
-            spells = {
-                { name = "FireEtherealNuke", },
-                { name = "BigFireNuke",      cond = function() return Config:GetSetting('ElementChoice') == 1 end, },
-                { name = "BigIceNuke",       cond = function() return Config:GetSetting('ElementChoice') == 2 end, },
-                { name = "BigMagicNuke",     cond = function() return Config:GetSetting('ElementChoice') == 3 end, },
-            },
-        },
-        {
-            gem = 3,
-            spells = {
-                { name = "WildNuke", },
+                { name = "FireNuke",     cond = function() return Config:GetSetting('ElementChoice') == 1 or Config:GetSetting('KeepFireMemmed') end, },
+                { name = "BigFireNuke",  cond = function() return Config:GetSetting('ElementChoice') == 1 or Config:GetSetting('KeepFireMemmed') end, },
+                { name = "IceNuke",      cond = function() return Config:GetSetting('ElementChoice') == 2 or Config:GetSetting('KeepIceMemmed') end, },
+                { name = "BigIceNuke",   cond = function() return Config:GetSetting('ElementChoice') == 2 or Config:GetSetting('KeepIceMemmed') end, },
+                { name = "MagicNuke",    cond = function() return Config:GetSetting('ElementChoice') == 3 or Config:GetSetting('KeepMagicMemmed') end, },
+                { name = "BigMagicNuke", cond = function() return Config:GetSetting('ElementChoice') == 3 or Config:GetSetting('KeepMagicMemmed') end, },
+                { name = "WildNuke",     cond = function() return Config:GetSetting('DoWildNuke') end, },
                 { name = "FireRain",     cond = function() return Config:GetSetting('DoRain') and Config:GetSetting('ElementChoice') == 1 end, },
                 { name = "IceRain",      cond = function() return Config:GetSetting('DoRain') and Config:GetSetting('ElementChoice') == 2 end, },
                 { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
                 { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
+                { name = "EvacSpell",    cond = function() return Config:GetSetting('KeepEvacMemmed') end, },
                 { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-            },
-        },
-        {
-            gem = 4,
-            spells = {
-                { name = "ChaosNuke", },
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-            },
-        },
-        {
-            gem = 5,
-            spells = {
+                { name = "JoltSpell", },
                 { name = "PBTimer4",     cond = function() return Core.IsModeActive('PBAE') end, },
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-            },
-        },
-        {
-            gem = 6,
-            spells = {
                 { name = "FireJyll",     cond = function() return Core.IsModeActive('PBAE') end, },
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-            },
-        },
-        {
-            gem = 7,
-            spells = {
                 { name = "IceJyll",      cond = function() return Core.IsModeActive('PBAE') end, },
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-
-
-            },
-        },
-        {
-            gem = 8,
-            spells = {
                 { name = "MagicJyll",    cond = function() return Core.IsModeActive('PBAE') end, },
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
                 { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-            },
-        },
-        {
-            gem = 9,
-            cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
-            spells = {
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", }, },
-        },
-        {
-            gem = 10,
-            cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
-            spells = {
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-
-            },
-        },
-        {
-            gem = 11,
-            cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
-            spells = {
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
-                { name = "SelfHPBuff", },
-            },
-        },
-        {
-            gem = 12,
-            cond = function(self, gem) return mq.TLO.Me.NumGems() >= gem end,
-            spells = {
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
                 { name = "SelfHPBuff", },
             },
         },
@@ -895,20 +769,55 @@ return {
             Header = "Damage",
             Category = "Direct",
             Index = 101,
-            Tooltip = "Choose an element to focus on.",
+            Tooltip = "Choose which element-specific nukes and buffs will be used. See FAQ for more details.",
             Type = "Combo",
             ComboOptions = { 'Fire', 'Ice', 'Magic', },
             Default = 1,
             Min = 1,
             Max = 3,
             RequiresLoadoutChange = true,
+            FAQ = "How do I select to use multiple elements in combat?",
+            Answer =
+                "   The 'Element Choice' setting determines which element you will use in combat. To avoid conflicts with the Familiar, 'Fury' and '-mancy' AA buffs, the default class config will focus on a single element at a time.\n\n" ..
+                "   The choice can be changed in combat (used in conjuction with the 'Keep X Memmed' settings), but we will not rescribe spells in combat, and Fury/Familiars will not be updated in the rotation until after combat is over.\n\n" ..
+                "   PBAE spells, if enabled, will use any available element, due to the nature of their recast timers.",
+        },
+        ['KeepFireMemmed']       = {
+            DisplayName = "Keep Fire Memmed",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 102,
+            Tooltip = "Regardless of our current element selection, keep fire spells memorized so that we can switch elements in combat without changing our loadout.",
+            RequiresLoadoutChange = true,
+            Default = false,
+        },
+        ['KeepIceMemmed']        = {
+            DisplayName = "Keep Ice Memmed",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 103,
+            Tooltip = "Regardless of our current element selection, keep ice spells memorized so that we can switch elements in combat without changing our loadout.",
+            RequiresLoadoutChange = true,
+            Default = false,
+        },
+        ['KeepMagicMemmed']      = {
+            DisplayName = "Keep Magic Memmed",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 103,
+            Tooltip = "Regardless of our current element selection, keep magic spells memorized so that we can switch elements in combat without changing our loadout.",
+            RequiresLoadoutChange = true,
+            Default = false,
         },
         ['DoManaBurn']           = {
             DisplayName = "Use Mana Burn AA",
             Group = "Abilities",
             Header = "Damage",
             Category = "Direct",
-            Index = 102,
+            Index = 104,
             Tooltip = "Enable usage of the Mana Burn series of AA.",
             RequiresLoadoutChange = true,
             Default = true,
@@ -918,7 +827,7 @@ return {
             Group = "Abilities",
             Header = "Damage",
             Category = "Direct",
-            Index = 103,
+            Index = 105,
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
             Tooltip = "**WILL BREAK MEZ** Use your selected element's Rain Spell as a single-target nuke. **WILL BREAK MEZ***",
@@ -932,7 +841,7 @@ return {
             Group = "Abilities",
             Header = "Damage",
             Category = "Direct",
-            Index = 104,
+            Index = 106,
             ConfigType = "Advanced",
             Tooltip = "The minimum distance a target must be to use a Rain (Rain AE Range: 25'). Used to avoid harming the caster.",
             Default = 30,
@@ -1061,13 +970,23 @@ return {
             Min = 1,
             Max = 99,
         },
+        ['KeepEvacMemmed']       = {
+            DisplayName = "Memorize Evac",
+            Group = "Abilities",
+            Header = "Utility",
+            Category = "Emergency",
+            Index = 101,
+            Tooltip = "Keep (Lesser) Evacuate memorized.",
+            Default = false,
+            RequiresLoadoutChange = true,
+        },
     },
     ['ClassFAQ']        = {
         [1] = {
             Question = "What is the current status of this class config?",
             Answer = "This class config is currently a Work-In-Progress that was originally based off of the Project Lazarus config.\n\n" ..
-                "  Up until level 66, it should work quite well, but may need some clickies managed on the clickies tab.\n\n" ..
-                "  After level 66, expect performance to degrade somewhat as not all EQMight custom spells or items are added, and some Laz-specific entries may remain.\n\n" ..
+                "  Up until level 70, it should work quite well, but may need some clickies managed on the clickies tab.\n\n" ..
+                "  After level 68, however, there hasn't been any playtesting... some AA may need to be added or removed still, and some Laz-specific entries may remain.\n\n" ..
                 "  Community effort and feedback are required for robust, resilient class configs, and PRs are highly encouraged!",
             Settings_Used = "",
         },

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -1351,8 +1351,6 @@ local _ClassConfig = {
             Default = 1,
             Min = 1,
             Max = 2,
-            FAQ = "I want to only use a Rogue Pet for the Backstabs, how do I do that?",
-            Answer = "Set the [PetType] setting to Rog and the Necro will only summon Rogue pets.",
         },
         ['BattleRez']         = {
             DisplayName = "Battle Rez",
@@ -1362,8 +1360,6 @@ local _ClassConfig = {
             Tooltip = "Do Rezes during combat.",
             RequiresLoadoutChange = true,
             Default = true,
-            FAQ = "I want to use my Battle Rez, how do I do that?",
-            Answer = "Set the [BattleRez] setting to true and the Necro will use their Battle Rez during combat.",
         },
         ['DoLifeBurn']        = {
             DisplayName = "Use Life Burn",
@@ -1372,8 +1368,6 @@ local _ClassConfig = {
             Category = "Direct",
             Tooltip = "Use Life Burn AA if your aggro is below 25%.",
             Default = true,
-            FAQ = "I want to use my Life Burn AA, how do I do that?",
-            Answer = "Set the [DoLifeBurn] setting to true and the Necro will use Life Burn AA if their aggro is below 25%.",
         },
         ['DoUnity']           = {
             DisplayName = "Cast Unity",
@@ -1383,8 +1377,6 @@ local _ClassConfig = {
             Tooltip = "Enable casting Mortifiers Unity.",
             Default = true,
             Index = 101,
-            FAQ = "I want to use my Unity AA, how do I do that?",
-            Answer = "Set the [DoUnity] setting to true and the Necro will use Mortifiers Unity when it is available.",
         },
         ['DeathBloomPercent'] = {
             DisplayName = "Death Bloom %",
@@ -1395,8 +1387,6 @@ local _ClassConfig = {
             Default = 40,
             Min = 1,
             Max = 100,
-            FAQ = "I am using Death Bloom to early or late, how do I adjust it?",
-            Answer = "Set the [DeathBloomPercent] setting to the desired % of mana you want to cast Death Bloom at.",
         },
         ['DoSnare']           = {
             DisplayName = "Use Snares",
@@ -1407,8 +1397,6 @@ local _ClassConfig = {
             Tooltip = "Use Snare(Snare Dot used until AA is available).",
             Default = false,
             RequiresLoadoutChange = true,
-            FAQ = "Why is my Necromancer not snaring?",
-            Answer = "Make sure Use Snares is enabled in your class settings.",
         },
         ['SnareCount']        = {
             DisplayName = "Snare Max Mob Count",
@@ -1420,9 +1408,6 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 99,
-            FAQ = "Why is my Shadow Knight Not snaring?",
-            Answer = "Make sure you have [DoSnare] enabled in your class settings.\n" ..
-                "Double check the Snare Max Mob Count setting, it will prevent snare from being used if there are more than [x] mobs on aggro.",
         },
         ['StartFDPct']        = {
             DisplayName = "FD Aggro Pct",
@@ -1433,8 +1418,6 @@ local _ClassConfig = {
             Default = 90,
             Min = 1,
             Max = 99,
-            FAQ = "How do I manage my aggro with Feign Death?",
-            Answer = "Set the [StartFDPct] setting to the desired % of aggro you want to FD at.",
         },
         ['StopFDPct']         = {
             DisplayName = "Stand Aggro Pct",
@@ -1445,8 +1428,6 @@ local _ClassConfig = {
             Default = 80,
             Min = 1,
             Max = 99,
-            FAQ = "How do I manage my aggro with Feign Death?",
-            Answer = "Set the [StopFDPct] setting to the desired % of aggro you want to Stand up from FD at.",
         },
         ['WakeDeadCorpseCnt'] = {
             DisplayName = "WtD Corpse Count",
@@ -1457,8 +1438,6 @@ local _ClassConfig = {
             Default = 5,
             Min = 1,
             Max = 20,
-            FAQ = "I want to use Wake the Dead when I have X corpses nearby, how do I do that?",
-            Answer = "Set the [WakeDeadCorpseCnt] setting to the desired number of corpses you want to cast Wake the Dead at.",
         },
         ['DoLich']            = {
             DisplayName = "Cast Lich",
@@ -1469,8 +1448,6 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
             FAQ = "I want to use my Lich spells, how do I do that?",
-            Answer = "Set the [DoLich] setting to true and the Necro will use Lich spells.\n" ..
-                "You will also want to set your [StopLichHP] and [StopLichMana] settings to the desired values so you do not Lich to Death.",
         },
         ['StopLichHP']        = {
             DisplayName = "Stop Lich HP",
@@ -1482,21 +1459,17 @@ local _ClassConfig = {
             Default = 25,
             Min = 1,
             Max = 99,
-            FAQ = "I want to stop Liching at a certain HP %, how do I do that?",
-            Answer = "Set the [StopLichHP] setting to the desired % of HP you want to stop Liching at.",
         },
         ['StopLichMana']      = {
             DisplayName = "Stop Lich Mana",
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Tooltip = "Cancel Lich at Mana Pct [x]",
+            Tooltip = "Cancel your Lich spell when your mana has increased to this percentage. (Selecting 101 will disable canceling lich based on mana percent.)",
             RequiresLoadoutChange = false,
             Default = 100,
             Min = 1,
-            Max = 100,
-            FAQ = "I want to stop Liching at a certain Mana %, how do I do that?",
-            Answer = "Set the [StopLichMana] setting to the desired % of Mana you want to stop Liching at.",
+            Max = 101,
         },
         ['DoScentDebuff']     = {
             DisplayName = "Use Scent Debuff",
@@ -1506,8 +1479,6 @@ local _ClassConfig = {
             Tooltip = "Use your Scent debuff spells or AA.",
             RequiresLoadoutChange = true, --this setting is used as a load condition
             Default = false,
-            FAQ = "Why am I not using a Scent debuff?",
-            Answer = "You can enable Scent use on the Spells and Abilities tab.",
         },
     },
     ['ClassFAQ']        = {

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -1170,11 +1170,11 @@ local _ClassConfig = {
             Header = "Buffs",
             Category = "Self",
             Index = 104,
-            Tooltip = "Cancel your Lich spell when your mana has increased to this percentage.",
+            Tooltip = "Cancel your Lich spell when your mana has increased to this percentage. (Selecting 101 will disable canceling lich based on mana percent.)",
             RequiresLoadoutChange = false,
             Default = 100,
             Min = 1,
-            Max = 100,
+            Max = 101,
         },
         ['DeathBloomPercent'] = {
             DisplayName = "Death Bloom %",

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1268,7 +1268,7 @@ function Casting.UseDisc(discSpell, targetId)
 
             if Casting.IsActiveDisc(discSpell.RankName.Name()) then
                 if me.ActiveDisc.ID() then
-                    Logger.log_debug("Cancelling Disc for %s -- Active Disc: [%s]", discSpell.RankName.Name(),
+                    Logger.log_debug("canceling Disc for %s -- Active Disc: [%s]", discSpell.RankName.Name(),
                         me.ActiveDisc.Name())
                     Core.DoCmd("/stopdisc")
                     mq.delay(20, function() return not me.ActiveDisc() end)


### PR DESCRIPTION
* [NEC - ALL] Canceling lich based on mana percent can now be disabled by setting the stop mana percent to 101 (the safety stop for health will still function).

* [WIZ - EQM] Revamped config to support EQM spell selection and rotation. Please refer to the config status FAQ in-game for details.

* [ENC, NEC - EQM] Added initial support for some DoT clickies.