### PR TITLE
Config Loading Improvements

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -90,7 +90,7 @@ local function RGMercsGUI()
 
     ImGui.SetNextWindowSize(ImVec2(500, 600), ImGuiCond.FirstUseEver)
 
-    if openGUI and Alive() then
+    if openGUI and Alive() and Config:SettingsLoaded() then
         if initPctComplete < 100 then
             LoaderUI:RenderLoader(initPctComplete, initMsg)
         else

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -601,13 +601,30 @@ function Module:Render()
             Config:SetSetting('Mode', newMode)
             self:RescanLoadout()
         end
-        ImGui.SameLine()
-        if ImGui.SmallButton("Rescan Loadout") then
+
+        Ui.RenderConfigSelector()
+
+        ImGui.SeparatorText("Config Actions")
+        --ImGui.Text("Actions:")
+        if ImGui.SmallButton(Icons.FA_EYE .. " Rescan Loadout") then
             self:RescanLoadout()
             Logger.log_info("\awManual loadout scan initiated.")
         end
+        Ui.Tooltip(
+            "Rescans settings to update memorized spells and rotations. May be needed if multiple settings are changed in rapid succession or when activatable AA are purchased.")
 
-        Ui.RenderConfigSelector()
+        ImGui.SameLine()
+        if ImGui.SmallButton(Icons.FA_REFRESH .. " Reload Current Config") then
+            ClassLoader.reloadConfig()
+            Logger.log_info("\awReloading your current config.")
+        end
+        Ui.Tooltip("Reload the current config from file without restarting RGMercs. Handy for those editing configs out-of-game on the fly.")
+
+        ImGui.SameLine()
+        if ImGui.SmallButton(Icons.FA_PENCIL .. " Create Custom Config") then
+            Modules:ExecModule("Class", "WriteCustomConfig")
+        end
+        Ui.Tooltip("Places a copy of the currently loaded class config in the MQ config directory for customization.\nWill back up the existing custom configuration.")
 
         ImGui.Separator()
 

--- a/modules/performance.lua
+++ b/modules/performance.lua
@@ -115,7 +115,7 @@ function Module:Init()
 end
 
 function Module:ShouldRender()
-    return Config:GetSetting('EnablePerfMonitoring')
+    return Config:GetSetting('EnablePerfMonitoring', true)
 end
 
 function Module:Render()

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -73,6 +73,7 @@ Config.Globals.SLPeerLooting                             = false
 
 -- Constants
 Config.Constants                                         = {}
+Config.Constants.SupportedEmuServers                     = Set.new({ "Project Lazarus", "HiddenForest", "EQ Might", })
 Config.Constants.LootModuleTypes                         = { 'None', 'LootNScoot', 'SmartLoot', }
 Config.Constants.RGCasters                               = Set.new({ "BRD", "BST", "CLR", "DRU", "ENC", "MAG", "NEC", "PAL", "RNG", "SHD",
     "SHM", "WIZ", })
@@ -210,7 +211,7 @@ Config.DefaultConfig               = {
     ['ClassConfigDir']       = {
         DisplayName = "Class Config Dir",
         Type = "Custom",
-        Default = Config.Globals.BuildType:lower() ~= "emu" and "Live" or Config.Globals.CurServer,
+        Default = (Config.Globals.BuildType:lower() == "emu" and Config.Constants.SupportedEmuServers:contains(Config.Globals.CurServer)) and Config.Globals.CurServer or "Live",
     },
     ['UseAssistList']        = {
         DisplayName = "Assist Outside of Group",

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -7,6 +7,7 @@ local Comms         = require("utils.comms")
 local Targeting     = require("utils.targeting")
 local Icons         = require('mq.ICONS')
 local Strings       = require("utils.strings")
+local ClassLoader   = require('utils.classloader')
 
 local animSpellGems = mq.FindTextureAnimation('A_SpellGems')
 local ICON_SIZE     = 20
@@ -131,25 +132,16 @@ function Ui.RenderConfigSelector()
         if changed then
             Config:SetSetting('ClassConfigDir', Config.Globals.ClassConfigDirs[newConfigDir])
             Config:SaveSettings()
-            Config:ClearAllModuleSettings()
-            Config:LoadSettings()
-            Modules:ExecAll("LoadSettings")
+            ClassLoader.reloadConfig()
         end
         Ui.Tooltip(
-            "Select your current server/environment.\nLive: Official EQ Servers (Live, Test, TLP).\nProject Lazurus: Laz-specific (Live may be better suited for other emu servers).\nAlpha, Beta: Configs in testing. Often preferred, with some caveats (see forum sticky).\nCustom: Copies of the above configs that you have edited yourself.")
+            "Select your current server/environment.\nLive: Official EQ Servers (Live, Test, TLP).\nProject Lazarus, EQ Might, Hidden Forest: Supported EMU servers.\nAlpha, Beta: Configs in testing. Often preferred, with some caveats (see forum sticky).\nCustom: Copies of the above configs that you have edited yourself.")
 
         ImGui.SameLine()
-        if ImGui.SmallButton(Icons.FA_REFRESH) then
+        if ImGui.SmallButton(Icons.FA_REFRESH .. " Refresh List") then
             Core.ScanConfigDirs()
         end
         Ui.Tooltip("Refreshes the class config directory list.")
-
-        ImGui.SameLine()
-        if ImGui.SmallButton('Create Custom Config') then
-            Modules:ExecModule("Class", "WriteCustomConfig")
-        end
-        Ui.Tooltip("Places a copy of the currently loaded class config in the MQ config directory for customization.\nWill back up the existing custom configuration.")
-        ImGui.NewLine()
     end
 end
 


### PR DESCRIPTION
* Added a button to reload the current config from file without restarting RGMercs.
* * Shoutout to Coldblooded for suggesting something that would have saved me approximately 896,432 cycles of /lua run rgmercs while creating class configs (had I thought of it first).
* Fixed a bug in creating custom configs for non-supported EMU servers (Thanks drawthow!)
* Fixed a bug preventing settings from updating properly when personas were changed.
* Updated some tooltips and rearranged some UI elements for config information.