### PR TITLE
EQ Might Rez Updates

### DIFF
--- a/class_configs/EQ Might/ber_class_config.lua
+++ b/class_configs/EQ Might/ber_class_config.lua
@@ -3,14 +3,23 @@ local Config    = require('utils.config')
 local Targeting = require("utils.targeting")
 local Casting   = require("utils.casting")
 local Logger    = require("utils.logger")
+local Core      = require("utils.core")
 
 return {
-    _version            = "2.0 - EQ Might (WIP)",
+    _version            = "2.1 - EQ Might",
     _author             = "Algar, Derple",
+    ['ModeChecks']      = {
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
+    },
     ['Modes']           = {
         'DPS',
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Vengeful Taelosian Blood Axe",
             "Raging Taelosian Alloy Axe",
@@ -291,6 +300,17 @@ return {
         },
     },
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         AETargetCheck = function(printDebug)
             local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()
             local haterPets = mq.TLO.SpawnCount("NPCpet xtarhater radius 80 zradius 50")()

--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -39,7 +39,7 @@ local Tooltips     = {
 }
 
 local _ClassConfig = {
-    _version            = "3.1 - EQ Might (WIP)",
+    _version            = "3.2 - EQ Might",
     _author             = "Algar, Derple, Grimmier, Tiddliestix, SonicZentropy",
     ['Modes']           = { --other modes to reorder spell priorities may be added back in at a later date.
         'General',
@@ -51,6 +51,7 @@ local _ClassConfig = {
         IsMezzing  = function() return Config:GetSetting('MezOn') end,
         IsCuring   = function() return Config:GetSetting('UseCure') end,
         IsCharming = function() return Config:GetSetting('CharmOn') and mq.TLO.Pet.ID() == 0 end,
+        IsRezing   = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Cures']           = {
         CureNow = function(self, type, targetId)
@@ -68,6 +69,11 @@ local _ClassConfig = {
         end,
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Blade of Vesagran",
             "Prismatic Dragon Blade",
@@ -230,6 +236,17 @@ local _ClassConfig = {
         },
     },
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         SwapInst = function(type)
             if not Config:GetSetting('SwapInstruments') then return end
             Logger.log_verbose("\ayBard SwapInst(): Swapping to Instrument Type: %s", type)

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -7,15 +7,21 @@ local Casting   = require("utils.casting")
 local Logger    = require("utils.logger")
 
 return {
-    _version              = "1.5 - EQ Might (WIP)",
+    _version              = "1.6 - EQ Might",
     _author               = "Derple, Algar",
     ['Modes']             = {
         'DPS',
     },
     ['ModeChecks']        = {
         IsHealing = function() return Config:GetSetting('DoHeals') end,
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['ItemSets']          = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Savage Lord's Totem",             -- Epic    -- Epic 1.5
             "Spiritcaller Totem of the Feral", -- Epic    -- Epic 2.0
@@ -326,6 +332,17 @@ return {
         },
     },
     ['HelperFunctions']   = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         DmgModActive = function(self) --Song active by name will check both Bestial Alignments (Self and Group)
             local disc = self.ResolvedActionMap['DmgModDisc']
             return Casting.IHaveBuff("Bestial Alignment") or (disc and disc() and Casting.IHaveBuff(disc.Name()))

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -8,18 +8,24 @@ local DanNet       = require('lib.dannet.helpers')
 local Logger       = require("utils.logger")
 
 local _ClassConfig = {
-    _version            = "1.4 - EQ Might (WIP)",
+    _version            = "1.5 - EQ Might",
     _author             = "Derple, Grimmier, Algar, Robban",
     ['ModeChecks']      = {
         CanMez     = function() return true end,
         CanCharm   = function() return true end,
         IsCharming = function() return Config:GetSetting('CharmOn') end,
         IsMezzing  = function() return Config:GetSetting('MezOn') end,
+        IsRezing   = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Modes']           = {
         'Default',
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Staff of Eternal Eloquence",
             "Oculus of Persuasion",
@@ -459,6 +465,17 @@ local _ClassConfig = {
         },
     },
     ['HelperFunctions'] = { --used to autoinventory our crystals after summon. Crystal is a group-wide spell on Laz.
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         StashCrystal = function(aaName)
             mq.delay("2s", function() return mq.TLO.Cursor() and mq.TLO.Cursor.ID() == mq.TLO.Me.AltAbility(aaName).Spell.Base(1)() end)
 

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -9,11 +9,11 @@ local DanNet      = require('lib.dannet.helpers')
 local Logger      = require("utils.logger")
 
 _ClassConfig      = {
-    _version            = "1.2 - EQ Might (WIP)",
+    _version            = "1.3 - EQ Might",
     _author             = "Derple, Morisato, Algar",
     ['ModeChecks']      = {
         IsTanking = function() return Core.IsModeActive("PetTank") end,
-        IsRezing = function() return mq.TLO.FindItem("Legendary Staff of Forbidden Rites")() end,
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Modes']           = {
         'DPS',
@@ -39,6 +39,11 @@ _ClassConfig      = {
         end
     end,
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Focus of Primal Elements",
             "Staff of Elemental Essence",
@@ -433,6 +438,16 @@ _ClassConfig      = {
     },
     -- Really the meat of this class.
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         DeleteEpicOrb = function(self)
             if mq.TLO.Cursor() and mq.TLO.Cursor.ID() > 0 then
                 Core.DoCmd("/autoinventory")
@@ -454,15 +469,6 @@ _ClassConfig      = {
                 end
             end
             Logger.log_warning("Warning: Mage pet orb not destroyed! An error or conflict has occured.")
-        end,
-        DoRez = function(self, corpseId)
-            if mq.TLO.Me.ItemReady("Legendary Staff of Forbidden Rites")() then
-                if Casting.OkayToRez(corpseId) then
-                    return Casting.UseItem("Legendary Staff of Forbidden Rites", corpseId)
-                end
-            end
-
-            return false
         end,
         user_tu_spell = function(self, aaName)
             local shroudSpell = self.ResolvedActionMap['ShroudSpell']

--- a/class_configs/EQ Might/mnk_class_config.lua
+++ b/class_configs/EQ Might/mnk_class_config.lua
@@ -6,12 +6,20 @@ local Logger       = require("utils.logger")
 local Core         = require("utils.core")
 
 local _ClassConfig = {
-    _version            = "2.1 - EQ Might (WIP)",
+    _version            = "2.2 - EQ Might",
     _author             = "Algar, Derple",
+    ['ModeChecks']      = {
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
+    },
     ['Modes']           = {
         'DPS',
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Transcended Fistwraps of Immortality",
             "Fistwraps of Celestial Discipline",
@@ -70,6 +78,17 @@ local _ClassConfig = {
         },
     },
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         --function to make sure we don't have non-hostiles in range before we use AE damage
         AETargetCheck = function(printDebug)
             local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -6,7 +6,7 @@ local Targeting    = require("utils.targeting")
 local Casting      = require("utils.casting")
 
 local _ClassConfig = {
-    _version            = "2.0 - EQ Might (WIP)",
+    _version            = "2.1 - EQ Might",
     _author             = "Algar, Derple",
     ['Modes']           = {
         'DPS',
@@ -14,6 +14,7 @@ local _ClassConfig = {
     ['ModeChecks']      = {
         CanCharm   = function() return true end,
         IsCharming = function() return (Config:GetSetting('CharmOn') and mq.TLO.Pet.ID() == 0) end,
+        IsRezing   = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Themes']          = {
         ['DPS'] = {
@@ -60,6 +61,11 @@ local _ClassConfig = {
         },
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Deathwhisper",
             "Soulwhisper",
@@ -830,6 +836,17 @@ local _ClassConfig = {
         },
     },
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         CancelLich = function(self)
             -- detspa means detremental spell affect
             -- spa is positive spell affect

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -8,10 +8,11 @@ local Movement  = require("utils.movement")
 local Strings   = require("utils.strings")
 
 return {
-    _version              = "2.0 - EQ Might (WIP)",
+    _version              = "2.1 - EQ Might",
     _author               = "Algar",
     ['ModeChecks']        = {
         IsHealing = function() return Config:GetSetting('DoHeals') end,
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Modes']             = {
         'DPS',
@@ -38,6 +39,11 @@ return {
         },
     },
     ['ItemSets']          = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Aurora, the Heartwood Blade",
             "Heartwood Blade",
@@ -320,6 +326,17 @@ return {
         },
     },
     ['HelperFunctions']   = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         combatNav = function(forceMove)
             if not Config:GetSetting('DoMelee') then
                 if not mq.TLO.Me.AutoFire() then

--- a/class_configs/EQ Might/rog_class_config.lua
+++ b/class_configs/EQ Might/rog_class_config.lua
@@ -7,15 +7,20 @@ local Strings   = require("utils.strings")
 local Logger    = require("utils.logger")
 
 return {
-    _version            = "2.1 - EQ Might (WIP)",
+    _version            = "2.2 - EQ Might",
     _author             = "Derple, Algar, mackal",
     ['ModeChecks']      = {
-        IsRezing = function() return mq.TLO.FindItem("Legendary Staff of Forbidden Rites")() end,
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Modes']           = {
         'DPS',
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['OoW_Chest'] = {
             "Whispering Tunic of Shadows",
             "Darkraider's Vest",
@@ -308,9 +313,11 @@ return {
     },
     ['HelperFunctions'] = {
         DoRez = function(self, corpseId)
-            if mq.TLO.Me.ItemReady("Legendary Staff of Forbidden Rites")() then
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
                 if Casting.OkayToRez(corpseId) then
-                    return Casting.UseItem("Legendary Staff of Forbidden Rites", corpseId)
+                    return Casting.UseItem(rezStaff, corpseId)
                 end
             end
 

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -75,10 +75,11 @@ local Tooltips     = {
 
 local _ClassConfig = {
     -- Added AEBlades line for AE taunt, return spears to ST
-    _version            = "2.5 - EQ Might (WIP)",
+    _version            = "2.6 - EQ Might",
     _author             = "Algar, Derple",
     ['ModeChecks']      = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Modes']           = {
         'Tank',
@@ -106,6 +107,11 @@ local _ClassConfig = {
         },
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Innoruuk's Dark Blessing",
             "Innoruuk's Voice",
@@ -331,6 +337,17 @@ local _ClassConfig = {
         -- pact of decay ... is this a lich? level 69
     },
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         --function to determine if we should AE taunt and optionally, if it is safe to do so
         AETauntCheck = function(printDebug)
             local mobs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -9,16 +9,22 @@ local Set          = require('mq.set')
 
 local _ClassConfig = {
     -- Added Mayhem line for AE taunt
-    _version            = "3.0 - EQ Might (WIP)",
+    _version            = "3.1 - EQ Might",
     _author             = "Algar, Derple",
     ['ModeChecks']      = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
     },
     ['Modes']           = {
         'Tank',
         'DPS',
     },
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Kreljnok's Sword of Eternal Power",
             "Champion's Sword of Eternal Power",
@@ -92,6 +98,17 @@ local _ClassConfig = {
         },
     },
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         --function to determine if we should AE taunt and optionally, if it is safe to do so
         AETauntCheck = function(printDebug)
             local mobs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -11,8 +11,11 @@ local Core      = require("utils.core")
 local Logger    = require("utils.logger")
 
 return {
-    _version            = "2.1 - EQ Might (WIP)",
+    _version            = "2.2 - EQ Might",
     _author             = "Derple, Algar",
+    ['ModeChecks']      = {
+        IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,
+    },
     ['Modes']           = {
         'DPS',
         'PBAE',
@@ -21,6 +24,11 @@ return {
         -- if this is enabled weaves will break.
     end,
     ['ItemSets']        = {
+        ['RezStaff'] = {
+            "Legendary Fabled Staff of Forbidden Rites",
+            "Fabled Staff of Forbidden Rites",
+            "Legendary Staff of Forbidden Rites",
+        },
         ['Epic'] = {
             "Staff of Phenomenal Power",
             "Staff of Prismatic Power",
@@ -232,6 +240,17 @@ return {
         -- },
     },
     ['HelperFunctions'] = {
+        DoRez = function(self, corpseId)
+            local rezStaff = self.ResolvedActionMap['RezStaff']
+
+            if mq.TLO.Me.ItemReady(rezStaff)() then
+                if Casting.OkayToRez(corpseId) then
+                    return Casting.UseItem(rezStaff, corpseId)
+                end
+            end
+
+            return false
+        end,
         --function to make sure we don't have non-hostiles in range before we use AE damage or non-taunt AE hate abilities
         AETargetCheck = function(minCount, printDebug)
             local haters = mq.TLO.SpawnCount("NPC xtarhater radius 80 zradius 50")()


### PR DESCRIPTION
* Rezzing is fully supported for all classes via the three versions of the Staff of Forbidden Rites, and will be enabled if any of them are in your inventory.
* You may wish to visit your Rez and Combat Rez settings to adjust who should (not) be using a rez at the appropriate time.