### PR TITLE
EQ Might Additions

### DIFF
--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -93,9 +93,15 @@ local _ClassConfig = {
             "Aegis of Superior Divinity",
         },
         ['BlueBand'] = {
+            "Legendary Ancient Frozen Blue Band",
             "Ancient Frozen Blue Band",
             "Fabled Blue Band of the Oak",
             "Blue Band of the Oak",
+        },
+        ['VampiricBlueBand'] = {
+            "Mythical Ancient Vampiric Blue Band",
+            "Legendary Ancient Vampiric Blue Band",
+            "Ancient Vampiric Blue Band",
         },
         ['Timer2HealItem'] = {
             "Legendary Weighted Hammer of Conviction",
@@ -456,8 +462,14 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "VampiricBlueBand",
+                type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("VampiricBlueBand") and mq.TLO.Me.Level() >= 68 end,
+            },
+            {
                 name = "BlueBand",
                 type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("BlueBand") and (mq.TLO.Me.Level() < 68 or not Core.GetResolvedActionMapItem("VampiricBlueBand")) end,
             },
             {
                 name = "GroupHeal",

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -83,9 +83,15 @@ local _ClassConfig = {
             "Staff of Everliving Brambles",
         },
         ['BlueBand'] = {
+            "Legendary Ancient Frozen Blue Band",
             "Ancient Frozen Blue Band",
             "Fabled Blue Band of the Oak",
             "Blue Band of the Oak",
+        },
+        ['VampiricBlueBand'] = {
+            "Mythical Ancient Vampiric Blue Band",
+            "Legendary Ancient Vampiric Blue Band",
+            "Ancient Vampiric Blue Band",
         },
         ['Timer2HealItem'] = {
             "Legendary Kelp-Covered Hammer",
@@ -409,8 +415,14 @@ local _ClassConfig = {
         },
         ['GroupHealPoint'] = {
             {
+                name = "VampiricBlueBand",
+                type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("VampiricBlueBand") and mq.TLO.Me.Level() >= 68 end,
+            },
+            {
                 name = "BlueBand",
                 type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("BlueBand") and (mq.TLO.Me.Level() < 68 or not Core.GetResolvedActionMapItem("VampiricBlueBand")) end,
             },
             {
                 name = "GroupHeal",

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -87,9 +87,15 @@ return {
             "Oathbound Breastplate",
         },
         ['BlueBand'] = {
+            "Legendary Ancient Frozen Blue Band",
             "Ancient Frozen Blue Band",
             "Fabled Blue Band of the Oak",
             "Blue Band of the Oak",
+        },
+        ['VampiricBlueBand'] = {
+            "Mythical Ancient Vampiric Blue Band",
+            "Legendary Ancient Vampiric Blue Band",
+            "Ancient Vampiric Blue Band",
         },
     },
     ['AbilitySets']       = {
@@ -462,6 +468,11 @@ return {
                 end,
             },
             {
+                name = "VampiricBlueBand",
+                type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("VampiricBlueBand") and mq.TLO.Me.Level() >= 68 end,
+            },
+            {
                 name = "Mantle of the Wyrmguard",
                 type = "Item",
                 load_cond = function(self) return mq.TLO.FindItem("=Mantle of the Wyrmguard")() end,
@@ -469,6 +480,7 @@ return {
             {
                 name = "BlueBand",
                 type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("BlueBand") and (mq.TLO.Me.Level() < 68 or not Core.GetResolvedActionMapItem("VampiricBlueBand")) end,
             },
             {
                 name = "WaveHeal",

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -85,9 +85,15 @@ local _ClassConfig = {
             "Blessed Spiritstaff of the Heyokah",
         },
         ['BlueBand'] = {
+            "Legendary Ancient Frozen Blue Band",
             "Ancient Frozen Blue Band",
             "Fabled Blue Band of the Oak",
             "Blue Band of the Oak",
+        },
+        ['VampiricBlueBand'] = {
+            "Mythical Ancient Vampiric Blue Band",
+            "Legendary Ancient Vampiric Blue Band",
+            "Ancient Vampiric Blue Band",
         },
         ['Timer2HealItem'] = {
             "Legendary Zun'Muram's Spear of Doom",
@@ -470,13 +476,27 @@ local _ClassConfig = {
                     return Targeting.BigHealsNeeded(target)
                 end,
             },
-            {
+            { -- use the blue band first if someone is lower health, don't load this if we don't have any blue band
                 name = "GroupRenewalHoT",
                 type = "Spell",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("VampiricBlueBand") or Core.GetResolvedActionMapItem("BlueBand") end,
+                cond = function(self, spell, target)
+                    return not Targeting.BigHealsNeeded(target)
+                end,
+            },
+            {
+                name = "VampiricBlueBand",
+                type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("VampiricBlueBand") and mq.TLO.Me.Level() >= 68 end,
             },
             {
                 name = "BlueBand",
                 type = "Item",
+                load_cond = function(self) return Core.GetResolvedActionMapItem("BlueBand") and (mq.TLO.Me.Level() < 68 or not Core.GetResolvedActionMapItem("VampiricBlueBand")) end,
+            },
+            { -- use this regardless of health setting if the blue band isn't ready
+                name = "GroupRenewalHoT",
+                type = "Spell",
             },
         },
         ["BigHealPoint"] = {

--- a/utils/event_handlers.lua
+++ b/utils/event_handlers.lua
@@ -232,6 +232,13 @@ mq.event('New Discipline', "You have learned a new discipline!", function()
     mq.flushevents("New Discipline")
 end)
 
+mq.event('Level Up', "You have gained a level! Welcome to level#*#", function()
+    -- we may have spells scribed for the new level already on EQ Might, where deleveling is a standard part of play
+    if Config.Globals.CurServer == "EQ Might" then
+        Modules:ExecModule("Class", "RescanLoadout")
+    end
+end)
+
 -- [ CAST RESULT HANDLERS ] --
 mq.event('Success1', "You begin casting#*#", function()
     Casting.SetLastCastResult(Config.Constants.CastResults.CAST_SUCCESS)


### PR DESCRIPTION
* Add support for Vampiric Blue Bands to healing classes.
* Added an automatic loadout rescan when a level is gained (EQ Might only).
* * This is to address spells being autoscribed at low level, and frequent de/relevel cycles that are common at higher levels.