### PR TITLE
Various Updates (See desc.)

### DIFF
--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -489,10 +489,8 @@ local _ClassConfig = {
             end
 
             Logger.log_info("Sending the %s to our bags.", mq.TLO.Cursor())
-
-            Comms.PrintGroupMessage("%s summoned, issuing autoinventory command momentarily.", mq.TLO.Cursor())
             mq.delay(Config:GetSetting("AICrystalDelay"))
-            Core.DoGroupCmd("/autoinventory")
+            Core.DoCmd("/autoinventory")
         end,
     },
     ['Rotations']       = {

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -579,7 +579,7 @@ _ClassConfig      = {
                 local delay = Config:GetSetting('AIGroupDelay')
                 Comms.PrintGroupMessage("%s summoned, issuing autoinventory command momentarily.", mq.TLO.Cursor())
                 mq.delay(delay)
-                Core.DoGroupCmd("/autoinventory")
+                Core.DoGroupOrRaidCmd("/autoinventory")
             elseif scope == "personal" then
                 local delay = Config:GetSetting('AISelfDelay')
                 mq.delay(delay)
@@ -881,6 +881,18 @@ _ClassConfig      = {
         },
         ['DPS'] = {
             {
+                name = "Artifact of Asterion",
+                type = "Item",
+                load_cond = function(self) return Config:GetSetting("UseDonorPet") and mq.TLO.FindItem("=Artifact of Asterion")() end,
+                cond = function(self, _) return mq.TLO.Me.Pet.ID() == 0 end,
+                post_activate = function(self, spell, success)
+                    if success and mq.TLO.Me.Pet.ID() > 0 then
+                        mq.delay(50) -- slight delay to prevent chat bug with command issue
+                        self:SetPetHold()
+                    end
+                end,
+            },
+            {
                 name = "SwarmPet",
                 type = "Spell",
                 load_cond = function() return Config:GetSetting('DoSwarmPet') > 1 end,
@@ -914,18 +926,6 @@ _ClassConfig      = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     return Targeting.TargetBodyIs(target, "Undead Pet")
-                end,
-            },
-            {
-                name = "Artifact of Asterion",
-                type = "Item",
-                load_cond = function(self) return Config:GetSetting("UseDonorPet") and mq.TLO.FindItem("=Artifact of Asterion")() end,
-                cond = function(self, _) return mq.TLO.Me.Pet.ID() == 0 end,
-                post_activate = function(self, spell, success)
-                    if success and mq.TLO.Me.Pet.ID() > 0 then
-                        mq.delay(50) -- slight delay to prevent chat bug with command issue
-                        self:SetPetHold()
-                    end
                 end,
             },
         },

--- a/class_configs/HiddenForest/mag_class_config.lua
+++ b/class_configs/HiddenForest/mag_class_config.lua
@@ -1000,7 +1000,7 @@ _ClassConfig      = {
                 local delay = Config:GetSetting('AIGroupDelay')
                 Comms.PrintGroupMessage("%s summoned, issuing autoinventory command momentarily.", mq.TLO.Cursor())
                 mq.delay(delay)
-                Core.DoGroupCmd("/autoinventory")
+                Core.DoGroupOrRaidCmd("/autoinventory")
             elseif scope == "personal" then
                 local delay = Config:GetSetting('AISelfDelay')
                 mq.delay(delay)

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -719,20 +719,19 @@ local _ClassConfig = {
             -- cond = function(self) return true end, --Code kept here for illustration, if there is no condition to check, this line is not required
             spells = {
                 --role and critical functions
-                { name = "MezAESong",       cond = function(self) return Config:GetSetting('DoAEMez') end, },
-                { name = "MezSong",         cond = function(self) return Config:GetSetting('DoSTMez') end, },
-                { name = "CharmSong",       cond = function(self) return Config:GetSetting('CharmOn') end, },
-                { name = "SlowSong",        cond = function(self) return Config:GetSetting('DoSTSlow') end, },
-                { name = "AESlowSong",      cond = function(self) return Config:GetSetting('DoAESlow') end, },
-                { name = "DispelSong",      cond = function(self) return Config:GetSetting('DoDispel') end, },
-                { name = "CureSong",        cond = function(self) return Config:GetSetting('UseCure') end, },
-                { name = "RunBuffSong",     cond = function(self) return Config:GetSetting('UseRunBuff') and not Casting.CanUseAA("Selo's Sonata") end, },
-                { name = "EndBreathSong",   cond = function(self) return Config:GetSetting('UseEndBreath') end, },
-                { name = "AccelerandoSong", cond = function(self) return Config:GetSetting('UseAccelerando') end, },
+                { name = "MezAESong",     cond = function(self) return Config:GetSetting('DoAEMez') end, },
+                { name = "MezSong",       cond = function(self) return Config:GetSetting('DoSTMez') end, },
+                { name = "CharmSong",     cond = function(self) return Config:GetSetting('CharmOn') end, },
+                { name = "SlowSong",      cond = function(self) return Config:GetSetting('DoSTSlow') end, },
+                { name = "AESlowSong",    cond = function(self) return Config:GetSetting('DoAESlow') end, },
+                { name = "DispelSong",    cond = function(self) return Config:GetSetting('DoDispel') end, },
+                { name = "CureSong",      cond = function(self) return Config:GetSetting('UseCure') end, },
+                { name = "RunBuffSong",   cond = function(self) return Config:GetSetting('UseRunBuff') and not Casting.CanUseAA("Selo's Sonata") end, },
+                { name = "EndBreathSong", cond = function(self) return Config:GetSetting('UseEndBreath') end, },
 
                 -- main group dps
-                { name = "WarMarchSong",    cond = function(self) return Config:GetSetting('UseMarch') > 1 end, },
-                { name = "AriaSong",        cond = function(self) return Config:GetSetting('UseAria') > 1 end, },
+                { name = "WarMarchSong",  cond = function(self) return Config:GetSetting('UseMarch') > 1 end, },
+                { name = "AriaSong",      cond = function(self) return Config:GetSetting('UseAria') > 1 end, },
                 {
                     name = "OverhasteSong",
                     cond = function(self)
@@ -772,21 +771,22 @@ local _ClassConfig = {
                         return Config:GetSetting('UseInsult') == 3 and (not Config:GetSetting('UseLLInsult') or not Core.GetResolvedActionMapItem('LLInsultSong'))
                     end,
                 },
-                { name = "LLInsultSong2", cond = function(self) return Config:GetSetting('UseInsult') == 3 and Config:GetSetting('UseLLInsult') end, },
+                { name = "LLInsultSong2",   cond = function(self) return Config:GetSetting('UseInsult') == 3 and Config:GetSetting('UseLLInsult') end, },
                 -- melee dps songs
-                { name = "SufferingSong", cond = function(self) return Config:GetSetting('UseSuffering') > 1 end, },
+                { name = "SufferingSong",   cond = function(self) return Config:GetSetting('UseSuffering') > 1 end, },
                 -- caster dps songs
-                { name = "FireBuffSong",  cond = function(self) return Config:GetSetting('UseFireBuff') > 1 end, },
-                { name = "ColdBuffSong",  cond = function(self) return Config:GetSetting('UseColdBuff') > 1 end, },
-                { name = "DotBuffSong",   cond = function(self) return Config:GetSetting('UseDotBuff') > 1 end, },
+                { name = "FireBuffSong",    cond = function(self) return Config:GetSetting('UseFireBuff') > 1 end, },
+                { name = "ColdBuffSong",    cond = function(self) return Config:GetSetting('UseColdBuff') > 1 end, },
+                { name = "DotBuffSong",     cond = function(self) return Config:GetSetting('UseDotBuff') > 1 end, },
                 -- healer songs
-                { name = "RecklessSong",  cond = function(self) return Config:GetSetting('UseReckless') > 1 end, },
+                { name = "AccelerandoSong", cond = function(self) return Config:GetSetting('UseAccelerando') end, },
+                { name = "RecklessSong",    cond = function(self) return Config:GetSetting('UseReckless') > 1 end, },
                 -- tank songs
-                { name = "SpitefulSong",  cond = function(self) return Config:GetSetting('UseSpiteful') > 1 end, },
-                { name = "SprySong",      cond = function(self) return Config:GetSetting('UseSpry') > 1 end, },
-                { name = "ResistSong",    cond = function(self) return Config:GetSetting('UseResist') > 1 end, },
+                { name = "SpitefulSong",    cond = function(self) return Config:GetSetting('UseSpiteful') > 1 end, },
+                { name = "SprySong",        cond = function(self) return Config:GetSetting('UseSpry') > 1 end, },
+                { name = "ResistSong",      cond = function(self) return Config:GetSetting('UseResist') > 1 end, },
                 -- filler
-                { name = "CalmSong",      cond = function(self) return true end, }, -- condition not needed, for uniformity
+                { name = "CalmSong",        cond = function(self) return true end, }, -- condition not needed, for uniformity
             },
         },
     },

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -1262,7 +1262,7 @@ _ClassConfig      = {
                 local delay = Config:GetSetting('AIGroupDelay')
                 Comms.PrintGroupMessage("%s summoned, issuing autoinventory command momentarily.", mq.TLO.Cursor())
                 mq.delay(delay)
-                Core.DoGroupCmd("/autoinventory")
+                Core.DoGroupOrRaidCmd("/autoinventory")
             elseif scope == "personal" then
                 local delay = Config:GetSetting('AISelfDelay')
                 mq.delay(delay)

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -1072,7 +1072,7 @@ _ClassConfig      = {
                 local delay = Config:GetSetting('AIGroupDelay')
                 Comms.PrintGroupMessage("%s summoned, issuing autoinventory command momentarily.", mq.TLO.Cursor())
                 mq.delay(delay)
-                Core.DoGroupCmd("/autoinventory")
+                Core.DoGroupOrRaidCmd("/autoinventory")
             elseif scope == "personal" then
                 local delay = Config:GetSetting('AISelfDelay')
                 mq.delay(delay)

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -124,27 +124,6 @@ Module.DefaultServerClickies            = {
     ['EQ Might']        = {
         [1] = {
             ['target'] = 'Self',
-            ['combat_state'] = 'Combat',
-            ['itemName'] = 'Veeshan\'s Distillate of Celestial Healing',
-            ['conditions'] = {
-                [1] = {
-                    ['target'] = 'Self',
-                    ['type'] = 'HP Threshold',
-                    ['args'] = {
-                        [1] = 0,
-                        [2] = 65,
-                    },
-                },
-                [2] = {
-                    ['target'] = 'Self',
-                    ['type'] = 'None',
-                    ['args'] = {},
-                },
-            },
-            ['iconId'] = 656,
-        },
-        [2] = {
-            ['target'] = 'Self',
             ['combat_state'] = 'Downtime',
             ['itemName'] = 'Ring of the Warden',
             ['conditions'] = {},

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -1013,11 +1013,11 @@ function Module:Render()
         ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, ImGui.GetStyle().FramePadding.x, 0)
         if campData.returnToCamp then
             if ImGui.Button("Break Group Camp", ImGui.GetWindowWidth() * .3, 18) then
-                Core.DoGroupCmd("/rgl campoff")
+                Core.DoGroupOrRaidCmd("/rgl campoff")
             end
         else
             if ImGui.Button("Set Group Camp Here", ImGui.GetWindowWidth() * .3, 18) then
-                Core.DoGroupCmd("/rgl campon")
+                Core.DoGroupOrRaidCmd("/rgl campon")
             end
         end
         ImGui.SameLine()

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -96,6 +96,21 @@ function Core.DoGroupCmd(cmd, ...)
     mq.cmd(formatted)
 end
 
+--- Executes a group command with the provided arguments.
+--- @param cmd string The command to be executed.
+--- @param ... any Additional arguments for the command.
+function Core.DoGroupOrRaidCmd(cmd, ...)
+    local dgcmd = "/dga /if ($\\{Zone.ID} == ${Zone.ID} && $\\{Group.Leader.Name.Equal[${Group.Leader.Name}]}) "
+    if mq.TLO.Raid.Members() > 0 then
+        dgcmd = "/dga /if ($\\{Zone.ID} == ${Zone.ID} && $\\{Raid.Leader.Name.Equal[${Raid.Leader.Name}]}) "
+    end
+    local formatted = cmd
+    if ... ~= nil then formatted = string.format(cmd, ...) end
+    formatted = dgcmd .. formatted
+    Logger.log_debug("\atRGMercs \awsent MQ \amGroup Command\aw: >> \ag%s\aw <<", formatted)
+    mq.cmd(formatted)
+end
+
 --- Checks the status of plugins.
 ---
 --- This function iterates over the provided table of plugins and performs a check on each one.


### PR DESCRIPTION
* Adjusted group commands function to allow broadcast to raid.
* * MAG(All) Will now trigger an autoinventory for all peers in the same zone/raid, rather than just in the same zone/group.
* * ENC(EQM) will no longer trigger autoinv for the group on crystal summon (holdover from Laz).
* Updated EQ Might server clickies.
* MAG (EQM) - Increased priority of mage donor pet resummon in combat.
* BRD (Live) - Decreased priority of accelerando line.