### PR TITLE
Auto-Attack Adjustments

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2136, }
+return { version = 2137, }

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -720,6 +720,16 @@ Config.DefaultConfig               = {
         Default = false,
         ConfigType = "Advanced",
     },
+    ['AutoAttackSafety']     = {
+        DisplayName = "Auto Attack Safety Check",
+        Group = "Combat",
+        Header = "Targeting",
+        Category = "Targeting Behavior",
+        Index = 6,
+        Tooltip = "Turn auto-attack off if we are not cleared to engage the current target.",
+        Default = true,
+        ConfigType = "Advanced",
+    },
 
     ['ScanNamedPriority']    = {
         DisplayName = "Scan Priority:",

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -54,6 +54,7 @@ function Targeting.ClearTarget()
         Config.Globals.ForceCombatID = 0
         if Config.Globals.ForceTargetID > 0 and not Targeting.IsSpawnXTHater(Config.Globals.ForceTargetID) then Config.Globals.ForceTargetID = 0 end
         if mq.TLO.Stick.Status():lower() == "on" then Movement:DoStickCmd("off") end
+        if mq.TLO.Me.Combat() then Core.DoCmd("/attack off") end
         Core.DoCmd("/target clear")
         if mq.TLO.Me.XTarget(1).TargetType() ~= "Auto Hater" then Targeting.ResetXTSlot(1) end
     end


### PR DESCRIPTION
* Attack will now be turned off by the ClearTarget function.
* ClearTarget will no longer be triggered when attack is turned on outside of combat.
* Attack will be turned off any time we are not clear to engage our current target unless the "Auto Attack Safety Check" is disabled by the user.
* Refactored/renested Attack off command when there is no target.