### PR TITLE
Expanded /rgl forcetarget

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2207, }
+return { version = 2208, }

--- a/init.lua
+++ b/init.lua
@@ -323,7 +323,6 @@ local function Main()
             Globals.ForceTargetID = 0
             Globals.IgnoredTargetIDs = Set.new({})
             Globals.AutoTargetID = 0
-            Globals.ForceCombatID = 0
         end
         mq.delay(100)
         Globals.CurZoneId = mq.TLO.Zone.ID()

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -1552,7 +1552,7 @@ function Module:GiveTime(combat_state)
 
         for i = 1, xtCount do
             local xtSpawn = mq.TLO.Me.XTarget(i)
-            if xtSpawn and xtSpawn.ID() > 0 and not xtSpawn.Dead() and not xtSpawn.Fleeing() and (math.ceil(xtSpawn.PctHPs() or 0)) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Globals.ForceCombatID) and Config.Constants.RGNotMezzedAnims:contains(xtSpawn.Animation()) and math.abs((mq.TLO.Me.Heading.Degrees() - (xtSpawn.Heading.Degrees() or 0))) < 100 then
+            if xtSpawn and xtSpawn.ID() > 0 and not xtSpawn.Dead() and not xtSpawn.Fleeing() and (math.ceil(xtSpawn.PctHPs() or 0)) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Globals.ForceTargetID) and Config.Constants.RGNotMezzedAnims:contains(xtSpawn.Animation()) and math.abs((mq.TLO.Me.Heading.Degrees() - (xtSpawn.Heading.Degrees() or 0))) < 100 then
                 Logger.log_debug("\arXT(%s) is behind us! \atTaking evasive maneuvers! \awMyHeader(\am%d\aw) ThierHeading(\am%d\aw)", xtSpawn.DisplayName() or "",
                     mq.TLO.Me.Heading.Degrees(), (xtSpawn.Heading.Degrees() or 0))
                 if os.clock() - Movement:GetLastStickTimer() < 0.5 then

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -125,34 +125,29 @@ Binds.Handlers    = {
     ['forcecombat'] = {
         usage = "/rgl forcecombat <id?>",
         about =
-        "Will force targeting and combat on a (potentially non-hostile) entity. If no ID is supplied, it will use your current target. See associated FAQ entry.",
+        "Alias for /rgl forcetarget. Will force the current target or <id> to be your autotarget no matter what until it is no longer valid. Can force combat on non-hostiles.",
         handler = function(targetId)
-            targetId = targetId and tonumber(targetId) or mq.TLO.Target.ID()
-            if targetId > 0 then
-                if mq.TLO.Target.ID() ~= targetId then
-                    Targeting.SetTarget(targetId, true)
-                end
-                Core.DoCmd("/xtarget set 1 currenttarget")
-                mq.delay("2s", function() return mq.TLO.Me.XTarget(1).ID() == mq.TLO.Target.ID() end)
-                Logger.log_info("\awForced Combat Targeting: %s", mq.TLO.Me.XTarget(1).CleanName())
-                Globals.ForceCombatID = targetId
-                Globals.ForceTargetID = targetId
-            else
-                Logger.log_info("\awForced Combat requires a valid supplied ID or target!")
+            local forcedTarget = targetId and mq.TLO.Spawn(targetId) or mq.TLO.Target
+            if forcedTarget and forcedTarget() and forcedTarget.ID() > 0 and (Targeting.TargetIsType("npc", forcedTarget) or Targeting.TargetIsType("npcpet", forcedTarget)) then
+                Globals.ForceTargetID = forcedTarget.ID()
+                Logger.log_info("\awForced Target: %s", forcedTarget.CleanName() or "None")
             end
+            Logger.log_warning("This command has been deprecated! The forcecombat command has been replaced by /rgl forcetarget and is slated for eventual removal.")
         end,
     },
     ['forcecombatclear'] = {
         usage = "/rgl forcecombatclear",
-        about = "Will cancel the current forced combat and reset the first XT slot if needed.",
+        about = "Alias for /rgl forcetargetclear. Will clear the current forced target.",
         handler = function()
-            Logger.log_info("\awDisabling forced combat against %s(id:%d)!", mq.TLO.Spawn(Globals.ForceCombatID).CleanName() or "Unknown", Globals.ForceCombatID)
-            Targeting.ClearTarget()
+            Globals.ForceTargetID = 0
+            Logger.log_info("\awForced target cleared.")
+            Logger.log_warning(
+                "This command has been deprecated! The forcecombatclear command has been replaced by /rgl forcetargetclear and is slated for eventual removal.")
         end,
     },
     ['forcetarget'] = {
         usage = "/rgl forcetarget <id?>",
-        about = "Will force the current target or <id> to be your autotarget no matter what until it is no longer valid.",
+        about = "Will force the current target or <id> to be your autotarget no matter what until it is no longer valid. Can force combat on non-hostiles.",
         handler = function(targetId)
             local forcedTarget = targetId and mq.TLO.Spawn(targetId) or mq.TLO.Target
             if forcedTarget and forcedTarget() and forcedTarget.ID() > 0 and (Targeting.TargetIsType("npc", forcedTarget) or Targeting.TargetIsType("npcpet", forcedTarget)) then

--- a/utils/comms.lua
+++ b/utils/comms.lua
@@ -82,7 +82,7 @@ function Comms.SendAllPeersDoCmd(inZoneOnly, includeSelf, cmd, ...)
     end
 end
 
-function Comms.SendHeartbeat(assist, curState, curAutoTarget, forceCombatId, chase, useMana, useEnd)
+function Comms.SendHeartbeat(assist, curState, curAutoTarget, forceTargetId, chase, useMana, useEnd)
     --if os.time() - Comms.LastHeartbeat < 1 then return end
     Comms.LastHeartbeat = os.time()
     local heartBeat = {
@@ -103,7 +103,7 @@ function Comms.SendHeartbeat(assist, curState, curAutoTarget, forceCombatId, cha
         Endurance     = useEnd and mq.TLO.Me.PctEndurance() or nil,
         Target        = mq.TLO.Target.DisplayName() or "None",
         TargetID      = mq.TLO.Target.ID() or 0,
-        ForceCombatID = forceCombatId,
+        ForceTargetID = forceTargetId,
         AutoTarget    = curAutoTarget,
         Assist        = assist,
         State         = curState,

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -190,12 +190,12 @@ Config.FAQ                         = {
     },
     [3] = {
         Question = "How do I force auto combat on a target that isn't aggressive or isn't hostile?",
-        Answer = "This is accomplished with the /rgl forcecombat <id?> command:\n\n" ..
+        Answer = "This is accomplished with the /rgl forcetarget <id?> command:\n\n" ..
             "The command accepts a target ID, and will fall back to your current target's ID if one is not supplied.\n\n" ..
-            "When commanded, the MA will add the target to the first XT slot and immediately force target.\n\n" ..
-            "The force combat state will be broadcasted to peers via actors, and will allow the target to check as valid even when the 'Target Non-Aggressives' setting is disabled." ..
+            "When commanded, the PC will add the target to the first XT slot and immediately force target.\n\n" ..
+            "The force target state can be issued to any PC, but if issued by the MA, it will be broadcasted to peers via actors, and will allow the target to check as valid even when the 'Target Non-Aggressives' setting is disabled." ..
             " Actors may need to be configured in MQ if all peers are not on the same PC. As an alternative, the setting above can be enabled temporarily.\n\n" ..
-            "Only one Force Combat target can be directed at a time, and the state will be cleared automatically. It can be cleared manually with the /rgl forcecombatclear command.",
+            "Only one Force Target can be directed at a time, and the state will be cleared automatically. It can be cleared manually with the /rgl forcetargetclear command.",
         Settings_Used = "",
     },
 }
@@ -709,7 +709,7 @@ Config.DefaultConfig               = {
         Category = "Targeting Behavior",
         Index = 4,
         Tooltip =
-        "Allow targeting of NPCs that are not aggressive (hostile) if they are targeted by our MA.\nNote: If combat has been forced on the target (by the MA via the forcecombat command), the target will also be allowed.",
+        "Allow targeting of NPCs that are not aggressive (hostile) if they are targeted by our MA.\nNote: If combat has been forced on the target (via a forcetarget command by this PC or the MA), the target will also be allowed.",
         Default = false,
         ConfigType = "Advanced",
     },

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -53,7 +53,6 @@ function Targeting.ClearTarget()
     if Config:GetSetting('DoAutoTarget') then
         Logger.log_debug("Clearing Target")
         Globals.AutoTargetID = 0
-        Globals.ForceCombatID = 0
         if Globals.ForceTargetID > 0 and not Targeting.IsSpawnXTHater(Globals.ForceTargetID) then Globals.ForceTargetID = 0 end
         if mq.TLO.Stick.Status():lower() == "on" then Movement:DoStickCmd("off") end
         if mq.TLO.Me.Combat() then Core.DoCmd("/attack off") end
@@ -238,7 +237,7 @@ function Targeting.GetHighestAggroPct()
     for i = 1, xtCount do
         local xtSpawn = mq.TLO.Me.XTarget(i)
 
-        if xtSpawn() and (xtSpawn.ID() or 0) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Globals.ForceCombatID) then
+        if xtSpawn() and (xtSpawn.ID() or 0) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Globals.ForceTargetID) then
             if xtSpawn.PctAggro() > highestPct then highestPct = xtSpawn.PctAggro() end
         end
     end
@@ -260,7 +259,7 @@ function Targeting.IHaveAggro(pct)
     for i = 1, xtCount do
         local xtSpawn = mq.TLO.Me.XTarget(i)
 
-        if xtSpawn() and (xtSpawn.ID() or 0) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Globals.ForceCombatID) then
+        if xtSpawn() and (xtSpawn.ID() or 0) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Globals.ForceTargetID) then
             if xtSpawn.PctAggro() >= pct then return true end
         end
     end
@@ -278,7 +277,7 @@ function Targeting.GetXTHaterIDs(printDebug)
 
     for i = 1, xtCount do
         local xtarg = mq.TLO.Me.XTarget(i)
-        if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (math.ceil(xtarg.PctHPs() or 0)) > 0 and (xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater" or xtarg.ID() == Globals.ForceCombatID) then
+        if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (math.ceil(xtarg.PctHPs() or 0)) > 0 and (xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater" or xtarg.ID() == Globals.ForceTargetID) then
             if printDebug then
                 Logger.log_verbose("GetXTHaters(): XT(%d) Counting %s(%d) as a hater.", i, xtarg.CleanName() or "None", xtarg.ID())
             end

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -532,7 +532,7 @@ function Ui.RenderForceTargetList(showPopout)
         local xtCount = mq.TLO.Me.XTarget() or 0
         for i = 1, xtCount do
             local xtarg = mq.TLO.Me.XTarget(i)
-            if xtarg and xtarg.ID() > 0 and (xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater" or xtarg.ID() == Globals.ForceCombatID) then
+            if xtarg and xtarg.ID() > 0 and (xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater" or xtarg.ID() == Globals.ForceTargetID) then
                 ImGui.PushID(string.format("##xtarg_%d", i))
                 ImGui.TableNextColumn()
                 if (Targeting.GetAutoTarget().ID() or 0) == xtarg.ID() then


### PR DESCRIPTION
* Forcetarget command can now be issued to any mercs PC, and the forced target will take priority over any other target.
* * If the force target command is issued to the MA, the PC will also consider this a force target if they don't currently already have a forced target.
* Forced Targets now bypass hostility or aggressiveness checks.
* /rgl forcecombat has become an alias of /rgl forcetarget, is now deprecated, and is slated for sunset.