### PR TITLE
Live Config Updates

### DIFF
--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -289,6 +289,23 @@ return {
             "Jarring Shock",
             "Jarring Impact",
         },
+        ['SnareDisc'] = {
+            "Tendon Slice",
+            "Tendon Shred",
+            "Tendon Rip",
+            "Tendon Rupture",
+            "Tendon Tear",
+            "Tendon Gash",
+            "Tendon Slash",
+            "Tendon Lacerate",
+            "Tendon Shear",
+            "Tendon Sever",
+            "Tendon Cleave",
+            "Crippling Strike",
+            "Leg Slice",
+            "Leg Cut",
+            "Leg Strike",
+        },
     },
     ['RotationOrder']   = {
         -- Downtime doesn't have state because we run the whole rotation at once.
@@ -298,6 +315,16 @@ return {
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and
                     Casting.OkayToBuff() and Casting.AmIBuffable()
+            end,
+        },
+        { --Keep things from running
+            name = 'Snare',
+            state = 1,
+            steps = 1,
+            load_cond = function() return Config:GetSetting('Timer10Disc') == 2 end,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and Targeting.GetXTHaterCount() <= Config:GetSetting('SnareCount')
             end,
         },
         {
@@ -394,6 +421,7 @@ return {
                         { name = 'Daxethrow', count_name = 'AutoAxeCount', },
                         { name = 'Daxeof',    count_name = 'AutoAxeCount', },
                         { name = 'Dicho',     count_name = 'DichoAxeCount', },
+                        { name = 'SnareDisc', count_name = 'AutoAxeCount', },
                     }
 
                     local summonNeededItem = function(summonSkill, itemId, count)
@@ -468,6 +496,15 @@ return {
                 type = "Disc",
                 cond = function(self, discSpell)
                     return Casting.SelfBuffCheck(discSpell)
+                end,
+            },
+        },
+        ['Snare'] = {
+            {
+                name = "SnareDisc",
+                type = "Disc",
+                cond = function(self, discSpell, target)
+                    return Casting.DetSpellCheck(discSpell) and Targeting.MobHasLowHP(target) and not Casting.SnareImmuneTarget(target)
                 end,
             },
         },
@@ -649,6 +686,7 @@ return {
             {
                 name = "Daxethrow",
                 type = "Disc",
+                load_cond = function(self) return Config:GetSetting('Timer10Disc') == 1 end,
             },
             {
                 name = "SharedBuff",
@@ -904,6 +942,31 @@ return {
             Category = "Self",
             Tooltip = "Enable using Disconcerting Discipline",
             Default = true,
+        },
+        ['Timer10Disc']     = {
+            DisplayName = "Timer 10 Disc Choice",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 101,
+            Tooltip = "Choose between your Axe Throw Disc or Snare Disc (Leg/Tendon line). The timer is shared.",
+            Type = "Combo",
+            ComboOptions = { 'Throw Disc', 'Snare Disc', },
+            Default = 1,
+            Min = 1,
+            Max = 2,
+            RequiresLoadoutChange = true,
+        },
+        ['SnareCount']      = {
+            DisplayName = "Snare Max Mob Count",
+            Group = "Abilities",
+            Header = "Debuffs",
+            Category = "Snare",
+            Index = 101,
+            Tooltip = "Only use snare if there are [x] or fewer mobs on aggro. Helpful for AoE groups.",
+            Default = 3,
+            Min = 1,
+            Max = 99,
         },
     },
     ['ClassFAQ']        = {

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -106,7 +106,7 @@ local _ClassConfig = {
             "Tarew's Aquatic Ayre", --Level 16
         },
         ['AriaSong'] = {
-            "Severyn's Aria",
+            "Aria of Kenburk",
             "Aria of Tenisbre", -- 125
             "Aria of Pli Xin Liako",
             "Aria of Margidor",
@@ -330,7 +330,8 @@ local _ClassConfig = {
             "Anthem de Arms",
         },
         ['FireBuffSong'] = {
-            -- CasterAriaSong - Level Range 72 - 113
+            -- CasterAriaSong - Level Range 72+
+            "Severyn's Aria",
             "Flariton's Aria", -- 125
             "Constance's Aria",
             "Sontalak's Aria",

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2264, }
+return { version = 2265, }


### PR DESCRIPTION
* [BRD] - Fix for FireBuff/Aria mixup (Thanks No_Songs_For_You!)

* [BER] Add support for snare.
* * The "Timer 10 Choice" option determines whether you use Axe Throw or Snare. Axe Throw is the default (for good reason, to editorialize).
* * Added snare to axe reagent checks.