### PR TITLE
Forcetarget Updates

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2280, }
+return { version = 2281, }

--- a/init.lua
+++ b/init.lua
@@ -451,8 +451,8 @@ local function Main()
                 Logger.log_debug("\ayClearing Target because we are not OkToEngage() and we are in combat!")
                 Targeting.ClearTarget()
             end
-        elseif mq.TLO.Me.Combat() and (Config:GetSetting('AutoAttackSafety') or not mq.TLO.Target()) then
-            Logger.log_debug("\ayTurning off attack because we don't have a target or we are not OkToEngage!")
+        elseif mq.TLO.Me.Combat() and (Config:GetSetting('AutoAttackSafetyCheck') or not mq.TLO.Target()) then
+            Logger.log_debug("\ayTurning off attack because we don't have a target or we are not OkToEngage the current target!")
             Core.DoCmd("/attack off")
         end
     end

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -128,7 +128,7 @@ Binds.Handlers    = {
         "Alias for /rgl forcetarget. Will force the current target or <id> to be your autotarget no matter what until it is no longer valid. Can force combat on non-hostiles.",
         handler = function(targetId)
             local forcedTarget = targetId and mq.TLO.Spawn(targetId) or mq.TLO.Target
-            if forcedTarget and forcedTarget() and forcedTarget.ID() > 0 and (Targeting.TargetIsType("npc", forcedTarget) or Targeting.TargetIsType("npcpet", forcedTarget)) then
+            if forcedTarget and forcedTarget() and forcedTarget.ID() > 0 and (Targeting.TargetIsType("npc", forcedTarget) or Targeting.TargetIsType("npcpet", forcedTarget) or Targeting.TargetIsType("object", forcedTarget)) then
                 Globals.ForceTargetID = forcedTarget.ID()
                 Logger.log_info("\awForced Target: %s", forcedTarget.CleanName() or "None")
             end
@@ -150,7 +150,7 @@ Binds.Handlers    = {
         about = "Will force the current target or <id> to be your autotarget no matter what until it is no longer valid. Can force combat on non-hostiles.",
         handler = function(targetId)
             local forcedTarget = targetId and mq.TLO.Spawn(targetId) or mq.TLO.Target
-            if forcedTarget and forcedTarget() and forcedTarget.ID() > 0 and (Targeting.TargetIsType("npc", forcedTarget) or Targeting.TargetIsType("npcpet", forcedTarget)) then
+            if forcedTarget and forcedTarget() and forcedTarget.ID() > 0 and (Targeting.TargetIsType("npc", forcedTarget) or Targeting.TargetIsType("npcpet", forcedTarget) or Targeting.TargetIsType("object", forcedTarget)) then
                 Globals.ForceTargetID = forcedTarget.ID()
                 Logger.log_info("\awForced Target: %s", forcedTarget.CleanName() or "None")
             end

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -456,6 +456,9 @@ function Combat.FindBestAutoTarget(validateFn)
                     Logger.log_debug("FindAutoTarget(): Forced Targeting: \ag%s\ax [ID: \ag%d\ax]", forceSpawn.CleanName() or "None", forceSpawn.ID())
                 end
             else
+                if mq.TLO.Me.XTarget(1).ID() == Globals.ForceTargetID then
+                    Targeting.ResetXTSlot(1)
+                end
                 Globals.ForceTargetID = 0
             end
         else

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -610,15 +610,14 @@ Config.DefaultConfig                                     = {
         Default = false,
         ConfigType = "Advanced",
     },
-    ['AutoAttackSafety']       = {
+    ['AutoAttackSafetyCheck']  = {
         DisplayName = "Auto Attack Safety Check",
         Group = "Combat",
         Header = "Targeting",
         Category = "Targeting Behavior",
         Index = 6,
-        Tooltip = "Turn auto-attack off if we are not cleared to engage the current target.",
-        Default = true,
-        ConfigType = "Advanced",
+        Tooltip = "Turn off auto-attack if we are not in combat and not cleared to engage the current target.",
+        Default = false,
     },
 
     ['ScanNamedPriority']      = {

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -430,7 +430,7 @@ end
 --- @param slot number The slot number to reset.
 function Targeting.ResetXTSlot(slot)
     Core.DoCmd("/xtarget set %d ET", slot)
-    mq.delay(200, function() return (mq.TLO.Me.XTarget(slot).TargetType():lower() or "empty target") == "empty target" end)
+    mq.delay(500, function() return (mq.TLO.Me.XTarget(slot).TargetType():lower() or "empty target") == "empty target" end)
     Core.DoCmd("/xtarget set %d autohater", slot)
 end
 


### PR DESCRIPTION
* Fix for /rgl forcetarget not initiating combat on objects (Thanks treadstone!)

* The auto attack safety check is now defaulted to false. Players wishing to use this feature may need to readjust the setting.