### PR TITLE
Farm: Add option for delaying between WP movements

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2298, }
+return { version = 2299, }


### PR DESCRIPTION
* We will now only move to the next waypoint if the "Waypoint Delay" (Default: 0s) time has been met.
* * Any pull at the current WP will reset this timer. E.g, if the waypoint delay is set to 10s, and you pull another target 8 seconds in, we will wait the full 10 seconds again after that combat has ended.

* Resolves #118

* Additional improvements for farm mode navigation and incrementing.