### PR TITLE
UseSong performance enhancements

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2332, }
+return { version = 2333, }

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1049,7 +1049,8 @@ Config.DefaultConfig                                     = {
         Header = "Common",
         Category = "Under the Hood",
         Index = 3,
-        Tooltip = "Wait Ping * [n] ms to allow songs to take effect before singing the next.",
+        Tooltip =
+        "Wait Ping * [n] ms to allow songs to take effect before singing the next. If this is set too low, the server may not register the song completion before we /stopsong.\nSetting this lower will not increase performance, as we will stop delaying as soon as the song buff is detected. This is strictly to solve for song clipping for those with high latency!",
         Default = 2,
         Min = 1,
         Max = 10,


### PR DESCRIPTION
Expanded buff checks during UseSong to reduce delay between songs, and greatly reduced (eliminated?) the chance of a false positive causing us to clip the song early.