### PR TITLE
Cure Improvements: Stagger Group AA Cures

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2350, }
+return { version = 2351, }

--- a/namedlist/named_eqmight.lua
+++ b/namedlist/named_eqmight.lua
@@ -796,7 +796,7 @@ return {
         "Vipera Ashenheart",
         "Vilria the Keeper",
         "Warden Hanvar",
-        "Overlord Muta Muram",
+        "Overlord Mata Muram",
     },
 
     ["provinggrounds"] = {

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1370,6 +1370,18 @@ Config.DefaultConfig                                     = {
         Max = 30,
         ConfigType = "Advanced",
     },
+    ['StaggerGroupAACures']    = {
+        DisplayName = "Stagger Group AA Cures",
+        Group = "Abilities",
+        Header = "Recovery",
+        Category = "Curing",
+        Index = 4,
+        Tooltip = "If you detect an actor peer already casting Radiant Cure or Group Purify Soul on a groupmate, do not check if cures are needed until they are finished.\n" ..
+            "This is a 'best-effort' setting that tries to avoid multiple healers using group AA cures at once on the same effect. It does not check for other spells. It is not foolproof.",
+        Default = true,
+        ConfigType = "Advanced",
+    },
+
     --Recovery/Rezzing
     ['DoRez']                  = {
         DisplayName = "Do Rez",


### PR DESCRIPTION
* Added "Stagger Group AA Cures" Option:
* * If you detect an actor peer already casting Radiant Cure or Group Purify Soul on a groupmate, do not check if cures are needed until they are finished. This is a 'best-effort' setting that tries to avoid multiple healers using group AA cures at once on the same effect. It does not check for other spells. It is not foolproof.