### PR TITLE
Add warning to the clicky header if that clicky is used in rotations

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2354, }
+return { version = 2355, }

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -13,6 +13,7 @@ local Targeting                         = require("utils.targeting")
 local Files                             = require("utils.files")
 local Tables                            = require("utils.tables")
 local Set                               = require("mq.Set")
+local Modules                           = require("utils.modules")
 local Icons                             = require('mq.ICONS')
 local animItems                         = mq.FindTextureAnimation("A_DragItem")
 
@@ -984,6 +985,16 @@ function Module:RenderClickyControls(clickies, clickyIdx, headerCursorPos, heade
     else
         ImGui.SameLine()
         ImGui.InvisibleButton(Icons.FA_CHEVRON_DOWN, ImVec2(22, 1))
+    end
+
+    if clickies[clickyIdx] then
+        local rotationClickies = Modules:ExecModule("Class", "GetRotationClickies")
+        local hasWarning = rotationClickies:contains(clickies[clickyIdx].itemName)
+        if hasWarning then
+            ImGui.SameLine()
+            ImGui.TextColored(Globals.Constants.Colors.ConditionFailColor, Icons.MD_WARNING)
+            Ui.Tooltip("This clicky is in use in your current class config loadout. Check for possible conflicts!")
+        end
     end
 
     ImGui.SetCursorPos(ImGui.GetWindowWidth() - offset_trash, headerCursorPos.y + yOffset)


### PR DESCRIPTION
This needs pulled in and adjusted before merge.
I have it 90% of the way there.