### PR TITLE
AutoTarget Update

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2401, }
+return { version = 2402, }

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -563,29 +563,42 @@ function Combat.FindBestAutoTarget(validateFn)
                 end
             end
 
-            if assistId == 0 then
-                if Config:GetSetting('UseAssistList') and Globals.MainAssist:len() > 0 then
-                    if heartbeat and heartbeat.Data then
-                        local targetID = tonumber(heartbeat.Data.TargetID) or 0
-                        if targetID and type(targetID) == 'number' then
-                            assistId = targetID
-                            assistTarget = mq.TLO.Spawn(targetID)
-                            Logger.log_verbose("\ayFindAutoTarget Assist's Target via Actors :: %s (%s)",
-                                assistTarget.CleanName() or "None", targetID)
-                        end
-                        if heartbeat.Data.TargetIsNamed then
-                            Globals.AutoTargetIsNamed = true
-                            assistTargetIsNamed = true
-                        end
-                    elseif mq.TLO.DanNet(Globals.MainAssist)() then
-                        local queryResult = DanNet.query(Globals.MainAssist, "Target.ID", 1000)
-                        if queryResult then
-                            assistId = tonumber(queryResult) or 0
-                            assistTarget = mq.TLO.Spawn(queryResult)
-                            Logger.log_verbose("\ayFindAutoTarget Assist's Target via DanNet :: %s (%s)",
-                                assistTarget.CleanName() or "None", queryResult)
-                        end
+            if assistId == 0 and Globals.MainAssist:len() > 0 then
+                -- check if the MA is an actor peer
+                if heartbeat and heartbeat.Data then
+                    local targetID = tonumber(heartbeat.Data.TargetID) or 0
+                    if targetID and type(targetID) == 'number' then
+                        assistId = targetID
+                        assistTarget = mq.TLO.Spawn(targetID)
+                        Logger.log_verbose("\ayFindAutoTarget Assist's Target via Actors :: %s (%s)",
+                            assistTarget.CleanName() or "None", targetID)
+                    end
+                    if heartbeat.Data.TargetIsNamed then
+                        Globals.AutoTargetIsNamed = true
+                        assistTargetIsNamed = true
+                    end
+                    -- check if the MA is a dannet peer
+                elseif mq.TLO.DanNet(Globals.MainAssist)() then
+                    local queryResult = DanNet.query(Globals.MainAssist, "Target.ID", 1000)
+                    if queryResult then
+                        assistId = tonumber(queryResult) or 0
+                        assistTarget = mq.TLO.Spawn(queryResult)
+                        Logger.log_verbose("\ayFindAutoTarget Assist's Target via DanNet :: %s (%s)",
+                            assistTarget.CleanName() or "None", queryResult)
+                    end
+                    -- Check for the Group/Raid Assist Target via TLO. Don't do this if we are using assist list, the assumption is we don't *want* to assist the group/raid
+                elseif not Config:GetSetting('UseAssistList') then
+                    assistId = Combat.GetGroupOrRaidAssistTargetId()
+                    assistTarget = mq.TLO.Spawn(assistId)
+                    Logger.log_verbose("\ayFindAutoTarget Assist's Target via Group/Raid TLO :: %s (%s)",
+                        assistTarget.CleanName() or "None", assistId)
+                else
+                    -- if we cant get a target any other way, just stay on our current one if its valid, rather then constantly retargeting an MA.
+                    if Combat.ValidCombatTarget(Globals.AutoTargetID) then
+                        assistId = Globals.AutoTargetID
                     else
+                        -- otherwise, manually target the MA to get their target of target. this is a last-ditch fallback. it would be much better to let a mercs toon be the MA.
+                        -- compromise here is to leave all mercs toons assisting a mercs MA, but the mercs MA setting an outsider to the MA, so we aren't all targeting randomly.
                         local assistSpawn = Core.GetMainAssistSpawn()
                         if assistSpawn and assistSpawn() then
                             Targeting.SetTarget(assistSpawn.ID(), true)
@@ -595,8 +608,6 @@ function Combat.FindBestAutoTarget(validateFn)
                                 assistTarget.CleanName() or "None")
                         end
                     end
-                else
-                    assistId = Combat.GetGroupOrRaidAssistTargetId()
                 end
             end
         end


### PR DESCRIPTION
* We will now check Actors for our autotarget before relying on assist TLOs, even when we are not using the assist list.
* In the absence of any other method to glean the MAs target, we will first attempt to stay on the current target rather than targeting the MA to find his target.
* This resolves #1010 