### PR TITLE
Refactor buff checks for actor use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 rgmercs.code-workspace
+.vscode/

--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -937,10 +937,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds tops.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Core.OkayToNotHeal() and Casting.OkayToBuff()
             end,

--- a/class_configs/Alpha (Live)/nec_class_config.lua
+++ b/class_configs/Alpha (Live)/nec_class_config.lua
@@ -802,7 +802,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Alpha (Live)/pal_class_config.lua
+++ b/class_configs/Alpha (Live)/pal_class_config.lua
@@ -943,10 +943,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -251,17 +251,16 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -678,7 +677,7 @@ return {
                     if (spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                         --laz specific deconflict with brell's vibrant barricade
-                        and Casting.PeerBuffCheck(40583, target, true)
+                        and Casting.AddedBuffCheck(40583, target)
                 end,
             },
             {

--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -606,8 +606,9 @@ local _ClassConfig = {
         },
         { --Spells that should be checked on group members
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self) return Casting.GetBuffableGroupIDs() end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.OkayToBuff()
             end,

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -462,7 +462,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -470,10 +470,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds tops.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Core.OkayToNotHeal() and Casting.OkayToBuff()
             end,

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -353,10 +353,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
@@ -370,7 +369,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -682,7 +681,8 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     if not Targeting.TargetIsAMelee(target) then return false end
-                    return Casting.GroupBuffCheck(spell, target) and Casting.PeerBuffCheck(5521, target, true) -- Don't cast if we have Hastening of Salik
+                    -- Don't cast if we have Hastening of Salik
+                    return Casting.GroupBuffCheck(spell, target) and Casting.AddedBuffCheck(5521, target)
                 end,
             },
             {

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -314,10 +314,9 @@ _ClassConfig    = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
@@ -941,8 +940,8 @@ _ClassConfig    = {
                     if not Targeting.TargetIsATank(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                         -- workarounds for laz
-                        and Casting.PeerBuffCheck(19847, target, true) -- necrotic pustules
-                        and Casting.PeerBuffCheck(8484, target, true)  -- decrepit skin
+                        and Casting.AddedBuffCheck(19847, target) -- necrotic pustules
+                        and Casting.AddedBuffCheck(5521, target)  -- decrepit skin
                 end,
                 post_activate = function(self, spell, success)
                     local petName = mq.TLO.Me.Pet.CleanName() or "None"

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -357,7 +357,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -611,10 +611,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff() and Core.OkayToNotHeal()
             end,
@@ -802,7 +801,7 @@ return {
                 load_cond = function() return Config:GetSetting('AegoSymbol') == 3 or Config:GetSetting('AegoSymbol') == 3 end,
                 cond = function(self, spell, target)
                     if (spell.TargetType() or ""):lower() == "single" and target.ID() ~= Core.GetMainAssistId() then return false end
-                    return Casting.GroupBuffCheck(spell, target) and Casting.PeerBuffCheck(3047, target, true) -- don't try to overwrite Kazad's Mark
+                    return Casting.GroupBuffCheck(spell, target) and Casting.AddedBuffCheck(3047, target) -- don't try to overwrite Kazad's Mark
                 end,
             },
             {

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -265,10 +265,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -442,7 +442,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             load_cond = function(self) return Config:GetSetting('DoPet') end,
             cond = function(self, combat_state)

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -405,7 +405,7 @@ return {
             name = 'CombatBuff',
             state = 1,
             steps = 1,
-            timer = 30, -- only run every 30 seconds at most.
+            timer = 10,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"

--- a/class_configs/HiddenForest/bst_class_config.lua
+++ b/class_configs/HiddenForest/bst_class_config.lua
@@ -229,17 +229,16 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -612,7 +611,7 @@ return {
                     if (spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                         --laz specific deconflict with brell's vibrant barricade
-                        and Casting.PeerBuffCheck(40583, target, true)
+                        and Casting.AddedBuffCheck(40583, target)
                 end,
             },
             {

--- a/class_configs/HiddenForest/clr_class_config.lua
+++ b/class_configs/HiddenForest/clr_class_config.lua
@@ -523,8 +523,9 @@ local _ClassConfig = {
         },
         { --Spells that should be checked on group members
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self) return Casting.GetBuffableGroupIDs() end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.OkayToBuff()
             end,

--- a/class_configs/HiddenForest/dru_class_config.lua
+++ b/class_configs/HiddenForest/dru_class_config.lua
@@ -427,7 +427,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -435,10 +435,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds tops.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Core.OkayToNotHeal() and Casting.OkayToBuff()
             end,

--- a/class_configs/HiddenForest/enc_class_config.lua
+++ b/class_configs/HiddenForest/enc_class_config.lua
@@ -322,10 +322,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
@@ -339,7 +338,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/HiddenForest/mag_class_config.lua
+++ b/class_configs/HiddenForest/mag_class_config.lua
@@ -783,10 +783,9 @@ _ClassConfig    = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/HiddenForest/nec_class_config.lua
+++ b/class_configs/HiddenForest/nec_class_config.lua
@@ -320,7 +320,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/HiddenForest/pal_class_config.lua
+++ b/class_configs/HiddenForest/pal_class_config.lua
@@ -543,10 +543,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff() and Core.OkayToNotHeal()
             end,

--- a/class_configs/HiddenForest/rng_class_config.lua
+++ b/class_configs/HiddenForest/rng_class_config.lua
@@ -261,10 +261,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/HiddenForest/shd_class_config.lua
+++ b/class_configs/HiddenForest/shd_class_config.lua
@@ -389,7 +389,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/HiddenForest/shm_class_config.lua
+++ b/class_configs/HiddenForest/shm_class_config.lua
@@ -528,7 +528,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -536,10 +536,9 @@ local _ClassConfig = {
         },
         { --Spells that should be checked on group members
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.OkayToBuff()
             end,

--- a/class_configs/HiddenForest/wiz_class_config.lua
+++ b/class_configs/HiddenForest/wiz_class_config.lua
@@ -391,7 +391,7 @@ return {
             name = 'CombatBuff',
             state = 1,
             steps = 1,
-            timer = 30, -- only run every 30 seconds at most.
+            timer = 10,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -676,10 +676,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
@@ -693,7 +692,7 @@ return {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -1110,8 +1110,9 @@ local _ClassConfig = {
         },
         { --Spells that should be checked on group members
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self) return Casting.GetBuffableGroupIDs() end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.OkayToBuff()
             end,

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -914,10 +914,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -839,10 +839,9 @@ local _ClassConfig    = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
@@ -856,7 +855,7 @@ local _ClassConfig    = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -886,7 +886,7 @@ _ClassConfig    = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this. Timer lowered for mage due to high volume of actions
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -894,10 +894,9 @@ _ClassConfig    = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -771,7 +771,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -885,10 +885,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -876,10 +876,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -819,7 +819,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -986,17 +986,16 @@ local _ClassConfig = {
         },
         { --Spells that should be checked on group members
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.OkayToBuff()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Live/wiz_class_config.lua
+++ b/class_configs/Live/wiz_class_config.lua
@@ -792,7 +792,7 @@ return {
             name = 'CombatBuff',
             state = 1,
             steps = 1,
-            timer = 30, -- only run every 30 seconds at most.
+            timer = 10,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -227,17 +227,16 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -620,7 +619,7 @@ return {
                     if (spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                         --laz specific deconflict with brell's vibrant barricade
-                        and Casting.PeerBuffCheck(40583, target, true)
+                        and Casting.AddedBuffCheck(40583, target)
                 end,
             },
             {

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -517,8 +517,9 @@ local _ClassConfig = {
         },
         { --Spells that should be checked on group members
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self) return Casting.GetBuffableGroupIDs() end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.OkayToBuff()
             end,

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -440,7 +440,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -448,10 +448,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds tops.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Core.OkayToNotHeal() and Casting.OkayToBuff()
             end,

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -322,10 +322,9 @@ local _ClassConfig = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
@@ -339,7 +338,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -608,7 +607,7 @@ local _ClassConfig = {
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     if self:GetResolvedActionMapItem('HasteManaCombo') or not Targeting.TargetIsAMelee(target) then return false end
-                    return Casting.GroupBuffCheck(spell, target) and Casting.PeerBuffCheck(40597, target, true) -- Fixes bad stacking check
+                    return Casting.GroupBuffCheck(spell, target) and Casting.AddedBuffCheck(40597, target) -- Fixes bad stacking check
                 end,
             },
             {

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -645,10 +645,9 @@ _ClassConfig      = {
         },
         {
             name = 'GroupBuff',
-            timer = 60, -- only run every 60 seconds top.
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,
@@ -1323,8 +1322,8 @@ _ClassConfig      = {
                     if not Targeting.TargetIsATank(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                         -- workarounds for laz
-                        and Casting.PeerBuffCheck(19847, target, true) -- necrotic pustules
-                        and Casting.PeerBuffCheck(8484, target, true)  -- decrepit skin
+                        and Casting.AddedBuffCheck(19847, target) -- necrotic pustules
+                        and Casting.AddedBuffCheck(8484, target)  -- decrepit skin
                 end,
                 post_activate = function(self, spell, success)
                     local petName = mq.TLO.Me.Pet.CleanName() or "None"

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -320,7 +320,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 30,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -538,10 +538,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff() and Core.OkayToNotHeal()
             end,

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -258,10 +258,9 @@ return {
         },
         {
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
             end,

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -379,7 +379,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -521,7 +521,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
@@ -529,10 +529,9 @@ local _ClassConfig = {
         },
         { --Spells that should be checked on group members
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal()) and Casting.OkayToBuff()
             end,
@@ -573,8 +572,7 @@ local _ClassConfig = {
             steps = 3,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and
-                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
+                return combat_state == "Combat" and Casting.BurnCheck() and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
             end,
         },
         {
@@ -583,10 +581,9 @@ local _ClassConfig = {
             state = 1,
             steps = 1,
             load_cond = function(self) return self:GetResolvedActionMapItem('MeleeProcBuff') end,
-            targetId = function(self) return { Core.GetMainAssistId(), } or {} end,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and
-                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
+                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
             end,
         },
         {
@@ -595,8 +592,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and
-                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
+                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
             end,
         },
         {
@@ -606,8 +602,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not mq.TLO.Me.Buff("Focus of Arcanum")() and
-                    (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
+                return combat_state == "Combat" and not mq.TLO.Me.Buff("Focus of Arcanum")() and (not Core.IsModeActive('Heal') or Core.OkayToNotHeal())
             end,
         },
 

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -382,7 +382,7 @@ return {
             name = 'CombatBuff',
             state = 1,
             steps = 1,
-            timer = 30, -- only run every 30 seconds at most.
+            timer = 10,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"

--- a/class_configs/example_class_config.lua
+++ b/class_configs/example_class_config.lua
@@ -309,10 +309,9 @@ local _ClassConfig = {
         },
         { -- SHD doesn't have group buffs! Listed as a reference as to where we get our table of buffable group IDs from!
             name = 'GroupBuff',
-            timer = 60,
-            targetId = function(self)
-                return Casting.GetBuffableGroupIDs()
-            end,
+            state = 1,
+            steps = 1,
+            targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 -- much simpler conditions here! "OkayToBuff" has things like... am I moving, is nav active, etc. Search for this function in the Casting util file!
                 return combat_state == "Downtime" and Casting.OkayToBuff()
@@ -343,7 +342,7 @@ local _ClassConfig = {
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
             name = 'PetBuff',
-            timer = 60,
+            timer = 10,
             --The targetId here is simply a condition statement, if we have a pet, we return the ID in a table; if not, we return an empty table.
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2450, }
+return { version = 2451, }

--- a/init.lua
+++ b/init.lua
@@ -311,7 +311,8 @@ local function RGInit(...)
     printf("\aw\awBy \ag%s", Config._author)
     printf("\aw****************************")
     -- keep these for easy editing/addition later
-    --  printf("\agThe new options panel is live! See our recent forum post or commit messages.")
+    printf("\agBuff handling has been revamped to rely on actors! See our recent forum post or commit messages.")
+    printf("\agYou may wish to take a moment to peruse the new options in Abilities > Buffs> Buff Rules.")
     printf("\awPlease visit us on the RG forums for the most recent news and updates.")
     printf("\aw Use \ag /rgl \aw or check our options panel for a list of commands.")
 
@@ -342,6 +343,8 @@ local function Main()
         Globals.CurInstance = mq.TLO.Me.Instance()
         return
     end
+
+    Core.UpdateBuffs()
 
     Events.DoEvents(true)
 

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -1633,7 +1633,7 @@ function Module:GiveTime()
                         elseif clicky.target == "Main Assist" then
                             ---@diagnostic disable-next-line: cast-local-type
                             target = Core.GetMainAssistSpawn()
-                            buffCheckPassed = Casting.PeerBuffCheck(item.Clicky.Spell.ID(), target, false)
+                            buffCheckPassed = Casting.GroupBuffItemCheck(clicky.itemName, target)
                         elseif clicky.target == "Auto Target" then
                             ---@diagnostic disable-next-line: cast-local-type
                             target = Targeting.GetAutoTarget()

--- a/utils/comms.lua
+++ b/utils/comms.lua
@@ -153,6 +153,11 @@ function Comms.SendHeartbeat(assist, chase)
         Chase         = chase,
         Invis         = mq.TLO.Me.Invis(),
         FreeInventory = mq.TLO.Me.FreeInventory(3)(),
+        Buffs         = Globals.CurrentBuffs,
+        Songs         = Globals.CurrentSongs,
+        Blocked       = Globals.CurrentBlocked,
+        PetBuffs      = Globals.CurrentPetBuffs,
+        PetBlocked    = Globals.CurrentPetBlocked,
     }
     Comms.BroadcastMessage("RGMercs", "Heartbeat", heartBeat)
     -- update our own heartbeat too

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -9,7 +9,7 @@ local Files                                              = require("utils.files"
 local Globals                                            = require("utils.globals")
 
 local Config                                             = {
-    _version = '1.5.1',
+    _version = '1.6.0',
     _subVersion = "Shattering of Ro",
     _name = "Config",
     _AppName = "RGMercs Lua Edition",
@@ -71,7 +71,6 @@ Config.FAQ                                               = {
             "The command accepts a target ID, and will fall back to your current target's ID if one is not supplied.\n\n" ..
             "When commanded, the PC will add the target to the first XT slot and immediately force target.\n\n" ..
             "The force target state can be issued to any PC, but if issued by the MA, it will be broadcasted to peers via actors, and will allow the target to check as valid even when the 'Target Non-Aggressives' setting is disabled." ..
-            " Actors may need to be configured in MQ if all peers are not on the same PC. As an alternative, the setting above can be enabled temporarily.\n\n" ..
             "Only one Force Target can be directed at a time, and the state will be cleared automatically. It can be cleared manually with the /rgl forcetargetclear command.",
         Settings_Used = "",
     },
@@ -1249,6 +1248,47 @@ Config.DefaultConfig                                     = {
         Tooltip = "Break Invis as part of /rgl say, qsay or rsay commands.",
         Default = false,
     },
+    ['ActorBuffScope']             = {
+        DisplayName = "Actor Buff Scope",
+        Group = "Abilities",
+        Header = "Buffs",
+        Category = "Buff Rules",
+        Index = 6,
+        Tooltip =
+        "Choose who to use group buffs on. Please note that we will only buff raid/in-zone if they are actor peers (other PCs running RGMercs on the local computer/network).",
+        Default = 1,
+        Min = 1,
+        Max = 3,
+        Type = "Combo",
+        ComboOptions = { 'Group', 'Raid', 'Any In-Zone', },
+        ConfigType = "Advanced",
+    },
+    ['BuffAssistList']             = {
+        DisplayName = "Buff Assist List",
+        Group = "Abilities",
+        Header = "Buffs",
+        Category = "Buff Rules",
+        Index = 8,
+        Tooltip = "Process group buff rotations on members of the Asist List.",
+        Default = true,
+    },
+    ['DoActorPetBuffs']            = {
+        DisplayName = "Buff Pets as PCs",
+        Group = "Abilities",
+        Header = "Buffs",
+        Category = "Buff Rules",
+        Index = 6,
+        Tooltip =
+        "Allow group pets to be targeted in PC group buff rotations.\nNote that only the pets buffs of PCs who have this setting enabled are discoverable.\nFurther note this incurs a minor performance penalty and is not advised in most situations.",
+        Default = false,
+        OnChange = function(oldValue, newValue)
+            if newValue == false then
+                Globals.CurrentPetBuffs = nil
+                Globals.CurrentPetBlocked = nil
+            end
+        end,
+    },
+
     -- Buffs/Self
     ['DoAlliance']                 = {
         DisplayName = "Do Alliance",

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -489,4 +489,76 @@ function Core.GetChaseTarget()
     return Modules:ExecModule("Movement", "GetChaseTarget")
 end
 
+function Core.UpdateBuffs()
+    Core.GetBuffTable()
+    Core.GetSongTable()
+    Core.GetBlockedTable()
+    if Config:GetSetting('DoActorPetBuffs') then
+        Core.GetPetBuffTable()
+        Core.GetPetBlockedTable()
+    end
+end
+
+function Core.GetBuffTable()
+    Globals.CurrentBuffs = {}
+
+    for i = 1, mq.TLO.Me.MaxBuffSlots() do
+        local buff = mq.TLO.Me.Buff(i)
+        if buff() and (buff.Spell.ID() or 0) > 0 then
+            table.insert(Globals.CurrentBuffs, buff.Spell.ID())
+        end
+    end
+end
+
+function Core.GetSongTable()
+    Globals.CurrentSongs = {}
+    local songSlots = Core.OnEMU() and 20 or 30
+
+    for i = 1, songSlots do
+        local song = mq.TLO.Me.Song(i)
+        if song() and (song.Spell.ID() or 0) > 0 then
+            table.insert(Globals.CurrentSongs, song.Spell.ID())
+        end
+    end
+end
+
+function Core.GetBlockedTable()
+    Globals.CurrentBlocked = {}
+
+    for i = 1, 60 do --afaik this is current max blocked buffs and that data is not exposed
+        local blocked = mq.TLO.Me.BlockedBuff(i)
+        if not blocked() then break end
+        table.insert(Globals.CurrentBlocked, blocked.ID())
+    end
+end
+
+function Core.GetPetBuffTable()
+    Logger.log_debug("Pet Buff Start")
+    Globals.CurrentPetBuffs = {}
+
+    if mq.TLO.Me.Pet.ID() > 0 then
+        for i = 1, 30 do
+            local buff = mq.TLO.Me.PetBuff(i)
+            if buff() and (buff.ID() or 0) > 0 then
+                table.insert(Globals.CurrentPetBuffs, buff.ID())
+            end
+        end
+    end
+    Logger.log_debug("Pet Buff Finish")
+end
+
+function Core.GetPetBlockedTable()
+    Logger.log_debug("Pet Block Start")
+    Globals.CurrentPetBlocked = {}
+
+    if mq.TLO.Me.Pet.ID() > 0 then
+        for i = 1, 60 do --afaik this is current max blocked buffs and that data is not exposed
+            local blocked = mq.TLO.Me.BlockedPetBuff(i)
+            if not blocked() then break end
+            table.insert(Globals.CurrentPetBlocked, blocked.ID())
+        end
+    end
+    Logger.log_debug("Pet Block Finish")
+end
+
 return Core

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -35,6 +35,11 @@ Globals.CorpseConned                  = false
 Globals.RezzedCorpses                 = {}
 Globals.SLPeerLooting                 = false
 Globals.LastBurnCheck                 = false
+Globals.CurrentBuffs                  = {}
+Globals.CurrentSongs                  = {}
+Globals.CurrentBlocked                = {}
+Globals.CurrentPetBuffs               = nil
+Globals.CurrentPetBlocked             = nil
 
 Globals.Constants                     = {}
 


### PR DESCRIPTION
Major Features
* Buff checks are now handled by shared actor data; DanNet and direct targeted are still currently available as fallback behavior. Performance is greatly improved (2.5-3x faster than checking via DanNet).
* Removed the timer from group buff rotations in all default configs; instead, we will execute one entry at a time. This allows us to react more quickly, without compromising other higher priority actions (e.g, healing).
* For actor peers (other PCs running RGMercs on the same PC/local network):
* * Added options to buff the entire raid, or any PCs in zone, if actor data is available.
* * Added the option to treat pets as PCs for group buff rotations, if actor data is available. Note that PCs will not report pet buffs via actors unless this setting is enabled, as there is a (minor) hit to performance. Generally, this setting is not advised, but present for use before pet affinity is available, when relying on charm pets, etc.
* * Buffing Assist List members with group buff rotations is now optional.

Under the Hood
* Created "GetBuffableIDs", a routing function for group buff rotations to properly select from Group/Raid/In-Zone based on current options.
* * Custom Config users will need to update their group buff rotation targets to use this new function to benefit from enhanced functionality, but the change is not breaking.
* Buff checks now primarily rely on cached buff, song and blocked lists being passed in the actor heartbeat.
* Refactored all buff checks to allow the option of skipping blocked buff or trigger checks, and (de/re)nested for better reading or flow.
* Split LocalBuffCheck into LocalBuffCheck and LocalPetBuffCheck.
* GroupBuffCheck now behaves exactly like GroupBuffAACheck, GroupBuffItemCheck. 
* Created "ResolveBuffCheck", a routing function very similar to the previous iteration of GroupBuffCheck.
* Created "AddedBuffCheck", a helper for class configs to make additional checks where normal stacking checks do not apply. Previously, this was done directly by PeerBuffCheck, but this will be simpler for a config editor to understand and implement (less passed variables, descriptive name, etc).