### PR TITLE
Update war_class_config.lua

### DIFF
--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -459,13 +459,7 @@ local _ClassConfig = {
             },
         },
         ['Defenses'] = {
-            {
-                name = "Protective",
-                type = "Disc",
-                cond = function(self, discSpell, target)
-                    return self.ClassConfig.HelperFunctions.DefenseBuffCheck(self)
-                end,
-            },
+            
             { --shares effect with OoW Chest and Warlord's Bravery
                 name = "StandDisc",
                 type = "Disc",
@@ -484,6 +478,13 @@ local _ClassConfig = {
                 name = "Warlord's Bravery",
                 type = "AA",
                 cond = function(self, aaName)
+                    return self.ClassConfig.HelperFunctions.DefenseBuffCheck(self)
+                end,
+            },
+			{
+                name = "Protective",
+                type = "Disc",
+                cond = function(self, discSpell, target)
                     return self.ClassConfig.HelperFunctions.DefenseBuffCheck(self)
                 end,
             },


### PR DESCRIPTION
Noted irregular behavior of Protective Surge disc being used and immediately clicked off and replaced with the more powerful Defensive disc.

Changed order of actions in Defenses rotation to avoid this interaction.