### PR TITLE
Feature: Custom Named List

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2671, }
+return { version = 2672, }

--- a/modules/named.lua
+++ b/modules/named.lua
@@ -2,8 +2,10 @@
 local mq           = require('mq')
 local Config       = require('utils.config')
 local Globals      = require("utils.globals")
+local Modules      = require("utils.modules")
 local Targeting    = require("utils.targeting")
 local Ui           = require("utils.ui")
+local Icons        = require('mq.ICONS')
 local NamedDefault = require("namedlist.named_default")
 local NamedEQMight = require("namedlist.named_eqmight")
 local Base         = require("modules.base")
@@ -26,18 +28,30 @@ Module.DefaultConfig   = {
         Type = "Custom",
         Default = false,
     },
+    ['CustomNamedList'] = {
+        DisplayName = "Custom Named List",
+        Type = "Custom",
+        Default = {},
+        Scope = "server",
+        OnChange = function() Modules.ModuleList["Named"].LastZoneID = -1 end,
+        FAQ = "Can I add my own named NPCs to RGMercs?",
+        Answer = "Open the Named module tab and add your current target via the Custom Named List editor. " ..
+            "This per-server, per-zone list is shared in real-time with all RGMercs peers on this machine.\n\n" ..
+            "From the command line: /rgl namedadd \"<name>\" or /rgl nameddelete \"<name>\".",
+    },
 }
 
 Module.FAQ             = {
     {
         Question = "Why am I not taking any special actions on a Named, boss, or mission mob?",
         Answer =
-            "  RGMercs default class configs fully support burning, using defenses, or other special actions on Named mobs, however, your target must be indentified as such. There are three methods for doing so:\n\n" ..
-            "  1) The Named List: RGMercs will consult the built-in Named List. If the mob is found on the list, it will be treated as a Named.\n\n" ..
-            "  2) The SpawnMaster TLO: If the 'Check SM For Named' setting is enabled, and the MQ2SpawnMaster plugin is loaded (highly recommended), you can simply add a mob to the watch list (see '/spawnmaster help'). We will query SpawnMaster via built-in data reporting (TLO), and if the mob is present, treat it as a named.\n\n" ..
-            "  3) The Alert Master TLO: If the 'Check AM For Named' setting is enabled, and the Alert Master script is loaded, you can simply add a mob to the alert list (see '/alertmaster help'). We will query Alert Master via built-in data reporting (TLO), and if the mob is present, treat it as a named.\n\n" ..
-            "  Using these methods, it is very easy to treat mission bosses as named, even if they are not on the named list, whose source was typically aimed at typical PH/rare spawn style mobs.\n\n" ..
-            "  Specific feedback on missing, incorrect, or otherwise erroneous entries on the RGMercs Named List is always welcome!\n\n",
+            "  RGMercs default class configs fully support burning, using defenses, or other special actions on Named mobs, " ..
+            "however, your target must be identified as such. There are several ways to make this happen:\n\n" ..
+            "  1) Add Named NPCs using the UI on the Named module tab, or using the CLI (search the command list for \"named\").\n\n" ..
+            "  2) The built-in Named List: RGMercs has a list of known nameds per zone. If a mob is on the list, RGMercs treats it as a Named automatically.\n\n" ..
+            "  3) SpawnMaster (optional): If 'Check SM For Named' is enabled and MQ2SpawnMaster is loaded, RGMercs queries it via TLO. Useful if you already maintain SpawnMaster watch lists.\n\n" ..
+            "  4) Alert Master (optional): If 'Check AM For Named' is enabled and the Alert Master script is loaded, RGMercs queries it via TLO. Useful if you already maintain Alert Master alert lists.\n\n" ..
+            "  Specific feedback on missing, incorrect, or otherwise erroneous entries on the built-in RGMercs Named List is always welcome!\n\n",
         Settings_Used = "",
     },
 }
@@ -48,11 +62,9 @@ end
 
 function Module:Render()
     Base.Render(self)
-
-    ImGui.SameLine()
-    Ui.RenderText("Make any mob \"named\" for burns by adding it to your MQ2SpawnMaster or Alert Master list! See burn settings.")
-    ImGui.NewLine()
     Ui.RenderZoneNamed()
+    ImGui.NewLine()
+    self:RenderCustomNamedList()
 end
 
 function Module:GiveTime()
@@ -65,8 +77,12 @@ end
 
 --- Caches the named list in the zone
 function Module:RefreshNamedCache()
-    if self.LastZoneID ~= mq.TLO.Zone.ID() then
-        self.LastZoneID = mq.TLO.Zone.ID()
+    local curZone = mq.TLO.Zone.ID()
+    -- LastUserList identity catches cross-instance edits; local edits invalidate via OnChange.
+    local userList = Config:GetSetting('CustomNamedList') or {}
+    if self.LastZoneID ~= curZone or self.LastUserList ~= userList then
+        self.LastZoneID = curZone
+        self.LastUserList = userList
         self.NamedList = {}
         local zoneName = mq.TLO.Zone.Name():lower()
 
@@ -77,6 +93,10 @@ function Module:RefreshNamedCache()
         zoneName = mq.TLO.Zone.ShortName():lower()
 
         for _, n in ipairs(self.DefNamed[zoneName] or {}) do
+            self.NamedList[n] = true
+        end
+
+        for _, n in ipairs(userList[zoneName] or {}) do
             self.NamedList[n] = true
         end
     end
@@ -144,6 +164,52 @@ function Module:IsNamed(spawn)
     if Config:GetSetting('CheckAMForNamed') and mq.TLO.AlertMaster ~= nil and mq.TLO.AlertMaster.IsNamed(spawn.DisplayName())() then return true end
 
     return false
+end
+
+function Module:AddNamedToCustomList(npcName)
+    Config:ZoneListAdd(npcName, 'CustomNamedList')
+end
+
+function Module:DeleteNamedFromCustomList(arg1)
+    Config:ZoneListDelete(arg1, 'CustomNamedList')
+end
+
+function Module:RenderCustomNamedList()
+    if ImGui.CollapsingHeader("Custom Named List") then
+        if mq.TLO.Target() and Targeting.TargetIsType("NPC") then
+            ImGui.PushID("##_small_btn_add_target_custom_named")
+            if ImGui.SmallButton("Add Target To List") then
+                self:AddNamedToCustomList(mq.TLO.Target.CleanName())
+            end
+            ImGui.PopID()
+        end
+
+        if ImGui.BeginTable("CustomNamedList", 3, bit32.bor(ImGuiTableFlags.Borders)) then
+            ImGui.TableSetupColumn('Id', ImGuiTableColumnFlags.WidthFixed, 40.0)
+            ImGui.TableSetupColumn('Name', ImGuiTableColumnFlags.WidthStretch, 150.0)
+            ImGui.TableSetupColumn('Controls', ImGuiTableColumnFlags.WidthFixed, 80.0)
+            ImGui.TableHeadersRow()
+
+            local zoneList = (Config:GetSetting('CustomNamedList') or {})[(mq.TLO.Zone.ShortName() or ""):lower()] or {}
+            for idx, npcName in ipairs(zoneList) do
+                ImGui.TableNextColumn()
+                Ui.RenderText(tostring(idx))
+                ImGui.TableNextColumn()
+                Ui.RenderText(npcName)
+                ImGui.TableNextColumn()
+                ImGui.PushID("##_small_btn_delete_custom_named_" .. tostring(idx))
+                if ImGui.SmallButton(Icons.FA_TRASH) then
+                    self:DeleteNamedFromCustomList(idx)
+                end
+                ImGui.PopID()
+            end
+
+            ImGui.EndTable()
+        end
+
+        ImGui.Spacing()
+        Ui.RenderText("Note: This list is shared in real-time with all RGMercs peers on this machine.")
+    end
 end
 
 return Module

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -243,6 +243,36 @@ Binds.Handlers    = {
             Config:ListClear("HealList")
         end,
     },
+    ['namedadd'] = {
+        usage = "/rgl namedadd <Name>",
+        about = "Adds <Name> to the User Named List for the current zone. If no name is entered, your target's name is used.",
+        handler = function(name)
+            if not name then
+                if not mq.TLO.Target() then
+                    Logger.log_error("/rgl namedadd - no name given and no valid target exists!")
+                    return
+                end
+                if not Targeting.TargetIsType("NPC") then
+                    Logger.log_error("/rgl namedadd - target must be an NPC!")
+                    return
+                end
+                name = mq.TLO.Target.CleanName()
+            end
+            Config:ZoneListAdd(name, "CustomNamedList")
+        end,
+    },
+    ['nameddelete'] = {
+        usage = "/rgl nameddelete (<Name> or <List#>)",
+        about = "Deletes (<Name> or <List#>) from the User Named List for the current zone. If no name is entered, your target's name is used.",
+        handler = function(arg1)
+            if not arg1 then arg1 = mq.TLO.Target.CleanName() end
+            if not arg1 then
+                Logger.log_error("/rgl nameddelete - no argument given and no valid target exists!")
+                return
+            end
+            Config:ZoneListDelete(arg1, "CustomNamedList")
+        end,
+    },
     ['backoff'] = {
         usage = "/rgl backoff <on|off>",
         about = "Toggles or sets backoff flag, which temporarily stops the PC from assisting or engaging.",

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -34,6 +34,7 @@ Config.TempSettings                                      = {}
 Config.TempSettings.lastModuleRegisteredTime             = 0
 Config.TempSettings.lastHighlightTime                    = Globals.GetTimeSeconds()
 Config.TempSettings.SettingToModuleCache                 = {}
+Config.TempSettings.SettingToScopeCache                  = {}
 Config.TempSettings.SettingsLowerToNameCache             = {}
 Config.TempSettings.SettingsCategoryToSettingMapping     = {}
 Config.TempSettings.PeerModuleSettingsLowerToNameCache   = {}
@@ -3054,6 +3055,34 @@ function Config:PeerGetSetting(peer, setting, failOk)
     return self.peerModuleSettings[Config.TempSettings.PeerSettingToModuleCache[setting]][setting]
 end
 
+function Config:SettingDbRead(module, key)
+    local scope = Config.TempSettings.SettingToScopeCache[key]
+    if scope == "server" then
+        return self.Db:getServerValue(Globals.ServerEnv, module, key)
+    end
+    return self.Db:getValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module, key)
+end
+
+function Config:SettingDbWrite(module, key, value)
+    local scope = Config.TempSettings.SettingToScopeCache[key]
+    if scope == "server" then
+        return self.Db:setServerValue(Globals.ServerEnv, module, key, value)
+    end
+    return self.Db:setValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module, key, value)
+end
+
+function Config:SettingDbDelete(module, key)
+    local scope = Config.TempSettings.SettingToScopeCache[key]
+    if scope == "server" then
+        return self.Db:deleteServerValue(Globals.ServerEnv, module, key)
+    elseif scope then
+        return self.Db:deleteValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module, key)
+    end
+    -- unknown scope (deprecated key) - try both, idempotent
+    self.Db:deleteValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module, key)
+    self.Db:deleteServerValue(Globals.ServerEnv, module, key)
+end
+
 --- Retrieves a specified setting.
 --- @param setting string The name of the setting to retrieve.
 --- @param failOk boolean? If true, the function will not raise an error if the setting is not found.
@@ -3068,7 +3097,7 @@ function Config:GetSetting(setting, failOk)
 
     local value = self:GetTempSetting(setting)
     if value == nil then
-        value = self.Db:getValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, Config.TempSettings.SettingToModuleCache[setting], setting)
+        value = self:SettingDbRead(Config.TempSettings.SettingToModuleCache[setting], setting)
     end
 
     return value
@@ -3226,7 +3255,7 @@ function Config:SetSetting(setting, value, tempOnly, noCallback)
         if tempOnly then
             self.moduleTempSettings[settingModuleName][setting] = cleanValue
         else
-            self.Db:setValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, settingModuleName, setting, cleanValue)
+            self:SettingDbWrite(settingModuleName, setting, cleanValue)
             self.moduleTempSettings[settingModuleName][setting] = nil
         end
     else
@@ -3330,7 +3359,7 @@ function Config.ResolveDefaults(defaults, settings, module)
             settings[k] = nil
             Logger.log_info("\aySetting [\am%s\ay] has been deprecated -- removing from your config.", k)
             if module then
-                Config.Db:deleteValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module, k)
+                Config:SettingDbDelete(module, k)
             end
             changed = true
         end
@@ -3405,6 +3434,8 @@ function Config:RegisterModuleSettings(module, settings, defaultSettings, faq, f
             Config.TempSettings.SettingsLowerToNameCache[setting:lower()] = setting
             self:RegisterCategoryToSettingMapping(setting)
         end
+
+        Config.TempSettings.SettingToScopeCache[setting] = v.Scope
     end
 
     if firstSaveRequired or settingsChanged then
@@ -3426,6 +3457,7 @@ function Config:ClearModuleSettings(module)
         self:UnRegisterCategoryToSettingMapping(setting)
         Config.TempSettings.SettingsLowerToNameCache[setting:lower()] = nil
         Config.TempSettings.SettingToModuleCache[setting] = nil
+        Config.TempSettings.SettingToScopeCache[setting] = nil
     end
 
     self.moduleTempSettings[module] = nil
@@ -3491,6 +3523,7 @@ function Config:ClearAllModuleSettings()
     self.moduleDefaultSettings = {}
     self.moduleSettingCategories = {}
     self.TempSettings.SettingToModuleCache = {}
+    self.TempSettings.SettingToScopeCache = {}
     self.TempSettings.SettingsLowerToNameCache = {}
     self.TempSettings.SettingsCategoryToSettingMapping = {}
     self.SettingsLoadComplete = false
@@ -3501,7 +3534,7 @@ function Config:SaveModuleSettings(module, settings)
     local settingsCategories = self:GetModuleSettingCategories(module):toList() or {}
 
     for setting, value in pairs(settings) do
-        self.Db:setValue(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module, setting, value)
+        self:SettingDbWrite(module, setting, value)
     end
     Logger.log_debug("\agModule %s - save settings requested!", module)
 
@@ -3704,19 +3737,66 @@ function Config:AssistMoveDown(id, listName)
     self:SetSetting(listName, list)
 end
 
-function Config:ConvertListNameToID(arg1, listName)
-    if arg1:match("^%d$") then
-        arg1 = tonumber(arg1)
-        return arg1
-    else
-        for idx, cur_name in ipairs(Config:GetSetting(listName) or {}) do
-            if cur_name:lower() == arg1:lower() then
-                arg1 = tonumber(idx)
-                return arg1
-            end
-        end
+--- Resolve a name-or-index argument to a 1-based index in `list`. Returns nil if invalid/not found.
+--- @param arg1 string|number
+--- @param list table
+--- @return number|nil
+function Config:ResolveListIndex(arg1, list)
+    if type(arg1) == 'number' then return arg1 end
+    if type(arg1) ~= 'string' then return nil end
+    if arg1:match("^%d+$") then return tonumber(arg1) end
+    for idx, cur in ipairs(list) do
+        if cur:lower() == arg1:lower() then return idx end
     end
-    return 0
+    return nil
+end
+
+function Config:ConvertListNameToID(arg1, listName)
+    local idx = self:ResolveListIndex(arg1, self:GetSetting(listName) or {})
+    return idx or 0
+end
+
+--- Adds the given name to a zone-keyed list for the current (or specified) zone.
+--- Storage shape: list[zoneShort] = { "Name 1", ... }. Silent on duplicates.
+--- @param name string The name to add.
+--- @param listName string The setting name of the zone-keyed list.
+--- @param zoneKey string? Optional zone short name (lowercase). Defaults to current zone.
+function Config:ZoneListAdd(name, listName, zoneKey)
+    zoneKey = zoneKey or (mq.TLO.Zone.ShortName() or ""):lower()
+    local list = self:GetSetting(listName) or {}
+    list[zoneKey] = list[zoneKey] or {}
+    for _, cur in ipairs(list[zoneKey]) do
+        if cur:lower() == name:lower() then return end
+    end
+    table.insert(list[zoneKey], name)
+    self:SetSetting(listName, list)
+    Logger.log_info("\ax%s [\ay%s\ax]: \ag%s\ax added at position \at%d\ax.", listName, zoneKey, name, #list[zoneKey])
+end
+
+--- Deletes a name (or index) from a zone-keyed list for the current (or specified) zone.
+--- @param arg1 string|number Either a name to match or a 1-based index.
+--- @param listName string The setting name of the zone-keyed list.
+--- @param zoneKey string? Optional zone short name (lowercase). Defaults to current zone.
+function Config:ZoneListDelete(arg1, listName, zoneKey)
+    if not arg1 then
+        Logger.log_error("\ar%s Delete: this command requires a valid argument!", listName)
+        return
+    end
+    zoneKey = zoneKey or (mq.TLO.Zone.ShortName() or ""):lower()
+    local list = self:GetSetting(listName) or {}
+    local zoneList = list[zoneKey]
+    if not zoneList or #zoneList == 0 then
+        Logger.log_error("\ar%s Delete: zone [\ay%s\ar] has no entries!", listName, zoneKey)
+        return
+    end
+    local idx = self:ResolveListIndex(arg1, zoneList)
+    if idx and idx >= 1 and idx <= #zoneList then
+        Logger.log_info("\ax%s [\ay%s\ax]: \ag%s\ax deleted.", listName, zoneKey, zoneList[idx])
+        table.remove(zoneList, idx)
+        self:SetSetting(listName, list)
+    else
+        Logger.log_error("\ar%s Delete: %s was not on the list or is not a valid argument!", listName, tostring(arg1))
+    end
 end
 
 function Config:GetCommandHandlers()
@@ -4027,7 +4107,11 @@ function Config:DbConsistencyCheck()
 end
 
 function Config:GetAllModuleSettingsFromDb(module)
-    return self.Db:getAll(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module) or {}
+    local out = self.Db:getAll(Globals.CurServer, Globals.CurLoadedChar, Globals.CurLoadedClass, module) or {}
+    for k, v in pairs(self.Db:getServerAll(Globals.ServerEnv, module) or {}) do
+        out[k] = v
+    end
+    return out
 end
 
 function Config:CharacterExistsInDb()

--- a/utils/config_db.lua
+++ b/utils/config_db.lua
@@ -42,6 +42,19 @@ local SCHEMA              = [[
 
     CREATE INDEX IF NOT EXISTS idx_config_lookup
         ON config_value(character_id, module, class);
+
+    CREATE TABLE IF NOT EXISTS server_config (
+        id         INTEGER PRIMARY KEY,
+        server_id  INTEGER NOT NULL REFERENCES server(id) ON DELETE CASCADE,
+        module     TEXT    NOT NULL,
+        key        TEXT    NOT NULL,
+        value_type TEXT    NOT NULL CHECK (value_type IN ('bool','number','string','lua')),
+        value      TEXT,
+        UNIQUE (server_id, module, key)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_server_config_lookup
+        ON server_config(server_id, module);
 ]]
 
 ---@param path        string        Full path to the .db file
@@ -94,8 +107,17 @@ function DB.new(path, onUpdate)
         -- previous totals for delta calculation
         prev         = { selects = 0, inserts = 0, deletes = 0, cacheHits = 0, cacheMisses = 0, },
     }
-    local self = setmetatable(
-        { _db = db, _onUpdate = onUpdate, _writeQueue = {}, _cache = {}, _dataVersion = 0, _externalVersion = -1, _telemetry = telemetry, _collectStats = false, }, DB)
+    local self = setmetatable({
+        _db = db,
+        _onUpdate = onUpdate,
+        _writeQueue = {},
+        _cache = {},
+        _serverCache = {},
+        _dataVersion = 0,
+        _externalVersion = -1,
+        _telemetry = telemetry,
+        _collectStats = false,
+    }, DB)
     self:_exec(SCHEMA)
     self._externalVersion = self:_getDataVersion()
 
@@ -646,6 +668,213 @@ function DB:deleteCharacter(serverName, charName)
     return ok
 end
 
+---@param serverName string
+---@param module     string
+---@param key        string
+---@return any|nil  deserialized value, or nil if not found
+function DB:getServerValue(serverName, module, key)
+    local moduleCache = self._serverCache[serverName] and self._serverCache[serverName][module]
+    local entry = moduleCache and moduleCache[key]
+    if entry == nil or entry.version < self._dataVersion then
+        if self._collectStats then
+            self._telemetry.cacheMisses = self._telemetry.cacheMisses + 1
+        end
+        return self:_fetchServerValue(serverName, module, key)
+    end
+    if self._collectStats then
+        self._telemetry.cacheHits = self._telemetry.cacheHits + 1
+    end
+    return entry.value
+end
+
+---@param serverName string
+---@param module     string
+---@return table  { key -> deserialized value }
+function DB:getServerAll(serverName, module)
+    local moduleCache = self._serverCache[serverName] and self._serverCache[serverName][module]
+    if moduleCache then
+        local stale = false
+        for _, entry in pairs(moduleCache) do
+            if entry.version < self._dataVersion then
+                stale = true
+                break
+            end
+        end
+        if stale then
+            if self._collectStats then
+                self._telemetry.cacheMisses = self._telemetry.cacheMisses + 1
+            end
+            self:_fetchServerModule(serverName, module)
+            moduleCache = self._serverCache[serverName][module]
+        elseif self._collectStats then
+            self._telemetry.cacheHits = self._telemetry.cacheHits + 1
+        end
+    else
+        if self._collectStats then
+            self._telemetry.cacheMisses = self._telemetry.cacheMisses + 1
+        end
+        self:_fetchServerModule(serverName, module)
+        moduleCache = self._serverCache[serverName] and self._serverCache[serverName][module]
+    end
+    if not moduleCache then return {} end
+    local out = {}
+    for k, entry in pairs(moduleCache) do
+        out[k] = entry.value
+    end
+    return out
+end
+
+---@param serverName string
+---@param module     string
+---@param key        string
+---@param value      any
+---@param vtype      string|nil  Inferred if omitted
+---@return boolean  true on success, false if busy (write queued for retry)
+function DB:setServerValue(serverName, module, key, value, vtype)
+    local serverId = self:upsertServer(serverName)
+    if not serverId then return false end
+    vtype = vtype or inferType(value)
+    local text = serialize(value, vtype)
+    local stmt = self:_prepare([[
+        INSERT INTO server_config(server_id, module, key, value_type, value)
+        VALUES(?,?,?,?,?)
+        ON CONFLICT(server_id, module, key)
+        DO UPDATE SET value_type=excluded.value_type, value=excluded.value;
+    ]])
+    if not stmt then return false end
+    stmt:bind(1, serverId)
+    stmt:bind(2, module)
+    stmt:bind(3, key)
+    stmt:bind(4, vtype)
+    stmt:bind(5, text)
+    local ok = self:_step(stmt)
+    stmt:finalize()
+    if self._collectStats then
+        if ok then
+            self._telemetry.inserts = self._telemetry.inserts + 1
+        else
+            self._telemetry.queuedWrites = self._telemetry.queuedWrites + 1
+        end
+    end
+    if not ok then
+        self:_enqueueWrite("setServerValue", serverName, module, key, value, vtype)
+    end
+    self:_serverCacheSet(serverName, module, key, value)
+    return ok
+end
+
+---@param serverName string
+---@param module     string
+---@param settings   table  { key -> value }
+---@return boolean  true on success, false if busy (write queued for retry)
+function DB:setServerAll(serverName, module, settings)
+    local serverId = self:upsertServer(serverName)
+    if not serverId then return false end
+
+    local stmt = self:_prepare([[
+        INSERT INTO server_config(server_id, module, key, value_type, value)
+        VALUES(?,?,?,?,?)
+        ON CONFLICT(server_id, module, key)
+        DO UPDATE SET value_type=excluded.value_type, value=excluded.value;
+    ]])
+    if not stmt then return false end
+
+    if not self:_exec("BEGIN IMMEDIATE TRANSACTION;") then
+        stmt:finalize()
+        self:_enqueueWrite("setServerAll", serverName, module, settings)
+        return false
+    end
+    for key, value in pairs(settings) do
+        local vtype = inferType(value)
+        stmt:bind(1, serverId)
+        stmt:bind(2, module)
+        stmt:bind(3, key)
+        stmt:bind(4, vtype)
+        stmt:bind(5, serialize(value, vtype))
+        if not self:_step(stmt) then
+            stmt:finalize()
+            self:_exec("ROLLBACK;")
+            if self._collectStats then
+                self._telemetry.queuedWrites = self._telemetry.queuedWrites + 1
+            end
+            self:_enqueueWrite("setServerAll", serverName, module, settings)
+            return false
+        end
+        if self._collectStats then
+            self._telemetry.inserts = self._telemetry.inserts + 1
+        end
+        stmt:reset()
+    end
+    stmt:finalize()
+    self:_exec("COMMIT;")
+    for key, value in pairs(settings) do
+        self:_serverCacheSet(serverName, module, key, value)
+    end
+    return true
+end
+
+---@param serverName string
+---@param module     string
+---@param key        string
+---@return boolean  true on success, false if busy (write queued for retry)
+function DB:deleteServerValue(serverName, module, key)
+    self:_serverCacheDel(serverName, module, key)
+    local stmt = self:_prepare([[
+        DELETE FROM server_config WHERE id IN (
+            SELECT sc.id FROM server_config sc
+            JOIN server s ON s.id = sc.server_id
+            WHERE s.name=? AND sc.module=? AND sc.key=?
+        );
+    ]])
+    if not stmt then return false end
+    stmt:bind(1, serverName)
+    stmt:bind(2, module)
+    stmt:bind(3, key)
+    local ok = self:_step(stmt)
+    stmt:finalize()
+    if self._collectStats then
+        if ok then
+            self._telemetry.deletes = self._telemetry.deletes + 1
+        else
+            self._telemetry.queuedWrites = self._telemetry.queuedWrites + 1
+        end
+    end
+    if not ok then
+        self:_enqueueWrite("deleteServerValue", serverName, module, key)
+    end
+    return ok
+end
+
+---@param serverName string
+---@param module     string
+---@return boolean  true on success, false if busy (write queued for retry)
+function DB:deleteServerModule(serverName, module)
+    self:_serverCacheDelModule(serverName, module)
+    local stmt = self:_prepare([[
+        DELETE FROM server_config WHERE id IN (
+            SELECT sc.id FROM server_config sc
+            JOIN server s ON s.id = sc.server_id
+            WHERE s.name=? AND sc.module=?
+        );
+    ]])
+    if not stmt then return false end
+    stmt:bind(1, serverName)
+    stmt:bind(2, module)
+    local ok = self:_step(stmt)
+    stmt:finalize()
+    if self._collectStats then
+        if ok then
+            self._telemetry.deletes = self._telemetry.deletes + 1
+        else
+            self._telemetry.queuedWrites = self._telemetry.queuedWrites + 1
+        end
+    end
+    if not ok then
+        self:_enqueueWrite("deleteServerModule", serverName, module)
+    end
+    return ok
+end
+
 --- In-Memory Cache
 -- Each entry: { value = v, version = N }
 -- _dataVersion is refreshed each tick. On read, if entry.version < _dataVersion
@@ -699,6 +928,30 @@ function DB:_cacheDelChar(serverName, charName)
     if serverCache then serverCache[charName] = nil end
 end
 
+function DB:_serverCacheSet(serverName, module, key, value)
+    local serverCache = self._serverCache[serverName]
+    if not serverCache then
+        serverCache = {}
+        self._serverCache[serverName] = serverCache
+    end
+    local moduleCache = serverCache[module]
+    if not moduleCache then
+        moduleCache = {}
+        serverCache[module] = moduleCache
+    end
+    moduleCache[key] = { value = value, version = self._dataVersion, }
+end
+
+function DB:_serverCacheDel(serverName, module, key)
+    local moduleCache = self._serverCache[serverName] and self._serverCache[serverName][module]
+    if moduleCache then moduleCache[key] = nil end
+end
+
+function DB:_serverCacheDelModule(serverName, module)
+    local serverCache = self._serverCache[serverName]
+    if serverCache then serverCache[module] = nil end
+end
+
 function DB:_fetchValue(serverName, charName, charClass, module, key)
     if self._collectStats then
         self._telemetry.selects = self._telemetry.selects + 1
@@ -739,6 +992,44 @@ function DB:_fetchModule(serverName, charName, charClass, module)
     stmt:bind(4, module)
     for row in stmt:nrows() do
         self:_cacheSet(serverName, charName, charClass, module, row.key, deserialize(row.value, row.value_type))
+    end
+    stmt:finalize()
+end
+
+function DB:_fetchServerValue(serverName, module, key)
+    if self._collectStats then
+        self._telemetry.selects = self._telemetry.selects + 1
+    end
+    local stmt = self:_prepare([[
+        SELECT sc.value, sc.value_type FROM server_config sc
+        JOIN server s ON s.id = sc.server_id
+        WHERE s.name=? AND sc.module=? AND sc.key=?;
+    ]])
+    if not stmt then return nil end
+    stmt:bind(1, serverName)
+    stmt:bind(2, module)
+    stmt:bind(3, key)
+    local rows = collectRows(stmt)
+    if not rows[1] then return nil end
+    local value = deserialize(rows[1].value, rows[1].value_type)
+    self:_serverCacheSet(serverName, module, key, value)
+    return value
+end
+
+function DB:_fetchServerModule(serverName, module)
+    if self._collectStats then
+        self._telemetry.selects = self._telemetry.selects + 1
+    end
+    local stmt = self:_prepare([[
+        SELECT sc.key, sc.value, sc.value_type FROM server_config sc
+        JOIN server s ON s.id = sc.server_id
+        WHERE s.name=? AND sc.module=?;
+    ]])
+    if not stmt then return end
+    stmt:bind(1, serverName)
+    stmt:bind(2, module)
+    for row in stmt:nrows() do
+        self:_serverCacheSet(serverName, module, row.key, deserialize(row.value, row.value_type))
     end
     stmt:finalize()
 end

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -1739,7 +1739,7 @@ function Ui.RenderZoneNamed()
 
             if spawnExists and namedSpawn.PctHPs() > 0 then
                 ImGui.TableNextColumn()
-                local _, clicked = ImGui.Selectable(named.Name, false)
+                local _, clicked = ImGui.Selectable(string.format("%s##%d", named.Name, namedSpawn.ID()), false)
                 if clicked then
                     namedSpawn.DoTarget()
                 end


### PR DESCRIPTION
* Users are now able to add their own named to a custom list from within RGMercs directly, using the UI or CLI.
* This list is shared in real-time with all RGMercs peers on a machine (this is not a character-specific setting).
* SpawnMaster/Alert Master support is unchanged.

Dev Notes:
* Added server-scoped DB settings to enable this feature.
* Refactored config library to pass in setting scope; per-character is the implied default.
* Mild refactors to standardize these lists with other areas they were used (e.g, Pull), further refactors are planned but out-of-scope for this update.