### PR TITLE
AA Set support

### DIFF
--- a/class_configs/EQ Might/ber_class_config.lua
+++ b/class_configs/EQ Might/ber_class_config.lua
@@ -88,6 +88,12 @@ return {
             "Unsettling Scream",
         },
     },
+    ['AASets']        = {
+        ['RageAA'] = {
+            "Cascading Rage",
+            "Untamed Rage",
+        },
+    },
     ['RotationOrder'] = {
         {
             name = 'Buffs',
@@ -203,7 +209,7 @@ return {
                 type = "Disc",
             },
             { -- goes to disc window
-                name_func = function(self) return Casting.GetFirstAA({ "Cascading Rage", "Untamed Rage", }) end,
+                name = "RageAA",
                 type = "AA",
             },
             { -- goes to disc window

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -367,6 +367,12 @@ local _ClassConfig = {
             "Ancient: Permafrost Veil",
         },
     },
+    ['AASets']            = {
+        ['FireDebuffAA'] = {
+            "Blessing of Ro",
+            "Hand of Ro",
+        },
+    },
     ['HealRotationOrder'] = {
         {
             name  = 'BigHealPoint',
@@ -723,11 +729,9 @@ local _ClassConfig = {
         },
         ['Debuff'] = {
             { -- Fire Debuff AA, will use the first(best) available
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Blessing of Ro", "Hand of Ro", })
-                end,
+                name = "FireDebuffAA",
                 type = "AA",
-                load_cond = function() return Config:GetSetting('DoFireDebuff') and Casting.CanUseAA("Hand of Ro") end,
+                load_cond = function() return Config:GetSetting('DoFireDebuff') and Core.GetResolvedActionMapItem('FireDebuffAA') end,
                 cond = function(self, aaName, target)
                     return Casting.DetAACheck(aaName)
                 end,
@@ -735,7 +739,7 @@ local _ClassConfig = {
             {
                 name = "FireDebuff",
                 type = "Spell",
-                load_cond = function() return Config:GetSetting('DoFireDebuff') and not Casting.CanUseAA("Hand of Ro") end,
+                load_cond = function() return Config:GetSetting('DoFireDebuff') and not Core.GetResolvedActionMapItem('FireDebuffAA') end,
                 cond = function(self, spell, target)
                     return Casting.DetSpellCheck(spell)
                 end,

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -343,6 +343,12 @@ local _ClassConfig = {
             "Renewal of Lucifer",
         },
     },
+    ['AASets']        = {
+        ['ManaRestore'] = {
+            "Mana Draw",
+            "Gather Mana",
+        },
+    },
     ['RotationOrder'] = {
         {
             name = 'Downtime',
@@ -521,9 +527,7 @@ local _ClassConfig = {
                 cond = function(self, spell) return Casting.SelfBuffCheck(spell) end,
             },
             { -- Mana Restore AA, will use the first(best) available
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Mana Draw", "Gather Mana", })
-                end,
+                name = "ManaRestore",
                 type = "AA",
                 cond = function(self, aaName) return mq.TLO.Me.PctMana() < 30 end,
             },

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -282,6 +282,13 @@ _ClassConfig    = {
             "Summon Orb",
         },
     },
+    ['AASets']        = {
+        ['ModRod'] = {
+            "Large Modulation Shard",
+            "Medium Modulation Shard",
+            "Small Modulation Shard",
+        },
+    },
     ['RotationOrder'] = { -- TODO: Add emergency rotation, shared health, etc
         {                 --Summon pet even when buffs are off on emu
             name = 'PetSummon',
@@ -848,11 +855,9 @@ _ClassConfig    = {
         },
         ['Summon ModRods'] = {
             { -- Mod Rod AA, will use the first(best) one found.
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Large Modulation Shard", "Medium Modulation Shard", "Small Modulation Shard", })
-                end,
+                name = "ModRod",
                 type = "AA",
-                load_cond = function() return Casting.CanUseAA("Small Modulation Shard") end,
+                load_cond = function() return Core.GetResolvedActionMapItem('ModRod') end,
                 cond = function(self, aaName, target)
                     if not Targeting.TargetIsACaster(target) then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
@@ -868,7 +873,7 @@ _ClassConfig    = {
             {
                 name = "ManaRodSummon",
                 type = "Spell",
-                load_cond = function() return not Casting.CanUseAA("Small Modulation Shard") end,
+                load_cond = function() return not Core.GetResolvedActionMapItem('ModRod') end,
                 cond = function(self, spell, target)
                     if not Targeting.TargetIsACaster(target) then return false end
                     local modRodItem = spell.RankName.Base(1)()
@@ -898,7 +903,7 @@ _ClassConfig    = {
                 { name = "PetHealSpell",     cond = function(self) return Config:GetSetting('DoPetHealSpell') end, },
                 { name = "FireOrbSummon", },
                 { name = "SingleCotH", },
-                { name = "ManaRodSummon",    cond = function(self) return Config:GetSetting('SummonModRods') and not Casting.CanUseAA("Small Modulation Shard") end, },
+                { name = "ManaRodSummon",    cond = function(self) return Config:GetSetting('SummonModRods') and not Core.GetResolvedActionMapItem('ModRod') end, },
                 { name = "FireShroud", },
                 { name = "LongDurDmgShield", },
             },

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -340,6 +340,12 @@ local _ClassConfig = {
             "Lesser Minionskin",
         },
     },
+    ['AASets']          = {
+        ['DeadSwarm'] = {
+            "Army of the Dead",
+            "Wake the Dead",
+        },
+    },
     ['RotationOrder']   = {
         { --Summon pet even when buffs are off on emu
             name = 'PetSummon',
@@ -482,7 +488,7 @@ local _ClassConfig = {
                     end
                     return "No Scent Item Found"
                 end,
-                type = "item",
+                type = "Item",
                 load_cond = function(self) return self.Helpers.GetScentItem ~= nil end,
                 cond = function(self, itemName, target)
                     return Casting.DetItemCheck(itemName)
@@ -714,9 +720,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Army of the Dead", "Wake the Dead", })
-                end,
+                name = "DeadSwarm",
                 type = "AA",
                 cond = function(self, aaName, target)
                     return mq.TLO.SpawnCount("corpse radius 100")() >= Config:GetSetting('WakeDeadCorpseCnt') and Globals.AutoTargetIsNamed

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -335,6 +335,13 @@ return {
             "Challenge for Honor",
         },
     },
+    ['AASets']            = {
+        ['Disruption'] = {
+            "Force of Disruption",
+            "Hand of Disruption",
+            "Divine Stun",
+        },
+    },
     ['SpellList']         = {
         {
             name = "Default",
@@ -822,7 +829,7 @@ return {
                 load_cond = function(self) return mq.TLO.FindItem("=Xeno's Faceguard")() end,
             },
             {
-                name = "Force of Disruption",
+                name = "Disruption",
                 type = "AA",
             },
             {
@@ -855,7 +862,7 @@ return {
                 load_cond = function(self) return mq.TLO.FindItem("=Xeno's Faceguard")() end,
             },
             {
-                name = "Force of Disruption",
+                name = "Disruption",
                 type = "AA",
             },
             {
@@ -1048,11 +1055,6 @@ return {
                 end,
             },
             {
-                name_func = function(self) return Casting.GetFirstAA({ "Hand of Disruption", "Divine Stun", }) end,
-                type = "AA",
-                load_cond = function(self) return not Core.IsTanking() or not Casting.CanUseAA("Force of Disruption") end,
-            },
-            {
                 name = "Bash",
                 type = "Ability",
                 cond = function(self)
@@ -1113,13 +1115,13 @@ return {
             end,
         },
         {
-            id = 'Force of Disruption',
+            id = 'Disruption',
             Type = "AA",
-            DisplayName = function() return Casting.CanUseAA("Force of Disruption") and "Force of Disruption" or "" end,
-            AbilityName = function() return Casting.CanUseAA("Force of Disruption") and "Force of Disruption" or "" end,
+            DisplayName = function() return Core.GetResolvedActionMapItem('Disruption') or "" end,
+            AbilityName = function() return Core.GetResolvedActionMapItem('Disruption') or "" end,
             AbilityRange = 150,
             cond = function(self)
-                return Casting.CanUseAA("Force of Disruption") and "Force of Disruption"
+                return Core.GetResolvedActionMapItem('Disruption')
             end,
         },
     },

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -108,6 +108,12 @@ local _ClassConfig = {
             "Healing Will Discipline",
         },
     },
+    ['AASets']        = {
+        ['AreaTaunt'] = {
+            "Enhanced Area Taunt",
+            "Area Taunt",
+        },
+    },
     ['Helpers']       = {
         DoRez = function(self, corpseId)
             local rezStaff = self.ResolvedActionMap['RezStaff']
@@ -371,7 +377,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name_func = function(self) return Casting.GetFirstAA({ "Enhanced Area Taunt", "Area Taunt", }) end,
+                name = "AreaTaunt",
                 type = "AA",
             },
         },

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -243,6 +243,18 @@ return {
         --     "Defense of Calrena",
         -- },
     },
+    ['AASets']        = {
+        ['Devastation'] = {
+            "Prolonged Destruction",
+            "Frenzied Devastation",
+        },
+        ['ManaBurn'] = {
+            "Volatile Mana Blaze",
+            "Mana Blaze",
+            "Mana Blast",
+            "Mana Burn",
+        },
+    },
     ['Helpers']       = {
         DoRez = function(self, corpseId)
             local rezStaff = self.ResolvedActionMap['RezStaff']
@@ -412,9 +424,7 @@ return {
                 type = "AA",
             },
             { --Crit Chance AA, will use the first(best) one found
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Prolonged Destruction", "Frenzied Devastation", })
-                end,
+                name = "Devastation",
                 type = "AA",
                 cond = function(self, aaName)
                     return Casting.SelfBuffAACheck(aaName)
@@ -425,9 +435,7 @@ return {
                 type = "AA",
             },
             {
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Volatile Mana Blaze", "Mana Blaze", "Mana Blast", "Mana Burn", })
-                end,
+                name = "ManaBurn",
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoManaBurn') end,
                 cond = function(self, aaName, target)

--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -728,7 +728,7 @@ return {
             },
             {
                 name = "Alliance",
-                type = "spell",
+                type = "Spell",
                 cond = function(self, spell)
                     return Config:GetSetting('DoAlliance') and Casting.CanAlliance() and
                         not Casting.TargetHasBuff(spell)

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -741,6 +741,12 @@ local _ClassConfig = {
             'Reanimation',
         },
     },
+    ['AASets']            = {
+        ['Disruption'] = {
+            "Force of Disruption",
+            "Divine Stun",
+        },
+    },
     ['Helpers']           = {
         DoRez = function(self, corpseId)
             local rezAction = false
@@ -1294,7 +1300,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name_func = function(self) return Casting.GetFirstAA({ "Force of Disruption", "Divine Stun", }) end,
+                name = "Disruption",
                 type = "AA",
             },
             {
@@ -1334,7 +1340,7 @@ local _ClassConfig = {
         },
         ['HateTools(AutoTarget)'] = {
             {
-                name_func = function(self) return Casting.GetFirstAA({ "Force of Disruption", "Divine Stun", }) end,
+                name = "Disruption",
                 type = "AA",
             },
             {
@@ -1690,7 +1696,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('Timer6Choice') == 2 end,
             },
             {
-                name_func = function(self) return Casting.GetFirstAA({ "Force of Disruption", "Divine Stun", }) end,
+                name = "Disruption",
                 type = "AA",
                 load_cond = function(self) return Core.IsTanking() end,
             },

--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -83,6 +83,12 @@ return {
             "Battle Focus Discipline",
         },
     },
+    ['AASets']        = {
+        ['RageAA'] = {
+            "Cascading Rage",
+            "Untamed Rage",
+        },
+    },
     ['RotationOrder'] = {
         {
             name = 'Buffs',
@@ -235,7 +241,7 @@ return {
                 type = "Disc",
             },
             { --goes to disc window on laz
-                name_func = function(self) return Casting.GetFirstAA({ "Cascading Rage", "Untamed Rage", }) end,
+                name = "RageAA",
                 type = "AA",
             },
             {

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -343,6 +343,12 @@ local _ClassConfig = {
             "Moon Shadow",
         },
     },
+    ['AASets']            = {
+        ['FireDebuffAA'] = {
+            "Blessing of Ro",
+            "Hand of Ro",
+        },
+    },
     ['HealRotationOrder'] = {
         {
             name  = 'BigHealPoint',
@@ -706,11 +712,9 @@ local _ClassConfig = {
         },
         ['Debuff'] = {
             { -- Fire Debuff AA, will use the first(best) available
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Blessing of Ro", "Hand of Ro", })
-                end,
+                name = "FireDebuffAA",
                 type = "AA",
-                load_cond = function() return Config:GetSetting('DoFireDebuff') and Casting.CanUseAA("Hand of Ro") end,
+                load_cond = function() return Config:GetSetting('DoFireDebuff') and Core.GetResolvedActionMapItem('FireDebuffAA') end,
                 cond = function(self, aaName, target)
                     return Casting.DetAACheck(aaName)
                 end,
@@ -718,7 +722,7 @@ local _ClassConfig = {
             {
                 name = "FireDebuff",
                 type = "Spell",
-                load_cond = function() return Config:GetSetting('DoFireDebuff') and not Casting.CanUseAA("Hand of Ro") end,
+                load_cond = function() return Config:GetSetting('DoFireDebuff') and not Core.GetResolvedActionMapItem('FireDebuffAA') end,
                 cond = function(self, spell, target)
                     return Casting.DetSpellCheck(spell)
                 end,

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -312,6 +312,12 @@ local _ClassConfig = {
             "Chromaburst",
         },
     },
+    ['AASets']        = {
+        ['ManaRestore'] = {
+            "Mana Draw",
+            "Gather Mana",
+        },
+    },
     ['RotationOrder'] = {
         {
             name = 'Downtime',
@@ -472,9 +478,7 @@ local _ClassConfig = {
                 cond = function(self, spell) return Casting.SelfBuffCheck(spell) end,
             },
             { -- Mana Restore AA, will use the first(best) available
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Mana Draw", "Gather Mana", })
-                end,
+                name = "ManaRestore",
                 type = "AA",
                 cond = function(self, aaName) return mq.TLO.Me.PctMana() < 30 end,
             },

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -244,6 +244,13 @@ _ClassConfig    = {
             "Frantic Flames",
         },
     },
+    ['AASets']        = {
+        ['ModRod'] = {
+            "Large Modulation Shard",
+            "Medium Modulation Shard",
+            "Small Modulation Shard",
+        },
+    },
     ['RotationOrder'] = { -- TODO: Add emergency rotation, shared health, etc
         {                 --Summon pet even when buffs are off on emu
             name = 'PetSummon',
@@ -827,11 +834,9 @@ _ClassConfig    = {
         },
         ['Summon ModRods'] = {
             { -- Mod Rod AA, will use the first(best) one found.
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Large Modulation Shard", "Medium Modulation Shard", "Small Modulation Shard", })
-                end,
+                name = "ModRod",
                 type = "AA",
-                load_cond = function() return Casting.CanUseAA("Small Modulation Shard") end,
+                load_cond = function() return Core.GetResolvedActionMapItem('ModRod') end,
                 cond = function(self, aaName, target)
                     if not Targeting.TargetIsACaster(target) then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
@@ -847,7 +852,7 @@ _ClassConfig    = {
             {
                 name = "ManaRodSummon",
                 type = "Spell",
-                load_cond = function() return not Casting.CanUseAA("Small Modulation Shard") end,
+                load_cond = function() return not Core.GetResolvedActionMapItem('ModRod') end,
                 cond = function(self, spell, target)
                     if not Targeting.TargetIsACaster(target) then return false end
                     local modRodItem = spell.RankName.Base(1)()
@@ -902,7 +907,7 @@ _ClassConfig    = {
                 { name = "FireOrbSummon", },
                 { name = "GroupCotH", },
                 { name = "SingleCotH",       cond = function() return not Casting.CanUseAA('Call of the Hero') end, },
-                { name = "ManaRodSummon",    cond = function(self) return Config:GetSetting('SummonModRods') and not Casting.CanUseAA("Small Modulation Shard") end, },
+                { name = "ManaRodSummon",    cond = function(self) return Config:GetSetting('SummonModRods') and not Core.GetResolvedActionMapItem('ModRod') end, },
                 { name = "FireShroud", },
                 { name = "LongDurDmgShield", },
             },
@@ -926,7 +931,7 @@ _ClassConfig    = {
                 { name = "GroupCotH", },
                 { name = "SingleCotH",       cond = function() return not Casting.CanUseAA('Call of the Hero') end, },
                 { name = "FireShroud", },
-                { name = "ManaRodSummon",    cond = function(self) return Config:GetSetting('SummonModRods') and not Casting.CanUseAA("Small Modulation Shard") end, },
+                { name = "ManaRodSummon",    cond = function(self) return Config:GetSetting('SummonModRods') and not Core.GetResolvedActionMapItem('ModRod') end, },
                 { name = "LongDurDmgShield", },
             },
         },

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -302,6 +302,12 @@ local _ClassConfig = {
         --     "Ignite Bones",
         -- },
     },
+    ['AASets']          = {
+        ['DeadSwarm'] = {
+            "Army of the Dead",
+            "Wake the Dead",
+        },
+    },
     ['RotationOrder']   = {
         { --Summon pet even when buffs are off on emu
             name = 'PetSummon',
@@ -688,9 +694,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Army of the Dead", "Wake the Dead", })
-                end,
+                name = "DeadSwarm",
                 type = "AA",
                 cond = function(self, aaName, target)
                     return mq.TLO.SpawnCount("corpse radius 100")() >= Config:GetSetting('WakeDeadCorpseCnt') and Globals.AutoTargetIsNamed

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -91,6 +91,12 @@ local _ClassConfig = {
             "Shocking Defense Discipline",
         },
     },
+    ['AASets']        = {
+        ['AreaTaunt'] = {
+            "Enhanced Area Taunt",
+            "Area Taunt",
+        },
+    },
     ['Helpers']       = {
         --function to make sure we don't have non-hostiles in range before we use AE damage or non-taunt AE hate abilities
 
@@ -347,7 +353,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name_func = function(self) return Casting.GetFirstAA({ "Enhanced Area Taunt", "Area Taunt", }) end,
+                name = "AreaTaunt",
                 type = "AA",
             },
         },

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -234,6 +234,23 @@ return {
             "Flaming Sword of Xuzl", --homework
         },
     },
+    ['AASets']        = {
+        ['Devastation'] = {
+            "Prolonged Destruction",
+            "Frenzied Devastation",
+        },
+        ['ManaBurn'] = {
+            "Volatile Mana Blaze",
+            "Mana Blaze",
+            "Mana Blast",
+            "Mana Burn",
+        },
+        ['FamiliarAA'] = {
+            "Kerafyrm's Prismatic Familiar",
+            "Ro's Flaming Familiar",
+            "Improved Familiar",
+        },
+    },
     ['Helpers']       = {
 
         RainCheck = function(target) -- I made a funny
@@ -419,9 +436,7 @@ return {
                 end,
             },
             { --Crit Chance AA, will use the first(best) one found
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Prolonged Destruction", "Frenzied Devastation", })
-                end,
+                name = "Devastation",
                 type = "AA",
                 cond = function(self, aaName)
                     return Casting.SelfBuffAACheck(aaName)
@@ -432,9 +447,7 @@ return {
                 type = "AA",
             },
             {
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Volatile Mana Blaze", "Mana Blaze", "Mana Blast", "Mana Burn", })
-                end,
+                name = "ManaBurn",
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoManaBurn') end,
                 cond = function(self, aaName, target)
@@ -678,9 +691,7 @@ return {
                 end,
             },
             { --Familiar AA, will use the first(best) one found
-                name_func = function(self)
-                    return Casting.GetFirstAA({ "Kerafyrm's Prismatic Familiar", "Ro's Flaming Familiar", "Improved Familiar", })
-                end,
+                name = "FamiliarAA",
                 type = "AA",
                 active_cond = function(self, aaName) return Casting.IHaveBuff(aaName) end,
                 cond = function(self, aaName)
@@ -690,7 +701,7 @@ return {
             {
                 name = "FamiliarBuff",
                 type = "Spell",
-                load_cond = function(self) return not Casting.CanUseAA("Improved Familiar") end,
+                load_cond = function(self) return not Core.GetResolvedActionMapItem('FamiliarAA') end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
                     return Casting.SelfBuffCheck(spell)

--- a/class_configs/example_class_config.lua
+++ b/class_configs/example_class_config.lua
@@ -85,7 +85,7 @@ local _ClassConfig = {
     -- For each table, the script will select the highest level spell out of those we have scribed.
     -- In the event that two spells of the same level are listed, the first spell found is the one used.
     -- Any spell/song/disc rotation entry should also have an entry here, even if it is a single spell!
-    -- Note that AA do not use sets (AA are referred to directly by name in their entries).
+    -- AA can be referred to directly by name in their entries (no set required), or grouped into an AASet when you want fallback resolution across ranked AA whose names change between ranks.
     -- Note that single items (i.e, not in a set) do not require an entry here (Items can be referred to directly by name in their entries).
     -- Generally, if you aren't using a spell line at all, you could consider commenting the entire thing out to stop it from being processed on load. This way it is still there if you change your mind.
     ['ItemSets']      = {
@@ -165,6 +165,17 @@ local _ClassConfig = {
             "Voice of Death",    -- level 50, 6% hate
             "Voice of Shadows",  -- level 46, 4% hate
             "Voice of Darkness", -- level 39, 2% hate
+        },
+    },
+
+    -- AA Sets work just like AbilitySets, but for AA where the ability name changes between ranks and you want the rotation to fall through to the first one you've purchased.
+    -- Most AA share a single name across ranks (e.g. "Visage of Death") and don't need a set -- just use name = "AA Name", type = "AA" in the rotation.
+    -- Reach for an AASet when the ranks have different names (e.g. a high-tier AA that supersedes a lower-tier one).
+    ['AASets']        = {
+        -- Illustrative only -- not a real SK progression. Patterned on real cases like the Berserker "Cascading Rage" -> "Untamed Rage" line.
+        ['ExampleRankedAA'] = {
+            "Newest Rank AA Name",
+            "Older Rank AA Name",
         },
     },
 

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2670, }
+return { version = 2671, }

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -245,7 +245,7 @@ Module.CommandHandlers                       = {
         "RGMercs will queue the mapped spell, song, AA, disc, or item (using smart targeting, or, if provided, on the specified <targetID>). The 'mapname' is the entry name from your rotation window.",
         handler = function(self, mapType, mapName, targetId)
             local action = Modules:ExecModule("Class", "GetResolvedActionMapItem", mapName)
-            if not action or not action() then
+            if not action or (type(action) ~= "string" and not action()) then
                 Logger.log_debug("\arUseMap: \"\ay%s\ar\" does not appear to be a valid mapped action! \awPlease note this value is case-sensitive.", mapName)
                 return false
             end
@@ -379,7 +379,7 @@ function Module:SetCombatMode(mode)
     self.TempSettings.ResolvingActions = true
 
     if self.ClassConfig then
-        self.ResolvedActionMap = Rotation.ResolveActions(self.ClassConfig.ItemSets, self.ClassConfig.AbilitySets)
+        self.ResolvedActionMap = Rotation.ResolveActions(self.ClassConfig.ItemSets, self.ClassConfig.AbilitySets, self.ClassConfig.AASets)
         self.TempSettings.ResolvingActions = false
 
         if self.ClassConfig.SpellList then
@@ -1460,8 +1460,7 @@ function Module:GiveTime()
                 Core.SafeCallFunc("GetCureSpells", self.ClassConfig.Cures.GetCureSpells, self)
             end
         end
-        self:SetRotationClickies()
-        self:SetRotationAAs()
+        self:SetRotationActions()
         self.TempSettings.NewCombatMode = false
         self.TempSettings.CombatModeSet = true
         self.TempSettings.CombatModeChangeTime = Globals.GetTimeSeconds()
@@ -1789,56 +1788,39 @@ function Module:TargetIsImmune(effect, targetId)
     return false
 end
 
-function Module:SetRotationClickies()
-    -- clear list for loadout rescan
+function Module:SetRotationActions()
+    -- clear lists for loadout rescan
+    self.TempSettings.RotationAAs = Set.new({})
     self.TempSettings.RotationClickies = Set.new({})
 
-    -- Check rotations for clickies, either by checking items that were resolved from the maps, or checking strings for item entries without a map
-    for _, rotation in pairs(self.TempSettings.RotationTable) do
-        for _, entry in ipairs(rotation) do
-            if entry.type:lower() == "item" and not entry.from_clicky then
-                local resolvedMap = self.ResolvedActionMap[entry.name]
-                if resolvedMap and mq.TLO.FindItem(string.format("=%s", resolvedMap))() then
-                    self.TempSettings.RotationClickies:add(resolvedMap)
-                elseif type(entry.name) == "string" and mq.TLO.FindItem(string.format("=%s", entry.name))() then
-                    self.TempSettings.RotationClickies:add(entry.name)
+    local aaSets = self.ClassConfig.AASets or {}
+    local itemSets = self.ClassConfig.ItemSets or {}
+
+    -- Single pass over the loaded (post-load_cond) rotation tables for both AA and Item tracking.
+    -- For set entries, all set members are added so warnings/highlights cover stepping-stone ranks too.
+    for _, rotationTable in ipairs({ self.TempSettings.RotationTable, self.TempSettings.HealRotationTable or {}, }) do
+        for _, rotation in pairs(rotationTable) do
+            for _, entry in ipairs(rotation) do
+                local entryType = entry.type:lower()
+                if entryType == "aa" then
+                    local set = aaSets[entry.name]
+                    if set then
+                        for _, aaName in ipairs(set) do
+                            self.TempSettings.RotationAAs:add(aaName)
+                        end
+                    else
+                        self.TempSettings.RotationAAs:add(entry.name)
+                    end
+                elseif entryType == "item" and not entry.from_clicky then
+                    local set = itemSets[entry.name]
+                    if set then
+                        for _, itemName in ipairs(set) do
+                            self.TempSettings.RotationClickies:add(itemName)
+                        end
+                    elseif type(entry.name) == "string" then
+                        self.TempSettings.RotationClickies:add(entry.name)
+                    end
                 end
-            end
-        end
-    end
-
-    -- do it again for heal rotation
-    for _, rotation in pairs(self.TempSettings.HealRotationTable or {}) do
-        for _, entry in ipairs(rotation) do
-            if entry.type:lower() == "item" and not entry.from_clicky then
-                local resolvedMap = self.ResolvedActionMap[entry.name]
-                if resolvedMap and mq.TLO.FindItem(string.format("=%s", resolvedMap))() then
-                    self.TempSettings.RotationClickies:add(resolvedMap)
-                elseif type(entry.name) == "string" and mq.TLO.FindItem(string.format("=%s", entry.Name))() then
-                    self.TempSettings.RotationClickies:add(entry.name)
-                end
-            end
-        end
-    end
-end
-
-function Module:SetRotationAAs()
-    self.TempSettings.RotationAAs = Set.new({})
-
-    -- Check rotations for clickies, either by checking items that were resolved from the maps, or checking strings for item entries without a map
-    for rname, rotation in pairs(self.ClassConfig.Rotations) do
-        for _, entry in ipairs(rotation) do
-            if entry.type:lower() == "aa" then
-                self.TempSettings.RotationAAs:add(entry.name)
-            end
-        end
-    end
-
-    -- do it again for heal rotation
-    for _, rotation in pairs(self.ClassConfig.HealRotations or {}) do
-        for _, entry in ipairs(rotation) do
-            if entry.type:lower() == "aa" then
-                self.TempSettings.RotationAAs:add(entry.name)
             end
         end
     end

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -2463,11 +2463,12 @@ function Casting.AutoMed()
     end
 end
 
---renamed function due to misleading name, deprecated.
+-- Deprecated 5/26 - Use AASets
 function Casting.GetBestAA(aaList)
     return Casting.GetFirstAA(aaList)
 end
 
+-- Deprecated 5/26 - Use AASets
 --- Retrieves the first available purchased AA in a list.
 --- @param aaList table The list of AA to check.
 --- @return string The name of the selected AA (or "None" if no ability was found).

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -38,6 +38,31 @@ function Rotation.GetBestItem(t)
     return selectedItem
 end
 
+--- Get the first available purchased AA from a list.
+---
+--- This function iterates through a list of AA names and returns the first one the character has purchased.
+---
+--- @param aaList table The list of AA names to evaluate.
+--- @return string|nil The first available AA name, or nil if none are purchased.
+function Rotation.GetBestAA(aaList)
+    local selectedAA = nil
+
+    for _, abil in ipairs(aaList or {}) do
+        if Casting.CanUseAA(abil) then
+            selectedAA = abil
+            break
+        end
+    end
+
+    if selectedAA then
+        Logger.log_debug("\agFound\ax %s!", selectedAA)
+    else
+        Logger.log_debug("\arNo AA found for slot!")
+    end
+
+    return selectedAA
+end
+
 --- Get the best spell from a list of spells.
 ---
 --- This function iterates through a list of spells and determines the best spell based on certain criteria.
@@ -179,11 +204,15 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
     end
 
     if entry.type:lower() == "aa" then
-        if Casting.AAReady(entry.name) then
+        --Allow us to pass entry names directly for AA in addition to Action Map tables
+        local aaName = resolvedActionMap[entry.name]
+        if not aaName then aaName = entry.name end
+
+        if Casting.AAReady(aaName) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseAA(entry.name, targetId, entry.allowDead, entry.retries)
+            ret, isGroup = Casting.UseAA(aaName, targetId, entry.allowDead, entry.retries)
         end
-        Logger.log_verbose("(AA) Trying to use %s :: %s", entry.name, ret and "\agSuccess" or "\arFailed!")
+        Logger.log_verbose("(AA) Trying to use %s :: %s", aaName, ret and "\agSuccess" or "\arFailed!")
     end
 
     if entry.type:lower() == "ability" then
@@ -224,7 +253,9 @@ function Rotation.GetEntryConditionArg(map, entry)
         condArg = map[entry.name] or mq.TLO.Spell(entry.name)
     elseif entryType == "item" then        -- item mapping is optional, entry.name can be an actual item name
         condArg = map[entry.name] or entry.name
-    else                                   -- AA/abils needs to return a name directly in case they share a name with a map
+    elseif entryType == "aa" then          -- AA mapping is optional, entry.name can be an actual AA name
+        condArg = map[entry.name] or entry.name
+    else                                   -- abils needs to return a name directly
         condArg = entry.name
     end
 
@@ -414,10 +445,11 @@ function Rotation.Run(caller, rotationTable, targetTable, resolvedActionMap, ste
     return lastStepIdx, anySuccess
 end
 
---- Maps available actions, including item and ability sets.
+--- Maps available actions, including item, ability, and AA sets.
 --- @param itemSets table A list of item sets to be equipped.
 --- @param abilitySets table A list of ability sets to be configured.
-function Rotation.ResolveActions(itemSets, abilitySets)
+--- @param aaSets table|nil A list of AA sets to resolve to the first purchased AA.
+function Rotation.ResolveActions(itemSets, abilitySets, aaSets)
     local resolvedActionMap = {}
 
     -- Map AbilitySet Items and Load Them
@@ -436,6 +468,11 @@ function Rotation.ResolveActions(itemSets, abilitySets)
         local spellTable = abilitySets[unresolvedName]
         Logger.log_debug("\ayFinding best spell for Set: \am%s", unresolvedName)
         resolvedActionMap[unresolvedName] = Rotation.GetBestSpell(spellTable, resolvedActionMap)
+    end
+
+    for unresolvedName, aaTable in pairs(aaSets or {}) do
+        Logger.log_debug("\ayFinding best AA for Set: \am%s", unresolvedName)
+        resolvedActionMap[unresolvedName] = Rotation.GetBestAA(aaTable)
     end
 
     return resolvedActionMap

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -1980,8 +1980,9 @@ function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotation
             if enabledRotationEntries[entry.name] == false then Ui.StrikeThroughText(entry.name) else Ui.RenderText(entry.name) end
             ImGui.TableNextColumn()
             local mappedAction = resolvedActionMap[entry.name]
-            if mappedAction then
-                if entry.type:lower() == "spell" then
+            local typeLower = entry.type:lower()
+            if typeLower == "spell" or typeLower == "song" or typeLower == "disc" then
+                if mappedAction then
                     ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Purple)
                     ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
                     local rankSpell = mappedAction.RankName
@@ -1990,116 +1991,71 @@ function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotation
                         rankSpell.Inspect()
                     end
                     ImGui.PopStyleColor(2)
-                    Ui.Tooltip(string.format("Spell: %s (click to inspect)", rankSpell() or "Unknown"))
-                elseif entry.type:lower() == "song" then
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Purple)
-                    ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
-                    local rankSpell = mappedAction.RankName
-                    local _, clicked = ImGui.Selectable(rankSpell())
-                    if clicked then
-                        rankSpell.Inspect()
-                    end
-                    ImGui.PopStyleColor(2)
-                    Ui.Tooltip(string.format("Song: %s (click to inspect)", rankSpell() or "Unknown"))
-                elseif entry.type:lower() == "disc" then
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Purple)
-                    ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
-                    local rankSpell = mappedAction.RankName
-                    local _, clicked = ImGui.Selectable(rankSpell())
-                    if clicked then
-                        rankSpell.Inspect()
-                    end
-                    ImGui.PopStyleColor(2)
-                    Ui.Tooltip(string.format("Disc: %s (click to inspect)", rankSpell() or "Unknown"))
-                elseif type(mappedAction) == "string" and entry.type:lower() == "item" then
-                    local item = mq.TLO.FindItem("=" .. mappedAction)
-                    if item() and item.Clicky() then
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.LightOrange)
-                        ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
-                        local _, clicked = ImGui.Selectable(mappedAction)
-                        local clickySpell = item.Clicky.Spell
-                        if clickySpell() and clicked then
-                            clickySpell.Inspect()
-                        end
-                        ImGui.PopStyleColor(2)
-                        Ui.Tooltip(string.format("Clicky Spell: %s (click to inspect)", clickySpell.Name() or "Unknown"))
-                    else
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Grey)
-                        Ui.RenderText(mappedAction)
-                        ImGui.PopStyleColor()
-                    end
+                    Ui.Tooltip(string.format("%s: %s (click to inspect)", entry.type, rankSpell() or "Unknown"))
                 else
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Grey)
-                    Ui.RenderText(mappedAction.Name() or mappedAction)
+                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
+                    Ui.RenderText("No %s Detected", entry.type)
                     ImGui.PopStyleColor()
                 end
-            else
-                if entry.type:lower() == "customfunc" then
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Yellow)
-                    Ui.RenderText(entry.desc or "Custom Function")
-                    ImGui.PopStyleColor()
-                elseif entry.type:lower() == "spell" then
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
-                    Ui.RenderText("No Spell Detected")
-                    ImGui.PopStyleColor()
-                elseif entry.type:lower() == "song" then
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
-                    Ui.RenderText("No Song Detected")
-                    ImGui.PopStyleColor()
-                elseif entry.type:lower() == "disc" then
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
-                    Ui.RenderText("No Disc Detected")
-                    ImGui.PopStyleColor()
-                elseif entry.type:lower() == "ability" then
-                    local abilTrained = mq.TLO.Me.Ability(entry.name)()
-                    if abilTrained then
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.LightRed)
-                        Ui.RenderText(entry.name)
-                        ImGui.PopStyleColor()
-                    else
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
-                        Ui.RenderText("No Ability Detected")
-                        ImGui.PopStyleColor()
+            elseif typeLower == "aa" then
+                local aaName = (type(mappedAction) == "string") and mappedAction or entry.name
+                local aaPurchased = mq.TLO.Me.AltAbility(aaName)() ~= nil
+                if aaPurchased then
+                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.LightBlue)
+                    ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
+                    local _, clicked = ImGui.Selectable(aaName)
+                    local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
+                    if aaSpell() and clicked then
+                        aaSpell.Inspect()
                     end
-                elseif entry.type:lower() == "aa" then
-                    local aaPurchased = mq.TLO.Me.AltAbility(entry.name)() ~= nil
-                    if aaPurchased then
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.LightBlue)
-                        ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
-                        local _, clicked = ImGui.Selectable(entry.name)
-                        local aaSpell = mq.TLO.Me.AltAbility(entry.name).Spell
-                        if aaSpell() and clicked then
-                            aaSpell.Inspect()
-                        end
-                        ImGui.PopStyleColor(2)
-                        Ui.Tooltip(string.format("AA Spell: %s (click to inspect)", aaSpell.Name() or "Unknown"))
-                    else
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
-                        Ui.RenderText("No AA Detected")
-                        ImGui.PopStyleColor()
-                    end
-                elseif entry.type:lower() == "item" then
-                    local item = mq.TLO.FindItem("=" .. entry.name)
-                    if item() and item.Clicky() then
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Yellow)
-                        ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
-                        local _, clicked = ImGui.Selectable(entry.name)
-                        local clickySpell = item.Clicky.Spell
-                        if clickySpell() and clicked then
-                            clickySpell.Inspect()
-                        end
-                        ImGui.PopStyleColor(2)
-                        Ui.Tooltip(string.format("Clicky Spell: %s (click to inspect)", clickySpell.Name() or "Unknown"))
-                    else
-                        ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
-                        Ui.RenderText("No Item Detected")
-                        ImGui.PopStyleColor()
-                    end
+                    ImGui.PopStyleColor(2)
+                    Ui.Tooltip(string.format("AA Spell: %s (click to inspect)", aaSpell.Name() or "Unknown"))
                 else
-                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Grey)
+                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
+                    Ui.RenderText("No AA Detected")
+                    ImGui.PopStyleColor()
+                end
+            elseif typeLower == "item" then
+                local itemName = (type(mappedAction) == "string") and mappedAction or entry.name
+                local item = mq.TLO.FindItem("=" .. itemName)
+                if item() and item.Clicky() then
+                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.LightOrange)
+                    ImGui.PushStyleColor(ImGuiCol.HeaderHovered, Globals.Constants.Colors.NearBlack)
+                    local _, clicked = ImGui.Selectable(itemName)
+                    local clickySpell = item.Clicky.Spell
+                    if clickySpell() and clicked then
+                        clickySpell.Inspect()
+                    end
+                    ImGui.PopStyleColor(2)
+                    Ui.Tooltip(string.format("Clicky Spell: %s (click to inspect)", clickySpell.Name() or "Unknown"))
+                else
+                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
+                    Ui.RenderText("No Item Detected")
+                    ImGui.PopStyleColor()
+                end
+            elseif typeLower == "ability" then
+                local abilTrained = mq.TLO.Me.Ability(entry.name)()
+                if abilTrained then
+                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.LightRed)
                     Ui.RenderText(entry.name)
                     ImGui.PopStyleColor()
+                else
+                    ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Red)
+                    Ui.RenderText("No Ability Detected")
+                    ImGui.PopStyleColor()
                 end
+            elseif typeLower == "customfunc" then
+                ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Yellow)
+                Ui.RenderText(entry.desc or "Custom Function")
+                ImGui.PopStyleColor()
+            else
+                ImGui.PushStyleColor(ImGuiCol.Text, Globals.Constants.Colors.Grey)
+                if mappedAction and type(mappedAction) ~= "string" and mappedAction.Name then
+                    Ui.RenderText(mappedAction.Name() or entry.name)
+                else
+                    Ui.RenderText(entry.name)
+                end
+                ImGui.PopStyleColor()
             end
 
             if Config:GetSetting('ShowDebugTiming') then


### PR DESCRIPTION
Add support for AA Sets.
* AA Sets are similar to spell and itemsets.
* Resolves #1006

Refactor Class Rotation UI
* Condensed some duplicate branches.
* Renested like abilities to live together (instead of maps vs unamapped).
* Ordered the function roughly by prevalence (e.g, customfunc last in the tree).

Properly pass AA set entries, refactor configs to use AASets
* Fixes for usemap handling on item/aa sets
* Improved the way we scan for rotation items for the AA Spy and the Clickies warnings (dedup/standardize)