### PR TITLE
WIZ(Live) - Add Ward of Destruction in burns

### DIFF
--- a/class_configs/Live/wiz_class_config.lua
+++ b/class_configs/Live/wiz_class_config.lua
@@ -876,6 +876,14 @@ return {
                 name = "Call of Xuzl",
                 type = "AA",
             },
+            { -- do not use on emu, can lead to serious xtarg issues
+                name = "Ward of Destruction",
+                type = "AA",
+                load_cond = function() return not Core.OnEMU() end,
+                cond = function(self, aaName, target)
+                    return Config:GetSetting('DoAEDamage')
+                end,
+            },
         },
         ['Aggro Management'] =
         {

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2705, }
+return { version = 2706, }


### PR DESCRIPTION
* Please note this ability requires the AE damage setting to be enabled.