### PR TITLE
Ber/Rng Class Config Edits (Live)

### DIFF
--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -237,8 +237,8 @@ return {
             "War Cry",
             "Battle Cry of Dravel",
             "War Cry of Dravel",
-            "Battle Cry of the Mastruq",
             "Ancient: Cry of Chaos",
+            "Battle Cry of the Mastruq",
         },
         ['CryDmg'] = {
             "Cry Havoc",
@@ -665,8 +665,8 @@ return {
                 end,
             },
             {
-                name = "War Cry of the Braxi",
-                type = "Disc",
+                name = "Braxi's Howl",
+                type = "AA",
                 cond = function(self, aaName)
                     return Casting.SelfBuffAACheck(aaName)
                 end,
@@ -675,7 +675,7 @@ return {
                 name = "HHEBuff",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not Casting.AAReady("War Cry of the Braxi") and Casting.NoDiscActive() and Casting.SelfBuffCheck(discSpell)
+                    return not Casting.AAReady("Braxi's Howl") and Casting.NoDiscActive() and Casting.SelfBuffCheck(discSpell)
                 end,
             },
         },

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -1516,7 +1516,7 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "Chamelon's Gift",
+                name = "Chameleon's Gift",
                 type = "AA",
                 tooltip = Tooltips.CG,
                 cond = function(self, spell)


### PR DESCRIPTION
Edited ber/rng_class_config.lua for live.
BER Edits:
War cry of the Braxi Disc (non existent) changed to Braxi's Howl AA.

Re-ordered Battle Cry of the Mastruq and Ancient: Cry of Chaos. They're both the same spell level so the tiebreaker was coming down to their order in the config file not which is better. Ancient: CoC is the better buff.

RNG Edits:
Updated spelling of Chamelon to Chameleon.

Thanks,
Fargrim