### PR TITLE
Config Updates, Cast Retry Setting

### DIFF
--- a/class_configs/EQ Might/ber_class_config.lua
+++ b/class_configs/EQ Might/ber_class_config.lua
@@ -71,7 +71,7 @@ return {
             "Cleaving Anger Discipline", -- Level 65
         },
         ['CryDisc'] = {
-            "Ancient: Cry of Sullon",    -- Level 68
+            "Ancient: Cry of Sullon",    -- Level 68 EQM Custom
             "Battle Cry of the Mastruq", -- Level 65
             "Ancient: Cry of Chaos",     -- Level 65
             "War Cry of Dravel",         -- Level 64
@@ -100,22 +100,22 @@ return {
             "Unpredictable Rage Discipline",    -- Level 66
         },
         ['HealingDisc'] = {                     --EQM Custom, 2m duration, 5m reuse, hp regen
-            "Lifebloom Will Discipline",        -- Level 70
-            "Rejuvenating Will Discipline",     -- Level 68
-            "Healing Determination Discipline", -- Level 66
+            "Lifebloom Will Discipline",        -- Level 70 EQM Custom
+            "Rejuvenating Will Discipline",     -- Level 68 EQM Custom
+            "Healing Determination Discipline", -- Level 66 EQM Custom
             "Healing Will Discipline",          -- Level 59
         },
         ['Scream'] = {                          -- Throwing/Archery Dmg taken debuff
             "Unsettling Scream",                -- Level 71
         },
         ['Revitalize'] = {
-            "Steely Revitalize",      -- Level 69
-            "Iron Revitalize",        -- Level 65
-            "Hardened Revitalize",    -- Level 55
-            "Revitalize",             -- Level 44
+            "Steely Revitalize",      -- Level 69 EQM Custom
+            "Iron Revitalize",        -- Level 65 EQM Custom
+            "Hardened Revitalize",    -- Level 55 EQM Custom
+            "Revitalize",             -- Level 44 EQM Custom
         },
         ['BattlecryHeal'] = {         -- EQM Custom, restores HP/End for group, 8m reuse
-            "Invigorating Battlecry", -- Level 63
+            "Invigorating Battlecry", -- Level 63 EQM Custom
         },
     },
     ['AASets']        = {

--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -121,7 +121,7 @@ local _ClassConfig = {
             "Tarew's Aquatic Ayre", -- Level 16
         },
         ['AriaSong'] = {
-            "Aria of the Harmoniarch",   -- Level 70 EQM
+            "Aria of the Harmoniarch",   -- Level 70 EQM Custom
             "Ancient: Call of Power",    -- Level 70
             "Eriki's Psalm of Power",    -- Level 69
             "Yelhun's Mystic Call",      -- Level 68
@@ -140,7 +140,7 @@ local _ClassConfig = {
             "Aura of Insight",  -- Level 55
         },
         ['GroupRegenSong'] = {
-            "Erollisi's Cantata",            -- Level 70 EQM
+            "Erollisi's Cantata",            -- Level 70
             "Cantata of Life",               -- Level 67
             "Wind of Marr",                  -- Level 62
             "Cantata of Replenishment",      -- Level 55
@@ -150,7 +150,7 @@ local _ClassConfig = {
             "Hymn of Restoration",           -- Level 6 hp only
         },
         ['AreaRegenSong'] = {
-            "Erollisi's Chorus",       -- Level 71 EQM
+            "Erollisi's Chorus",       -- Level 71
             "Chorus of Life",          -- Level 69
             "Chorus of Marr",          -- Level 64
             "Ancient: Lcea's Lament",  -- Level 60
@@ -239,7 +239,7 @@ local _ClassConfig = {
             "Kelin's Lucid Lullaby",      -- Level 15
         },
         ['MezAESong'] = {
-            "Wave of Morell", -- Level 66
+            "Wave of Morell", -- Level 66 EQM Custom
         },
         ['Jonthan'] = {
             "Jonthan's Mightful Caretaker", -- Level 70
@@ -269,18 +269,18 @@ local _ClassConfig = {
         ['MitigationSong'] = {
             "Song of the Dryads", -- Level 71
             "Verse of Vesagran",  -- Level 69
-            "Verse of Huell",     -- Level 65
+            "Verse of Huell",     -- Level 65 EQM Custom
         },
         ['Protective'] = {
-            "Protective Surge Discipline", -- Level 55
+            "Protective Surge Discipline", -- Level 55 EQM Custom
         },
         ['Skals'] = {
-            "Skal's Stance Discipline", -- Level 61
+            "Skal's Stance Discipline", -- Level 61 EQM Custom
         },
         ['Revitalize'] = {
-            "Iron Revitalize",     -- Level 68
-            "Hardened Revitalize", -- Level 62
-            "Revitalize",          -- Level 51
+            "Iron Revitalize",     -- Level 68 EQM Custom
+            "Hardened Revitalize", -- Level 62 EQM Custom
+            "Revitalize",          -- Level 51 EQM Custom
         },
     },
     ['Helpers']       = {

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -84,7 +84,7 @@ return {
         },
         ['BloodDot'] = {
             -- Poison DoT Instant Cast
-            "Diregriffon's Bite", -- Level 70 EQM
+            "Diregriffon's Bite", -- Level 70
             "Chimera Blood",      -- Level 66
             "Turepta Blood",      -- Level 65
             "Scorpion Venom",     -- Level 61
@@ -113,7 +113,7 @@ return {
             "Salve",             -- Level 1
         },
         ['PetHealSpell'] = {
-            "Healing of Uluanes",      -- Level 70 EQM Custom
+            "Healing of Uluanes",      -- Level 70
             "Healing of Mikkily",      -- Level 66
             "Healing of Sorsha",       -- Level 61
             "Sha's Restoration",       -- Level 55
@@ -146,7 +146,7 @@ return {
             "Arag's Celerity",       -- Level 63
             "Sha's Ferocity",        -- Level 59
             "Omakin's Alacrity",     -- Level 55
-            "Bond of The Wild",      -- Level 52
+            "Bond of the Wild",      -- Level 52
             "Yekan's Quickening",    -- Level 37
         },
         ['PetGrowl'] = {
@@ -178,7 +178,7 @@ return {
             "Spiritual Light",      -- Level 41
         },
         ['PetBlockSpell'] = {
-            "Mammoth-Hide Guard",    -- Level 70 EQM
+            "Mammoth-Hide Guard",    -- Level 70
             "Feral Guard",           -- Level 69
             "Protection of Calliav", -- Level 64
             "Guard of Calliav",      -- Level 58
@@ -190,7 +190,7 @@ return {
         },
         ['FocusSpell'] = {
             -- Single target Talismans ( Like Focus)
-            "Focus of Amilan",    -- Level 70 EQM Group
+            "Focus of Amilan",    -- Level 70 Group
             "Focus of Alladnu",   -- Level 67
             "Talisman of Kragg",  -- Level 62
             "Talisman of Altuna", -- Level 58
@@ -216,17 +216,17 @@ return {
             "Bestial Fury Discipline", -- Level 60
         },
         ['ProtDisc'] = {
-            "Skal's Stance Discipline",     -- Level 61
+            "Skal's Stance Discipline",     -- Level 61 EQM Custom
             "Protective Spirit Discipline", -- Level 55
         },
         -- ['VigorBuff'] = {
         --     "Feral Vigor",
         -- },
         ['Minionskin'] = {        --EQM Custom: HP/Regen/mitigation (May need to block druid HP buff line on pet)
-            "Major Minionskin",   -- Level 66
-            "Greater Minionskin", -- Level 56
-            "Minionskin",         -- Level 43
-            "Lesser Minionskin",  -- Level 30
+            "Major Minionskin",   -- Level 66 EQM Custom
+            "Greater Minionskin", -- Level 56 EQM Custom
+            "Minionskin",         -- Level 43 EQM Custom
+            "Lesser Minionskin",  -- Level 30 EQM Custom
         },
         ['Rake'] = {
             "Rake", -- Level 67

--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -236,8 +236,8 @@ local _ClassConfig = {
         },
         ['DivineBuff'] = {
             --Divine Buffs REQUIRES extra spell slot because of the 90s recast
-            "Divine Incursion",    -- Level 69
-            "Divine Interaction",  -- Level 65
+            "Divine Incursion",    -- Level 69 EQM Custom
+            "Divine Interaction",  -- Level 65 EQM Custom
             "Divine Intervention", -- Level 60
             "Death Pact",          -- Level 51
         },
@@ -346,9 +346,9 @@ local _ClassConfig = {
             "Strike",                 -- Level 1
         },
         ['QuickNuke'] = {             -- Might specific
-            "Verdict of Ascension",   -- Level 69
-            "Verdict of Radiance",    -- Level 65
-            "Verdict of Light",       -- Level 60
+            "Verdict of Ascension",   -- Level 69 EQM Custom
+            "Verdict of Radiance",    -- Level 65 EQM Custom
+            "Verdict of Light",       -- Level 60 EQM Custom
         },
         -- ['HammerPet'] = {
         --     "Unswerving Hammer of Retribution", -- Level 68

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -160,8 +160,8 @@ local _ClassConfig = {
         },
         ['GroupHeal'] = {
             "Moonshadow",                  -- Level 70
-            "Lunarglow",                   -- Level 66
-            "Lunargleam",                  -- Level 61
+            "Lunarglow",                   -- Level 66 EQM Custom
+            "Lunargleam",                  -- Level 61 EQM Custom
         },
         ['ATKDebuff'] = {                  -- ATK Debuff
             "Sun's Corona",                -- Level 67
@@ -377,13 +377,13 @@ local _ClassConfig = {
             "Lesser Succor",      -- Level 18
         },
         ['Minionskin'] = {        --EQM Custom: HP/Regen/mitigation (May need to block druid HP buff line on pet)
-            "Major Minionskin",   -- Level 66
-            "Greater Minionskin", -- Level 56
-            "Minionskin",         -- Level 43
+            "Major Minionskin",   -- Level 66 EQM Custom
+            "Greater Minionskin", -- Level 56 EQM Custom
+            "Minionskin",         -- Level 43 EQM Custom
         },
         ['ColdSlow'] = {
-            "Permafrost Grip",          -- Level 68
-            "Ancient: Permafrost Veil", -- Level 60
+            "Permafrost Grip",          -- Level 68 EQM Custom
+            "Ancient: Permafrost Veil", -- Level 60 EQM Custom
         },
     },
     ['AASets']            = {

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -82,7 +82,7 @@ local _ClassConfig = {
         },
         ['ManaRegen'] = {
             "Seer's Intuition",                  -- Level 71
-            "Ancient: Blessing of Clairvoyance", -- Level 70
+            "Ancient: Blessing of Clairvoyance", -- Level 70 EQM Custom
             "Voice of Clairvoyance",             -- Level 70
             "Clairvoyance",                      -- Level 68
             "Voice of Quellious",                -- Level 65
@@ -98,11 +98,11 @@ local _ClassConfig = {
             "Ward of Bedazzlement", -- Level 70
         },
         ['TankIllusionBuff'] = {
-            "Boon of the Brute", -- Level 66
+            "Boon of the Brute", -- Level 66 EQM Custom
         },
         ['IllusionBuff'] = {
-            "Boon of the Sanguinarch", -- Level 68
-            "Boon of the Vampire",     -- Level 65
+            "Boon of the Sanguinarch", -- Level 68 EQM Custom
+            "Boon of the Vampire",     -- Level 65 EQM Custom
             "Night's Dark Terror",     -- Level 63
             "Boon of the Garou",       -- Level 40
         },
@@ -344,19 +344,19 @@ local _ClassConfig = {
         --     "Colored Chaos",  -- Level 69
         -- },
         ['Minionskin'] = {        --EQM Custom: HP/Regen/mitigation (May need to block druid HP buff line on pet)
-            "Major Minionskin",   -- Level 66
-            "Greater Minionskin", -- Level 56
-            "Minionskin",         -- Level 43
-            "Lesser Minionskin",  -- Level 30
+            "Major Minionskin",   -- Level 66 EQM Custom
+            "Greater Minionskin", -- Level 56 EQM Custom
+            "Minionskin",         -- Level 43 EQM Custom
+            "Lesser Minionskin",  -- Level 30 EQM Custom
         },
         ['KoadicRune'] = {
-            "Koadic's Guard IV",  -- Level 67
-            "Koadic's Guard III", -- Level 62
-            "Koadic's Guard II",  -- Level 55
-            "Koadic's Guard I",   -- Level 43
+            "Koadic's Guard IV",  -- Level 67 EQM Custom
+            "Koadic's Guard III", -- Level 62 EQM Custom
+            "Koadic's Guard II",  -- Level 55 EQM Custom
+            "Koadic's Guard I",   -- Level 43 EQM Custom
         },
         ['PetHealSpell'] = {
-            "Renewal of Lucifer", -- Level 68
+            "Renewal of Lucifer", -- Level 68 EQM Custom
         },
     },
     ['AASets']        = {

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -78,7 +78,7 @@ _ClassConfig    = {
         --- Nukes
         ['SwarmPet'] = {
             "Raging Servant",            -- Level 70
-            "Restrained Raging Servant", -- Level 65
+            "Restrained Raging Servant", -- Level 65 EQM Custom
         },
         -- ['ChaoticNuke'] = {
         --     -- Chaotic Nuke with Beneficial Effect >= LVL69
@@ -310,10 +310,10 @@ _ClassConfig    = {
             "Wind of the Desert", -- Level 60
         },
         ['Minionskin'] = {        --EQM Custom: HP/Regen/mitigation (May need to block druid HP buff line on pet)
-            "Major Minionskin",   -- Level 66
-            "Greater Minionskin", -- Level 56
-            "Minionskin",         -- Level 43
-            "Lesser Minionskin",  -- Level 30
+            "Major Minionskin",   -- Level 66 EQM Custom
+            "Greater Minionskin", -- Level 56 EQM Custom
+            "Minionskin",         -- Level 43 EQM Custom
+            "Lesser Minionskin",  -- Level 30 EQM Custom
         },
         ['EpicPetOrb'] = {
             "Summon Orb", -- Level 45
@@ -487,7 +487,7 @@ _ClassConfig    = {
                         Core.DoCmd("/destroy")
                         mq.delay(50, function() return mq.TLO.Cursor() == nil end)
                         if not mq.TLO.FindItem("28034")() then
-                            return
+                            return true
                         end
                     else
                         Logger.Log_warning("Warning: We seem to have something else on the cursor! Do you have another item named 'Orb of Mastery'? Aborting delete.")
@@ -495,6 +495,7 @@ _ClassConfig    = {
                 end
             end
             Logger.log_warning("Warning: Mage pet orb not destroyed! An error or conflict has occured.")
+            return false
         end,
         HandleItemSummon = function(self, itemSource, scope) --scope: "personal" or "group" summons
             if not itemSource and itemSource() then return false end

--- a/class_configs/EQ Might/mnk_class_config.lua
+++ b/class_configs/EQ Might/mnk_class_config.lua
@@ -58,7 +58,7 @@ local _ClassConfig = {
             "Dragon Fang",          -- Level 69
         },
         ['FistsOfWu'] = {
-            "Fists Of Wu", -- Level 68
+            "Fists of Wu", -- Level 68
         },
         ['MeleeMit'] = {
             "Impenetrable Discipline", -- Level 70
@@ -73,7 +73,7 @@ local _ClassConfig = {
             "Heel of Kanji", -- Level 70
         },
         ['Focus'] = {
-            "Last Mile Focus Discipline", -- Level 69
+            "Last Mile Focus Discipline", -- Level 69 EQM Custom
             "Speed Focus Discipline",     -- Level 63
         },
         ['Palm'] = {
@@ -85,13 +85,13 @@ local _ClassConfig = {
         --     "Resistant Discipline", -- Level 30
         -- },
         ['HealingDisc'] = {                     --EQM Custom, 2m duration, 5m reuse, hp regen
-            "Lifebloom Will Discipline",        -- Level 70
-            "Rejuvenating Will Discipline",     -- Level 68
-            "Healing Determination Discipline", -- Level 66
+            "Lifebloom Will Discipline",        -- Level 70 EQM Custom
+            "Rejuvenating Will Discipline",     -- Level 68 EQM Custom
+            "Healing Determination Discipline", -- Level 66 EQM Custom
             "Healing Will Discipline",          -- Level 59
         },
         ['Claw'] = {
-            "Panther Claw", -- Level 66
+            "Panther Claw", -- Level 66 EQM Custom
             "Leopard Claw", -- Level 61
         },
     },

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -95,7 +95,7 @@ local _ClassConfig = {
             "Minor Shielding",      -- Level 1
         },
         ['SelfRune'] = {
-            "WraithSkin",   -- Level 71
+            "Wraithskin",   -- Level 71
             "Dull Pain",    -- Level 69
             "Force Shield", -- Level 63
             "Manaskin",     -- Level 52
@@ -132,7 +132,7 @@ local _ClassConfig = {
         },
         ['DurationTap'] = {
             "Dyn`leth's Grasp",       -- Level 71
-            "Ancient: Chiasa's Kiss", -- Level 68
+            "Ancient: Chiasa's Kiss", -- Level 68 EQM Custom
             -- "Fang of Death",         -- Level 68
             -- "Night's Beckon",        -- Level 65
             -- "Saryrn's Kiss",         -- Level 62
@@ -218,7 +218,7 @@ local _ClassConfig = {
             -- "Chaos Venom",     -- Level 70 (worse than corath venom)
             "Corath Venom",       -- Level 69
             "Blood of Thule",     -- Level 65
-            "Virulent Bolt",      -- Level 59
+            "Virulent Bolt",      -- Level 59 EQM Custom
             "Envenomed Bolt",     -- Level 50
             "Chilling Embrace",   -- Level 36
             "Venom of the Snake", -- Level 34
@@ -228,7 +228,7 @@ local _ClassConfig = {
             -- "Chaos Venom",     -- Level 70 (worse than corath venom)
             "Corath Venom",       -- Level 69
             "Blood of Thule",     -- Level 65
-            "Virulent Bolt",      -- Level 59
+            "Virulent Bolt",      -- Level 59 EQM Custom
             "Envenomed Bolt",     -- Level 50
             "Chilling Embrace",   -- Level 36
             "Venom of the Snake", -- Level 34
@@ -347,10 +347,10 @@ local _ClassConfig = {
         --     "Ignite Bones", -- Level 42
         -- },
         ['Minionskin'] = {        --EQM Custom: HP/Regen/mitigation (May need to block druid HP buff line on pet)
-            "Major Minionskin",   -- Level 66
-            "Greater Minionskin", -- Level 56
-            "Minionskin",         -- Level 43
-            "Lesser Minionskin",  -- Level 30
+            "Major Minionskin",   -- Level 66 EQM Custom
+            "Greater Minionskin", -- Level 56 EQM Custom
+            "Minionskin",         -- Level 43 EQM Custom
+            "Lesser Minionskin",  -- Level 30 EQM Custom
         },
     },
     ['AASets']          = {

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -147,7 +147,7 @@ return {
         },
         ['QuickUndeadNuke'] = {
             -- Undead Quick Nuke with chance to snare and reduce AC
-            "Burial Rites", -- Level 70 EQM Custom
+            "Burial Rites", -- Level 70
             "Last Rites",   -- Level 68 - Timer 7
         },
         ['DDProc'] = {
@@ -171,7 +171,7 @@ return {
             "Desist",                  -- Level 13 - Not Timer 5, filler
         },
         ['StunTimer4'] = {
-            "Sacred Force",    -- Level 70 EQM Custom
+            "Sacred Force",    -- Level 70
             "Force of Piety",  -- Level 66
             "Force of Akilae", -- Level 62
             "Force",           -- Level 52 - Not Timer 4, filler
@@ -196,7 +196,7 @@ return {
         --     "Resolution",        -- Level 60
         -- },
         ['Brells'] = {
-            "Ancient: Brell's Brawny Bulwark", -- Level 70
+            "Ancient: Brell's Brawny Bulwark", -- Level 70 EQM Custom
             "Brell's Brawny Bulwark",          -- Level 70
             "Brell's Stalwart Shield",         -- Level 65
             "Brell's Mountainous Barrier",     -- Level 60
@@ -249,7 +249,7 @@ return {
         },
         ['TouchHeal'] = {
             -- Target Light Heal
-            "Sacred Touch",     -- Level 70 EQM Custom
+            "Sacred Touch",     -- Level 70
             "Touch of Piety",   -- Level 66
             "Touch of Nife",    -- Level 61
             "Superior Healing", -- Level 57
@@ -339,11 +339,11 @@ return {
         },
         ['GuardDisc'] = {
             "Armor of Righteousness",     -- Level 71
-            "Ancient: Guard of Chivalry", -- Level 68
+            "Ancient: Guard of Chivalry", -- Level 68 EQM Custom
             "Guard of Righteousness",     -- Level 67
             "Guard of Humility",          -- Level 61
             "Guard of Piety",             -- Level 56
-            "Squire Guard",               -- Level 40
+            "Squire Guard",               -- Level 40 EQM Custom
         },
         ['ACBuff'] = {
             "Bulwark of Piety", -- Level 69
@@ -353,11 +353,11 @@ return {
         },
         ['BladeDisc'] = {
             "Whirlwind Blade", -- Level 65
-            "Mayhem Blade",    -- Level 52
+            "Mayhem Blade",    -- Level 52 EQM Custom
         },
         ['Protective'] = {
-            "Protective Discipline",       -- Level 69
-            "Protective Surge Discipline", -- Level 45
+            "Protective Discipline",       -- Level 69 EQM Custom
+            "Protective Surge Discipline", -- Level 45 EQM Custom
         },
         ['SelfHeal'] = {                   -- EQM Custom Zero-Casttime Self-heal
             "Blessed Mantle Heal",         -- Level 66 EQM Custom

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -165,7 +165,7 @@ return {
             "Salve",                 -- Level 1
         },
         ['SwarmDot'] = {
-            "Cloud of Wasps", -- Level 70
+            "Cloud of Wasps", -- Level 70 EQM Custom
             "Locust Swarm",   -- Level 67
             "Drifting Death", -- Level 62
             "Fire Swarm",     -- Level 55
@@ -229,7 +229,7 @@ return {
             "Jolting Kicks",  -- Level 71
         },
         ['Skals'] = {
-            "Skal's Stance Discipline", -- Level 61
+            "Skal's Stance Discipline", -- Level 61 EQM Custom
         },
         -- ['JoltProcBuff'] = {
         --     "Jolting Blades", -- Level 54

--- a/class_configs/EQ Might/rog_class_config.lua
+++ b/class_configs/EQ Might/rog_class_config.lua
@@ -88,18 +88,18 @@ return {
             "Deadly Precision Discipline",      -- Level 63
         },
         ['HealingDisc'] = {                     --EQM Custom, 2m duration, 5m reuse, hp regen
-            "Lifebloom Will Discipline",        -- Level 70
-            "Rejuvenating Will Discipline",     -- Level 68
-            "Healing Determination Discipline", -- Level 66
+            "Lifebloom Will Discipline",        -- Level 70 EQM Custom
+            "Rejuvenating Will Discipline",     -- Level 68 EQM Custom
+            "Healing Determination Discipline", -- Level 66 EQM Custom
             "Healing Will Discipline",          -- Level 59
         },
         ['PoisonGuide'] = {
             "Guide of Toxicity", -- Level 71
         },
         ['Revitalize'] = {
-            "Iron Revitalize",     -- Level 68
-            "Hardened Revitalize", -- Level 62
-            "Revitalize",          -- Level 51
+            "Iron Revitalize",     -- Level 68 EQM Custom
+            "Hardened Revitalize", -- Level 62 EQM Custom
+            "Revitalize",          -- Level 51 EQM Custom
         },
     },
     ['RotationOrder'] = {

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -151,7 +151,7 @@ local _ClassConfig = {
             "Soul Shield",                -- Level 67
             "Soul Guard",                 -- Level 61
             "Ichor Guard",                -- Level 56 Timer 5
-            "Squire Guard",               -- Level 40
+            "Squire Guard",               -- Level 40 EQM Custom
         },
         ['BlockDisc'] = {
             "Deflection Discipline", -- Level 59
@@ -182,7 +182,7 @@ local _ClassConfig = {
         },
         ['Horror'] = {                 -- HP Tap Proc
             "Shroud of the Nightborn", -- Level 71
-            "Marrowthirst Horror",     -- Level 70 EQM Added
+            "Marrowthirst Horror",     -- Level 70
             "Shroud of Discord",       -- Level 67 Buff Slot 1 <
             "Black Shroud",            -- Level 65
             "Shroud of Chaos",         -- Level 63
@@ -226,7 +226,7 @@ local _ClassConfig = {
             "Spike of Disease", -- Level 1
         },
         ['BondTap'] = {
-            "Bond of the Blacktalon", -- Level 70 EQM Added
+            "Bond of the Blacktalon", -- Level 70
             "Bond of Inruku",         -- Level 66
             "Bond of Death",          -- Level 62
             "Vampiric Curse",         -- Level 57
@@ -281,13 +281,13 @@ local _ClassConfig = {
         -- },
         ['BiteTap'] = {
             "Ancient: Bite of Muram", -- Level 70
-            "Blacktalon Bite",        -- Level 70 EQM Added
+            "Blacktalon Bite",        -- Level 70
             "Inruku's Bite",          -- Level 67
             "Ancient: Bite of Chaos", -- Level 65
             "Zevfeer's Bite",         -- Level 62
         },
         ['Terror'] = {
-            "Terror of Vergalid", -- Level 70 EQM added
+            "Terror of Vergalid", -- Level 70
             "Terror of Discord",  -- Level 67
             "Terror of Thule",    -- Level 63
             "Terror of Terris",   -- Level 59
@@ -296,7 +296,7 @@ local _ClassConfig = {
             "Terror of Darkness", -- Level 33
         },
         ['Terror2'] = {
-            "Terror of Vergalid", -- Level 70 EQM added
+            "Terror of Vergalid", -- Level 70
             "Terror of Discord",  -- Level 67
             "Terror of Thule",    -- Level 63
             "Terror of Terris",   -- Level 59
@@ -305,7 +305,7 @@ local _ClassConfig = {
             "Terror of Darkness", -- Level 33
         },
         ['Terror3'] = {
-            "Terror of Vergalid", -- Level 70 EQM added
+            "Terror of Vergalid", -- Level 70
             "Terror of Discord",  -- Level 67
             "Terror of Thule",    -- Level 63
             "Terror of Terris",   -- Level 59
@@ -350,17 +350,17 @@ local _ClassConfig = {
         },
         ['BladeDisc'] = {
             "Whirlwind Blade",    -- Level 65
-            "Mayhem Blade",       -- Level 52
+            "Mayhem Blade",       -- Level 52 EQM Custom
         },
         ['Minionskin'] = {        --EQM Custom: HP/Regen/mitigation (May need to block druid HP buff line on pet)
-            "Major Minionskin",   -- Level 66
-            "Greater Minionskin", -- Level 56
-            "Minionskin",         -- Level 43
-            "Lesser Minionskin",  -- not castable for SHD
+            "Major Minionskin",   -- Level 66 EQM Custom
+            "Greater Minionskin", -- Level 56 EQM Custom
+            "Minionskin",         -- Level 43 EQM Custom
+            "Lesser Minionskin",  -- not castable for SHD EQM Custom
         },
         ['Protective'] = {
-            "Protective Discipline",       -- Level 69
-            "Protective Surge Discipline", -- Level 45
+            "Protective Discipline",       -- Level 69 EQM Custom
+            "Protective Surge Discipline", -- Level 45 EQM Custom
         },
         ['ForPower'] = {
             "Challenge for Power", -- Level 71

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -151,7 +151,7 @@ local _ClassConfig = {
     ['AbilitySets']       = {
         ['GroupFocusSpell'] = {
             -- Focus Spell - Group Spells will be used on everyone
-            "Ancient: Blessing of Wunshi", -- Level 70 EQM
+            "Ancient: Blessing of Wunshi", -- Level 70 EQM Custom
             "Talisman of Wunshi",          -- Level 70 - Group
             "Focus of the Seventh",        -- Level 65 - Group
             "Khura's Focusing",            -- Level 60 - Group
@@ -276,9 +276,9 @@ local _ClassConfig = {
             -- "Spirit of the Panther",   -- Level 69, group spell == less casting, longer duration, more avail to do other things
             -- "Talisman of the Leopard", -- Level 66 EQ Might Custom, but item only currently
             -- "Spirit of the Leopard",   -- Level 61, group spell == less casting, longer duration, more avail to do other things
-            "Talisman of the Jaguar", -- Level 61
+            "Talisman of the Jaguar", -- Level 61 EQM Custom
             -- "Spirit of the Jaguar",    -- Level 57, group spell == less casting, longer duration, more avail to do other things
-            "Talisman of the Puma",   -- Level 55
+            "Talisman of the Puma",   -- Level 55 EQM Custom
             "Spirit of the Puma",     -- Level 50
         },
         ['SlowProcBuff'] = {
@@ -303,7 +303,7 @@ local _ClassConfig = {
             "Minor Healing",              -- Level 1
         },
         ['GroupRenewalHoT'] = {
-            "Ancient: Ghost of Vitality", -- Level 70
+            "Ancient: Ghost of Vitality", -- Level 70 EQM Custom
             "Ghost of Renewal",           -- Level 70
         },
         ['SnareHot'] = {
@@ -315,7 +315,7 @@ local _ClassConfig = {
             "Spiritual Serenity",     -- Level 70
             "Breath of Trushar",      -- Level 65
             "Quiescence",             -- Level 65
-            "Spiritual Rejuvenation", -- Level 62
+            "Spiritual Rejuvenation", -- Level 62 EQM Custom
         },
         ['CanniSpell'] = {
             "Ancestral Bargain",          -- Level 71
@@ -391,7 +391,7 @@ local _ClassConfig = {
             "True Spirit",          -- Level 61
             "Spirit of the Howler", -- Level 55
             "Frenzied Spirit",      -- Level 45
-            "Guardian spirit",      -- Level 41
+            "Guardian Spirit",      -- Level 41
             "Vigilant Spirit",      -- Level 37
             "Companion Spirit",     -- Level 32
         },
@@ -440,17 +440,17 @@ local _ClassConfig = {
             "Putrid Decay",       -- Level 66
         },
         ['Minionskin'] = {        --EQM Custom: HP/Regen/mitigation (May need to block druid HP buff line on pet)
-            "Major Minionskin",   -- Level 66
-            "Greater Minionskin", -- Level 56
-            "Minionskin",         -- Level 43
+            "Major Minionskin",   -- Level 66 EQM Custom
+            "Greater Minionskin", -- Level 56 EQM Custom
+            "Minionskin",         -- Level 43 EQM Custom
         },
         ['MeleeBuff'] = {
-            "Ancient: Talisman of Might", -- Level 70, Group
+            "Ancient: Talisman of Might", -- Level 70, EQM Custom - Group
             "Talisman of Might",          -- Level 70, Group
             "Spirit of Might",            -- Level 67, Single Target
         },
         ['VirulentDot'] = {               -- waiting to see where this goes for now, this is worse than some lower level dots
-            "Virulent Bolt",              -- Level 58
+            "Virulent Bolt",              -- Level 58 EQM Custom
         },
     },
     ['Helpers']           = {

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -79,14 +79,14 @@ local _ClassConfig = {
     ['AbilitySets']   = {
         ['StandDisc'] = {             -- Timer 1
             "Final Stand Discipline", -- Level 71
-            "Shelter Me Discipline",  -- Level 69
+            "Shelter Me Discipline",  -- Level 69 EQM Custom
             -- "Stonewall Discipline", -- Level 65
             "Defensive Discipline",   -- Level 55
             "Evasive Discipline",     -- Level 52
         },
         ['StanceDisc'] = {
-            "Myrmidon Stance Discipline", -- Level 61
-            "Warrior Stance Discipline",  -- Level 40
+            "Myrmidon Stance Discipline", -- Level 61 EQM Custom
+            "Warrior Stance Discipline",  -- Level 40 EQM Custom
         },
         ['Fortitude'] = {                 -- Timer 3
             "Fortitude Discipline",       -- Level 59
@@ -99,7 +99,7 @@ local _ClassConfig = {
             "Vortex Blade",    -- Level 74
             "Cyclone Blade",   -- Level 67
             "Whirlwind Blade", -- Level 61
-            "Mayhem Blade",    -- Level 45
+            "Mayhem Blade",    -- Level 45 EQM Custom
         },
         ['AddHate'] = {
             "Ancient: Chaos Cry",    -- Level 65
@@ -125,7 +125,7 @@ local _ClassConfig = {
             "Savage Onslaught Discipline", -- Level 68
         },
         ['StrikeDisc'] = {
-            "Mighty Blow Discipline",   -- Level 66
+            "Mighty Blow Discipline",   -- Level 66 EQM Custom
             "Fellstrike Discipline",    -- Level 58
             "Mighty Strike Discipline", -- Level 54
         },
@@ -136,23 +136,23 @@ local _ClassConfig = {
         --     "Shocking Defense Discipline", -- Level 70
         -- },
         ['Protective'] = {
-            "Protective Discipline",            -- Level 69
-            "Protective Surge Discipline",      -- Level 45
+            "Protective Discipline",            -- Level 69 EQM Custom
+            "Protective Surge Discipline",      -- Level 45 EQM Custom
         },
         ['HealingDisc'] = {                     --EQM Custom, 2m duration, 5m reuse, hp regen
-            "Lifebloom Will Discipline",        -- Level 70
-            "Rejuvenating Will Discipline",     -- Level 68
-            "Healing Determination Discipline", -- Level 66
+            "Lifebloom Will Discipline",        -- Level 70 EQM Custom
+            "Rejuvenating Will Discipline",     -- Level 68 EQM Custom
+            "Healing Determination Discipline", -- Level 66 EQM Custom
             "Healing Will Discipline",          -- Level 59
         },
         ['Revitalize'] = {
-            "Steely Revitalize",      -- Level 69
-            "Iron Revitalize",        -- Level 65
-            "Hardened Revitalize",    -- Level 55
-            "Revitalize",             -- Level 44
+            "Steely Revitalize",      -- Level 69 EQM Custom
+            "Iron Revitalize",        -- Level 65 EQM Custom
+            "Hardened Revitalize",    -- Level 55 EQM Custom
+            "Revitalize",             -- Level 44 EQM Custom
         },
         ['BattlecryHeal'] = {         -- EQM Custom, restores HP/End for group, 8m reuse
-            "Invigorating Battlecry", -- Level 63
+            "Invigorating Battlecry", -- Level 63 EQM Custom
         },
     },
     ['AASets']        = {

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -102,7 +102,7 @@ return {
         ['BigFireNuke'] = {                  -- Level 51-70, Long Cast, Heavy Damage
             "Ether Flame",                   -- Level 70
             "Ancient: Core Fire",            -- Level 68
-            "Corona Flare",                  -- Level 67 EQM Custom
+            "Corona Flare",                  -- Level 67
             "Ancient: Strike of Chaos",      -- Level 65
             "White Fire",                    -- Level 65
             "Strike of Solusek",             -- Level 65

--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -50,282 +50,281 @@ return {
     },
     ['AbilitySets']   = {
         ['EndRegen'] = {
-            "Hiatus V", -- 126
-            "Second Wind",
-            "Third Wind",
-            "Fourth Wind",
-            "Respite",
-            "Reprieve",
-            "Rest",
-            "Breather",
-            "Hiatus",
-            "Relax",
-            "Night's Calming",
-            "Convalesce",
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Relax",           -- Level 111
+            "Hiatus",          -- Level 106
+            "Breather",        -- Level 101
+            "Rest",            -- Level 96
+            "Reprieve",        -- Level 91
+            "Respite",         -- Level 86
+            "Fourth Wind",     -- Level 82
+            "Third Wind",      -- Level 77
+            "Second Wind",     -- Level 72
         },
         ['BerAura'] = {
-            "Aura of Rage",
-            "Bloodlust Aura",
+            "Bloodlust Aura", -- Level 70
+            "Aura of Rage",   -- Level 55
         },
         ['Dicho'] = {
-            "Dichotomic Rage",
-            "Dissident Rage",
-            "Composite Rage",
-            "Ecliptic Rage",
-            "Reciprocal Rage",
+            "Reciprocal Rage", -- Level 121
+            "Ecliptic Rage",   -- Level 116
+            "Composite Rage",  -- Level 111
+            "Dissident Rage",  -- Level 106
+            "Dichotomic Rage", -- Level 101
         },
         ['Dfrenzy'] = {
-            "Obliterating Frenzy III", -- 127
-            "Eviscerating Frenzy",
-            "Oppressing Frenzy",
-            "Overpowering Frenzy",
-            "Overwhelming Frenzy",
-            "Conquering Frenzy",
-            "Vanquishing Frenzy",
-            "Demolishing Frenzy",
-            "Mangling Frenzy",
-            "Vindicating Frenzy",
+            "Obliterating Frenzy", -- Level 127
+            "Eviscerating Frenzy", -- Level 121
+            "Oppressing Frenzy",   -- Level 116
+            "Vindicating Frenzy",  -- Level 111
+            "Mangling Frenzy",     -- Level 106
+            "Demolishing Frenzy",  -- Level 101
+            "Vanquishing Frenzy",  -- Level 96
+            "Conquering Frenzy",   -- Level 91
+            "Overwhelming Frenzy", -- Level 86
+            "Overpowering Frenzy", -- Level 81
         },
         ['Bfrenzy'] = {
-            "Augmented Frenzy VII", -- 129
-            "Torrid Frenzy",
-            "Steel Frenzy",
-            "Augmented Frenzy",
-            "Stormwild Frenzy",
-            "Fighting Frenzy",
-            "Combat Frenzy",
-            "Restless Frenzy",
-            "Battle Frenzy",
-            "Amplified Frenzy",
-            "Fearless Frenzy",
-            "Buttressed Frenzy",
-            "Blinding Frenzy",
-            "Heightened Frenzy",
-            -- "Desperate Frenzy",
-            "Magnified Frenzy",
-            "Bolstered Frenzy",
+            "Augmented Frenzy VII", -- Level 129
+            -- "Desperate Frenzy",  -- Level 125
+            "Heightened Frenzy",    -- Level 124
+            "Blinding Frenzy",      -- Level 120
+            "Buttressed Frenzy",    -- Level 119
+            "Restless Frenzy",      -- Level 115
+            "Magnified Frenzy",     -- Level 114
+            "Torrid Frenzy",        -- Level 110
+            "Bolstered Frenzy",     -- Level 109
+            "Stormwild Frenzy",     -- Level 105
+            "Amplified Frenzy",     -- Level 104
+            "Fearless Frenzy",      -- Level 100
+            "Augmented Frenzy",     -- Level 99
+            "Steel Frenzy",         -- Level 95
+            "Fighting Frenzy",      -- Level 90
+            "Combat Frenzy",        -- Level 85
+            "Battle Frenzy",        -- Level 80
         },
         ['Dvolley'] = {
-            "Obliterating Volley", -- 130
-            "Rage Volley",
-            "Destroyer's Volley",
-            "Annihilator's Volley",
-            "Decimator's Volley",
-            "Eradicator's Volley",
-            "Savage Volley",
-            "Sundering Volley",
-            "Brutal Volley",
-            "Demolishing Volley",
-            "Mangling Volley",
-            "Vindicating Volley",
-            "Pulverizing Volley",
-            "Eviscerating Volley",
+            "Obliterating Volley",  -- Level 130
+            "Eviscerating Volley",  -- Level 124
+            "Pulverizing Volley",   -- Level 119
+            "Vindicating Volley",   -- Level 114
+            "Mangling Volley",      -- Level 109
+            "Demolishing Volley",   -- Level 104
+            "Brutal Volley",        -- Level 99
+            "Sundering Volley",     -- Level 94
+            "Savage Volley",        -- Level 89
+            "Eradicator's Volley",  -- Level 84
+            "Decimator's Volley",   -- Level 79
+            "Annihilator's Volley", -- Level 74
+            "Destroyer's Volley",   -- Level 69
+            "Rage Volley",          -- Level 61
         },
         ['Daxethrow'] = {
-            "Obliterating Axe Throw", -- 128
-            "Maiming Axe Throw",
-            "Vigorous Axe Throw",
-            "Energetic Axe Throw",
-            "Spirited Axe Throw",
-            "Brutal Axe Throw",
-            "Demolishing Axe Throw",
-            "Mangling Axe Throw",
-            "Vindicating Axe Throw",
-            "Rending Axe Throw",
+            "Obliterating Axe Throw", -- Level 128
+            "Rending Axe Throw",      -- Level 123
+            "Maiming Axe Throw",      -- Level 118
+            "Vindicating Axe Throw",  -- Level 113
+            "Mangling Axe Throw",     -- Level 108
+            "Demolishing Axe Throw",  -- Level 103
+            "Brutal Axe Throw",       -- Level 98
+            "Spirited Axe Throw",     -- Level 93
+            "Energetic Axe Throw",    -- Level 88
+            "Vigorous Axe Throw",     -- Level 83
         },
         ['Daxeof'] = {
-            "Axe of Trung", -- 130
-            "Axe of Rallos",
-            "Axe of Graster",
-            "Axe of Illdaera",
-            "Axe of Zurel",
-            "Axe of the Aeons",
-            "Axe of Empyr",
-            "Axe of Derakor",
-            "Axe of Xin Diabo",
-            "Axe of Orrak",
+            "Axe of Trung",     -- Level 130
+            "Axe of Orrak",     -- Level 125
+            "Axe of Xin Diabo", -- Level 120
+            "Axe of Derakor",   -- Level 115
+            "Axe of Empyr",     -- Level 107
+            "Axe of the Aeons", -- Level 102
+            "Axe of Zurel",     -- Level 100
+            "Axe of Illdaera",  -- Level 95
+            "Axe of Graster",   -- Level 90
+            "Axe of Rallos",    -- Level 85
         },
         ['Phantom'] = {
-            "Phantom Assailant",
+            "Phantom Assailant", -- Level 100
         },
         ['Alliance'] = {
-            "Demolisher's Alliance,",
-            "Mangler's Covenant",
-            "Vindicator's Coalition",
-            "Conqueror's Conjunction",
-            "Eviscerator's Covariance",
-
+            "Eviscerator's Covariance", -- Level 125
+            "Conqueror's Conjunction",  -- Level 120
+            "Vindicator's Coalition",   -- Level 115
+            "Mangler's Covenant",       -- Level 110
+            "Demolisher's Alliance",    -- Level 105
         },
         ['CheapShot'] = {
-            "Slap in the Face IX", -- 128
-            "Slap in the Face",
-            "Kick in the Teeth",
-            "Punch in The Throat",
-            "Kick in the Shins",
-            "Sucker Punch",
-            "Rabbit Punch",
-            "Swift Punch",
+            "Slap in the Face IX", -- Level 128
+            "Swift Punch",         -- Level 117
+            "Rabbit Punch",        -- Level 112
+            "Sucker Punch",        -- Level 107
+            "Kick in the Shins",   -- Level 102
+            "Punch in The Throat", -- Level 97
+            "Kick in the Teeth",   -- Level 92
+            "Slap in the Face",    -- Level 87
         },
         ['AESlice'] = {
-            "Arcblade",
-            "Arcslice",
-            "Arcsteel",
-            "Arcslash",
-            "Arcshear",
-            "Arcscale",
+            "Arcscale", -- Level 124
+            "Arcshear", -- Level 119
+            "Arcslash", -- Level 114
+            "Arcsteel", -- Level 109
+            "Arcslice", -- Level 104
+            "Arcblade", -- Level 99
         },
         ['AEVicious'] = {
-            "Vicous Spiral VII", -- 127
-            "Vicious Spiral",
-            "Vicious Cyclone",
-            "Vicious Cycle",
-            "Vicious Revolution",
-            "Vicious Whirl",
+            "Vicious Spiral VII", -- Level 127
+            "Vicious Whirl",      -- Level 117
+            "Vicious Revolution", -- Level 112
+            "Vicious Cycle",      -- Level 107
+            "Vicious Cyclone",    -- Level 102
+            "Vicious Spiral",     -- Level 97
         },
         ['FrenzyBoost'] = {
-            "Augmented Frenzy VII", -- 129
-            "Augmented Frenzy",
-            "Amplified Frenzy",
-            "Bolstered Frenzy",
-            "Magnified Frenzy",
-            "Buttressed Frenzy",
-            "Heightened Frenzy",
+            "Augmented Frenzy VII", -- Level 129
+            "Heightened Frenzy",    -- Level 124
+            "Buttressed Frenzy",    -- Level 119
+            "Magnified Frenzy",     -- Level 114
+            "Bolstered Frenzy",     -- Level 109
+            "Amplified Frenzy",     -- Level 104
+            "Augmented Frenzy",     -- Level 99
         },
         ['RageStrike'] = {
-            "Festering Rage VII", -- 127
-            "Roiling Rage",
-            "Festering Rage",
-            "Bubbling Rage",
-            "Smoldering Rage",
-            "Seething Rage",
-            "Frothing Rage",
+            "Festering Rage VII", -- Level 127
+            "Roiling Rage",       -- Level 122
+            "Frothing Rage",      -- Level 117
+            "Seething Rage",      -- Level 112
+            "Smoldering Rage",    -- Level 107
+            "Bubbling Rage",      -- Level 102
+            "Festering Rage",     -- Level 98
         },
         ['SharedBuff'] = {
-            "Shared Bloodlust X", -- 130
-            "Shared Barbarism",
-            "Shared Bloodlust",
-            "Shared Brutality",
-            "Shared Savagery",
-            "Shared Viciousness",
-            "Shared Cruelty",
-            "Shared Ruthlessness",
-            "Shared Atavism",
-            "Shared Violence",
+            "Shared Bloodlust X",  -- Level 130
+            "Shared Barbarism",    -- Level 125
+            "Shared Violence",     -- Level 120
+            "Shared Atavism",      -- Level 115
+            "Shared Ruthlessness", -- Level 110
+            "Shared Cruelty",      -- Level 105
+            "Shared Viciousness",  -- Level 100
+            "Shared Savagery",     -- Level 95
+            "Shared Brutality",    -- Level 90
+            "Shared Bloodlust",    -- Level 85
         },
         ['PrimaryBurnDisc'] = {
-            "Berserking Discipline",
-            "Sundering Discipline",
-            "Brutal Discipline",
+            "Brutal Discipline",     -- Level 100
+            "Sundering Discipline",  -- Level 95
+            "Berserking Discipline", -- Level 75
         },
         ['CleavingDisc'] = {
-            "Cleaving Rage Discipline",
-            "Cleaving Anger Discipline",
-            "Cleaving Acrimony Discipline",
+            "Cleaving Acrimony Discipline", -- Level 86
+            "Cleaving Anger Discipline",    -- Level 65
+            "Cleaving Rage Discipline",     -- Level 54
         },
         ['FlurryDisc'] = {
-            "Vengeful Flurry Discipline",
-            "Avenging Flurry Discipline",
+            "Avenging Flurry Discipline", -- Level 89
+            "Vengeful Flurry Discipline", -- Level 70
         },
         ['DisconDisc'] = {
-            "Disconcerting Discipline",
+            "Disconcerting Discipline", -- Level 104
         },
         ['ResolveDisc'] = {
-            "Frenzied Resolve Discipline",
+            "Frenzied Resolve Discipline", -- Level 94
         },
         ['HHEBuff'] = {
-            "Battle Cry",
-            "War Cry",
-            "Battle Cry of Dravel",
-            "War Cry of Dravel",
-            "Ancient: Cry of Chaos",
-            "Battle Cry of the Mastruq",
+            "Ancient: Cry of Chaos",     -- Level 65
+            "Battle Cry of the Mastruq", -- Level 65
+            "War Cry of Dravel",         -- Level 64
+            "Battle Cry of Dravel",      -- Level 57
+            "War Cry",                   -- Level 50
+            "Battle Cry",                -- Level 30
         },
         ['CryDmg'] = {
-            "Cry Havoc",
-            "Cry Carnage",
+            "Cry Carnage", -- Level 98
+            "Cry Havoc",   -- Level 68
         },
         ['Tendon'] = {
-            "Tendon Cleave", -- 126
-            "Tendon Slice",
-            "Tendon Shred",
-            "Tendon Cleave",
-            "Tendon Sever",
-            "Tendon Shear",
-            "Tendon Lacerate",
-            "Tendon Slash",
-            "Tendon Gash",
-            "Tendon Tear",
-            "Tendon Rupture",
-            "Tendon Rip",
+            "Tendon Slice",    -- Level 121
+            "Tendon Shred",    -- Level 116
+            "Tendon Rip",      -- Level 111
+            "Tendon Rupture",  -- Level 106
+            "Tendon Tear",     -- Level 101
+            "Tendon Gash",     -- Level 96
+            "Tendon Slash",    -- Level 91
+            "Tendon Lacerate", -- Level 86
+            "Tendon Shear",    -- Level 81
+            "Tendon Sever",    -- Level 76
+            "Tendon Cleave",   -- Level 71
+            "Tendon Cleave",   -- Level 71
         },
         ['SappingStrike'] = {
-            "Sapping Strikes",
-            "Shriveling Strikes",
-            "Draining Strikes",
+            "Draining Strikes",   -- Level 123
+            "Shriveling Strikes", -- Level 113
+            "Sapping Strikes",    -- Level 103
         },
         ['ReflexDisc'] = {
-            "Reflexive Retaliation",
-            "Instinctive Retaliation",
+            "Instinctive Retaliation", -- Level 118
+            "Reflexive Retaliation",   -- Level 113
         },
         ['RestFrenzy'] = {
-            "Desperate Frenzy",
-            "Blinding Frenzy",
-            "Restless Frenzy",
+            "Desperate Frenzy", -- Level 125
+            "Blinding Frenzy",  -- Level 120
+            "Restless Frenzy",  -- Level 115
         },
         ['RetaliationDodge'] = {
-            "Anticipatory Retaliation", -- 129
-            "Preemptive Retaliation",
-            "Primed Retaliation",
-            "Premature Retaltion",
-            "Proactive Retaliation",
-            "Prior Retaliation",
-            "Advanced Retaliation",
-            "Early Retaliation",
+            "Anticipatory Retaliation", -- Level 126
+            "Preemptive Retaliation",   -- Level 121
+            "Primed Retaliation",       -- Level 116
+            "Premature Retaliation",    -- Level 111
+            "Proactive Retaliation",    -- Level 106
+            "Prior Retaliation",        -- Level 101
+            "Advanced Retaliation",     -- Level 96
+            "Early Retaliation",        -- Level 91
         },
         ['TempleStun'] = {
-            "Temple Strike XVI", -- 128
-            "Temple Shatter",
-            "Temple Bash",
-            "Temple Blow",
-            "Temple Chop",
-            "Temple Crack",
-            "Temple Crush",
-            "Temple Demolish",
-            "Temple Shatter",
-            "Temple Slam",
-            "Temple Smash",
-            "Temple Strike",
+            "Temple Strike XVI", -- Level 128
+            "Temple Shatter",    -- Level 118
+            "Temple Shatter",    -- Level 118
+            "Temple Crack",      -- Level 113
+            "Temple Slam",       -- Level 108
+            "Temple Demolish",   -- Level 103
+            "Temple Crush",      -- Level 98
+            "Temple Smash",      -- Level 93
+            "Temple Chop",       -- Level 88
+            "Temple Bash",       -- Level 83
+            "Temple Strike",     -- Level 78
+            "Temple Blow",       -- Level 73
         },
         ['JarringStrike'] = {
-            "Jarring Strike XVI", -- 129
-            "Jarring Crash",
-            "Jarring Strike",
-            "Jarring Smash",
-            "Jarring Clash",
-            "Jarring Slam",
-            "Jarring Blow",
-            "Jarring Crush",
-            "Jarring Smite",
-            "Jarring Jolt",
-            "Jarring Shock",
-            "Jarring Impact",
+            "Jarring Strike XVI", -- Level 129
+            "Jarring Crash",      -- Level 124
+            "Jarring Impact",     -- Level 119
+            "Jarring Shock",      -- Level 114
+            "Jarring Jolt",       -- Level 109
+            "Jarring Smite",      -- Level 104
+            "Jarring Crush",      -- Level 99
+            "Jarring Blow",       -- Level 94
+            "Jarring Slam",       -- Level 89
+            "Jarring Clash",      -- Level 84
+            "Jarring Smash",      -- Level 79
+            "Jarring Strike",     -- Level 74
         },
         ['SnareDisc'] = {
-            "Tendon Slice",
-            "Tendon Shred",
-            "Tendon Rip",
-            "Tendon Rupture",
-            "Tendon Tear",
-            "Tendon Gash",
-            "Tendon Slash",
-            "Tendon Lacerate",
-            "Tendon Shear",
-            "Tendon Sever",
-            "Tendon Cleave",
-            "Crippling Strike",
-            "Leg Slice",
-            "Leg Cut",
-            "Leg Strike",
+            "Tendon Slice",     -- Level 121
+            "Tendon Shred",     -- Level 116
+            "Tendon Rip",       -- Level 111
+            "Tendon Rupture",   -- Level 106
+            "Tendon Tear",      -- Level 101
+            "Tendon Gash",      -- Level 96
+            "Tendon Slash",     -- Level 91
+            "Tendon Lacerate",  -- Level 86
+            "Tendon Shear",     -- Level 81
+            "Tendon Sever",     -- Level 76
+            "Tendon Cleave",    -- Level 71
+            "Crippling Strike", -- Level 67
+            "Leg Slice",        -- Level 54
+            "Leg Cut",          -- Level 32
+            "Leg Strike",       -- Level 8
         },
     },
     ['RotationOrder'] = {

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -127,545 +127,545 @@ local _ClassConfig = {
         ['RunBuffSong'] = {
             -- Selo's Accelerato not used so that we don't go back to a short duration
             -- Other songs omitted due to issues with constant reinvis, etc.
-            "Selo's Accelerating Chorus", -- level 49, SoL
-            "Selo's Accelerando",         -- level 5, Base Game
+            "Selo's Accelerating Chorus", -- Level 49, SoL
+            "Selo's Accelerando",         -- Level 5, Base Game
         },
         ['EndBreathSong'] = {
-            "Tarew's Aquatic Ayre", -- level 16, Base Game
+            "Tarew's Aquatic Ayre", -- Level 16, Base Game
         },
         ['AriaSong'] = {
-            "Aria of Kenburk",           -- level 126, SoR
-            "Aria of Tenisbre",          -- level 121, LS
-            "Aria of Pli Xin Liako",     -- level 116, ToL
-            "Aria of Margidor",          -- level 111, ToV
-            "Aria of Begalru",           -- level 106, RoS
-            "Aria of Maetanrus",         -- level 101, TDS
-            "Aria of Va'Ker",            -- level 96, RoF
-            "Aria of the Orator",        -- level 91, VoA
-            "Aria of the Composer",      -- level 86, HoT
-            "Aria of the Poet",          -- level 81, SoD
-            "Aria of the Artist",        -- level 76, SoF
-            "Ancient: Call of Power",    -- level 70, OoW
-            "Eriki's Psalm of Power",    -- level 69, OoW
-            "Yelhun's Mystic Call",      -- level 68, OoW
-            "Echo of the Trusik",        -- level 65, GoD
-            "Rizlona's Call of Flame",   -- level 64, PoP (overhaste/spell damage)
+            "Aria of Kenburk",           -- Level 126, SoR
+            "Aria of Tenisbre",          -- Level 121, LS
+            "Aria of Pli Xin Liako",     -- Level 116, ToL
+            "Aria of Margidor",          -- Level 111, ToV
+            "Aria of Begalru",           -- Level 106, RoS
+            "Aria of Maetanrus",         -- Level 101, TDS
+            "Aria of Va'Ker",            -- Level 96, RoF
+            "Aria of the Orator",        -- Level 91, VoA
+            "Aria of the Composer",      -- Level 86, HoT
+            "Aria of the Poet",          -- Level 81, SoD
+            "Aria of the Artist",        -- Level 76, SoF
+            "Ancient: Call of Power",    -- Level 70, OoW
+            "Eriki's Psalm of Power",    -- Level 69, OoW
+            "Yelhun's Mystic Call",      -- Level 68, OoW
+            "Echo of the Trusik",        -- Level 65, GoD
+            "Rizlona's Call of Flame",   -- Level 64, PoP (overhaste/spell damage)
         },
         ['OverhasteSong'] = {            -- before effects are combined in aria
-            "Warsong of the Vah Shir",   -- level 60, SoL (overhaste only)
-            "Battlecry of the Vah Shir", -- level 52, SoL (overhaste only)
+            "Warsong of the Vah Shir",   -- Level 60, SoL (overhaste only)
+            "Battlecry of the Vah Shir", -- Level 52, SoL (overhaste only)
         },
         ['SpellDmgSong'] = {             -- before effects are combined in aria
-            "Rizlona's Fire",            -- level 53, LDoN (spell damage only)
-            "Rizlona's Embers",          -- level 45, LDoN (spell damage only)
+            "Rizlona's Fire",            -- Level 53, LDoN (spell damage only)
+            "Rizlona's Embers",          -- Level 45, LDoN (spell damage only)
         },
         ['SufferingSong'] = {
-            "Sorrowful Song of Suffering IX", -- level 130, SoR
-            "Kanghammer's Song of Suffering", -- level 125, LS
-            "Shojralen's Song of Suffering",  -- level 119, ToL
-            "Omorden's Song of Suffering",    -- level 114, ToV
-            "Travenro's Song of Suffering",   -- level 109, RoS
-            "Fjilnauk's Song of Suffering",   -- level 104, TDS
-            "Kaficus' Song of Suffering",     -- level 99, RoF
-            "Hykast's Song of Suffering",     -- level 94, VoA
-            "Noira's Song of Suffering",      -- level 89. HoT
-            "Storm Blade",                    -- level 69, DoN (not the same song line, but is a HP decrease proc)
-            "Song of the Storm",              -- level 61, DoN (not the same song line, but is a HP decrease proc)
+            "Sorrowful Song of Suffering IX", -- Level 130, SoR
+            "Kanghammer's Song of Suffering", -- Level 124, LS
+            "Shojralen's Song of Suffering",  -- Level 119, ToL
+            "Omorden's Song of Suffering",    -- Level 114, ToV
+            "Travenro's Song of Suffering",   -- Level 109, RoS
+            "Fjilnauk's Song of Suffering",   -- Level 104, TDS
+            "Kaficus' Song of Suffering",     -- Level 99, RoF
+            "Hykast's Song of Suffering",     -- Level 94, VoA
+            "Noira's Song of Suffering",      -- Level 89, . HoT
+            "Storm Blade",                    -- Level 69, DoN (not the same song line, but is a HP decrease proc)
+            "Song of the Storm",              -- Level 61, DoN (not the same song line, but is a HP decrease proc)
         },
         ['SprySonataSong'] = {
-            "Boberstler's Spry Sonata", -- level 128, SoR
-            "Dhakka's Spry Sonata",     -- level 123, LS
-            "Xetheg's Spry Sonata",     -- level 118, ToL
-            "Kellek's Spry Sonata",     -- level 113, ToV
-            "Kluzen's Spry Sonata",     -- level 108, RoS
-            "Doben's Spry Sonata",      -- level 98, RoF
-            "Terasal's Spry Sonata",    -- level 93, VoA
-            "Sionachie's Spry Sonata",  -- level 88, HoT
-            "Dance of the Dragorn",     -- level 83, SoD
-            "Coldcrow's Spry Sonata",   -- level 78, SoF
+            "Boberstler's Spry Sonata", -- Level 128, SoR
+            "Dhakka's Spry Sonata",     -- Level 123, LS
+            "Xetheg's Spry Sonata",     -- Level 118, ToL
+            "Kellek's Spry Sonata",     -- Level 113, ToV
+            "Kluzen's Spry Sonata",     -- Level 108, RoS
+            "Doben's Spry Sonata",      -- Level 98, RoF
+            "Terasal's Spry Sonata",    -- Level 93, VoA
+            "Sionachie's Spry Sonata",  -- Level 88, HoT
+            "Dance of the Dragorn",     -- Level 83, SoD
+            "Coldcrow's Spry Sonata",   -- Level 78, SoF
             "Aviak's Wondrous Warble",  -- Level 73, TBS
         },
         ['CrescendoSong'] = {
-            "Alliana's Lively Crescendo",    -- level 129, SoR
-            "Regar's Lively Crescendo",      -- level 124. LS
-            "Zelinstein's Lively Crescendo", -- level 119, ToL
-            "Zburator's Lively Crescendo",   -- level 114, ToV
-            "Jembel's Lively Crescendo",     -- level 109, RoS
-            "Silisia's Lively Crescendo",    -- level 104, TDS
-            "Motlak's Lively Crescendo",     -- level 100, RoF
-            "Kolain's Lively Crescendo",     -- level 95, VoA
-            "Lyssa's Lively Crescendo",      -- level 90, HoT
-            "Gruber's Lively Crescendo",     -- level 85, SoD
-            "Kaerra's Spirited Crescendo",   -- level 80, SoF
-            "Veshma's Lively Crescendo",     -- level 75, TSS
+            "Alliana's Lively Crescendo",    -- Level 129, SoR
+            "Regar's Lively Crescendo",      -- Level 124, . LS
+            "Zelinstein's Lively Crescendo", -- Level 119, ToL
+            "Zburator's Lively Crescendo",   -- Level 114, ToV
+            "Jembel's Lively Crescendo",     -- Level 109, RoS
+            "Silisia's Lively Crescendo",    -- Level 104, TDS
+            "Motlak's Lively Crescendo",     -- Level 100, RoF
+            "Kolain's Lively Crescendo",     -- Level 95, VoA
+            "Lyssa's Lively Crescendo",      -- Level 90, HoT
+            "Gruber's Lively Crescendo",     -- Level 85, SoD
+            "Kaerra's Spirited Crescendo",   -- Level 80, SoF
+            "Veshma's Lively Crescendo",     -- Level 75, TSS
         },
         ['ArcaneSong'] = {
-            "Arcane Aria XII", -- level 129, SoR
-            "Arcane Rhythm",   -- level 124, LS
-            "Arcane Harmony",  -- level 120, ToL
-            "Arcane Symphony", -- level 115, ToV
-            "Arcane Ballad",   -- level 110, RoS
-            "Arcane Melody",   -- level 105, TDS
-            "Arcane Hymn",     -- level 100, RoF
-            "Arcane Address",  -- level 95, VoA
-            "Arcane Chorus",   -- level 90, HoT
-            "Arcane Arietta",  -- level 85, SoD
-            "Arcane Anthem",   -- level 80, SoF (only spell proc)
-            "Arcane Aria",     -- level 70, PoR (only spell proc)
+            "Arcane Aria XII", -- Level 129, SoR
+            "Arcane Rhythm",   -- Level 124, LS
+            "Arcane Harmony",  -- Level 120, ToL
+            "Arcane Symphony", -- Level 115, ToV
+            "Arcane Ballad",   -- Level 110, RoS
+            "Arcane Melody",   -- Level 105, TDS
+            "Arcane Hymn",     -- Level 100, RoF
+            "Arcane Address",  -- Level 95, VoA
+            "Arcane Chorus",   -- Level 90, HoT
+            "Arcane Arietta",  -- Level 85, SoD
+            "Arcane Anthem",   -- Level 80, SoF (only spell proc)
+            "Arcane Aria",     -- Level 70, PoR (only spell proc)
         },
         ['InsultSong'] = {     --alternating timers are necessary to always use the best when the user only opts to use one insult
             --Bard Timers alternate between 6 and 3 every expansion, with some early exception. Use nopush if available.
-            -- "Cutting Insult X",      -- level 127, SoR (push, timer 6)
-            "Yaran's Disdain",  -- level 123, TOB (nopush, timer 3)
-            -- "Eoreg's Insult",        -- level 122, LS (push, timer 3)
-            "Nord's Disdain",   -- level 118, NoS (nopush, timer 6)
-            -- "Sogran's Insult",       -- level 117, ToL (push, timer 6)
-            "Yelinak's Insult", -- level 115, CoV (nopush, timer 3)
-            --"Omorden's Insult",       -- level 112, ToV (push, timer 3)
-            "Sathir's Insult",  -- level 110, RoS (nopush, timer 6)
-            --"Travenro's Insult",      -- level 107, RoS (push, timer 6)
-            "Tsaph's Insult",   -- level 105, Eok (nopush, timer 3)
-            -- "Fjilnauk's Insult",      -- level 102, TDS (push, timer 3)
-            -- "Kaficus' Insult",  -- level 100, RoF (push, timer 6)
-            "Garath's Insult",  -- level 97, CoTH (nopush, timer 6)
-            "Hykast's Insult",  -- level 95, VoA (push, timer 3)
-            "Lyrin's Insult",   -- level 90, HoT (push, timer 6)
-            "Venimor's Insult", -- level 85, UF (push, timer 3)
+            -- "Cutting Insult X",  -- Level 127, SoR (push, timer 6)
+            "Yaran's Disdain",  -- Level 123, TOB (nopush, timer 3)
+            -- "Eoreg's Insult",    -- Level 122, LS (push, timer 3)
+            "Nord's Disdain",   -- Level 118, NoS (nopush, timer 6)
+            -- "Sogran's Insult",   -- Level 117, ToL (push, timer 6)
+            "Yelinak's Insult", -- Level 115, CoV (nopush, timer 3)
+            -- "Omorden's Insult",  -- Level 112, ToV (push, timer 3)
+            "Sathir's Insult",  -- Level 110, RoS (nopush, timer 6)
+            -- "Travenro's Insult", -- Level 107, RoS (push, timer 6)
+            "Tsaph's Insult",   -- Level 105, Eok (nopush, timer 3)
+            -- "Fjilnauk's Insult", -- Level 102, TDS (push, timer 3)
+            -- "Kaficus' Insult",   -- Level 100, RoF (push, timer 6)
+            "Garath's Insult",  -- Level 97, CoTH (nopush, timer 6)
+            "Hykast's Insult",  -- Level 95, VoA (push, timer 3)
+            "Lyrin's Insult",   -- Level 90, HoT (push, timer 6)
+            "Venimor's Insult", -- Level 85, UF (push, timer 3)
         },
         ['InsultSong2'] = {
             --Keep these two sets identical so timers will always be different unless people skip spells (which is their problem)
-            -- "Cutting Insult X",      -- level 127, SoR (push, timer 6)
-            "Yaran's Disdain",  -- level 123, TOB (nopush, timer 3)
-            -- "Eoreg's Insult",        -- level 122, LS (push, timer 3)
-            "Nord's Disdain",   -- level 118, NoS (nopush, timer 6)
-            -- "Sogran's Insult",       -- level 117, ToL (push, timer 6)
-            "Yelinak's Insult", -- level 115, CoV (nopush, timer 3)
-            --"Omorden's Insult",       -- level 112, ToV (push, timer 3)
-            "Sathir's Insult",  -- level 110, RoS (nopush, timer 6)
-            --"Travenro's Insult",      -- level 107, RoS (push, timer 6)
-            "Tsaph's Insult",   -- level 105, Eok (nopush, timer 3)
-            -- "Fjilnauk's Insult",      -- level 102, TDS (push, timer 3)
-            -- "Kaficus' Insult",  -- level 100, RoF (push, timer 6)
-            "Garath's Insult",  -- level 97, CoTH (nopush, timer 6)
-            "Hykast's Insult",  -- level 95, VoA (push, timer 3)
-            "Lyrin's Insult",   -- level 90, HoT (push, timer 6)
-            "Venimor's Insult", -- level 85, UF (push, timer 3)
+            -- "Cutting Insult X",  -- Level 127, SoR (push, timer 6)
+            "Yaran's Disdain",  -- Level 123, TOB (nopush, timer 3)
+            -- "Eoreg's Insult",    -- Level 122, LS (push, timer 3)
+            "Nord's Disdain",   -- Level 118, NoS (nopush, timer 6)
+            -- "Sogran's Insult",   -- Level 117, ToL (push, timer 6)
+            "Yelinak's Insult", -- Level 115, CoV (nopush, timer 3)
+            -- "Omorden's Insult",  -- Level 112, ToV (push, timer 3)
+            "Sathir's Insult",  -- Level 110, RoS (nopush, timer 6)
+            -- "Travenro's Insult", -- Level 107, RoS (push, timer 6)
+            "Tsaph's Insult",   -- Level 105, Eok (nopush, timer 3)
+            -- "Fjilnauk's Insult", -- Level 102, TDS (push, timer 3)
+            -- "Kaficus' Insult",   -- Level 100, RoF (push, timer 6)
+            "Garath's Insult",  -- Level 97, CoTH (nopush, timer 6)
+            "Hykast's Insult",  -- Level 95, VoA (push, timer 3)
+            "Lyrin's Insult",   -- Level 90, HoT (push, timer 6)
+            "Venimor's Insult", -- Level 85, UF (push, timer 3)
         },
         ['LLInsultSong'] = {    -- use the lowest we have until we have a nopush, then use that
-            "Garath's Insult",  -- level 97, CoTH (nopush, timer 6)
-            "Lyrin's Insult",   -- level 90, HoT (push, timer 6)
+            "Garath's Insult",  -- Level 97, CoTH (nopush, timer 6)
+            "Lyrin's Insult",   -- Level 90, HoT (push, timer 6)
         },
         ['LLInsultSong2'] = {   -- use the lowest we have until we have a nopush, then use that
-            "Tsaph's Insult",   -- level 105, Eok (nopush, timer 3)
-            "Venimor's Insult", -- level 85, UF (push, timer 3)
+            "Tsaph's Insult",   -- Level 105, Eok (nopush, timer 3)
+            "Venimor's Insult", -- Level 85, UF (push, timer 3)
         },
         ['DichoSong'] = {
             -- DichoSong Level Range - 101+
-            "Reciprocal Psalm", -- level 121, ToB
-            "Ecliptic Psalm",   -- level 116, NoS
-            "Composite Psalm",  -- level 111, CoV
-            "Dissident Psalm",  -- level 106, TBL
-            "Dichotomic Psalm", -- level 101, TBM
+            "Reciprocal Psalm", -- Level 121, ToB
+            "Ecliptic Psalm",   -- Level 116, NoS
+            "Composite Psalm",  -- Level 111, CoV
+            "Dissident Psalm",  -- Level 106, TBL
+            "Dichotomic Psalm", -- Level 101, TBM
         },
         ['BardDPSAura'] = {
-            "Aura of Kenburk",       -- level 130, SoR
-            "Aura of Tenisbre",      -- level 125, LS
-            "Aura of Pli Xin Liako", -- level 120, ToL
-            "Aura of Margidor",      -- level 115, ToV
-            "Aura of Begalru",       -- level 110, RoS
-            "Aura of Maetanrus",     -- level 105, TDS
-            "Aura of Va'Ker",        -- level 100, RoF
-            "Aura of the Orator",    -- level 95, VoA
-            "Aura of the Composer",  -- level 90, HoT
-            "Aura of the Poet",      -- level 85, SoD
-            "Aura of the Artist",    -- level 80, SoF
-            "Aura of the Muse",      -- level 70, PoR
-            "Aura of Insight",       -- level 55, PoR
+            "Aura of Kenburk",       -- Level 130, SoR
+            "Aura of Tenisbre",      -- Level 125, LS
+            "Aura of Pli Xin Liako", -- Level 120, ToL
+            "Aura of Margidor",      -- Level 115, ToV
+            "Aura of Begalru",       -- Level 110, RoS
+            "Aura of Maetanrus",     -- Level 105, TDS
+            "Aura of Va'Ker",        -- Level 100, RoF
+            "Aura of the Orator",    -- Level 95, VoA
+            "Aura of the Composer",  -- Level 90, HoT
+            "Aura of the Poet",      -- Level 85, SoD
+            "Aura of the Artist",    -- Level 80, SoF
+            "Aura of the Muse",      -- Level 70, PoR
+            "Aura of Insight",       -- Level 55, PoR
         },
         ['BardRegenAura'] = {
-            "Aura of Quellious",     -- level 127, SoR
-            "Aura of Shalowain",     -- level 122, LS
-            "Aura of Shei Vinitras", -- level 117, ToL
-            "Aura of Vhal`Sera",     -- level 112, ToV
-            "Aura of Xigam",         -- level 107, RoS
-            "Aura of Sionachie",     -- level 102, TDS
-            "Aura of Salarra",       -- level 97, RoF
-            "Aura of Lunanyn",       -- level 92, VoA
-            "Aura of Renewal",       -- level 87, HoT
-            "Aura of Rodcet",        -- level 82, SoD
+            "Aura of Quellious",     -- Level 127, SoR
+            "Aura of Shalowain",     -- Level 122, LS
+            "Aura of Shei Vinitras", -- Level 117, ToL
+            "Aura of Vhal`Sera",     -- Level 112, ToV
+            "Aura of Xigam",         -- Level 107, RoS
+            "Aura of Sionachie",     -- Level 102, TDS
+            "Aura of Salarra",       -- Level 97, RoF
+            "Aura of Lunanyn",       -- Level 92, VoA
+            "Aura of Renewal",       -- Level 87, HoT
+            "Aura of Rodcet",        -- Level 82, SoD
         },
         ['GroupRegenSong'] = {
             --Note level 77 pulse only offers a heal% buff and is not included here.
-            "Pulse of Quellious",            -- level 126, SoR
-            "Pulse of August",               -- level 121, LS
-            "Pulse of Nikolas",              -- level 116, ToL
-            "Pulse of Vhal`Sera",            -- level 111, ToV
-            "Pulse of Xigam",                -- level 106, RoS
-            "Pulse of Sionachie",            -- level 101, TDS
-            "Pulse of Salarra",              -- level 96, RoF
-            "Pulse of Lunanyn",              -- level 91, VoA
-            "Pulse of Renewal",              -- levle 86 (start hp/mana/endurance/increased healing)
-            "Cantata of Rodcet",             -- level 81, SoD
-            "Cantata of Restoration",        -- level 76, SoF
-            "Erollisi's Cantata",            -- level 71, TSS
-            "Cantata of Life",               -- level 67, OoW
-            "Wind of Marr",                  -- level 62, PoP
-            "Cantata of Replenishment",      -- level 55, RoK
-            "Cantata of Soothing",           -- level 34, SoV (start hp/mana. Slightly less mana. They can custom if it they want the 2 mana/tick)
-            "Cassindra's Chorus of Clarity", -- level 32, Base Game (mana only)
-            "Cassindra's Chant of Clarity",  -- level 20, SoL (mana only)
-            "Hymn of Restoration",           -- level 6, Base Game (hp only)
+            "Pulse of Quellious",            -- Level 126, SoR
+            "Pulse of August",               -- Level 121, LS
+            "Pulse of Nikolas",              -- Level 116, ToL
+            "Pulse of Vhal`Sera",            -- Level 111, ToV
+            "Pulse of Xigam",                -- Level 106, RoS
+            "Pulse of Sionachie",            -- Level 101, TDS
+            "Pulse of Salarra",              -- Level 96, RoF
+            "Pulse of Lunanyn",              -- Level 91, VoA
+            "Pulse of Renewal",              -- Level 86, levle 86 (start hp/mana/endurance/increased healing)
+            "Cantata of Rodcet",             -- Level 81, SoD
+            "Cantata of Restoration",        -- Level 76, SoF
+            "Erollisi's Cantata",            -- Level 71, TSS
+            "Cantata of Life",               -- Level 67, OoW
+            "Wind of Marr",                  -- Level 62, PoP
+            "Cantata of Replenishment",      -- Level 55, RoK
+            "Cantata of Soothing",           -- Level 34, SoV (start hp/mana. Slightly less mana. They can custom if it they want the 2 mana/tick)
+            "Cassindra's Chorus of Clarity", -- Level 32, Base Game (mana only)
+            "Cassindra's Chant of Clarity",  -- Level 20, SoL (mana only)
+            "Hymn of Restoration",           -- Level 6, Base Game (hp only)
         },
         ['AreaRegenSong'] = {
-            "Chorus of Quellious",     -- level 125, SoR
-            "Chorus of Shalowain",     -- level 123, LS
-            "Chorus of Shei Vinitras", -- level 118, ToL
-            "Chorus of Vhal`Sera",     -- level 113, ToV
-            "Chorus of Xigam",         -- level 108, RoS
-            "Chorus of Sionachie",     -- level 103, TDS
-            "Chorus of Salarra",       -- level 98, RoF
-            "Chorus of Lunanyn",       -- level 93, VoA
-            "Chorus of Renewal",       -- level 88, HoT
-            "Chorus of Rodcet",        -- level 83, SoD
-            "Chorus of Restoration",   -- level 78, SoF
-            "Erollisi's Chorus",       -- level 73, TSS
-            "Chorus of Life",          -- level 69, OoW
-            "Chorus of Marr",          -- level 64, PoP
-            "Ancient: Lcea's Lament",  -- level 60, SoL
-            "Chorus of Replenishment", -- level 58, SoL
+            "Chorus of Quellious",     -- Level 128, SoR
+            "Chorus of Shalowain",     -- Level 123, LS
+            "Chorus of Shei Vinitras", -- Level 118, ToL
+            "Chorus of Vhal`Sera",     -- Level 113, ToV
+            "Chorus of Xigam",         -- Level 108, RoS
+            "Chorus of Sionachie",     -- Level 103, TDS
+            "Chorus of Salarra",       -- Level 98, RoF
+            "Chorus of Lunanyn",       -- Level 93, VoA
+            "Chorus of Renewal",       -- Level 88, HoT
+            "Chorus of Rodcet",        -- Level 83, SoD
+            "Chorus of Restoration",   -- Level 78, SoF
+            "Erollisi's Chorus",       -- Level 73, TSS
+            "Chorus of Life",          -- Level 69, OoW
+            "Chorus of Marr",          -- Level 64, PoP
+            "Ancient: Lcea's Lament",  -- Level 60, SoL
+            "Chorus of Replenishment", -- Level 58, SoL
         },
         ['WarMarchSong'] = {
-            "War March of the Burning Host",    -- level 129, SoR
-            "War March of Nokk",                -- level 124, LS
-            "War March of Centien Xi Va Xakra", -- level 119, ToL
-            "War March of Radiwol",             -- level 114, ToV
-            "War March of Dekloaz",             -- level 109, RoS
-            "War March of Jocelyn",             -- level 104, TDS
-            "War March of Protan",              -- level 99, RoF
-            "War March of Illdaera",            -- level 94, VoA
-            "War March of Dagda",               -- level 89, HoT
-            "War March of Brekt",               -- level 84, SoD
-            "War March of Meldrath",            -- level 79, SoF
-            "War March of Muram",               -- level 68, OoW
-            "War March of the Mastruq",         -- level 65, GoD
-            "Warsong of Zek",                   -- level 62, PoP
-            "McVaxius' Rousing Rondo",          -- level 57, RoK
-            "Vilia's Chorus of Celerity",       -- level 54, RoK (melee haste only, 45%)
-            "Verses of Victory",                -- level 50, Base Game
-            "McVaxius' Berserker Crescendo",    -- level 42, Base Game
-            "Vilia's Verses of Celerity",       -- level 36, Base Game
-            "Anthem de Arms",                   -- level 10, Base Game
+            "War March of the Burning Host",    -- Level 129, SoR
+            "War March of Nokk",                -- Level 124, LS
+            "War March of Centien Xi Va Xakra", -- Level 119, ToL
+            "War March of Radiwol",             -- Level 114, ToV
+            "War March of Dekloaz",             -- Level 109, RoS
+            "War March of Jocelyn",             -- Level 104, TDS
+            "War March of Protan",              -- Level 99, RoF
+            "War March of Illdaera",            -- Level 94, VoA
+            "War March of Dagda",               -- Level 89, HoT
+            "War March of Brekt",               -- Level 84, SoD
+            "War March of Meldrath",            -- Level 79, SoF
+            "War March of Muram",               -- Level 68, OoW
+            "War March of the Mastruq",         -- Level 65, GoD
+            "Warsong of Zek",                   -- Level 62, PoP
+            "McVaxius' Rousing Rondo",          -- Level 57, RoK
+            "Vilia's Chorus of Celerity",       -- Level 54, RoK (melee haste only, 45%)
+            "Verses of Victory",                -- Level 50, Base Game
+            "McVaxius' Berserker Crescendo",    -- Level 42, Base Game
+            "Vilia's Verses of Celerity",       -- Level 36, Base Game
+            "Anthem de Arms",                   -- Level 10, Base Game
         },
         ['FireBuffSong'] = {
             -- CasterAriaSong - Level Range 72+
-            "Severyn's Aria",                    -- level 127, SoR
-            "Flariton's Aria",                   -- level 122, LS
-            "Constance's Aria",                  -- level 118, ToL
-            "Sontalak's Aria",                   -- level 113, ToV
-            "Qunard's Aria",                     -- level 108, RoS
-            "Nilsara's Aria",                    -- level 103, TDS
-            "Gosik's Aria",                      -- level 98, RoF
-            "Daevan's Aria",                     -- level 93, VoA
-            "Sotor's Aria",                      -- level 88, HoT
-            "Talendor's Aria",                   -- level 83, SoD
-            "Performer's Explosive Aria",        -- level 78, SoF
-            "Performer's Psalm of Pyrotechnics", -- level 73, TSS
+            "Severyn's Aria",                    -- Level 127, SoR
+            "Flariton's Aria",                   -- Level 122, LS
+            "Constance's Aria",                  -- Level 118, ToL
+            "Sontalak's Aria",                   -- Level 113, ToV
+            "Qunard's Aria",                     -- Level 108, RoS
+            "Nilsara's Aria",                    -- Level 103, TDS
+            "Gosik's Aria",                      -- Level 98, RoF
+            "Daevan's Aria",                     -- Level 93, VoA
+            "Sotor's Aria",                      -- Level 88, HoT
+            "Talendor's Aria",                   -- Level 83, SoD
+            "Performer's Explosive Aria",        -- Level 78, SoF
+            "Performer's Psalm of Pyrotechnics", -- Level 73, TSS
         },
         ['SlowSong'] = {
-            "Requiem of Time",          -- level 64, PoP (slow only, best slow at 54%)
-            "Angstlich's Assonance",    -- level 60, RoK, 40% slow (slow/HP DoT)
-            "Largo's Assonant Binding", -- level 51, RoK, (35% slow, 131% snare)
-            "Selo's Consonant Chain",   -- level 23, Base Game (40 % slow, 160% snare)
+            "Requiem of Time",          -- Level 64, PoP (slow only, best slow at 54%)
+            "Angstlich's Assonance",    -- Level 60, RoK, 40% slow (slow/HP DoT)
+            "Largo's Assonant Binding", -- Level 51, RoK, (35% slow, 131% snare)
+            "Selo's Consonant Chain",   -- Level 23, Base Game (40 % slow, 160% snare)
         },
         ['AESlowSong'] = {
             -- AESlowSong - Level Range 20 - 114 (Single target works better)
-            "Zinnia's Melodic Binding",     -- level 124, LS
-            "Radiwol's Melodic Binding",    -- level 114, ToV
-            "Dekloaz's Melodic Binding",    -- level 109, RoS
-            "Protan's Melodic Binding",     -- level 99, RoF
-            "Zuriki's Song of Shenanigans", -- level 67, OoW
-            "Melody of Mischief",           -- level 62, PoP
-            "Selo's Assonant Strain",       -- level 54, RoK
-            "Selo's Chords of Cessation",   -- level 48, Base Game
-            "Largo's Melodic Binding",      -- level 20, Base Game
+            "Zinnia's Melodic Binding",     -- Level 124, LS
+            "Radiwol's Melodic Binding",    -- Level 114, ToV
+            "Dekloaz's Melodic Binding",    -- Level 109, RoS
+            "Protan's Melodic Binding",     -- Level 99, RoF
+            "Zuriki's Song of Shenanigans", -- Level 67, OoW
+            "Melody of Mischief",           -- Level 62, PoP
+            "Selo's Assonant Strain",       -- Level 54, RoK
+            "Selo's Chords of Cessation",   -- Level 48, Base Game
+            "Largo's Melodic Binding",      -- Level 20, Base Game
         },
         ['AccelerandoSong'] = {
-            "Alleviating Accelerando VIII", -- level 128, SoR
-            "Appeasing Accelerando",        -- level 123, LS
-            "Satisfying Accelerando",       -- level 118 ToL
-            "Placating Accelerando",        -- level 113, ToV
-            "Atoning Accelerando",          -- level 108, RoS
-            "Allaying Accelerando",         -- level 103, TDS
-            "Ameliorating Accelerando",     -- level 98, RoF
-            "Assuaging Accelerando",        -- level 93, VoA
-            "Alleviating Accelerando",      -- level 88, HoT
+            "Alleviating Accelerando VIII", -- Level 128, SoR
+            "Appeasing Accelerando",        -- Level 123, LS
+            "Satisfying Accelerando",       -- Level 118, ToL
+            "Placating Accelerando",        -- Level 113, ToV
+            "Atoning Accelerando",          -- Level 108, RoS
+            "Allaying Accelerando",         -- Level 103, TDS
+            "Ameliorating Accelerando",     -- Level 98, RoF
+            "Assuaging Accelerando",        -- Level 93, VoA
+            "Alleviating Accelerando",      -- Level 88, HoT
         },
         ['SpitefulSong'] = {
             -- SpitefulSong - Level Range 90 -
-            "Matriarch's Spiteful Lyric", -- level 130, SoR
-            "Tatalros' Spiteful Lyric",   -- level 125, LS
-            "Von Deek's Spiteful Lyric",  -- level 120, ToL
-            "Omorden's Spiteful Lyric",   -- level 115, ToV
-            "Travenro's Spiteful Lyric",  -- level 110, RoS
-            "Fjilnauk's Spiteful Lyric",  -- level 105, TDS
-            "Kaficus' Spiteful Lyric",    -- level 100, RoF
-            "Hykast's Spiteful Lyric",    -- level 95, VoA
-            "Lyrin's Spiteful Lyric",     -- level 90, HoT
+            "Matriarch's Spiteful Lyric", -- Level 130, SoR
+            "Tatalros' Spiteful Lyric",   -- Level 125, LS
+            "Von Deek's Spiteful Lyric",  -- Level 120, ToL
+            "Omorden's Spiteful Lyric",   -- Level 115, ToV
+            "Travenro's Spiteful Lyric",  -- Level 110, RoS
+            "Fjilnauk's Spiteful Lyric",  -- Level 105, TDS
+            "Kaficus' Spiteful Lyric",    -- Level 100, RoF
+            "Hykast's Spiteful Lyric",    -- Level 95, VoA
+            "Lyrin's Spiteful Lyric",     -- Level 90, HoT
         },
         ['RecklessSong'] = {
-            "Onkrin's Reckless Renewal",   -- level 128, SoR
-            "Grayleaf's Reckless Renewal", -- level 125, LS
-            "Kai's Reckless Renewal",      -- level 118, ToL
-            "Reivaj's Reckless Renewal",   -- level 113, ToV
-            "Rigelon's Reckless Renewal",  -- level 108, RoS
-            "Rytan's Reckless Renewal",    -- level 103, TDS
-            "Ruaabri's Reckless Renewal",  -- level 98, RoF
-            "Ryken's Reckless Renewal",    -- level 93 VoA
+            "Onkrin's Reckless Renewal",   -- Level 128, SoR
+            "Grayleaf's Reckless Renewal", -- Level 123, LS
+            "Kai's Reckless Renewal",      -- Level 118, ToL
+            "Reivaj's Reckless Renewal",   -- Level 113, ToV
+            "Rigelon's Reckless Renewal",  -- Level 108, RoS
+            "Rytan's Reckless Renewal",    -- Level 103, TDS
+            "Ruaabri's Reckless Renewal",  -- Level 98, RoF
+            "Ryken's Reckless Renewal",    -- Level 93, VoA
         },
         ['ColdBuffSong'] = {
             -- ColdBuffSong - Level Range 72 - 112 **
-            "Fatesong of the Polar Vortex", -- level 127, SoR
-            "Fatesong of Zoraxmen",         -- level 122, LS
-            "Fatesong of Lucca",            -- level 117, ToL
-            "Fatesong of Radiwol",          -- level 112, ToV
-            "Fatesong of Dekloaz",          -- level 107, RoS
-            "Fatesong of Jocelyn",          -- level 102, TDS
-            "Fatesong of Protan",           -- level 97, RoF
-            "Fatesong of Illdaera",         -- level 92, VoA
-            "Fatesong of Fergar",           -- level 87, HoT
-            "Fatesong of the Gelidran",     -- level 82, SoD
-            "Garadell's Fatesong",          -- level 77, SoF
-            "Weshlu's Chillsong Aria",      -- level 72, TSS
+            "Fatesong of the Polar Vortex", -- Level 127, SoR
+            "Fatesong of Zoraxmen",         -- Level 122, LS
+            "Fatesong of Lucca",            -- Level 117, ToL
+            "Fatesong of Radiwol",          -- Level 112, ToV
+            "Fatesong of Dekloaz",          -- Level 107, RoS
+            "Fatesong of Jocelyn",          -- Level 102, TDS
+            "Fatesong of Protan",           -- Level 97, RoF
+            "Fatesong of Illdaera",         -- Level 92, VoA
+            "Fatesong of Fergar",           -- Level 87, HoT
+            "Fatesong of the Gelidran",     -- Level 82, SoD
+            "Garadell's Fatesong",          -- Level 77, SoF
+            "Weshlu's Chillsong Aria",      -- Level 72, TSS
         },
         ['DotBuffSong'] = {
             -- Fire & Magic Dots song
-            "Danfol's Psalm of Potency",       -- level 128, SoR
-            "Tatalros' Psalm of Potency",      -- level 123, LS
-            "Fyrthek Fior's Psalm of Potency", -- level 118, ToL
-            "Velketor's Psalm of Potency",     -- level 113, ToV
-            "Akett's Psalm of Potency",        -- level 108, RoS
-            "Horthin's Psalm of Potency",      -- level 103, TDS
-            "Siavonn's Psalm of Potency",      -- level 98, RoF
-            "Wasinai's Psalm of Potency",      -- level 93, VoA
-            "Lyrin's Psalm of Potency",        -- level 88, HoT
-            "Druzzil's Psalm of Potency",      -- level 83, SoD
-            "Erradien's Psalm of Potency",     -- level 78, SoF
+            "Danfol's Psalm of Potency",       -- Level 128, SoR
+            "Tatalros' Psalm of Potency",      -- Level 123, LS
+            "Fyrthek Fior's Psalm of Potency", -- Level 118, ToL
+            "Velketor's Psalm of Potency",     -- Level 113, ToV
+            "Akett's Psalm of Potency",        -- Level 108, RoS
+            "Horthin's Psalm of Potency",      -- Level 103, TDS
+            "Siavonn's Psalm of Potency",      -- Level 98, RoF
+            "Wasinai's Psalm of Potency",      -- Level 93, VoA
+            "Lyrin's Psalm of Potency",        -- Level 88, HoT
+            "Druzzil's Psalm of Potency",      -- Level 83, SoD
+            "Erradien's Psalm of Potency",     -- Level 78, SoF
         },
         ['FireDotSong'] = {
-            "Severyn's Chant of Flame",     -- level 130, SoR
-            "Kindleheart's Chant of Flame", -- level 125, LS
-            "Shak Dathor's Chant of Flame", -- level 120, ToL
-            "Sontalak's Chant of Flame",    -- level 115, ToV
-            "Qunard's Chant of Flame",      -- level 110, RoS
-            "Nilsara's Chant of Flame",     -- level 105, TDS
-            "Gosik's Chant of Flame",       -- level 100, RoF
-            "Daevan's Chant of Flame",      -- level 95, VoA
-            "Sotor's Chant of Flame",       -- level 90, HoT
-            "Talendor's Chant of Flame",    -- level 85, SoD
-            "Tjudawos' Chant of Flame",     -- level 80 SoF
-            "Vulka's Chant of Flame",       -- level 70, OoW
-            "Tuyen's Chant of Fire",        -- level 65, PoP
-            "Tuyen's Chant of Flame",       -- level 38, Base Game
+            "Severyn's Chant of Flame",     -- Level 130, SoR
+            "Kindleheart's Chant of Flame", -- Level 125, LS
+            "Shak Dathor's Chant of Flame", -- Level 120, ToL
+            "Sontalak's Chant of Flame",    -- Level 115, ToV
+            "Qunard's Chant of Flame",      -- Level 110, RoS
+            "Nilsara's Chant of Flame",     -- Level 105, TDS
+            "Gosik's Chant of Flame",       -- Level 100, RoF
+            "Daevan's Chant of Flame",      -- Level 95, VoA
+            "Sotor's Chant of Flame",       -- Level 90, HoT
+            "Talendor's Chant of Flame",    -- Level 85, SoD
+            "Tjudawos' Chant of Flame",     -- Level 80, SoF
+            "Vulka's Chant of Flame",       -- Level 70, OoW
+            "Tuyen's Chant of Fire",        -- Level 65, PoP
             -- Misc Dot -- Or Minsc Dot (HEY HEY BOO BOO!)
-            "Ancient: Chaos Chant",         -- level 65, GoD
-            "Angstlich's Assonance",        -- level 60, RoK (also decrease melee slow 40%)
-            "Fufil's Diminishing Dirge",    -- level 60, LDoN (also decrease magic resist 34)
-            "Fufil's Curtailing Chant",     -- level 30, Base Game
+            "Ancient: Chaos Chant",         -- Level 65, GoD
+            "Angstlich's Assonance",        -- Level 60, RoK (also decrease melee slow 40%)
+            "Fufil's Diminishing Dirge",    -- Level 60, LDoN (also decrease magic resist 34)
+            "Tuyen's Chant of Flame",       -- Level 38, Base Game
+            "Fufil's Curtailing Chant",     -- Level 30, Base Game
         },
         ['IceDotSong'] = {
-            "Tsikut's Chant of Frost",      -- level 127, SoR
-            "Swarn's Chant of Frost",       -- level 122, LS
-            "Sylra Fris' Chant of Frost",   -- level 117, ToL
-            "Yelinak's Chant of Frost",     -- level 112, ToV
-            "Ekron's Chant of Frost",       -- level 107, RoS
-            "Kirchen's Chant of Frost",     -- level 102 TDS
-            "Edoth's Chant of Frost",       -- level 97, RoF
-            "Kalbrok's Chant of Frost",     -- level 92, VoA
-            "Fergar's Chant of Frost",      -- level 87, HoT
-            "Gorenaire's Chant of Frost",   -- level 82, SoD
-            "Zeixshi-Kar's Chant of Frost", -- level 77, SoF
+            "Tsikut's Chant of Frost",      -- Level 127, SoR
+            "Swarn's Chant of Frost",       -- Level 122, LS
+            "Sylra Fris' Chant of Frost",   -- Level 117, ToL
+            "Yelinak's Chant of Frost",     -- Level 112, ToV
+            "Ekron's Chant of Frost",       -- Level 107, RoS
+            "Kirchen's Chant of Frost",     -- Level 102, TDS
+            "Edoth's Chant of Frost",       -- Level 97, RoF
+            "Kalbrok's Chant of Frost",     -- Level 92, VoA
+            "Fergar's Chant of Frost",      -- Level 87, HoT
+            "Gorenaire's Chant of Frost",   -- Level 82, SoD
+            "Zeixshi-Kar's Chant of Frost", -- Level 77, SoF
             "Vulka's Chant of Frost",       -- Level 67, OW
-            "Tuyen's Chant of Ice",         -- level 63, PoP
-            "Tuyen's Chant of Frost",       -- level 46, Base Game
             -- Misc Dot -- Or Minsc Dot (HEY HEY BOO BOO!)
-            "Ancient: Chaos Chant",         -- level 65, GoD
-            "Angstlich's Assonance",        -- level 60, RoK (also decrease melee slow 40%)
-            "Fufil's Diminishing Dirge",    -- level 60, LDoN (also decrease magic resist 34)
-            "Fufil's Curtailing Chant",     -- level 30, Base Game
+            "Ancient: Chaos Chant",         -- Level 65, GoD
+            "Tuyen's Chant of Ice",         -- Level 63, PoP
+            "Angstlich's Assonance",        -- Level 60, RoK (also decrease melee slow 40%)
+            "Fufil's Diminishing Dirge",    -- Level 60, LDoN (also decrease magic resist 34)
+            "Tuyen's Chant of Frost",       -- Level 46, Base Game
+            "Fufil's Curtailing Chant",     -- Level 30, Base Game
         },
         ['PoisonDotSong'] = {
-            "Khrosik's Chant of Poison",      -- level 128, SoR
-            "Marsin's Chant of Poison",       -- level 123, LS
-            "Cruor's Chant of Poison",        -- level 118, ToL
-            "Malvus's Chant of Poison",       -- level 113, ToV
-            "Nexona's Chant of Poison",       -- level 108, RoS
-            "Serisaria's Chant of Poison",    -- level 103, TDS
-            "Slaunk's Chant of Poison",       -- level 98, RoF
-            "Hiqork's Chant of Poison",       -- level 93, VoA
-            "Spinechiller's Chant of Poison", -- level 88, HoT
-            "Severilous' Chant of Poison",    -- level 83 SoD
-            "Kildrukaun's Chant of Poison",   -- level 78, SoF
-            "Vulka's Chant of Poison",        -- level 68, OoW
-            "Tuyen's Chant of Venom",         -- level 63, PoP
-            "Tuyen's Chant of Poison",        -- level 50, PoP
+            "Khrosik's Chant of Poison",      -- Level 128, SoR
+            "Marsin's Chant of Poison",       -- Level 123, LS
+            "Cruor's Chant of Poison",        -- Level 118, ToL
+            "Malvus's Chant of Poison",       -- Level 113, ToV
+            "Nexona's Chant of Poison",       -- Level 108, RoS
+            "Serisaria's Chant of Poison",    -- Level 103, TDS
+            "Slaunk's Chant of Poison",       -- Level 98, RoF
+            "Hiqork's Chant of Poison",       -- Level 93, VoA
+            "Spinechiller's Chant of Poison", -- Level 88, HoT
+            "Severilous' Chant of Poison",    -- Level 83, SoD
+            "Kildrukaun's Chant of Poison",   -- Level 78, SoF
+            "Vulka's Chant of Poison",        -- Level 68, OoW
             -- Misc Dot -- Or Minsc Dot (HEY HEY BOO BOO!)
-            "Ancient: Chaos Chant",           -- level 65, GoD
-            "Angstlich's Assonance",          -- level 60, RoK (also decrease melee slow 40%)
-            "Fufil's Diminishing Dirge",      -- level 60, LDoN (also decrease magic resist 34)
-            "Fufil's Curtailing Chant",       -- level 30, Base Game
+            "Ancient: Chaos Chant",           -- Level 65, GoD
+            "Tuyen's Chant of Venom",         -- Level 63, PoP
+            "Angstlich's Assonance",          -- Level 60, RoK (also decrease melee slow 40%)
+            "Fufil's Diminishing Dirge",      -- Level 60, LDoN (also decrease magic resist 34)
+            "Tuyen's Chant of Poison",        -- Level 50, PoP
+            "Fufil's Curtailing Chant",       -- Level 30, Base Game
         },
         ['DiseaseDotSong'] = {
-            "Pustim's Chant of Disease",     -- level 126, SoR
-            "Goremand's Chant of Disease",   -- level 121, LS
-            "Coagulus' Chant of Disease",    -- level 116. ToL
-            "Zlexak's Chant of Disease",     -- level 111, ToV
-            "Hoshkar's Chant of Disease",    -- level 106, RoS
-            "Horthin's Chant of Disease",    -- level 101, TDS
-            "Siavonn's Chant of Disease",    -- level 96, RoF
-            "Wasinai's Chant of Disease",    -- level 91, VoA
-            "Shiverback's Chant of Disease", -- level 86, HoT
-            "Trakanon's Chant of Disease",   -- level 81, SoD
-            "Vyskudra's Chant of Disease",   -- level 76, SoF
-            "Vulka's Chant of Disease",      -- level 66, OoW
-            "Tuyen's Chant of the Plague",   -- level 61, PoP
-            "Tuyen's Chant of Disease",      -- level 42, PoP
+            "Pustim's Chant of Disease",     -- Level 126, SoR
+            "Goremand's Chant of Disease",   -- Level 121, LS
+            "Coagulus' Chant of Disease",    -- Level 116, . ToL
+            "Zlexak's Chant of Disease",     -- Level 111, ToV
+            "Hoshkar's Chant of Disease",    -- Level 106, RoS
+            "Horthin's Chant of Disease",    -- Level 101, TDS
+            "Siavonn's Chant of Disease",    -- Level 96, RoF
+            "Wasinai's Chant of Disease",    -- Level 91, VoA
+            "Shiverback's Chant of Disease", -- Level 86, HoT
+            "Trakanon's Chant of Disease",   -- Level 81, SoD
+            "Vyskudra's Chant of Disease",   -- Level 76, SoF
+            "Vulka's Chant of Disease",      -- Level 66, OoW
             -- Misc Dot -- Or Minsc Dot (HEY HEY BOO BOO!)
-            "Ancient: Chaos Chant",          -- level 65, GoD
-            "Angstlich's Assonance",         -- level 60, RoK (also decrease melee slow 40%)
-            "Fufil's Diminishing Dirge",     -- level 60, LDoN (also decrease magic resist 34)
-            "Fufil's Curtailing Chant",      -- level 30, Base Game
+            "Ancient: Chaos Chant",          -- Level 65, GoD
+            "Tuyen's Chant of the Plague",   -- Level 61, PoP
+            "Angstlich's Assonance",         -- Level 60, RoK (also decrease melee slow 40%)
+            "Fufil's Diminishing Dirge",     -- Level 60, LDoN (also decrease magic resist 34)
+            "Tuyen's Chant of Disease",      -- Level 42, PoP
+            "Fufil's Curtailing Chant",      -- Level 30, Base Game
         },
         ['CureSong'] = {
-            "Mastery: Aria of Absolution", -- level 126, SoR
-            "Aria of Absolution",          -- level 96, RoF
-            "Aria of Impeccability",       -- level 91, VoA
-            "Aria of Amelioration",        -- level 86, HoT
-            --"Firion's Blessed Clarinet",          -- level 84, SoD (corruption only)
-            --"Kirathas' Cleansing Clarinet",       -- level 79, SoF (corruption only)
-            --"Aria of Innocence",                  -- level 52, LoY (curse only)
-            "Aria of Asceticism", -- level 45, LoY (poison/disease only)
+            "Mastery: Aria of Absolution", -- Level 126, SoR
+            "Aria of Absolution",          -- Level 96, RoF
+            "Aria of Impeccability",       -- Level 91, VoA
+            "Aria of Amelioration",        -- Level 86, HoT
+            -- "Firiona's Blessed Clarinet",   -- Level 84, SoD (corruption only)
+            -- "Kirathas' Cleansing Clarinet", -- Level 79, SoF (corruption only)
+            -- "Aria of Innocence",            -- Level 52, LoY (curse only)
+            "Aria of Asceticism", -- Level 45, LoY (poison/disease only)
         },
         ['AllianceSong'] = {
-            "Covariance of Sticks and Stones",  -- level 125, ToB
-            "Conjunction of Sticks and Stones", -- level 120, NoS
-            "Coalition of Sticks and Stones",   -- level 115, CoV
-            "Covenant of Sticks and Stones",    -- level 110, TBL
-            "Alliance of Sticks and Stones",    -- level 102, EoK
+            "Covariance of Sticks and Stones",  -- Level 125, ToB
+            "Conjunction of Sticks and Stones", -- Level 120, NoS
+            "Coalition of Sticks and Stones",   -- Level 115, CoV
+            "Covenant of Sticks and Stones",    -- Level 110, TBL
+            "Alliance of Sticks and Stones",    -- Level 102, EoK
         },
         ['CharmSong'] = {
             -- Demand line has memblur chance, but costs significantly more mana
-            "Voice of Keftlik",           -- level 129, SoR (up to 128)
-            -- "Yaran's Demand",                   -- level 124, ToB (up to 123, 40% memblur)
-            "Voice of Suja",              -- level 124, LS (up to 123)
-            -- "Omiyad's Demand",                   -- level 119, NoS (up to 118, 40% memblur)
-            "Voice of the Diabo",         -- level 119, ToL (up to 118)
-            -- "Desirae's Demand",                  -- level 114. CoV (up to 113, 40% memblur)
-            "Voice of Zburator",          -- level 114, ToV (up to 113)
-            -- "Dawnbreeze's Demand",               -- level 109, TBL (up to 108, 40% memblur)
-            "Voice of Jembel",            -- level 109, RoS (up to 108)
-            -- "Silisia's Demand",                  -- level 102, EoK (up to 103, 40% memblur)
-            "Voice of Silisia",           -- level 104, TDS (up to 103)
-            "Voice of Motlak",            -- level 99, RoF (up to 98)
-            "Voice of Kolain",            -- level 94, VoA (up to 94)
-            "Voice of Sionachie",         -- level 89, HoT (up to 88)
-            "Voice of the Mindshear",     -- level 84, SoD (up to SoD)
-            "Yowl of the Bloodmoon",      -- level 79, SoF (up to 78)
-            "Beckon of the Tuffein",      -- level 73, TSS (up to 73)
-            "Voice of the Vampire",       -- level 70, OoW (up to 68)
-            "Call of the Banshee",        -- level 64, PoP (up to 57)
-            "Solon's Bewitching Bravura", -- level 39, Base Game (up to 51)
-            "Solon's Song of the Sirens", -- level 27, Base Game (up to 37)
+            "Voice of Keftlik",           -- Level 129, SoR (up to 128)
+            -- "Yaran's Demand",          -- Level 124, ToB (up to 123, 40% memblur)
+            "Voice of Suja",              -- Level 124, LS (up to 123)
+            -- "Omiyad's Demand",         -- Level 119, NoS (up to 118, 40% memblur)
+            "Voice of the Diabo",         -- Level 119, ToL (up to 118)
+            -- "Desirae's Demand",        -- Level 114, . CoV (up to 113, 40% memblur)
+            "Voice of Zburator",          -- Level 114, ToV (up to 113)
+            -- "Dawnbreeze's Demand",     -- Level 109, TBL (up to 108, 40% memblur)
+            "Voice of Jembel",            -- Level 109, RoS (up to 108)
+            "Voice of Silisia",           -- Level 104, TDS (up to 103)
+            -- "Silisia's Demand",        -- Level 102, EoK (up to 103, 40% memblur)
+            "Voice of Motlak",            -- Level 99, RoF (up to 98)
+            "Voice of Kolain",            -- Level 94, VoA (up to 94)
+            "Voice of Sionachie",         -- Level 89, HoT (up to 88)
+            "Voice of the Mindshear",     -- Level 84, SoD (up to SoD)
+            "Yowl of the Bloodmoon",      -- Level 79, SoF (up to 78)
+            "Beckon of the Tuffein",      -- Level 74, TSS (up to 73)
+            "Voice of the Vampire",       -- Level 70, OoW (up to 68)
+            "Call of the Banshee",        -- Level 64, PoP (up to 57)
+            "Solon's Bewitching Bravura", -- Level 39, Base Game (up to 51)
+            "Solon's Song of the Sirens", -- Level 27, Base Game (up to 37)
         },
         ['ReflexStrike'] = {
             -- Bard ReflexStrike - Restores mana to group
-            "Reflexive Retort",
-            "Reflexive Rejoinder",
-            "Reflexive Rebuttal",
+            "Reflexive Rebuttal",  -- Level 113
+            "Reflexive Rejoinder", -- Level 105
+            "Reflexive Retort",    -- Level 100
         },
         ['ChordsAE'] = {
             -- ChordsAE only work if target is not moving on Live
-            "Selo's Chords of Cessation", -- level 48, Base Game
-            "Chords of Dissonance",       -- level 2, Base Game
+            "Selo's Chords of Cessation", -- Level 48, Base Game
+            "Chords of Dissonance",       -- Level 2, Base Game
         },
         ['AmpSong'] = {
-            "Amplification", -- level 30, SoL
+            "Amplification", -- Level 30, SoL
         },
         ['DispelSong'] = {
             -- Dispel Song - For pulling to avoid Summons
-            "Druzzil's Disillusionment",  -- level 62, PoP (dispel 9)
-            -- "Song of Highsun",                  -- level 56, RoK (dispel 9, also ports NPC to spawn point)
-            "Syvelian's Anti-Magic Aria", -- level 40, Base Game (dispel 4)
+            "Druzzil's Disillusionment",  -- Level 62, PoP (dispel 9)
+            -- "Song of Highsun",         -- Level 56, RoK (dispel 9, also ports NPC to spawn point)
+            "Syvelian's Anti-Magic Aria", -- Level 40, Base Game (dispel 4)
         },
         ['ResistSong'] = {
             -- Resists Song
-            "Psalm of Veeshan VII",    -- level 128, SoR
-            "Psalm of the Nomad",      -- level 123, LS
-            "Psalm of the Pious",      -- level 118, ToL
-            "Psalm of the Restless",   -- level 113, ToV
-            "Second Psalm of Veeshan", -- level 108, RoS
-            "Psalm of the Forsaken",   -- level 98, CoTF
-            "Psalm of Veeshan",        -- level 63, PoP
-            "Psalm of Purity",         -- level 37, Base Game (poison only)
-            "Psalm of Cooling",        -- level 33, Base Game (fire onyl)
-            "Psalm of Vitality",       -- level 29, Base Game (disease only)
-            "Psalm of Warmth",         -- level 25, Base Game (cold only)
+            "Psalm of Veeshan VII",    -- Level 128, SoR
+            "Psalm of the Nomad",      -- Level 123, LS
+            "Psalm of the Pious",      -- Level 118, ToL
+            "Psalm of the Restless",   -- Level 113, ToV
+            "Second Psalm of Veeshan", -- Level 108, RoS
+            "Psalm of the Forsaken",   -- Level 98, CoTF
+            "Psalm of Veeshan",        -- Level 63, PoP
+            "Psalm of Purity",         -- Level 37, Base Game (poison only)
+            "Psalm of Cooling",        -- Level 33, Base Game (fire onyl)
+            "Psalm of Vitality",       -- Level 29, Base Game (disease only)
+            "Psalm of Warmth",         -- Level 25, Base Game (cold only)
         },
         ['MezSong'] = {
             -- Lullaby line has lower max level and has pushback, but you get them earlier.
-            "Slumber of Keftlik	",      -- level 129, SoR (up to 133)
-            -- "Lullaby of the Sundered",            -- level 126, SoR (up to 130)
-            "Slumber of Suja",          -- level 124, LS (up to 128,)
-            -- "Lullaby of the Forgotten",           -- level 121, LS (up to 125)
-            "Slumber of the Diabo",     -- level 119, ToL (up to 123)
-            -- "Lullaby of Nightfall",              -- level 116, ToL (up to 120)
-            "Slumber of Zburator",      -- level 114, ToV (up to 118)
-            -- "Lullaby of Zburator",               -- level 111, ToV (up to 115)
-            "Slumber of Jembel",        -- level 109, RoS (up to 113)
-            -- "Lullaby of Jembel",                 -- level 106, RoS (up to 110)
-            "Slumber of Silisia",       -- level 104, TDS (up to 108)
-            -- "Lullaby of Silisia",                -- level 101, TDS (up to 105)
-            "Slumber of Motlak",        -- level 99, RoF (up to 103)
-            -- "Lullaby of the Forsaken",           -- level 96, RoF (up to 100)
-            "Slumber of Kolain",        -- level 94, VoA (up to 98)
-            -- "Lullaby of the Forlorn",            -- level 91, VoA (up to 95)
-            "Slumber of Sionachie",     -- level 89, HoT (up to 93)
-            -- "Lullaby of the Lost",               -- level 86, HoT (up to 90)
-            "Slumber of the Mindshear", -- level 84, SoD (up to 88)
-            -- "Serenity of Oceangreen",            -- level 81, SoD (up to 85)
-            "Command of Queen Veneneu", -- level 79, SoF (up to 83)
-            -- "Amber's Last Lullaby",              -- level 76, SoF (up to 80)
-            "Queen Eletyl's Screech",   -- level 74, TSS (up to 79)
-            -- "Aelfric's Last Lullaby",            -- level 71, TSS (up to 75)
-            "Vulka's Lullaby",          -- level 70, OoW (up to 73)
-            "Creeping Dreams",          -- level 68, DoD (up to 73)
-            "Luvwen's Lullaby",         -- level 67, OoW (up to 70)
-            "Lullaby of Morell",        -- level 65, PoP (up to 68)
-            "Dreams of Terris",         -- level 64, PoP (up to 65)
-            "Dreams of Thule",          -- level 62, PoP (up to 62)
-            "Dreams of Ayonae",         -- level 58, SoL (up to 57)
-            "Song of Twilight",         -- level 53, RoK (up to 55)
-            "Sionachie's Dreams",       -- level 40, SoL (up to 53)
-            "Crission's Pixie Strike",  -- level 28, Base Game (up to 45)
-            "Kelin's Lucid Lullaby",    -- level 15, Base Game (up to 30)
+            "Slumber of Keftlik",       -- Level 129, SoR (up to 133)
+            -- "Lullaby of the Sundered",  -- Level 126, SoR (up to 130)
+            "Slumber of Suja",          -- Level 124, LS (up to 128,)
+            -- "Lullaby of the Forgotten", -- Level 121, LS (up to 125)
+            "Slumber of the Diabo",     -- Level 119, ToL (up to 123)
+            -- "Lullaby of Nightfall",     -- Level 116, ToL (up to 120)
+            "Slumber of Zburator",      -- Level 114, ToV (up to 118)
+            -- "Lullaby of Zburator",      -- Level 111, ToV (up to 115)
+            "Slumber of Jembel",        -- Level 109, RoS (up to 113)
+            -- "Lullaby of Jembel",        -- Level 106, RoS (up to 110)
+            "Slumber of Silisia",       -- Level 104, TDS (up to 108)
+            -- "Lullaby of Silisia",       -- Level 101, TDS (up to 105)
+            "Slumber of Motlak",        -- Level 99, RoF (up to 103)
+            -- "Lullaby of the Forsaken",  -- Level 96, RoF (up to 100)
+            "Slumber of Kolain",        -- Level 94, VoA (up to 98)
+            -- "Lullaby of the Forlorn",   -- Level 91, VoA (up to 95)
+            "Slumber of Sionachie",     -- Level 89, HoT (up to 93)
+            -- "Lullaby of the Lost",      -- Level 86, HoT (up to 90)
+            "Slumber of the Mindshear", -- Level 84, SoD (up to 88)
+            -- "Serenity of Oceangreen",   -- Level 81, SoD (up to 85)
+            "Command of Queen Veneneu", -- Level 79, SoF (up to 83)
+            -- "Amber's Last Lullaby",     -- Level 76, SoF (up to 80)
+            "Queen Eletyl's Screech",   -- Level 74, TSS (up to 79)
+            -- "Aelfric's Last Lullaby",   -- Level 71, TSS (up to 75)
+            "Vulka's Lullaby",          -- Level 70, OoW (up to 73)
+            "Creeping Dreams",          -- Level 68, DoD (up to 73)
+            "Luvwen's Lullaby",         -- Level 67, OoW (up to 70)
+            "Lullaby of Morell",        -- Level 65, PoP (up to 68)
+            "Dreams of Terris",         -- Level 64, PoP (up to 65)
+            "Dreams of Thule",          -- Level 62, PoP (up to 62)
+            "Dreams of Ayonae",         -- Level 58, SoL (up to 57)
+            "Song of Twilight",         -- Level 53, RoK (up to 55)
+            "Sionachie's Dreams",       -- Level 40, SoL (up to 53)
+            "Crission's Pixie Strike",  -- Level 28, Base Game (up to 45)
+            "Kelin's Lucid Lullaby",    -- Level 15, Base Game (up to 30)
         },
         ['MezAESong'] = {
             -- MezAESong - Level Range 85 - 115 **
-            "Wave of Slumber X",     -- level 130, SoR (up to 133)
-            "Wave of Stupor",        -- level 125, LS (up to 128)
-            "Wave of Nocturn",       -- level 120, ToL (up to 123)
-            "Wave of Sleep",         -- level 115, ToV (up to 118)
-            "Wave of Somnolence",    -- level 110, RoS (up to 113)
-            "Wave of Torpor",        -- level 105, TDS (up to 108)
-            "Wave of Quietude",      -- level 100, RoF (up to 103)
-            "Wave of the Conductor", -- level 95, VoA (up to 98)
-            "Wave of Dreams",        -- level 90, HoT (up to 93)
-            "Wave of Slumber",       -- level 85. UF (up to 88)
+            "Wave of Slumber X",     -- Level 130, SoR (up to 133)
+            "Wave of Stupor",        -- Level 125, LS (up to 128)
+            "Wave of Nocturn",       -- Level 120, ToL (up to 123)
+            "Wave of Sleep",         -- Level 115, ToV (up to 118)
+            "Wave of Somnolence",    -- Level 110, RoS (up to 113)
+            "Wave of Torpor",        -- Level 105, TDS (up to 108)
+            "Wave of Quietude",      -- Level 100, RoF (up to 103)
+            "Wave of the Conductor", -- Level 95, VoA (up to 98)
+            "Wave of Dreams",        -- Level 90, HoT (up to 93)
+            "Wave of Slumber",       -- Level 85, . UF (up to 88)
         },
         ['Jonthan'] = {
-            "Jonthan's Mightful Caretaker", -- level 71,. TBS
-            "Jonthan's Inspiration",        -- level 58, RoK
-            "Jonthan's Provocation",        -- level 45, Base Game
-            "Jonthan's Whistling Warsong",  -- level 7, Base Game
+            "Jonthan's Mightful Caretaker", -- Level 71, . TBS
+            "Jonthan's Inspiration",        -- Level 58, RoK
+            "Jonthan's Provocation",        -- Level 45, Base Game
+            "Jonthan's Whistling Warsong",  -- Level 7, Base Game
         },
         ['CalmSong'] = {
             -- CalmSong - Level Range 8+ --Included for manual use with /rgl usemap
@@ -674,7 +674,7 @@ local _ClassConfig = {
             "Silence of Quietus",        -- Level 116, TOL (up to 120)
             "Silence of Zburator",       -- Level 111, ToV (up to 115)
             "Silence of Jembel",         -- Level 106, RoS (up to 110)
-            "Silence of the Silisia",    -- Level 101, TDS (up to 105)
+            "Silence of Silisia",        -- Level 101, TDS (up to 105)
             "Silence of the Forsaken",   -- Level 96, RoF (up to 100)
             "Silence of the Windsong",   -- Level 91, VoA (up to 95)
             "Silence of the Dreamer",    -- Level 86, HoT (up to 90)
@@ -686,7 +686,7 @@ local _ClassConfig = {
             "Kelin's Lugubrious Lament", -- Level 8, Base Game, (up to 60)
         },
         ['ThousandBlades'] = {
-            "Thousand Blades",
+            "Thousand Blades", -- Level 69
         },
     },
     ['Helpers']       = {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -54,619 +54,617 @@ return {
     ['AbilitySets']       = {       --TODO/Under Consideration: Add AoE Roar line, add rotation entry (tie it to Do AoE setting), swap in instead of lance 2, especially since the last lance2 is level 112
         ['SwarmPet'] = {
             "Bark at the Moon XII", -- Level 130
-            "Bestial Empathy",      -- Level 68
-            "Bark at the Moon",     -- Level 75
-            "Howl at the Moon",     -- Level 80
-            "Yowl at the Moon",     -- Level 85
-            "Shout at the Moon",    -- Level 90
-            "Scream at the Moon",   -- Level 95
-            "Yell at the Moon",     -- Level 100
-            "Cry at the Moon",      -- Level 105
-            "Roar at the Moon",     -- Level 110
-            "Bay at the Moon",      -- Level 115
-            "Bellow at the Moon",   -- Level 120
             "Shriek at the Moon",   -- Level 125
+            "Bellow at the Moon",   -- Level 120
+            "Bay at the Moon",      -- Level 115
+            "Roar at the Moon",     -- Level 110
+            "Cry at the Moon",      -- Level 105
+            "Yell at the Moon",     -- Level 100
+            "Scream at the Moon",   -- Level 95
+            "Shout at the Moon",    -- Level 90
+            "Yowl at the Moon",     -- Level 85
+            "Howl at the Moon",     -- Level 80
+            "Bark at the Moon",     -- Level 75
+            "Bestial Empathy",      -- Level 68
         },
         ['Feralgia'] = {
             -- Swarm Pet and Growl combination
             "Grimclaw's Feralgia",   -- Level 130
-            "Haergen's Feralgia",    -- Level 85
-            "Tuzil's Feralgia",      -- Level 90
-            "Yahnoa's Feralgia",     -- Level 95
-            "Kesar's Feralgia",      -- Level 100
-            "Krenk's Feralgia",      -- Level 105
-            "Akalit's Feralgia",     -- Level 110
-            "Griklor's Feralgia",    -- Level 115
-            "Ander's Feralgia",      -- Level 120
             "SingleMalt's Feralgia", -- Level 125
+            "Ander's Feralgia",      -- Level 120
+            "Griklor's Feralgia",    -- Level 115
+            "Akalit's Feralgia",     -- Level 110
+            "Krenk's Feralgia",      -- Level 105
+            "Kesar's Feralgia",      -- Level 100
+            "Yahnoa's Feralgia",     -- Level 95
+            "Tuzil's Feralgia",      -- Level 90
+            "Haergen's Feralgia",    -- Level 85
         },
         ['FrozenPoi'] = {
             -- Cold/Poison Nuke Fast Cast
             "Frozen Venom X",    -- Level 128
-            "Frozen Venom",      -- Level 84
-            "Frozen Venin",      -- Level 89
-            "Frozen Cyanin",     -- Level 94
-            "Frozen Carbomate",  -- Level 99
-            "Frozen Miasma",     -- Level 103
-            "Frozen Toxin",      -- Level 108
-            "Frozen Malignance", -- Level 113
-            "Frozen Blight",     -- Level 118
             "Frozen Creep",      -- Level 123
+            "Frozen Blight",     -- Level 118
+            "Frozen Malignance", -- Level 113
+            "Frozen Toxin",      -- Level 108
+            "Frozen Miasma",     -- Level 103
+            "Frozen Carbomate",  -- Level 99
+            "Frozen Cyanin",     -- Level 94
+            "Frozen Venin",      -- Level 89
+            "Frozen Venom",      -- Level 84
         },
         ['Maelstrom'] = {
             -- Cold/Poison/Disease Nuke Fast Cast
             "Tallongast's Maelstrom", -- Level 130
-            "Kron's Maelstrom",       -- Level 90
-            "Bale's Maelstrom",       -- Level 95
-            "Nak's Maelstrom",        -- Level 100
-            "Visoracius' Maelstrom",  -- Level 105
-            "Beramos' Maelstrom",     -- Level 110
-            "Vkjen's Maelstrom",      -- Level 115
-            "Va Xakra's Maelstrom",   -- Level 120
             "Rimeclaw's Maelstrom",   -- Level 125
+            "Va Xakra's Maelstrom",   -- Level 120
+            "Vkjen's Maelstrom",      -- Level 115
+            "Beramos' Maelstrom",     -- Level 110
+            "Visoracius' Maelstrom",  -- Level 105
+            "Nak's Maelstrom",        -- Level 100
+            "Bale's Maelstrom",       -- Level 95
+            "Kron's Maelstrom",       -- Level 90
         },
         ['PoiBite'] = {
             -- Poison Nuke Fast Cast
             "Khrosik's Bite",       -- Level 129
-            "Bite of the Empress",  -- Level 73
-            "Bite of the Borrower", -- Level 78
-            "Bite of the Vitrik",   -- Level 83
-            "Sarsez' Bite",         -- Level 88
-            "Rotsil's Bite",        -- Level 93
-            "Poantaar's Bite",      -- Level 98
-            "Kreig's Bite",         -- Level 103
-            "Mawmun's Bite",        -- Level 108
-            "Bloodmaw's Bite",      -- Level 113
-            "Zelniak's Bite",       -- Level 118
             "Mortimus' Bite",       -- Level 123
+            "Zelniak's Bite",       -- Level 118
+            "Bloodmaw's Bite",      -- Level 113
+            "Mawmun's Bite",        -- Level 108
+            "Kreig's Bite",         -- Level 103
+            "Poantaar's Bite",      -- Level 98
+            "Rotsil's Bite",        -- Level 93
+            "Sarsez' Bite",         -- Level 88
+            "Bite of the Vitrik",   -- Level 83
+            "Bite of the Borrower", -- Level 78
+            "Bite of the Empress",  -- Level 73
         },
         ['Icelance1'] = {
             -- Lance 1 Timer 7 Ice Nuke Fast Cast
-            "Frigid Lance XII",      -- Level 128 - Timer 7
-            "Blast of Frost",        -- Level 12 - Timer 7
-            "Frost Shard",           -- Level 47 - Timer 7
-            "Blizzard Blast",        -- Level 59 - Timer ???
-            "Frost Spear",           -- Level 63 - Timer 7
-            "Ancient: Frozen Chaos", -- Level 65 - Timer 7
-            "Ancient: Savage Ice",   -- Level 70 - Timer 7
-            "Jagged Torrent",        -- Level 79 - Timer 7
-            "Glacial Lance",         -- Level 89 - Timer 7
-            "Kromrif Lance",         -- Level 99 - Timer 7
-            "Frostbite Lance",       -- Level 107 - Timer 7
-            "Crystalline Lance",     -- Level 117 - Timer 7
+            "Frigid Lance XII",      -- Level 128, - Timer 7
+            "Crystalline Lance",     -- Level 117, - Timer 7
+            "Frostbite Lance",       -- Level 107, - Timer 7
+            "Kromrif Lance",         -- Level 99, - Timer 7
+            "Glacial Lance",         -- Level 89, - Timer 7
+            "Jagged Torrent",        -- Level 79, - Timer 7
+            "Ancient: Savage Ice",   -- Level 70, - Timer 7
+            "Ancient: Frozen Chaos", -- Level 65, - Timer 7
+            "Frost Spear",           -- Level 63, - Timer 7
+            "Blizzard Blast",        -- Level 59, - Timer ???
+            "Frost Shard",           -- Level 47, - Timer 7
+            "Blast of Frost",        -- Level 12, - Timer 7
         },
         ['Icelance2'] = {
             -- Lance 2 Timer 11 Ice Nuke Fast Cast
-            "Ice Spear",       -- Level 33 - Timer 11
-            "Ice Shard",       -- Level 54 - Timer 11
-            "Trushar's Frost", -- Level 65 - Timer 11
-            "Glacier Spear",   -- Level 69 - Timer 11
-            "Spiked Sleet",    -- Level 74 - Timer 11
-            "Frigid Lance",    -- Level 84 - Timer 11
-            "Frostrift Lance", -- Level 94 - Timer 11
-            "Kromtus Lance",   -- Level 102 - Timer 11
-            "Restless Lance",  -- Level 112 - Timer 11
-            "Ankexfen Lance",  -- Level 122 - Timer 11
+            "Ankexfen Lance",  -- Level 122, - Timer 11
+            "Restless Lance",  -- Level 112, - Timer 11
+            "Kromtus Lance",   -- Level 102, - Timer 11
+            "Frostrift Lance", -- Level 94, - Timer 11
+            "Frigid Lance",    -- Level 84, - Timer 11
+            "Spiked Sleet",    -- Level 74, - Timer 11
+            "Glacier Spear",   -- Level 69, - Timer 11
+            "Trushar's Frost", -- Level 65, - Timer 11
+            "Ice Shard",       -- Level 54, - Timer 11
+            "Ice Spear",       -- Level 33, - Timer 11
         },
         ['AERoar'] = {
             -- PBAE Roar Timer 11 Ice Nuke Fast Cast
             "Glacial Roar IX", -- Level 129
-            "Glacial Roar",    -- Level 89 - Timer 11
-            "Frostrift Roar",  -- Level 94 - Timer 11
-            "Kromrif Roar",    -- Level 99 - Timer 11
-            "Kromtus Roar",    -- Level 104 - Timer 11
-            "Frostbite Roar",  -- Level 109 - Timer 11
-            "Restless Roar",   -- Level 114 - Timer 11
-            "Polar Roar",      -- Level 119 - Timer 11
-            "Hoarfrost Roar",  -- Level 124 - Timer 11
+            "Hoarfrost Roar",  -- Level 124, - Timer 11
+            "Polar Roar",      -- Level 119, - Timer 11
+            "Restless Roar",   -- Level 114, - Timer 11
+            "Frostbite Roar",  -- Level 109, - Timer 11
+            "Kromtus Roar",    -- Level 104, - Timer 11
+            "Kromrif Roar",    -- Level 99, - Timer 11
+            "Frostrift Roar",  -- Level 94, - Timer 11
+            "Glacial Roar",    -- Level 89, - Timer 11
         },
         ['EndemicDot'] = {
             "Tsetsian Endemic XII",  -- Level 127
-            "Sicken",                -- Level 14
-            "Malaria",               -- Level 40
-            "Plague",                -- Level 65
-            "Festering Malady",      -- Level 70
-            "Fever Spike",           -- Level 72
-            "Fever Surge",           -- Level 77
-            "Tsetsian Endemic",      -- Level 82
-            "Shiverback Endemic",    -- Level 87
-            "Silbar's Endemic",      -- Level 92
-            "Natigo's Endemic",      -- Level 97
-            "Hemocoraxius' Endemic", -- Level 102
-            "Elkikatar's Endemic",   -- Level 107
-            "Neemzaq's Endemic",     -- Level 112
-            "Vampyric Endemic",      -- Level 117
             "Fevered Endemic",       -- Level 122
+            "Vampyric Endemic",      -- Level 117
+            "Neemzaq's Endemic",     -- Level 112
+            "Elkikatar's Endemic",   -- Level 107
+            "Hemocoraxius' Endemic", -- Level 102
+            "Natigo's Endemic",      -- Level 97
+            "Silbar's Endemic",      -- Level 92
+            "Shiverback Endemic",    -- Level 87
+            "Tsetsian Endemic",      -- Level 82
+            "Fever Surge",           -- Level 77
+            "Fever Spike",           -- Level 72
+            "Festering Malady",      -- Level 70
+            "Plague",                -- Level 65
+            "Malaria",               -- Level 40
+            "Sicken",                -- Level 14
         },
         ['BloodDot'] = {
             "Spiter Blood",        -- Level 127
-            "Tainted Breath",      -- Level 19
-            "Envenomed Breath",    -- Level 35
-            "Venom of the Snake",  -- Level 52
-            "Scorpion Venom",      -- Level 61
-            "Turepta Blood",       -- Level 65
-            "Chimera Blood",       -- Level 66
-            "Diregriffon's Bite",  -- Level 71
-            "Falrazim's Gnashing", -- Level 76
-            "Ikaav Blood",         -- Level 81
-            "Spinechiller Blood",  -- Level 90
-            "Binaesa Blood",       -- Level 91
-            "Asp Blood",           -- Level 96
-            "Glistenwing Blood",   -- Level 101
-            "Polybiad Blood",      -- Level 106
-            "Ikatiar's Blood",     -- Level 111
-            "Akhevan Blood",       -- Level 116
             "Forgebound Blood",    -- Level 121
+            "Akhevan Blood",       -- Level 116
+            "Ikatiar's Blood",     -- Level 111
+            "Polybiad Blood",      -- Level 106
+            "Glistenwing Blood",   -- Level 101
+            "Asp Blood",           -- Level 96
+            "Binaesa Blood",       -- Level 91
+            "Spinechiller Blood",  -- Level 86
+            "Ikaav Blood",         -- Level 81
+            "Falrazim's Gnashing", -- Level 76
+            "Diregriffon's Bite",  -- Level 71
+            "Chimera Blood",       -- Level 66
+            "Turepta Blood",       -- Level 65
+            "Scorpion Venom",      -- Level 61
+            "Venom of the Snake",  -- Level 52
+            "Envenomed Breath",    -- Level 35
+            "Tainted Breath",      -- Level 19
         },
         ['ColdDot'] = {
             "Shar`Drahn's Chill", -- Level 130
-            "Edoth's Chill",      -- Level 99
-            "Kirchen's Chill",    -- Level 104
-            "Ekron's Chill",      -- Level 109
-            "Endaroky's Chill",   -- Level 114
-            "Sylra Fris' Chill",  -- Level 119
             "Lazam's Chill",      -- Level 124
-
+            "Sylra Fris' Chill",  -- Level 119
+            "Endaroky's Chill",   -- Level 114
+            "Ekron's Chill",      -- Level 109
+            "Kirchen's Chill",    -- Level 104
+            "Edoth's Chill",      -- Level 99
         },
         ['SlowSpell'] = {
             -- Slow Spell
-            "Drowsy",          -- Level 20
-            "Sha's Lethargy",  -- Level 50
-            "Sha's Advantage", -- Level 60
-            "Sha's Revenge",   -- Level 65
-            "Sha's Legacy",    -- Level 70
             "Sha's Reprisal",  -- Level 87
+            "Sha's Legacy",    -- Level 70
+            "Sha's Revenge",   -- Level 65
+            "Sha's Advantage", -- Level 60
+            "Sha's Lethargy",  -- Level 50
+            "Drowsy",          -- Level 20
         },
         ['DichoSpell'] = {
             -- Dicho Spell
-            "Dichotomic Fury", -- Level 101
-            "Dissident Fury",  -- Level 106
-            "Composite Fury",  -- Level 111
-            "Ecliptic Fury",   -- Level 116
             "Reciprocal Fury", -- Level 121
+            "Ecliptic Fury",   -- Level 116
+            "Composite Fury",  -- Level 111
+            "Dissident Fury",  -- Level 106
+            "Dichotomic Fury", -- Level 101
         },
         ['HealSpell'] = {
             "Lydora's Mending",    -- Level 127
-            "Salve",               -- Level 1
-            "Minor Healing",       -- Level 6
-            "Light Healing",       -- Level 18
-            "Healing",             -- Level 28
-            "Greater Healing",     -- Level 38
-            "Spirit Salve",        -- Level 48
-            "Chloroblast",         -- Level 59
-            "Trushar's Mending",   -- Level 65
-            "Muada's Mending",     -- Level 67
-            "Minohten Mending",    -- Level 72
-            "Daria's Mending",     -- Level 77
-            "Cadmael's Mending",   -- Level 82
-            "Jorra's Mending",     -- Level 87
-            "Mending of the Izon", -- Level 92
-            "Jaerol's Mending",    -- Level 97
-            "Sabhattin's Mending", -- Level 102
-            "Deltro's Mending",    -- Level 107
-            "Bethun's Mending",    -- Level 112
-            "Korah's Mending",     -- Level 117
             "Thornhost's Mending", -- Level 122
+            "Korah's Mending",     -- Level 117
+            "Bethun's Mending",    -- Level 112
+            "Deltro's Mending",    -- Level 107
+            "Sabhattin's Mending", -- Level 102
+            "Jaerol's Mending",    -- Level 97
+            "Mending of the Izon", -- Level 92
+            "Jorra's Mending",     -- Level 87
+            "Cadmael's Mending",   -- Level 82
+            "Daria's Mending",     -- Level 77
+            "Minohten Mending",    -- Level 72
+            "Muada's Mending",     -- Level 67
+            "Trushar's Mending",   -- Level 65
+            "Chloroblast",         -- Level 59
+            "Spirit Salve",        -- Level 48
+            "Greater Healing",     -- Level 38
+            "Healing",             -- Level 28
+            "Light Healing",       -- Level 18
+            "Minor Healing",       -- Level 6
+            "Salve",               -- Level 1
         },
         ['PetHealSpell'] = {
             "Salve of Lydora",         -- Level 126
-            "Sharik's Replenishing",   -- Level 9
-            "Keshuval's Rejuvenation", -- Level 15
-            "Herikol's Soothing",      -- Level 27
-            "Yekan's Recovery",        -- Level 36
-            "Vigor of Zehkes",         -- Level 49
-            "Aid of Khurenz",          -- Level 52
-            "Sha's Restoration",       -- Level 55
-            "Healing of Sorsha",       -- Level 61
-            "Healing of Mikkily",      -- Level 66
-            "Healing of Uluanes",      -- Level 71
-            "Salve of Feldan",         -- Level 76
-            "Salve of Reshan",         -- Level 81
-            "Salve of Sevna",          -- Level 86
-            "Salve of Yubai",          -- Level 91
-            "Salve of Blezon",         -- Level 96
-            "Salve of Clorith",        -- Level 101
-            "Salve of Artikla",        -- Level 106
-            "Salve of Tobart",         -- Level 111
-            "Salve of Jaegir",         -- Level 116
             "Salve of Homer",          -- Level 121
+            "Salve of Jaegir",         -- Level 116
+            "Salve of Tobart",         -- Level 111
+            "Salve of Artikla",        -- Level 106
+            "Salve of Clorith",        -- Level 101
+            "Salve of Blezon",         -- Level 96
+            "Salve of Yubai",          -- Level 91
+            "Salve of Sevna",          -- Level 86
+            "Salve of Reshan",         -- Level 81
+            "Salve of Feldan",         -- Level 76
+            "Healing of Uluanes",      -- Level 71
+            "Healing of Mikkily",      -- Level 66
+            "Healing of Sorsha",       -- Level 61
+            "Sha's Restoration",       -- Level 55
+            "Aid of Khurenz",          -- Level 52
+            "Vigor of Zehkes",         -- Level 49
+            "Yekan's Recovery",        -- Level 36
+            "Herikol's Soothing",      -- Level 27
+            "Keshuval's Rejuvenation", -- Level 15
+            "Sharik's Replenishing",   -- Level 9
         },
         ['PetSpell'] = {
             "Spirit of Orvain",     -- Level 128
-            "Spirit of Sharik",     -- Level 8
-            "Spirit of Khaliz",     -- Level 15
-            "Spirit of Keshuval",   -- Level 21
-            "Spirit of Herikol",    -- Level 30
-            "Spirit of Yekan",      -- Level 39
-            "Spirit of Kashek",     -- Level 46
-            "Spirit of Omakin",     -- Level 54
-            "Spirit of Zehkes",     -- Level 56
-            "Spirit of Khurenz",    -- Level 58
-            "Spirit of Khati Sha",  -- Level 60
-            "Spirit of Arag",       -- Level 62
-            "Spirit of Sorsha",     -- Level 64
-            "Spirit of Alladnu",    -- Level 68
-            "Spirit of Rashara",    -- Level 70
-            "Spirit of Uluanes",    -- Level 73
-            "Spirit of Silverwing", -- Level 78
-            "Spirit of Hoshkar",    -- Level 83
-            "Spirit of Averc",      -- Level 88
-            "Spirit of Kolos",      -- Level 93
-            "Spirit of Lachemit",   -- Level 98
-            "Spirit of Avalit",     -- Level 103
-            "Spirit of Akalit",     -- Level 108
-            "Spirit of Blizzent",   -- Level 113
-            "Spirit of Panthea",    -- Level 118
             "Spirit of Shae",       -- Level 123
+            "Spirit of Panthea",    -- Level 118
+            "Spirit of Blizzent",   -- Level 113
+            "Spirit of Akalit",     -- Level 108
+            "Spirit of Avalit",     -- Level 103
+            "Spirit of Lachemit",   -- Level 98
+            "Spirit of Kolos",      -- Level 93
+            "Spirit of Averc",      -- Level 88
+            "Spirit of Hoshkar",    -- Level 83
+            "Spirit of Silverwing", -- Level 78
+            "Spirit of Uluanes",    -- Level 73
+            "Spirit of Rashara",    -- Level 70
+            "Spirit of Alladnu",    -- Level 68
+            "Spirit of Sorsha",     -- Level 64
+            "Spirit of Arag",       -- Level 62
+            "Spirit of Khati Sha",  -- Level 60
+            "Spirit of Khurenz",    -- Level 58
+            "Spirit of Zehkes",     -- Level 56
+            "Spirit of Omakin",     -- Level 54
+            "Spirit of Kashek",     -- Level 46
+            "Spirit of Yekan",      -- Level 39
+            "Spirit of Herikol",    -- Level 30
+            "Spirit of Keshuval",   -- Level 21
+            "Spirit of Khaliz",     -- Level 15
+            "Spirit of Sharik",     -- Level 8
         },
         ['PetGroupEndRegenProc'] = {
             --Pet Group End Regen Proc*
             "Fatiguing Bite VI", -- Level 128
-            "Fatiguing Bite",
-            "Exhausting Bite",
-            "Depleting Bite",
-            "Wearying Bite",
-            "Sapping Bite",
+            "Sapping Bite",      -- Level 123
+            "Wearying Bite",     -- Level 117
+            "Depleting Bite",    -- Level 112
+            "Exhausting Bite",   -- Level 107
+            "Fatiguing Bite",    -- Level 97
         },
         ['PetSpellGuard'] = {
             "Spellbreaker's Guard XI", -- Level 130
-            "Spellbreaker's Guard",
-            "Spellbreaker's Bulwark",
-            "Spellbreaker's Aegis",
-            "Spellbreaker's Rampart",
-            "Spellbreaker's Armor",
-            "Spellbreaker's Ward",
-            "Spellbreaker's Palisade",
-            "Spellbreaker's Keep",
-            "Spellbreaker's Citadel",
-            "Spellbreaker's Fortress",
-            "Spellbreaker's Synergy",
+            "Spellbreaker's Synergy",  -- Level 125
+            "Spellbreaker's Fortress", -- Level 120
+            "Spellbreaker's Citadel",  -- Level 115
+            "Spellbreaker's Keep",     -- Level 110
+            "Spellbreaker's Palisade", -- Level 105
+            "Spellbreaker's Ward",     -- Level 100
+            "Spellbreaker's Armor",    -- Level 95
+            "Spellbreaker's Rampart",  -- Level 90
+            "Spellbreaker's Aegis",    -- Level 85
+            "Spellbreaker's Bulwark",  -- Level 80
+            "Spellbreaker's Guard",    -- Level 75
         },
         ['PetSlowProc'] = {
             --Pet Slow Proc*
-            "Steeltrap Jaws",
-            "Lockfang Jaws",
-            "Fellgrip Jaws",
-            "Deadlock Jaws",
+            "Deadlock Jaws",  -- Level 90
+            "Fellgrip Jaws",  -- Level 85
+            "Lockfang Jaws",  -- Level 80
+            "Steeltrap Jaws", -- Level 75
         },
         ['PetOffenseBuff'] = {
             "Pack Leader's Aggression", -- Level 126
-            "Neivr's Aggression",
-            "Mea's Aggression",
-            "Plakt's Aggression",
-            "Sekmoset's Aggression",
-            "Virzak's Aggression",
-            "Horasug's Aggression",
-            "Panthea's Aggression",
-            "Magna's Aggression",
+            "Magna's Aggression",       -- Level 121
+            "Panthea's Aggression",     -- Level 116
+            "Horasug's Aggression",     -- Level 111
+            "Virzak's Aggression",      -- Level 106
+            "Sekmoset's Aggression",    -- Level 101
+            "Plakt's Aggression",       -- Level 96
+            "Mea's Aggression",         -- Level 91
+            "Neivr's Aggression",       -- Level 86
         },
         ['PetDefenseBuff'] = {
             "Pack Leader's Protection", -- Level 126
-            "Neivr's Protection",
-            "Mea's Protection",
-            "Plakt's Protection",
-            "Sekmoset's Protection",
-            "Virzak's Protection",
-            "Horasug's Protection",
-            "Panthea's Protection",
-            "Magna's Protection",
+            "Magna's Protection",       -- Level 121
+            "Panthea's Protection",     -- Level 116
+            "Horasug's Protection",     -- Level 111
+            "Virzak's Protection",      -- Level 106
+            "Sekmoset's Protection",    -- Level 101
+            "Plakt's Protection",       -- Level 96
+            "Mea's Protection",         -- Level 91
+            "Neivr's Protection",       -- Level 86
         },
         ['PetHaste'] = {
             --Pet Haste*
-            "Warder's Unity VI", -- Level 129, combines haste and damage proc
-            "Yekan's Quickening",
-            "Bond of The Wild",
-            "Omakin's Alacrity",
-            "Sha's Ferocity",
-            "Arag's Celerity",
-            "Growl of the Beast",
-            "Unparalleled Voracity",
-            "Peerless Penchant",
-            "Unrivaled Rapidity",
-            "Incomparable Velocity",
-            "Exceptional Velocity",
-            "Extraordinary Velocity",
-            "Tremendous Velocity",
-            "Astounding Velocity",
-            "Unsurpassed Velocity",
-            "Insatiable Voracity",
+            "Warder's Unity VI",      -- Level 129, combines haste and damage proc
+            "Insatiable Voracity",    -- Level 123
+            "Unsurpassed Velocity",   -- Level 118
+            "Astounding Velocity",    -- Level 113
+            "Tremendous Velocity",    -- Level 108
+            "Extraordinary Velocity", -- Level 98
+            "Exceptional Velocity",   -- Level 93
+            "Incomparable Velocity",  -- Level 88
+            "Unrivaled Rapidity",     -- Level 83
+            "Peerless Penchant",      -- Level 78
+            "Unparalleled Voracity",  -- Level 73
+            "Growl of the Beast",     -- Level 68
+            "Arag's Celerity",        -- Level 63
+            "Sha's Ferocity",         -- Level 59
+            "Omakin's Alacrity",      -- Level 55
+            "Bond of The Wild",       -- Level 52
+            "Yekan's Quickening",     -- Level 37
         },
         ['PetGrowl'] = {
-            "Growl of the Panther XIV", -- Level 129
-            "Growl of the Panther",
-            "Growl of the Puma",
-            "Growl of the Jaguar",
-            "Growl of the Tiger",
-            "Growl of the Lion",
-            "Growl of the Snow Leopard",
-            "Growl of the Leopard",
-            "Growl of the Sabretooth",
-            "Growl of the Lioness",
-            "Growl of the Clouded Leopard",
+            "Growl of the Panther XIV",     -- Level 129
+            "Growl of the Clouded Leopard", -- Level 119
+            "Growl of the Lioness",         -- Level 114
+            "Growl of the Sabretooth",      -- Level 109
+            "Growl of the Snow Leopard",    -- Level 99
+            "Growl of the Lion",            -- Level 94
+            "Growl of the Tiger",           -- Level 89
+            "Growl of the Jaguar",          -- Level 84
+            "Growl of the Puma",            -- Level 79
+            "Growl of the Panther",         -- Level 69
+            "Growl of the Leopard",         -- Level 61
         },
         ['PetHealProc'] = {
             --Pet Heal proc buff*
-            "Protective Warder",
-            "Sympathetic Warder",
-            "Convivial Warder",
-            "Mending Warder",
-            "Invigorating Warder",
-            "Empowering Warder",
-            "Bolstering Warder",
-            "Friendly Pet",
+            "Protective Warder",   -- Level 118
+            "Sympathetic Warder",  -- Level 113
+            "Convivial Warder",    -- Level 108
+            "Mending Warder",      -- Level 103
+            "Invigorating Warder", -- Level 98
+            "Empowering Warder",   -- Level 93
+            "Bolstering Warder",   -- Level 88
+            "Friendly Pet",        -- Level 83
         },
         ['PetDamageProc'] = {
-            "Spirit of Irdrath", -- Level 129
-            "Spirit of Shoru",
-            "Spirit of Lightning",
-            "Spirit of the Blizzard",
-            "Spirit of Inferno",
-            "Spirit of the Scorpion",
-            "Spirit of Vermin",
-            "Spirit of Wind",
-            "Spirit of the Storm",
-            "Spirit of Snow",
-            "Spirit of Flame",
-            "Spirit of Rellic",
-            "Spirit of Irionu",
-            "Spirit of Oroshar",
-            "Spirit of Lairn",
-            "Spirit of Jeswin",
-            "Spirit of Vaxztn",
-            "Spirit of Kron",
-            "Spirit of Bale",
-            "Spirit of Nak",
-            "Spirit of Visoracius",
-            "Spirit of Beramos",
-            "Spirit of Mandrikai",
-            "Spirit of Siver",
-            "Ally's Unity",
-            "Comrade's Unity",
+            "Spirit of Irdrath",      -- Level 129
+            "Spirit of Shoru",        -- Level 124
+            "Spirit of Siver",        -- Level 119
+            "Comrade's Unity",        -- Level 119
+            "Spirit of Mandrikai",    -- Level 114
+            "Ally's Unity",           -- Level 114
+            "Spirit of Beramos",      -- Level 109
+            "Spirit of Visoracius",   -- Level 104
+            "Spirit of Nak",          -- Level 99
+            "Spirit of Bale",         -- Level 94
+            "Spirit of Kron",         -- Level 89
+            "Spirit of Vaxztn",       -- Level 84
+            "Spirit of Jeswin",       -- Level 79
+            "Spirit of Lairn",        -- Level 74
+            "Spirit of Oroshar",      -- Level 70
+            "Spirit of Irionu",       -- Level 68
+            "Spirit of Rellic",       -- Level 63
+            "Spirit of Flame",        -- Level 56
+            "Spirit of Snow",         -- Level 54
+            "Spirit of the Storm",    -- Level 53
+            "Spirit of Wind",         -- Level 51
+            "Spirit of Vermin",       -- Level 46
+            "Spirit of the Scorpion", -- Level 38
+            "Spirit of Inferno",      -- Level 28
+            "Spirit of the Blizzard", -- Level 18
+            "Spirit of Lightning",    -- Level 13
         },
         ['UnityBuff'] = {
             -- --Combined ManaRegenBuff and AtkHPBuff
             "Feralist's Unity VII", -- Level 130
-            "Spiritual Unity",
-            "Stormblood's Unity",
-            "Feralist's Unity",
-            "Reclaimer's Unity",
-            "Chieftain's Unity",
-            "Wildfang's Unity",
+            "Wildfang's Unity",     -- Level 125
+            "Chieftain's Unity",    -- Level 120
+            "Reclaimer's Unity",    -- Level 115
+            "Feralist's Unity",     -- Level 110
+            "Stormblood's Unity",   -- Level 105
+            "Spiritual Unity",      -- Level 100
         },
         ['KillShotBuff'] = {
             --Pet Dmg Absorb + HoT buff*
-            "Natural Collaboration",
-            "Natural Cooperation",
-            "Natural Affiliation",
-            "Natural Cooperation",
-            "Natural Alliance",
-            "Symbiotic Alliance",
-            "Warder's Alliance",
+            "Warder's Alliance",     -- Level 121
+            "Symbiotic Alliance",    -- Level 116
+            "Natural Alliance",      -- Level 111
+            "Natural Affiliation",   -- Level 101
+            "Natural Cooperation",   -- Level 96
+            "Natural Cooperation",   -- Level 96
+            "Natural Collaboration", -- Level 91
         },
         ['RunSpeedBuff'] = {
-            "Spirit of wolf",
+            "Spirit of Tala'Tak", -- Level 79
+            -- "Pack Shrew",          -- Level 44, ].
             -- Spirit of the Shrew Is Only 30% Speed Flat So Removed it from the List as its too slow
-            --   [] = "Spirit of the Shrew"],
-            --   [] = "Pack Shrew"].
-            "Spirit of Tala'Tak",
+            -- "Spirit of the Shrew", -- Level 39, ],
+            "Spirit of wolf", -- Level 24
         },
         ['ManaRegenBuff'] = {
             "Spiritual Enlightenment XVII", -- Level 128
-            "Spiritual Light",
-            "Spiritual Radiance",
-            "Spiritual Purity",
-            "Spiritual Dominion",
-            "Spiritual Ascendance",
-            "Spiritual Enlightenment",
-            "Spiritual Epiphany",
-            "Spiritual Edification",
-            "Spiritual Enhancement",
-            "Spiritual Enrichment",
-            "Spiritual Evolution",
-            "Spiritual Elaboration",
-            "Spiritual Empowerment",
-            "Spiritual Enhancement",
-            "Spiritual Insight",
-            "Spiritual Erudition",
-            "Spiritual Enduement",
+            "Spiritual Enduement",          -- Level 123
+            "Spiritual Erudition",          -- Level 118
+            "Spiritual Insight",            -- Level 113
+            "Spiritual Empowerment",        -- Level 108
+            "Spiritual Elaboration",        -- Level 103
+            "Spiritual Evolution",          -- Level 99
+            "Spiritual Enrichment",         -- Level 94
+            "Spiritual Enhancement",        -- Level 89
+            "Spiritual Enhancement",        -- Level 89
+            "Spiritual Edification",        -- Level 84
+            "Spiritual Epiphany",           -- Level 79
+            "Spiritual Enlightenment",      -- Level 74
+            "Spiritual Ascendance",         -- Level 69
+            "Spiritual Dominion",           -- Level 64
+            "Spiritual Purity",             -- Level 59
+            "Spiritual Radiance",           -- Level 52
+            "Spiritual Light",              -- Level 41
         },
         ['AllianceDot'] = {
             -- Alliance Spell for Beastlords 100+
-            "Venomous Alliance",    -- Level 101
-            "Venomous Covenant",    -- Level 108
-            "Venomous Coalition",   -- Level 113
-            "Venomous Conjunction", -- Level 118
             "Venomous Covariance",  -- Level 123
+            "Venomous Conjunction", -- Level 118
+            "Venomous Coalition",   -- Level 113
+            "Venomous Covenant",    -- Level 108
+            "Venomous Alliance",    -- Level 101
         },
         ['PetBlockSpell'] = {
-            "Ward of Calliav",       -- Level 49
-            "Guard of Calliav",      -- Level 58
-            "Protection of Calliav", -- Level 64
-            "Feral Guard",           -- Level 69
-            "Mammoth-Hide Guard",    -- Level 71
-            "Dragonscale Guard",     -- Level 76
-            "Bulwark of Tri'Qaras",  -- Level 77
-            "Spectral Rampart",      -- Level 88
-            "Beastwood Rampart",     -- Level 93
-            "Aegis of Nefori",       -- Level 99
-            "Aegis of Japac",        -- Level 104
-            "Aegis of Zeklor",       -- Level 109
-            "Aegis of Orfur",        -- Level 114
-            "Aegis of Rumblecrush",  -- Level 119
             "Aegis of Valorforged",  -- Level 124
+            "Aegis of Rumblecrush",  -- Level 119
+            "Aegis of Orfur",        -- Level 114
+            "Aegis of Zeklor",       -- Level 109
+            "Aegis of Japac",        -- Level 104
+            "Aegis of Nefori",       -- Level 99
+            "Beastwood Rampart",     -- Level 93
+            "Spectral Rampart",      -- Level 88
+            "Bulwark of Tri'Qaras",  -- Level 77
+            "Dragonscale Guard",     -- Level 76
+            "Mammoth-Hide Guard",    -- Level 71
+            "Feral Guard",           -- Level 69
+            "Protection of Calliav", -- Level 64
+            "Guard of Calliav",      -- Level 58
+            "Ward of Calliav",       -- Level 49
         },
         ['PetBlockAuspice'] = {
-
             -- Pet Block Auspice - Timer 16
-            "Auspice of Shadows",    -- Level 96
-            "Auspice of Eternity",   -- Level 102
-            "Auspice of Esianti",    -- Level 107
-            "Auspice of Kildrukaun", -- Level 112
-            "Auspice of Valia",      -- Level 117
             "Auspice of Usira",      -- Level 122
+            "Auspice of Valia",      -- Level 117
+            "Auspice of Kildrukaun", -- Level 112
+            "Auspice of Esianti",    -- Level 107
+            "Auspice of Eternity",   -- Level 102
+            "Auspice of Shadows",    -- Level 96
         },
         ['PetHotSpell'] = {
             "Lydora's Melioration",  -- Level 127
-            "Minax's Mending",       -- Level 82
-            "Wilap's Mending",       -- Level 87
-            "Yurv's Mending",        -- Level 92
-            "Huaene's Melioration",  -- Level 97
-            "Tirik's Melioration",   -- Level 102
-            "Virzak's Melioration",  -- Level 107
-            "Kallis' Melioration",   -- Level 112
             "Cissela's Melioration", -- Level 117
+            "Kallis' Melioration",   -- Level 112
+            "Virzak's Melioration",  -- Level 107
+            "Tirik's Melioration",   -- Level 102
+            "Huaene's Melioration",  -- Level 97
+            "Yurv's Mending",        -- Level 92
+            "Wilap's Mending",       -- Level 87
+            "Minax's Mending",       -- Level 82
         },
         ['PetPromisedSpell'] = {
             "Promised Mending XII",    -- Level 128
-            "Promised Mending",        -- Level 73
-            "Promised Recovery",       -- Level 78
-            "Promised Rejuvenation",   -- Level 83
-            "Promised Wardmending",    -- Level 88
-            "Promised Amendment",      -- Level 93
-            "Promised Amelioration",   -- Level 98
-            "Promised Invigoration",   -- Level 103
-            "Promised Alleviation",    -- Level 108
-            "Promised Healing",        -- Level 113
-            "Promised Relief",         -- Level 118
             "Promised Reconstitution", -- Level 123
+            "Promised Relief",         -- Level 118
+            "Promised Healing",        -- Level 113
+            "Promised Alleviation",    -- Level 108
+            "Promised Invigoration",   -- Level 103
+            "Promised Amelioration",   -- Level 98
+            "Promised Amendment",      -- Level 93
+            "Promised Wardmending",    -- Level 88
+            "Promised Rejuvenation",   -- Level 83
+            "Promised Recovery",       -- Level 78
+            "Promised Mending",        -- Level 73
         },
         ['AvatarSpell'] = {
             -- Str Stam Dex Buff
             "Infusion of Spirit", -- Level 61
         },
         ['PetCrippleBite'] = {
-            "Dire Bite",
+            "Dire Bite", -- Level 117
         },
         ['FocusSpell'] = {
-            "Focus of Aramna", -- Level 126
-            "Inner Fire",
-            "Talisman of Tnarg",
-            "Talisman of Altuna",
-            "Talisman of Kragg",
-            "Focus of Alladnu",
+            "Focus of Aramna",        -- Level 126
+            "Focus of Skull Crusher", -- Level 121
+            "Focus of Jaegir",        -- Level 116
+            "Focus of Tobart",        -- Level 111
+            "Focus of Artikla",       -- Level 106
+            "Focus of Okasi",         -- Level 101
+            "Focus of Sanera",        -- Level 96
+            "Focus of Klar",          -- Level 91
+            "Focus of Emiq",          -- Level 86
+            "Focus of Yemall",        -- Level 81
+            "Focus of Zott",          -- Level 76
             -- Group Focus Spells
-            "Focus of Amilan",
-            "Focus of Zott",
-            "Focus of Yemall",
-            "Focus of Emiq",
-            "Focus of Klar",
-            "Focus of Sanera",
-            "Focus of Okasi",
-            "Focus of Artikla",
-            "Focus of Tobart",
-            "Focus of Jaegir",
-            "Focus of Skull Crusher",
+            "Focus of Amilan",        -- Level 71
+            "Focus of Alladnu",       -- Level 67
+            "Talisman of Kragg",      -- Level 62
+            "Talisman of Altuna",     -- Level 58
+            "Talisman of Tnarg",      -- Level 53
+            "Inner Fire",             -- Level 7
         },
         ['AtkHPBuff'] = {
-            "Spiritual Vigor XV", -- Level 127
-            "Spiritual Vigor",
-            "Spiritual Vitality",
-            "Spiritual Vim",
-            "Spiritual Vivacity",
-            "Spiritual Verve",
-            "Spiritual Valor",
-            "Spiritual Valiance",
-            "Spiritual Vindication",
-            "Spiritual Vivification",
-            "Spiritual Vibrancy",
-            "Spiritual Vehemence",
-            "Spiritual Vigor",
-            "Spiritual Valiancy",
+            "Spiritual Vigor XV",     -- Level 127
+            "Spiritual Valiancy",     -- Level 122
+            "Spiritual Vehemence",    -- Level 112
+            "Spiritual Vibrancy",     -- Level 107
+            "Spiritual Vivification", -- Level 102
+            "Spiritual Vindication",  -- Level 97
+            "Spiritual Valiance",     -- Level 92
+            "Spiritual Valor",        -- Level 87
+            "Spiritual Verve",        -- Level 82
+            "Spiritual Vivacity",     -- Level 77
+            "Spiritual Vim",          -- Level 72
+            "Spiritual Vitality",     -- Level 67
+            "Spiritual Vigor",        -- Level 62
+            "Spiritual Vigor",        -- Level 62
+            "Spiritual Strength",     -- Level 60
             --Single Target Atk+HP Buff* - Does Not Stack with Pally brells or Ranger Buff - is Middle ground Buff has HP & Atk
-            "Spiritual Brawn",
-            "Spiritual Strength",
+            "Spiritual Brawn",        -- Level 42
         },
         ['AtkBuff'] = {
             -- - Single Ferocity
-            "Savagery",                  -- Level 60
-            "Ferocity",                  -- Level 65
-            "Ferocity of Irionu",        -- Level 70
-            "Ruthless Ferocity",         -- Level 75
-            "Vicious Ferocity",          -- Level 80
-            "Savage Ferocity",           -- Level 85
-            "Callous Ferocity",          -- Level 90
-            "Brutal Ferocity",           -- Level 92
+            "Shared Merciless Ferocity", -- Level 100
             -- Group Ferocity
             "Shared Brutal Ferocity",    -- Level 95
-            "Shared Merciless Ferocity", -- Level 100
+            "Brutal Ferocity",           -- Level 92
+            "Callous Ferocity",          -- Level 90
+            "Savage Ferocity",           -- Level 85
+            "Vicious Ferocity",          -- Level 80
+            "Ruthless Ferocity",         -- Level 75
+            "Ferocity of Irionu",        -- Level 70
+            "Ferocity",                  -- Level 65
+            "Savagery",                  -- Level 60
         },
         ['EndRegenDisc'] = {
-            "Hiatus V", -- Level 126
-            "Respite",
-            "Reprieve",
-            "Rest",
-            "Breather",
-            "Hiatus",
-            "Relax",
-            "Night's Calming",
-            "Convalesce",
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Relax",           -- Level 111
+            "Hiatus",          -- Level 106
+            "Breather",        -- Level 101
+            "Rest",            -- Level 96
+            "Reprieve",        -- Level 91
+            "Respite",         -- Level 86
         },
         ['Maul'] = {
             -- Maul Disc - This is Used with Beastlord Synergy Buffs
             "Harrow XII", -- Level 129
-            "Rake",
-            "Harrow",
-            "Foray",
-            "Rush",
-            "Barrage",
-            "Pummel",
-            "Maul",
-            "Mangle",
-            "Batter",
-            "Clobber",
-            "Wallop",
+            "Wallop",     -- Level 124
+            "Clobber",    -- Level 119
+            "Batter",     -- Level 114
+            "Mangle",     -- Level 109
+            "Maul",       -- Level 104
+            "Pummel",     -- Level 100
+            "Barrage",    -- Level 95
+            "Rush",       -- Level 90
+            "Foray",      -- Level 85
+            "Harrow",     -- Level 80
+            "Rake",       -- Level 70
         },
         ['SingleClaws'] = {
             --Single target claws*
-            "Focused Clamor of Claws",
+            "Focused Clamor of Claws", -- Level 98
         },
         ['BestialBuffDisc'] = {
             "Bestial Vivisection VI", -- Level 126
-            "Bestial Vivisection",
-            "Bestial Rending",
-            "Bestial Evulsing",
-            "Bestial Savagery",
-            "Bestial Fierceness",
+            "Bestial Fierceness",     -- Level 116
+            "Bestial Savagery",       -- Level 106
+            "Bestial Evulsing",       -- Level 96
+            "Bestial Rending",        -- Level 91
+            "Bestial Vivisection",    -- Level 86
         },
         ['AEClaws'] = {
             "Flurry of Claws IX", -- Level 127
-            "Flurry of Claws",
-            "Tumult of Claws",
-            "Clamor of Claws",
-            "Tempest of Claws",
-            "Storm of Claws",
-            "Maelstrom of Claws",
-            "Eruption of Claws",
-            "Barrage of Claws",
+            "Barrage of Claws",   -- Level 122
+            "Eruption of Claws",  -- Level 117
+            "Maelstrom of Claws", -- Level 112
+            "Storm of Claws",     -- Level 107
+            "Tempest of Claws",   -- Level 102
+            "Clamor of Claws",    -- Level 97
+            "Tumult of Claws",    -- Level 92
+            "Flurry of Claws",    -- Level 87
         },
         ['FuryDisc'] = {
             --HHE Burn Disc* - Dicho/Dissident Replace this @ 101 outside of burns
-            "Nature's Fury",
-            "Kolos' Fury",
-            "Ruaabri's Fury",
+            "Ruaabri's Fury", -- Level 98
+            "Kolos' Fury",    -- Level 93
+            "Nature's Fury",  -- Level 88
         },
         ['DmgModDisc'] = {
             --All Skills Damage Modifier*
-            "Bestial Fury Discipline",
-            "Empathic Fury",
-            "Savage Fury",
-            "Savage Rage",
-            "Savage Rancor",
+            "Savage Rancor",           -- Level 104
+            "Savage Rage",             -- Level 99
+            "Savage Fury",             -- Level 94
+            "Empathic Fury",           -- Level 69
+            "Bestial Fury Discipline", -- Level 60
         },
         ['EndRegenProcDisc'] = {
-            "Reflexive Rending",
-            "Reflexive Sundering",
-            "Reflexive Riving",
-            "Reflexive Slashing", -- Level 124
+            "Reflexive Slashing",  -- Level 124
+            "Reflexive Riving",    -- Level 114
+            "Reflexive Sundering", -- Level 105
+            "Reflexive Rending",   -- Level 100
         },
         ['VinDisc'] = {
             -- Vindication Disc
-            "Al`ele's Vindication",
-            "Venon's Vindication",
-            "Ikatiar's Vindication",
-            "Kejaan's Vindication",
-            "Ikatiar's Vindication",
             "Xanathan's Vindication", -- Level 125
+            "Kejaan's Vindication",   -- Level 120
+            "Ikatiar's Vindication",  -- Level 115
+            "Ikatiar's Vindication",  -- Level 115
+            "Venon's Vindication",    -- Level 110
+            "Al`ele's Vindication",   -- Level 102
         },
     },
     ['HealRotationOrder'] = {

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -110,644 +110,644 @@ local _ClassConfig = {
         },
     },
     ['AbilitySets']       = {
-        ['WardBuff'] = {          -- Level 97+
-            "Ward of Virtue VII", -- 127
-            "Ward of Certitude",
-            "Ward of Surety",
-            "Ward of Assurance",
-            "Ward of Righteousness",
-            "Ward of Persistence",
-            "Ward of Commitment",
+        ['WardBuff'] = {             -- Level 97+
+            "Ward of Virtue VII",    -- Level 127
+            "Ward of Commitment",    -- Level 122
+            "Ward of Persistence",   -- Level 117
+            "Ward of Righteousness", -- Level 112
+            "Ward of Assurance",     -- Level 107
+            "Ward of Surety",        -- Level 102
+            "Ward of Certitude",     -- Level 97
         },
         ['HealingLight'] = {
-            "Eminent Light", -- Level 128
-            "Minor Healing",
-            "Light Healing",
-            "Healing",
-            "Greater Healing",
-            "Superior Healing",
-            "Healing Light",
-            "Divine Light",
-            "Ethereal Light",
-            "Supernal Light",
-            "Holy Light",
-            "Pious Light",
-            "Ancient: Hallowed Light",
-            "Sacred Light",
-            "Solemn Light",
-            "Devout Light",
-            "Earnest Light",
-            "Zealous Light",
-            "Reverent Light",
-            "Ardent Light",
-            "Merciful Light",
-            "Sincere Light",
-            "Fervent Light",
-            "Avowed Light",
+            "Eminent Light",           -- Level 128
+            "Avowed Light",            -- Level 123
+            "Fervent Light",           -- Level 118
+            "Sincere Light",           -- Level 113
+            "Merciful Light",          -- Level 108
+            "Ardent Light",            -- Level 103
+            "Reverent Light",          -- Level 98
+            "Zealous Light",           -- Level 93
+            "Earnest Light",           -- Level 88
+            "Devout Light",            -- Level 83
+            "Solemn Light",            -- Level 78
+            "Sacred Light",            -- Level 73
+            "Ancient: Hallowed Light", -- Level 70
+            "Pious Light",             -- Level 68
+            "Holy Light",              -- Level 65
+            "Supernal Light",          -- Level 63
+            "Ethereal Light",          -- Level 58
+            "Divine Light",            -- Level 53
+            "Healing Light",           -- Level 45
+            "Superior Healing",        -- Level 30
+            "Greater Healing",         -- Level 20
+            "Healing",                 -- Level 10
+            "Light Healing",           -- Level 4
+            "Minor Healing",           -- Level 1
         },
-        ['RemedyHeal'] = {     -- Not great until 96/RoF (Graceful)
-            -- "Remedy", No place to slot this, Ethereal used as a fallback at some level ranges
-            "Holy Remedy XIV", -- 126
-            "Ethereal Remedy",
-            "Supernal Remedy",
-            "Pious Remedy",
-            "Sacred Remedy",
-            "Solemn Remedy",
-            "Devout Remedy",
-            "Earnest Remedy",
-            "Faithful Remedy",
-            "Graceful Remedy",
-            "Spiritual Remedy",
-            "Merciful Remedy",
-            "Sincere Remedy",
-            "Guileless Remedy",
-            "Avowed Remedy",
+        ['RemedyHeal'] = {             -- Not great until 96/RoF (Graceful)
+            "Holy Remedy XIV",         -- Level 126
+            "Avowed Remedy",           -- Level 121
+            "Guileless Remedy",        -- Level 116
+            "Sincere Remedy",          -- Level 111
+            "Merciful Remedy",         -- Level 106
+            "Spiritual Remedy",        -- Level 101
+            "Graceful Remedy",         -- Level 96
+            "Faithful Remedy",         -- Level 91
+            "Earnest Remedy",          -- Level 86
+            "Devout Remedy",           -- Level 81
+            "Solemn Remedy",           -- Level 76
+            "Sacred Remedy",           -- Level 71
+            "Pious Remedy",            -- Level 66
+            "Supernal Remedy",         -- Level 61
+            "Ethereal Remedy",         -- Level 59
+            -- "Remedy",        -- Level 51, No place to slot this, Ethereal used as a fallback at some level ranges
         },
         ['RemedyHeal2'] = {
-            "Holy Remedy XIV", -- 126
-            "Graceful Remedy",
-            "Spiritual Remedy",
-            "Merciful Remedy",
-            "Sincere Remedy",
-            "Guileless Remedy",
-            "Avowed Remedy",
+            "Holy Remedy XIV",        -- Level 126
+            "Avowed Remedy",          -- Level 121
+            "Guileless Remedy",       -- Level 116
+            "Sincere Remedy",         -- Level 111
+            "Merciful Remedy",        -- Level 106
+            "Spiritual Remedy",       -- Level 101
+            "Graceful Remedy",        -- Level 96
         },
         ['Renewal'] = {               -- Level 70 +, large heal, slower cast
-            "Desperate Renewal XIII", -- 130
-            "Desperate Renewal",
-            "Frantic Renewal",
-            "Frenetic Renewal",
-            "Frenzied Renewal",
-            "Fervent Renewal",
-            "Fraught Renewal",
-            "Furial Renewal",
-            "Dire Renewal",
-            "Determined Renewal",
-            "Heroic Renewal",
+            "Desperate Renewal XIII", -- Level 130
+            "Heroic Renewal",         -- Level 125
+            "Determined Renewal",     -- Level 120
+            "Dire Renewal",           -- Level 115
+            "Furial Renewal",         -- Level 110
+            "Fraught Renewal",        -- Level 100
+            "Fervent Renewal",        -- Level 95
+            "Frenzied Renewal",       -- Level 90
+            "Frenetic Renewal",       -- Level 85
+            "Frantic Renewal",        -- Level 80
+            "Desperate Renewal",      -- Level 70
         },
-        ['Renewal2'] = { -- Level 70 +, large heal, slower cast
-            "Desperate Renewal",
-            "Frantic Renewal",
-            "Frenetic Renewal",
-            "Frenzied Renewal",
-            "Fervent Renewal",
-            "Fraught Renewal",
-            "Furial Renewal",
-            "Dire Renewal",
-            "Determined Renewal",
-            "Heroic Renewal",
+        ['Renewal2'] = {              -- Level 70 +, large heal, slower cast
+            "Heroic Renewal",         -- Level 125
+            "Determined Renewal",     -- Level 120
+            "Dire Renewal",           -- Level 115
+            "Furial Renewal",         -- Level 110
+            "Fraught Renewal",        -- Level 100
+            "Fervent Renewal",        -- Level 95
+            "Frenzied Renewal",       -- Level 90
+            "Frenetic Renewal",       -- Level 85
+            "Frantic Renewal",        -- Level 80
+            "Desperate Renewal",      -- Level 70
         },
-        ['Renewal3'] = { -- Level 70 +, large heal, slower cast
-            "Desperate Renewal",
-            "Frantic Renewal",
-            "Frenetic Renewal",
-            "Frenzied Renewal",
-            "Fervent Renewal",
-            "Fraught Renewal",
-            "Furial Renewal",
-            "Dire Renewal",
-            "Determined Renewal",
-            "Heroic Renewal",
+        ['Renewal3'] = {              -- Level 70 +, large heal, slower cast
+            "Heroic Renewal",         -- Level 125
+            "Determined Renewal",     -- Level 120
+            "Dire Renewal",           -- Level 115
+            "Furial Renewal",         -- Level 110
+            "Fraught Renewal",        -- Level 100
+            "Fervent Renewal",        -- Level 95
+            "Frenzied Renewal",       -- Level 90
+            "Frenetic Renewal",       -- Level 85
+            "Frantic Renewal",        -- Level 80
+            "Desperate Renewal",      -- Level 70
         },
         ['DichoHeal'] = {
-            "Undying Life",
-            "Dissident Blessing",
-            "Composite Blessing",
-            "Ecliptic Blessing",
-            "Reciprocal Blessing",
+            "Reciprocal Blessing",       -- Level 121
+            "Ecliptic Blessing",         -- Level 116
+            "Composite Blessing",        -- Level 111
+            "Dissident Blessing",        -- Level 106
+            "Undying Life",              -- Level 101
         },
-        ['GroupFastHeal'] = {        -- Level 98
-            "Syllable of Wellbeing", -- 128
-            "Syllable of Acceptance",
-            "Syllable of Convalescence",
-            "Syllable of Mending",
-            "Syllable of Soothing",
-            "Syllable of Invigoration",
-            "Syllable of Renewal",
+        ['GroupFastHeal'] = {            -- Level 98
+            "Syllable of Wellbeing",     -- Level 128
+            "Syllable of Acceptance",    -- Level 123
+            "Syllable of Invigoration",  -- Level 118
+            "Syllable of Soothing",      -- Level 113
+            "Syllable of Mending",       -- Level 108
+            "Syllable of Convalescence", -- Level 103
+            "Syllable of Renewal",       -- Level 98
         },
         ['GroupHealCure'] = {
-            "Word of Replenishment", -- 129
-            "Word of Restoration",   -- Poi/Dis
-            "Word of Replenishment", -- Poi/Dis/Curse
-            "Word of Vivification",
-            "Word of Vivacity",
-            "Word of Recovery",
-            "Word of Resurgence",
-            "Word of Rehabilitation",
-            "Word of Reformation",
-            "Word of Greater Reformation",
-            "Word of Greater Restoration",
-            "Word of Greater Replenishment",
-            "Word of Greater Rejuvenation",
-            "Word of Greater Vivification",
+            "Word of Greater Vivification",  -- Level 124
+            "Word of Greater Rejuvenation",  -- Level 120
+            "Word of Greater Replenishment", -- Level 115
+            "Word of Greater Restoration",   -- Level 110
+            "Word of Greater Reformation",   -- Level 105
+            "Word of Reformation",           -- Level 100
+            "Word of Rehabilitation",        -- Level 95
+            "Word of Resurgence",            -- Level 90
+            "Word of Recovery",              -- Level 85
+            "Word of Vivacity",              -- Level 80
+            "Word of Vivification",          -- Level 69
+            "Word of Replenishment",         -- Level 64
+            "Word of Replenishment",         -- Level 64, Poi/Dis/Curse
+            "Word of Restoration",           -- Level 57, Poi/Dis
         },
         ['GroupHealNoCure'] = {
             -----Group Heals No Cure Slot 5
-            "Word of Wellbeing", -- 126
-            "Word of Health",
-            "Word of Healing",
-            "Word of Vigor",
-            "Word of Restoration", -- No good NoCure in these level ranges using w/Cure... Note Word of Redemption omitted (12sec cast)
-            "Word of Replenishment",
-            "Word of Vivification",
-            "Word of Vivacity",
-            "Word of Recovery",
-            "Word of Awakening", --86, back to no cures
-            "Word of Recuperation",
-            "Word of Renewal",
-            "Word of Convalescence",
-            "Word of Mending",
-            "Word of Soothing",
-            "Word of Redress",
-            "Word of Acceptance",
+            "Word of Wellbeing",     -- Level 126
+            "Word of Acceptance",    -- Level 121
+            "Word of Redress",       -- Level 116
+            "Word of Soothing",      -- Level 111
+            "Word of Mending",       -- Level 106
+            "Word of Convalescence", -- Level 101
+            "Word of Renewal",       -- Level 96
+            "Word of Recuperation",  -- Level 91
+            "Word of Awakening",     -- Level 86, back to no cures
+            "Word of Recovery",      -- Level 85
+            "Word of Vivacity",      -- Level 80
+            "Word of Vivification",  -- Level 69
+            "Word of Replenishment", -- Level 64
+            "Word of Restoration",   -- Level 57, No good NoCure in these level ranges using w/Cure... Note Word of Redemption omitted (12sec cast)
+            "Word of Vigor",         -- Level 52
+            "Word of Healing",       -- Level 45
+            "Word of Health",        -- Level 30
         },
         ['HealNuke'] = {
             -- Heal Tank and Nuke Tanks Target -- Intervention Lines
-            "Eminent Intervention", -- Level 128
-            "Holy Intervention",
-            "Celestial Intervention",
-            "Elysian Intervention",
-            "Virtuous Intervention",
-            "Mystical Intervention",
-            "Merciful Intervention",
-            "Sincere Intervention",
-            "Atoned Intervention",
-            "Avowed Intervention",
+            "Eminent Intervention",   -- Level 128
+            "Avowed Intervention",    -- Level 123
+            "Atoned Intervention",    -- Level 118
+            "Sincere Intervention",   -- Level 113
+            "Merciful Intervention",  -- Level 108
+            "Mystical Intervention",  -- Level 103
+            "Virtuous Intervention",  -- Level 98
+            "Elysian Intervention",   -- Level 93
+            "Celestial Intervention", -- Level 88
+            "Holy Intervention",      -- Level 83
         },
         ['HealNuke2'] = {
             -- Heal Tank and Nuke Tanks Target -- Intervention Lines
-            "Eminent Intervention", -- Level 128
-            "Holy Intervention",
-            "Celestial Intervention",
-            "Elysian Intervention",
-            "Virtuous Intervention",
-            "Mystical Intervention",
-            "Merciful Intervention",
-            "Sincere Intervention",
-            "Atoned Intervention",
-            "Avowed Intervention",
+            "Eminent Intervention",   -- Level 128
+            "Avowed Intervention",    -- Level 123
+            "Atoned Intervention",    -- Level 118
+            "Sincere Intervention",   -- Level 113
+            "Merciful Intervention",  -- Level 108
+            "Mystical Intervention",  -- Level 103
+            "Virtuous Intervention",  -- Level 98
+            "Elysian Intervention",   -- Level 93
+            "Celestial Intervention", -- Level 88
+            "Holy Intervention",      -- Level 83
         },
         ['HealNuke3'] = {
             -- Heal Tank and Nuke Tanks Target -- Intervention Lines
-            "Eminent Intervention", -- Level 128
-            "Holy Intervention",
-            "Celestial Intervention",
-            "Elysian Intervention",
-            "Virtuous Intervention",
-            "Mystical Intervention",
-            "Merciful Intervention",
-            "Sincere Intervention",
-            "Atoned Intervention",
-            "Avowed Intervention",
+            "Eminent Intervention",   -- Level 128
+            "Avowed Intervention",    -- Level 123
+            "Atoned Intervention",    -- Level 118
+            "Sincere Intervention",   -- Level 113
+            "Merciful Intervention",  -- Level 108
+            "Mystical Intervention",  -- Level 103
+            "Virtuous Intervention",  -- Level 98
+            "Elysian Intervention",   -- Level 93
+            "Celestial Intervention", -- Level 88
+            "Holy Intervention",      -- Level 83
         },
         ['NukeHeal'] = {
             -- Nuke Target and Heal Tank -  Dps Heals
-            "Eminent Contravention", -- 130
-            "Holy Contravention",
-            "Celestial Contravention",
-            "Elysian Contravention",
-            "Virtuous Contravention",
-            "Ardent Contravention",
-            "Merciful Contravention",
-            "Sincere Contravention",
-            "Divine Contravention",
-            "Avowed Contravention",
+            "Eminent Contravention",   -- Level 130
+            "Avowed Contravention",    -- Level 125
+            "Divine Contravention",    -- Level 120
+            "Sincere Contravention",   -- Level 115
+            "Merciful Contravention",  -- Level 110
+            "Ardent Contravention",    -- Level 105
+            "Virtuous Contravention",  -- Level 100
+            "Elysian Contravention",   -- Level 95
+            "Celestial Contravention", -- Level 90
+            "Holy Contravention",      -- Level 85
         },
         ['NukeHeal2'] = {
             -- Nuke Target and Heal Tank -  Dps Heals
-            "Eminent Contravention", -- 130
-            "Holy Contravention",
-            "Celestial Contravention",
-            "Elysian Contravention",
-            "Virtuous Contravention",
-            "Ardent Contravention",
-            "Merciful Contravention",
-            "Sincere Contravention",
-            "Divine Contravention",
-            "Avowed Contravention",
+            "Eminent Contravention",   -- Level 130
+            "Avowed Contravention",    -- Level 125
+            "Divine Contravention",    -- Level 120
+            "Sincere Contravention",   -- Level 115
+            "Merciful Contravention",  -- Level 110
+            "Ardent Contravention",    -- Level 105
+            "Virtuous Contravention",  -- Level 100
+            "Elysian Contravention",   -- Level 95
+            "Celestial Contravention", -- Level 90
+            "Holy Contravention",      -- Level 85
         },
         ['NukeHeal3'] = {
             -- Nuke Target and Heal Tank -  Dps Heals
-            "Eminent Contravention", -- 130
-            "Holy Contravention",
-            "Celestial Contravention",
-            "Elysian Contravention",
-            "Virtuous Contravention",
-            "Ardent Contravention",
-            "Merciful Contravention",
-            "Sincere Contravention",
-            "Divine Contravention",
-            "Avowed Contravention",
+            "Eminent Contravention",   -- Level 130
+            "Avowed Contravention",    -- Level 125
+            "Divine Contravention",    -- Level 120
+            "Sincere Contravention",   -- Level 115
+            "Merciful Contravention",  -- Level 110
+            "Ardent Contravention",    -- Level 105
+            "Virtuous Contravention",  -- Level 100
+            "Elysian Contravention",   -- Level 95
+            "Celestial Contravention", -- Level 90
+            "Holy Contravention",      -- Level 85
         },
         ['ReverseDS'] = {
             -- Reverse Damage Shield Proc (LVL >=85) -- Ignoring the Mark Line
-            "Erud's Retort",
-            "Fintar's Retort",
-            "Galvos' Retort",
-            "Olsif's Retort",
-            "Vicarum's Retort",
-            "Curate's Retort",
-            "Jorlleag's Retort",
-            "Axoeviq's Retort",
-            "Hazuri's Retort",
+            "Hazuri's Retort",   -- Level 125
+            "Axoeviq's Retort",  -- Level 120
+            "Jorlleag's Retort", -- Level 115
+            "Curate's Retort",   -- Level 110
+            "Vicarum's Retort",  -- Level 105
+            "Olsif's Retort",    -- Level 100
+            "Galvos' Retort",    -- Level 95
+            "Fintar's Retort",   -- Level 90
+            "Erud's Retort",     -- Level 85
         },
         ['SelfHPBuff'] = {
             --Self Buff for Mana Regen and armor
-            "Armor of the Eminent", -- 130
-            "Armor of Protection",
-            "Blessed Armor of the Risen",
-            "Ancient: High Priest's Bulwark",
-            "Armor of the Zealot",
-            "Armor of the Pious",
-            "Armor of the Sacred",
-            "Armor of the Solemn",
-            "Armor of the Devout",
-            "Armor of the Earnest",
-            "Armor of the Zealous",
-            "Armor of the Reverent",
-            "Armor of the Ardent",
-            "Armor of the Merciful",
-            "Armor of Sincerity",
-            "Armor of Penance",
-            "Armor of the Avowed",
+            "Armor of the Eminent",           -- Level 130
+            "Armor of the Avowed",            -- Level 125
+            "Armor of Penance",               -- Level 120
+            "Armor of Sincerity",             -- Level 115
+            "Armor of the Merciful",          -- Level 110
+            "Armor of the Ardent",            -- Level 105
+            "Armor of the Reverent",          -- Level 100
+            "Armor of the Zealous",           -- Level 95
+            "Armor of the Earnest",           -- Level 90
+            "Armor of the Devout",            -- Level 85
+            "Armor of the Solemn",            -- Level 80
+            "Armor of the Sacred",            -- Level 75
+            "Armor of the Pious",             -- Level 70
+            "Armor of the Zealot",            -- Level 65
+            "Ancient: High Priest's Bulwark", -- Level 60
+            "Blessed Armor of the Risen",     -- Level 58
+            "Armor of Protection",            -- Level 34
         },
         ['GroupHealProcBuff'] = {
             ----Self buff casts group heal on AE spell damage
-            "Divine Consequence",
-            "Divine Reaction",
-            "Divine Response",
-            "Divine Contingency",
-            "Divine Rejoinder",
+            "Divine Rejoinder",   -- Level 124
+            "Divine Contingency", -- Level 118
+            "Divine Consequence", -- Level 113
+            "Divine Reaction",    -- Level 108
+            "Divine Response",    -- Level 102
         },
         ['AegoBuff'] = {
             ----Use HP Type one until Temperance at 40... Group Buff at 45 (Blessing of Temperance)
-            "Unified Hand of Aegolism XV", -- Level 130
-            "Courage",
-            "Center",
-            "Daring",
-            "Bravery",
-            "Valor",
-            "Temperance",
-            "Blessing of Temperance",
-            "Aegolism",
-            "Ancient: Gift of Aegolism",
-            "Blessing of Aegolism",
-            "Hand of Virtue",
-            "Hand of Conviction",
-            "Hand of Tenacity",
-            "Hand Of Temerity",
-            "Hand of Gallantry",
-            "Hand of Reliance",
-            "Unified Hand of Credence",
-            "Unified Hand of Certitude",
-            "Unified Hand of Surety",
-            "Unified Hand of Assurance",
-            "Unified Hand of Righteousness",
-            "Unified Hand of Persistence",
-            "Unified Hand of Infallibility",
+            "Unified Hand of Aegolism XV",   -- Level 130
+            "Unified Hand of Infallibility", -- Level 125
+            "Unified Hand of Persistence",   -- Level 120
+            "Unified Hand of Righteousness", -- Level 115
+            "Unified Hand of Assurance",     -- Level 110
+            "Unified Hand of Surety",        -- Level 105
+            "Unified Hand of Certitude",     -- Level 100
+            "Unified Hand of Credence",      -- Level 95
+            "Hand of Reliance",              -- Level 90
+            "Hand of Gallantry",             -- Level 85
+            "Hand Of Temerity",              -- Level 80
+            "Hand of Tenacity",              -- Level 75
+            "Hand of Conviction",            -- Level 70
+            "Hand of Virtue",                -- Level 65
+            "Aegolism",                      -- Level 60
+            "Ancient: Gift of Aegolism",     -- Level 60
+            "Blessing of Aegolism",          -- Level 60
+            "Blessing of Temperance",        -- Level 45
+            "Temperance",                    -- Level 40
+            "Valor",                         -- Level 32
+            "Bravery",                       -- Level 22
+            "Daring",                        -- Level 17
+            "Center",                        -- Level 7
+            "Courage",                       -- Level 1
         },
-        ['ACBuff'] = { --Sometimes single, sometimes group, used on tank before Aego or until it is rolled into Unified (Symbol)
-            "Order of the Earnest",
-            "Ward of the Earnest",
-            "Order of the Devout",
-            "Ward of the Devout",
-            "Order of the Resolute",
-            "Ward of the Resolute",
-            "Ward of the Dauntless",
-            "Ward of Valliance",
-            "Ward of Gallantry",
-            "Bulwark of Faith",
-            "Shield of Words",
-            "Armor of Faith",
-            "Guard",
-            "Spirit Armor",
-            "Holy Armor",
+        ['ACBuff'] = {                       --Sometimes single, sometimes group, used on tank before Aego or until it is rolled into Unified (Symbol)
+            "Order of the Earnest",          -- Level 90
+            "Ward of the Earnest",           -- Level 86
+            "Order of the Devout",           -- Level 85
+            "Ward of the Devout",            -- Level 81
+            "Order of the Resolute",         -- Level 80
+            "Ward of the Resolute",          -- Level 76
+            "Ward of the Dauntless",         -- Level 71
+            "Ward of Valiance",              -- Level 66
+            "Ward of Gallantry",             -- Level 61
+            "Bulwark of Faith",              -- Level 57
+            "Shield of Words",               -- Level 45
+            "Armor of Faith",                -- Level 35
+            "Guard",                         -- Level 25
+            "Spirit Armor",                  -- Level 15
+            "Holy Armor",                    -- Level 1
         },
         ['ShiningBuff'] = {
             --Tank Buff Traditionally Shining Series of Buffs
-            "Shining Rampart IX",
-            "Shining Rampart",
-            "Shining Armor",
-            "Shining Bastion",
-            "Shining Bulwark",
-            "Shining Fortress",
-            "Shining Aegis",
-            "Shining Fortitude",
-            "Shining Steel",
+            "Shining Rampart IX", -- Level 130
+            "Shining Steel",      -- Level 124
+            "Shining Fortitude",  -- Level 119
+            "Shining Aegis",      -- Level 114
+            "Shining Fortress",   -- Level 109
+            "Shining Bulwark",    -- Level 104
+            "Shining Bastion",    -- Level 99
+            "Shining Armor",      -- Level 94
+            "Shining Rampart",    -- Level 89
         },
-        ['SingleVieBuff'] = { -- Level 20-73 We don't use this once we have the group version
-            "Aegis of Vie",
-            "Panoply of Vie",
-            "Bulwark of Vie",
-            "Protection of Vie",
-            "Guard of Vie",
-            "Ward of Vie",
+        ['SingleVieBuff'] = {     -- Level 20-73 We don't use this once we have the group version
+            "Aegis of Vie",       -- Level 73
+            "Panoply of Vie",     -- Level 67
+            "Bulwark of Vie",     -- Level 62
+            "Protection of Vie",  -- Level 54
+            "Guard of Vie",       -- Level 40
+            "Ward of Vie",        -- Level 20
         },
         ['GroupVieBuff'] = {
-            "Rallied Bulwark of Vie", -- 130
-            "Rallied Aegis of Vie",
-            "Rallied Shield of Vie",
-            "Rallied Palladium of Vie",
-            "Rallied Rampart of Vie",
-            "Rallied Armor of Vie",
-            "Rallied Bastion of Vie",
-            "Rallied Greater Ward of Vie",
-            "Rallied Greater Guard of Vie",
-            "Rallied Greater Protection of Vie",
-            "Rallied Greater Aegis of Vie",
+            "Rallied Bulwark of Vie",            -- Level 130
+            "Rallied Greater Aegis of Vie",      -- Level 125
+            "Rallied Greater Protection of Vie", -- Level 115
+            "Rallied Greater Guard of Vie",      -- Level 110
+            "Rallied Greater Ward of Vie",       -- Level 105
+            "Rallied Bastion of Vie",            -- Level 100
+            "Rallied Armor of Vie",              -- Level 95
+            "Rallied Rampart of Vie",            -- Level 90
+            "Rallied Palladium of Vie",          -- Level 85
+            "Rallied Shield of Vie",             -- Level 80
+            "Rallied Aegis of Vie",              -- Level 75
         },
         ['GroupSymbolBuff'] = {
             ----Group Symbols
-            "Symbol of Transal",
-            "Symbol of Ryltan",
-            "Symbol of Pinzarn",
-            "Symbol of Naltron",
-            "Symbol of Marzin",
-            "Naltron's Mark",
-            "Marzin's Mark",
-            "Kazad's Mark",
-            "Balikor's Mark",
-            "Elushar's Mark",
-            "Kaerra's Mark",
-            "Darianna's Mark",
-            "Ealdun's Mark",
-            "Unified Hand of the Triumvirate",
-            "Unified Hand of Gezat",
-            "Unified Hand of Nonia",
-            "Unified Hand of Emra",
-            "Unified Hand of Jorlleag",
-            "Unified Hand of Assurance",
-            "Unified Hand of the Diabo",
-            "Unified Hand of Helmsbane",
+            "Unified Hand of Helmsbane",       -- Level 125
+            "Unified Hand of the Diabo",       -- Level 120
+            "Unified Hand of Jorlleag",        -- Level 115
+            "Unified Hand of Emra",            -- Level 110
+            "Unified Hand of Assurance",       -- Level 110
+            "Unified Hand of Nonia",           -- Level 105
+            "Unified Hand of Gezat",           -- Level 100
+            "Unified Hand of the Triumvirate", -- Level 95
+            "Ealdun's Mark",                   -- Level 90
+            "Darianna's Mark",                 -- Level 85
+            "Kaerra's Mark",                   -- Level 80
+            "Elushar's Mark",                  -- Level 75
+            "Balikor's Mark",                  -- Level 70
+            "Kazad's Mark",                    -- Level 63
+            "Marzin's Mark",                   -- Level 60
+            "Naltron's Mark",                  -- Level 58
+            "Symbol of Marzin",                -- Level 54
+            "Symbol of Naltron",               -- Level 41
+            "Symbol of Pinzarn",               -- Level 31
+            "Symbol of Ryltan",                -- Level 21
+            "Symbol of Transal",               -- Level 11
         },
         ['AbsorbAura'] = {
             ----Aura Buffs - Aura Name is seperate than the buff name
-            "Aura of the Pious",
-            "Aura of the Zealot",
-            "Aura of the Reverent",
-            "Aura of the Persistent",
+            "Aura of the Persistent", -- Level 119
+            "Aura of the Reverent",   -- Level 100
+            "Aura of the Pious",      -- Level 70
+            "Aura of the Zealot",     -- Level 55
         },
         ['HPAura'] = {
             ---- Aura Buff 2 - Aura Name is the same as the buff name
-            "Bastion of Divinity",
-            "Circle of Divinity",
-            "Aura of Divinity",
+            "Bastion of Divinity", -- Level 120
+            "Aura of Divinity",    -- Level 100
+            "Circle of Divinity",  -- Level 80
         },
         ['DivineBuff'] = {
             --Divine Buffs REQUIRES extra spell slot because of the 90s recast
-            "Divine Interstition", -- 127
-            "Death Pact",
-            "Divine Intervention",
-            "Divine Intercession",
-            "Divine Invocation",
-            "Divine Interposition",
-            "Divine Indemnification",
-            "Divine Imposition",
-            "Divine Intermediation",
-            "Divine Interference",
+            "Divine Interstition",    -- Level 127
+            "Divine Interference",    -- Level 122
+            "Divine Intermediation",  -- Level 112
+            "Divine Imposition",      -- Level 107
+            "Divine Indemnification", -- Level 102
+            "Divine Interposition",   -- Level 97
+            "Divine Invocation",      -- Level 92
+            "Divine Intercession",    -- Level 87
+            "Divine Intervention",    -- Level 60
+            "Death Pact",             -- Level 51
         },
         ['TwinHealNuke'] = {
-            "Unyielding Denunciation", -- 129
-            "Glorious Denunciation",
-            "Glorious Censure",
-            "Glorious Admonition",
-            "Glorious Rebuke",
-            "Glorious Judgment",
-            "Unyielding Judgment",
-            "Unyielding Censure",
-            "Unyielding Rebuke",
-            "Unyielding Admonition",
+            "Unyielding Denunciation", -- Level 129
+            "Unyielding Admonition",   -- Level 124
+            "Unyielding Rebuke",       -- Level 119
+            "Unyielding Censure",      -- Level 114
+            "Unyielding Judgment",     -- Level 109
+            "Glorious Judgment",       -- Level 104
+            "Glorious Rebuke",         -- Level 99
+            "Glorious Admonition",     -- Level 94
+            "Glorious Censure",        -- Level 89
+            "Glorious Denunciation",   -- Level 84
         },
         ['RezSpell'] = {
-            "Reviviscence",
-            "Resurrection",
-            "Restoration",
-            "Resuscitate",
-            "Renewal",
-            "Revive",
-            "Reparation",
-            "Reconstitution",
-            "Reanimation",
+            "Reviviscence",   -- Level 56
+            "Resurrection",   -- Level 47
+            "Restoration",    -- Level 42
+            "Resuscitate",    -- Level 37
+            "Renewal",        -- Level 32
+            "Revive",         -- Level 27
+            "Reparation",     -- Level 22
+            "Reconstitution", -- Level 18
+            "Reanimation",    -- Level 12
         },
         ['AERezSpell'] = {
-            "Superior Reviviscence",
-            "Eminent Reviviscence",
-            "Greater Reviviscence",
-            "Larger Reviviscence",
+            "Superior Reviviscence", -- Level 76
+            "Eminent Reviviscence",  -- Level 71
+            "Greater Reviviscence",  -- Level 66
+            "Larger Reviviscence",   -- Level 61
         },
         ['ClutchHeal'] = {
             -- 11th-17th Rejuv Spell Line Clutch Heals Require Life below 35-45% to cast
-            "Twentieth Dictum", -- 127
-            "Eleventh-Hour",
-            "Twelfth Night",
-            "Thirteenth Salve",
-            "Fourteenth Catalyst",
-            "Fifteenth Emblem",
-            "Sixteenth Serenity",
-            "Seventeenth Rejuvenation",
-            "Eighteenth Rejuvenation",
-            "Nineteenth Commandment",
+            "Twentieth Dictum",         -- Level 127
+            "Nineteenth Commandment",   -- Level 122
+            "Eighteenth Rejuvenation",  -- Level 117
+            "Seventeenth Rejuvenation", -- Level 112
+            "Sixteenth Serenity",       -- Level 107
+            "Fifteenth Emblem",         -- Level 97
+            "Fourteenth Catalyst",      -- Level 92
+            "Thirteenth Salve",         -- Level 87
+            "Twelfth Night",            -- Level 82
+            "Eleventh-Hour",            -- Level 77
         },
         ['GroupInfusionBuff'] = {
             -- Hand of Infusion Line
-            "Hand of Faithful Infusion",
-            "Hand of Graceful Infusion",
-            "Hand of Merciful Infusion",
-            "Hand of Sincere Infusion",
-            "Hand of Unyielding Infusion",
-            "Hand of Avowed Infusion",
+            "Hand of Avowed Infusion",     -- Level 124
+            "Hand of Unyielding Infusion", -- Level 119
+            "Hand of Sincere Infusion",    -- Level 114
+            "Hand of Merciful Infusion",   -- Level 109
+            "Hand of Graceful Infusion",   -- Level 99
+            "Hand of Faithful Infusion",   -- Level 94
         },
         ['SingleElixir'] = {
-            "Eminent Elixir",   -- 127
-            "Celestial Remedy", -- Level 19
-            "Celestial Health",
-            "Celestial Healing",
-            "Celestial Elixir",
-            "Supernal Elixir",
-            "Holy Elixir",
-            "Pious Elixir",
-            "Sacred Elixir",
-            "Solemn Elixir",
-            "Devout Elixir",
-            "Earnest Elixir",
+            "Eminent Elixir",    -- Level 127
+            "Earnest Elixir",    -- Level 87
+            "Devout Elixir",     -- Level 82
+            "Solemn Elixir",     -- Level 77
+            "Sacred Elixir",     -- Level 72
+            "Pious Elixir",      -- Level 67
+            "Holy Elixir",       -- Level 65
+            "Supernal Elixir",   -- Level 62
+            "Celestial Elixir",  -- Level 59
+            "Celestial Healing", -- Level 44
+            "Celestial Health",  -- Level 29
+            "Celestial Remedy",  -- Level 19
         },
         ['GroupElixir'] = {
             -- Group Hot Line - Elixirs No Cure
-            "Elixir of Absolution", -- 130
-            "Ethereal Elixir",      -- Level 59
-            "Elixir of Divinity",
-            "Elixir of Redemption",
-            "Elixir of Atonement",
-            "Elixir of Expiation",
-            "Elixir of the Ardent",
-            "Elixir of the Beneficent",
-            "Elixir of the Acquittal",
-            "Elixir of the Seas",
-            "Elixir of Wulthan",
-            "Elixir of Transcendence",
-            "Elixir of Benevolence",
-            "Elixir of Realization",
+            "Elixir of Absolution",     -- Level 130
+            "Elixir of Realization",    -- Level 125
+            "Elixir of Benevolence",    -- Level 120
+            "Elixir of Transcendence",  -- Level 115
+            "Elixir of Wulthan",        -- Level 110
+            "Elixir of the Seas",       -- Level 105
+            "Elixir of the Acquittal",  -- Level 100
+            "Elixir of the Beneficent", -- Level 95
+            "Elixir of the Ardent",     -- Level 90
+            "Elixir of Expiation",      -- Level 85
+            "Elixir of Atonement",      -- Level 80
+            "Elixir of Redemption",     -- Level 75
+            "Elixir of Divinity",       -- Level 70
+            "Ethereal Elixir",          -- Level 60
         },
         ['GroupAcquittal'] = {
             -- Group Hot Line Cure + Hot 99+
-            "Eminent Acquittal", -- 129
-            "Cleansing Acquittal",
-            "Ardent Acquittal",
-            "Merciful Acquittal",
-            "Sincere Acquittal",
-            "Devout Acquittal",
-            "Avowed Acquittal",
+            "Eminent Acquittal",   -- Level 129
+            "Avowed Acquittal",    -- Level 124
+            "Devout Acquittal",    -- Level 119
+            "Sincere Acquittal",   -- Level 114
+            "Merciful Acquittal",  -- Level 109
+            "Ardent Acquittal",    -- Level 104
+            "Cleansing Acquittal", -- Level 99
         },
         ['SpellBlessing'] = {
             -- Spell haste Blessings 15-92, defunct at 95 due to Unifieds.
             -- -- Do not add future version unless you have verified that they are not simply Symbol/Aego Unified triggers.
-            "Blessing of Piety",
-            "Blessing of Faith",
-            "Blessing of Reverence",
-            "Aura of Reverence",
-            "Blessing of Devotion",
-            "Aura of Devotion",
-            "Blessing of Purpose",
-            "Aura of Purpose",
-            "Blessing of Resolve",
-            "Aura of Resolve",
-            "Blessing of Loyalty",
-            "Aura of Loyalty",
-            "Blessing of Will",
-            "Hand of Will",
+            "Hand of Will",          -- Level 87
+            "Blessing of Will",      -- Level 86
+            "Aura of Loyalty",       -- Level 82
+            "Blessing of Loyalty",   -- Level 81
+            "Aura of Resolve",       -- Level 77
+            "Blessing of Resolve",   -- Level 76
+            "Aura of Purpose",       -- Level 72
+            "Blessing of Purpose",   -- Level 71
+            "Aura of Devotion",      -- Level 69
+            "Blessing of Devotion",  -- Level 67
+            "Aura of Reverence",     -- Level 64
+            "Blessing of Reverence", -- Level 62
+            "Blessing of Faith",     -- Level 35
+            "Blessing of Piety",     -- Level 15
         },
         ['CureAll'] = {
-            "Sanctified Blood",
-            "Expurgated Blood",
-            "Unblemished Blood",
-            "Cleansed Blood",
-            "Perfected Blood",
-            "Purged Blood",   -- does not cure corruption
-            "Purified Blood", -- does not cure curse, 5 level gap where we will use this without curing curse, but AA should cover
-            -- "Pure Blood", --Much better single cures occur after this one
+            "Sanctified Blood",  -- Level 119
+            "Expurgated Blood",  -- Level 109
+            "Unblemished Blood", -- Level 104
+            "Cleansed Blood",    -- Level 99
+            "Perfected Blood",   -- Level 94
+            "Purged Blood",      -- Level 89, does not cure corruption
+            "Purified Blood",    -- Level 84, does not cure curse, 5 level gap where we will use this without curing curse, but AA should cover
+            -- "Pure Blood",     -- Level 51, Much better single cures occur after this one
         },
         ['CureCorrupt'] = {
-            "Purge Corruption",
-            "Extricate Corruption",
-            "Nullify Corruption",
-            "Abrogate Corruption",
-            "Eradicate Corruption",
-            "Dissolve Corruption", -- group from here up
-            "Pristine Blood",      -- single target from here down
-            "Abolish Corruption",
-            "Vitiate Corruption",
-            "Expunge Corruption",
+            "Purge Corruption",     -- Level 119
+            "Extricate Corruption", -- Level 109
+            "Nullify Corruption",   -- Level 104
+            "Abrogate Corruption",  -- Level 99
+            "Eradicate Corruption", -- Level 94
+            "Dissolve Corruption",  -- Level 89, group from here up
+            "Pristine Blood",       -- Level 87, single target from here down
+            "Abolish Corruption",   -- Level 84
+            "Vitiate Corruption",   -- Level 79
+            "Expunge Corruption",   -- Level 64
         },
         ['CurePoison'] = {
-            "Antidote",
-            "Eradicate Poison",
-            "Abolish Poison",
-            "Counteract Poison",
-            "Cure Poison",
+            "Antidote",          -- Level 58
+            "Eradicate Poison",  -- Level 52
+            "Abolish Poison",    -- Level 48
+            "Counteract Poison", -- Level 22
+            "Cure Poison",       -- Level 1
         },
         ['CureDisease'] = {
-            "Eradicate Disease",
-            "Counteract Disease",
-            "Cure Disease",
+            "Eradicate Disease",  -- Level 58
+            "Counteract Disease", -- Level 28
+            "Cure Disease",       -- Level 4
         },
         ['CureCurse'] = {
-            "Eradicate Curse",
-            "Remove Greater Curse",
-            "Remove Curse",
-            "Remove Lesser Curse",
-            "Remove Minor Curse",
+            "Eradicate Curse",      -- Level 54
+            "Remove Greater Curse", -- Level 54
+            "Remove Curse",         -- Level 38
+            "Remove Lesser Curse",  -- Level 23
+            "Remove Minor Curse",   -- Level 8
         },
         ['YaulpSpell'] = {
-            "Yaulp V", -- Level 56, first rank with haste/mana regen
-            "Yaulp VI",
-            "Yaulp VII",
-            "Yaulp VIII",
-            "Yaulp IX",           -- Level 76, AA starts at 75 with Yaulp IX
+            "Yaulp IX",              -- Level 76, AA starts at 75 with Yaulp IX
+            "Yaulp VIII",            -- Level 71
+            "Yaulp VII",             -- Level 69
+            "Yaulp VI",              -- Level 65
+            "Yaulp V",               -- Level 56, first rank with haste/mana regen
         },
-        ['StunTimer6'] = {        -- Timer 6 Stun, Fast Cast, Level 63+ (with ToT Heal 88+)
-            "Sound of Vehemence", -- 128
-            "Sound of Heroism",
-            "Sound of Providence",
-            "Sound of Rebuke",
-            "Sound of Wrath",
-            "Sound of Thunder",
-            "Sound of Plangency",
-            "Sound of Fervor",
-            "Sound of Fury",
-            "Sound of Reverberance",
-            "Sound of Resonance",
-            "Sound of Zeal",
-            "Sound of Divinity",
-            "Sound of Might",
+        ['StunTimer6'] = {           -- Timer 6 Stun, Fast Cast, Level 63+ (with ToT Heal 88+)
+            "Sound of Vehemence",    -- Level 128
+            "Sound of Heroism",      -- Level 123
+            "Sound of Providence",   -- Level 118
+            "Sound of Rebuke",       -- Level 113
+            "Sound of Wrath",        -- Level 108
+            "Sound of Thunder",      -- Level 103
+            "Sound of Plangency",    -- Level 98
+            "Sound of Fervor",       -- Level 93
+            "Sound of Fury",         -- Level 88
+            "Sound of Reverberance", -- Level 83
+            "Sound of Resonance",    -- Level 78
+            "Sound of Zeal",         -- Level 73
+            "Sound of Divinity",     -- Level 68
+            "Sound of Might",        -- Level 63
             --Filler before this
-            "Tarnation",     -- Timer 4, up to Level 65
-            "Force",         -- No Timer #, up to Level 58
-            "Holy Might",    -- No Timer #, up to Level 55
+            "Tarnation",             -- Level 61, Timer 4, up to Level 65
+            "Force",                 -- Level 31, No Timer #, up to Level 58
+            "Holy Might",            -- Level 16, No Timer #, up to Level 55
         },
-        ['LowLevelStun'] = { --Adding a second stun at low levels
-            "Stun",
+        ['LowLevelStun'] = {         --Adding a second stun at low levels
+            "Stun",                  -- Level 2
         },
-        ['UndeadNuke'] = {        -- Level 4+
-            "Expunge the Undead", -- Level 129
-            "Banish the Undead",
-            "Extirpate the Undead",
-            "Obliterate the Undead",
-            "Repudiate the Undead",
-            "Eradicate the Undead",
-            "Abrogate the Undead",
-            "Abolish the Undead",
-            "Annihilate the Undead",
-            "Desolate Undead",
-            "Destroy Undead",
-            "Exile Undead",
-            "Banish Undead",
-            "Expel Undead",
-            "Dismiss Undead",
-            "Expulse Undead",
-            "Ward Undead",
+        ['UndeadNuke'] = {           -- Level 4+
+            "Expunge the Undead",    -- Level 129
+            "Banish the Undead",     -- Level 121
+            "Extirpate the Undead",  -- Level 116
+            "Obliterate the Undead", -- Level 111
+            "Repudiate the Undead",  -- Level 106
+            "Eradicate the Undead",  -- Level 101
+            "Abrogate the Undead",   -- Level 96
+            "Abolish the Undead",    -- Level 91
+            "Annihilate the Undead", -- Level 86
+            "Desolate Undead",       -- Level 68
+            "Destroy Undead",        -- Level 64
+            "Exile Undead",          -- Level 55
+            "Banish Undead",         -- Level 43
+            "Expel Undead",          -- Level 33
+            "Dismiss Undead",        -- Level 23
+            "Expulse Undead",        -- Level 13
+            "Ward Undead",           -- Level 4
         },
         ['MagicNuke'] = {
-            "Veto", -- 127
-            "Strike",
-            "Furor",
-            "Smite",
-            "Wrath",
-            "Retribution",
-            "Judgment",
-            "Condemnation",
-            "Order",
-            "Reproach",
-            "Reproval",
-            "Reprehend",
-            "Rebuke",
-            "Remonstrance",
-            "Castigation",
-            "Justice",
-            "Sanction",
-            "Injunction",
-            "Divine Writ",
-            "Decree",
+            "Veto",         -- Level 127
+            "Decree",       -- Level 122
+            "Divine Writ",  -- Level 117
+            "Injunction",   -- Level 112
+            "Sanction",     -- Level 107
+            "Justice",      -- Level 102
+            "Castigation",  -- Level 97
+            "Remonstrance", -- Level 92
+            "Rebuke",       -- Level 87
+            "Reprehend",    -- Level 82
+            "Reproval",     -- Level 72
+            "Reproach",     -- Level 67
+            "Order",        -- Level 65
+            "Condemnation", -- Level 62
+            "Judgment",     -- Level 56
+            "Retribution",  -- Level 44
+            "Wrath",        -- Level 29
+            "Smite",        -- Level 14
+            "Furor",        -- Level 5
+            "Strike",       -- Level 1
         },
         ['HammerPet'] = {
-            "Hammer of Emminence", -- 127
-            "Unswerving Hammer of Faith",
-            "Unswerving Hammer of Retribution",
-            "Unflinching Hammer of Zeal",
-            "Indomitable Hammer of Zeal",
-            "Unwavering Hammer of Zeal",
-            "Devout Hammer of Zeal",
-            "Infallible Hammer of Zeal",
-            "Infallible Hammer of Reverence",
-            "Ardent Hammer of Zeal",
-            "Unyielding Hammer of Zeal",
-            "Unyielding Hammer of Obliteration",
-            "Incorruptible Hammer of Obliteration",
-            "Unrelenting Hammer of Zeal",
+            "Hammer of Eminence",                   -- Level 127
+            "Unrelenting Hammer of Zeal",           -- Level 124
+            "Incorruptible Hammer of Obliteration", -- Level 119
+            "Unyielding Hammer of Obliteration",    -- Level 114
+            "Unyielding Hammer of Zeal",            -- Level 109
+            "Ardent Hammer of Zeal",                -- Level 104
+            "Infallible Hammer of Reverence",       -- Level 99
+            "Infallible Hammer of Zeal",            -- Level 94
+            "Devout Hammer of Zeal",                -- Level 89
+            "Unwavering Hammer of Zeal",            -- Level 84
+            "Indomitable Hammer of Zeal",           -- Level 79
+            "Unflinching Hammer of Zeal",           -- Level 74
+            "Unswerving Hammer of Retribution",     -- Level 68
+            "Unswerving Hammer of Faith",           -- Level 54
         },
         ['CompleteHeal'] = {
-            "Complete Heal",
+            "Complete Heal", -- Level 39
         },
-    }, -- end AbilitySets
+    },                       -- end AbilitySets
     ['Helpers']           = {
         DoRez = function(self, corpseId)
             local rezAction = false

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -122,723 +122,721 @@ local _ClassConfig = {
     ['AbilitySets']       = {
         ['Alliance'] = {
             --, Buff >= LVL102
-            "Bosquetender's Alliance,",
-            "Arbor Tender's Coalition",
-            "Arboreal Atonement",
-            "Ferntender's Covariance",
+            "Ferntender's Covariance",  -- Level 125
+            "Arboreal Atonement",       -- Level 120
+            "Arbor Tender's Coalition", -- Level 115
+            "Bosquetender's Alliance",  -- Level 102
         },
         ['FireAura'] = {
             -- Spell Series >= 87LVL Minimum
-            "Wildspark Aura",
-            "Wildblaze Aura",
-            "Wildfire Aura",
+            "Wildspark Aura", -- Level 97
+            "Wildblaze Aura", -- Level 92
+            "Wildfire Aura",  -- Level 87
         },
         ['IceAura'] = {
             -- Spell Series >= 88LVL Minimum -- Only Heroic Aura that will be used
-            "Frostfell Aura IX",
-            "Coldburst Aura",
-            "Nightchill Aura",
-            "Icerend Aura",
-            "Frostreave Aura",
-            "Frostweave Aura",
-            "Frostone Aura",
-            "Frostcloak Aura",
-            "Frostfell Aura",
+            "Frostfell Aura IX", -- Level 128
+            "Coldburst Aura",    -- Level 123
+            "Nightchill Aura",   -- Level 118
+            "Icerend Aura",      -- Level 113
+            "Frostreave Aura",   -- Level 108
+            "Frostweave Aura",   -- Level 103
+            "Frostone Aura",     -- Level 98
+            "Frostcloak Aura",   -- Level 93
+            "Frostfell Aura",    -- Level 88
         },
         ['HealingAura'] = {
             -- Healing Aura >= 55
-            "Aura of Life",
-            "Aura of the Grove",
+            "Aura of Life",      -- Level 70
+            "Aura of the Grove", -- Level 55
         },
         ['SingleTgtCure'] = {
             -- Single Target Multi-Cure >= 84
-            "Mastery: Sanctified Blood",
-            "Expurgated Blood",
-            "Unblemished Blood",
-            "Cleansed Blood",
-            "Perfected Blood",
-            "Purged Blood",
-            "Purified Blood",
-            "Sanctified Blood",
+            "Mastery: Sanctified Blood", -- Level 128
+            "Sanctified Blood",          -- Level 118
+            "Expurgated Blood",          -- Level 108
+            "Unblemished Blood",         -- Level 103
+            "Cleansed Blood",            -- Level 99
+            "Perfected Blood",           -- Level 94
+            "Purged Blood",              -- Level 89
+            "Purified Blood",            -- Level 84
         },
         ['CureCorrupt'] = {
-            "Mastery: Chant of the Zelniak",
-            "Chant of the Zelniak",
-            "Chant of the Wulthan",
-            "Chant of the Kromtus",
-            "Chant of Jaerol",
-            "Chant of the Izon",
-            "Chant of the Tae Ew",
-            "Chant of the Burynai",
-            "Chant of the Darkvine",
-            "Chant of the Napaea",
-            "Cure Corruption",
+            "Mastery: Chant of the Zelniak", -- Level 127
+            "Chant of the Zelniak",          -- Level 117
+            "Chant of the Wulthan",          -- Level 107
+            "Chant of the Kromtus",          -- Level 102
+            "Chant of Jaerol",               -- Level 99
+            "Chant of the Izon",             -- Level 94
+            "Chant of the Tae Ew",           -- Level 89
+            "Chant of the Burynai",          -- Level 84
+            "Chant of the Darkvine",         -- Level 79
+            "Chant of the Napaea",           -- Level 64
+            "Cure Corruption",               -- Level 61
         },
         ['GroupCure'] = {
             -- Group Multi-Cure >=91
-            "Mastery: Nightwhisper's Breeze",
-            "Nightwhisper's Breeze",
-            "Wildtender's Breeze",
-            "Copsetender's Breeze",
-            "Bosquetender's Breeze",
-            "Fawnwalker's Breeze",
+            "Mastery: Nightwhisper's Breeze", -- Level 126
+            "Nightwhisper's Breeze",          -- Level 116
+            "Wildtender's Breeze",            -- Level 106
+            "Copsetender's Breeze",           -- Level 101
+            "Bosquetender's Breeze",          -- Level 96
+            "Fawnwalker's Breeze",            -- Level 91
         },
         ['CharmSpell'] = {
             -- Charm Spells >= 14
-            "Beast's Beckoning XVIII",
-            "Beast's Bestowing",
-            "Beast's Bellowing",
-            "Beast's Beckoning",
-            "Beast's Beseeching",
-            "Beast's Bidding",
-            "Beast's Bespelling",
-            "Beast's Behest",
-            "Beast's Beguiling",
-            "Beast's Befriending",
-            "Beast's Bewitching",
-            "Beast's Beckoning",
-            "Nature's Beckon",
-            "Command of Tunare",
-            "Tunare's Request",
-            "Call of Karana",
-            "Allure of the Wild",
-            "Beguile Animals",
-            "Charm Animals",
-            "Befriend Animal",
+            "Beast's Beckoning XVIII", -- Level 126
+            "Beast's Bestowing",       -- Level 121
+            "Beast's Bellowing",       -- Level 116
+            "Beast's Beseeching",      -- Level 106
+            "Beast's Bidding",         -- Level 101
+            "Beast's Bespelling",      -- Level 96
+            "Beast's Behest",          -- Level 91
+            "Beast's Beguiling",       -- Level 86
+            "Beast's Befriending",     -- Level 81
+            "Beast's Bewitching",      -- Level 76
+            "Beast's Beckoning",       -- Level 71
+            "Beast's Beckoning",       -- Level 71
+            "Nature's Beckon",         -- Level 70
+            "Command of Tunare",       -- Level 63
+            "Tunare's Request",        -- Level 55
+            "Call of Karana",          -- Level 52
+            "Allure of the Wild",      -- Level 43
+            "Beguile Animals",         -- Level 33
+            "Charm Animals",           -- Level 23
+            "Befriend Animal",         -- Level 13
         },
         ['QuickHealSurge'] = {
             -- Main Quick heal >=75
-            "Adrenaline Surge XII",
-            "Adrenaline Fury",
-            "Adrenaline Spate",
-            "Adrenaline Deluge",
-            "Adrenaline Barrage",
-            "Adrenaline Torrent",
-            "Adrenaline Rush",
-            "Adrenaline Flood",
-            "Adrenaline Blast",
-            "Adrenaline Burst",
-            "Adrenaline Swell",
-            "Adrenaline Surge",
-            "Adrenaline Spate",
+            "Adrenaline Surge XII", -- Level 129
+            "Adrenaline Fury",      -- Level 124
+            "Adrenaline Spate",     -- Level 119
+            "Adrenaline Spate",     -- Level 119
+            "Adrenaline Deluge",    -- Level 114
+            "Adrenaline Barrage",   -- Level 109
+            "Adrenaline Torrent",   -- Level 104
+            "Adrenaline Rush",      -- Level 100
+            "Adrenaline Flood",     -- Level 95
+            "Adrenaline Blast",     -- Level 90
+            "Adrenaline Burst",     -- Level 85
+            "Adrenaline Swell",     -- Level 80
+            "Adrenaline Surge",     -- Level 75
         },
         ['QuickHeal'] = {
             -- Backup Quick heal >= LVL90
-            "Rejuvilation IX",
-            "Resuscitation",
-            "Sootheseance",
-            "Rejuvenescence",
-            "Revitalization",
-            "Resurgence",
-            "Vivification",
-            "Invigoration",
-            "Rejuvilation",
-            "Sootheseance",
+            "Rejuvilation IX", -- Level 130
+            "Resuscitation",   -- Level 125
+            "Sootheseance",    -- Level 120
+            "Sootheseance",    -- Level 120
+            "Rejuvenescence",  -- Level 115
+            "Revitalization",  -- Level 110
+            "Resurgence",      -- Level 105
+            "Vivification",    -- Level 100
+            "Invigoration",    -- Level 95
+            "Rejuvilation",    -- Level 90
         },
         ['LongHeal'] = {
             -- Long Heal >= 1 -- skipped 10s cast heals.
-            "Puravida XI",
-            "Vivavida",
-            "Clotavida",
-            "Viridavida",
-            "Curavida",
-            "Panavida",
-            "Sterivida",
-            "Sanavida",
-            "Benevida",
-            "Granvida",
-            "Puravida",
-            "Pure Life",
-            "Chlorotrope",
-            "Sylvan Infusion",
-            "Nature's Infusion",
-            "Nature's Touch",
-            "Chloroblast",
-            "Forest's Renewal",
-            "Superior Healing",
-            "Nature's Renewal",
-            "Healing Water",
-            "Greater Healing",
-            "Healing",
-            "Light Healing",
-            "Minor Healing",
+            "Puravida XI",       -- Level 127
+            "Vivavida",          -- Level 122
+            "Clotavida",         -- Level 117
+            "Viridavida",        -- Level 112
+            "Curavida",          -- Level 107
+            "Panavida",          -- Level 102
+            "Sterivida",         -- Level 97
+            "Sanavida",          -- Level 92
+            "Benevida",          -- Level 87
+            "Granvida",          -- Level 82
+            "Puravida",          -- Level 77
+            "Pure Life",         -- Level 72
+            "Chlorotrope",       -- Level 68
+            "Sylvan Infusion",   -- Level 65
+            "Nature's Infusion", -- Level 63
+            "Nature's Touch",    -- Level 60
+            "Chloroblast",       -- Level 55
+            "Forest's Renewal",  -- Level 49
+            "Superior Healing",  -- Level 44
+            "Nature's Renewal",  -- Level 39
+            "Healing Water",     -- Level 34
+            "Greater Healing",   -- Level 29
+            "Healing",           -- Level 19
+            "Light Healing",     -- Level 9
+            "Minor Healing",     -- Level 1
         },
         ['QuickGroupHeal'] = {
             -- Quick Group heal >= LVL78
-            "Survival of the Fittest XI",
-            "Survival of the Heroic",
-            "Survival of the Unrelenting",
-            "Survival of the Favored",
-            "Survival of the Auspicious",
-            "Survival of the Serendipitous",
-            "Survival of the Fortuitous",
-            "Survival of the Prosperous",
-            "Survival of the Propitious",
-            "Survival of the Felicitous",
-            "Survival of the Fittest",
-            "Survival of the Unrelenting",
+            "Survival of the Fittest XI",    -- Level 128
+            "Survival of the Heroic",        -- Level 123
+            "Survival of the Unrelenting",   -- Level 118
+            "Survival of the Unrelenting",   -- Level 118
+            "Survival of the Favored",       -- Level 113
+            "Survival of the Auspicious",    -- Level 108
+            "Survival of the Serendipitous", -- Level 103
+            "Survival of the Fortuitous",    -- Level 98
+            "Survival of the Prosperous",    -- Level 93
+            "Survival of the Propitious",    -- Level 88
+            "Survival of the Felicitous",    -- Level 83
+            "Survival of the Fittest",       -- Level 78
         },
         ['LongGroupHeal'] = {
             -- Long Group heal >= LVL 70
-            "Lunamend",
-            "Lunacea",
-            "Lunarush",
-            "Lunalesce",
-            "Lunasalve",
-            "Lunasoothe",
-            "Lunassuage",
-            "Lunalleviation",
-            "Lunamelioration",
-            "Lunulation",
-            "Crescentbloom",
-            "Lunarlight",
-            "Moonshadow",
-            "Lunarush",
+            "Lunamend",        -- Level 130
+            "Lunacea",         -- Level 125
+            "Lunarush",        -- Level 120
+            "Lunarush",        -- Level 120
+            "Lunalesce",       -- Level 115
+            "Lunasalve",       -- Level 110
+            "Lunasoothe",      -- Level 105
+            "Lunassuage",      -- Level 100
+            "Lunalleviation",  -- Level 95
+            "Lunamelioration", -- Level 90
+            "Lunulation",      -- Level 85
+            "Crescentbloom",   -- Level 80
+            "Lunarlight",      -- Level 75
+            "Moonshadow",      -- Level 70
         },
         ['PromHeal'] = {
             -- Promised Heals Line Druid
-            "Promised Reknit X",
-            "Promised Regrowth",
-            "Promised Reknit",
-            "Promised Replenishment",
-            "Promised Revitalization",
-            "Promised Recovery",
-            "Promised Regeneration",
-            "Promised Rebirth",
-            "Promised Refreshment",
-            "Promised Revivification",
+            "Promised Reknit X",       -- Level 127
+            "Promised Regrowth",       -- Level 122
+            "Promised Revivification", -- Level 117
+            "Promised Refreshment",    -- Level 112
+            "Promised Rebirth",        -- Level 107
+            "Promised Regeneration",   -- Level 102
+            "Promised Recovery",       -- Level 97
+            "Promised Revitalization", -- Level 92
+            "Promised Replenishment",  -- Level 87
+            "Promised Reknit",         -- Level 82
         },
         ['FrostDebuff'] = {
             -- Frost Debuff Series -- >= 74LVL -- On Bar
-            "Gelid Frost XI",
-            "Mythic Frost",
-            "Primal Frost",
-            "Restless Frost",
-            "Glistening Frost",
-            "Moonbright Frost",
-            "Lustrous Frost",
-            "Silver Frost",
-            "Argent Frost",
-            "Blanched Frost",
-            "Gelid Frost",
-            "Hoar Frost",
+            "Gelid Frost XI",   -- Level 129
+            "Mythic Frost",     -- Level 124
+            "Primal Frost",     -- Level 119
+            "Restless Frost",   -- Level 114
+            "Glistening Frost", -- Level 109
+            "Moonbright Frost", -- Level 104
+            "Lustrous Frost",   -- Level 99
+            "Silver Frost",     -- Level 94
+            "Argent Frost",     -- Level 89
+            "Blanched Frost",   -- Level 84
+            "Gelid Frost",      -- Level 79
+            "Hoar Frost",       -- Level 74
         },
         ['RoDebuff'] = {
             -- Ro Debuff Series -- >= 37LVL -- AA Starts at LVL (Single Target) -- On Bar Until AA
-            "Grasp of Ro IX",
-            "Clench of Ro",
-            "Cinch of Ro",
-            "Clasp of Ro",
-            "Cowl of Ro",
-            "Crush of Ro",
-            "Cowl of Ro",
-            "Clutch of Ro",
-            "Grip of Ro",
-            "Grasp of Ro",
-            "Sun's Corona",
-            "Ro's Illumination",
-            "Ro's Smoldering Disjunction",
-            "Fixation of Ro",
-            "Ro's Fiery Sundering",
+            "Grasp of Ro IX",              -- Level 126
+            "Clench of Ro",                -- Level 121
+            "Cinch of Ro",                 -- Level 116
+            "Clasp of Ro",                 -- Level 111
+            "Cowl of Ro",                  -- Level 106
+            "Cowl of Ro",                  -- Level 106
+            "Crush of Ro",                 -- Level 101
+            "Clutch of Ro",                -- Level 96
+            "Grip of Ro",                  -- Level 91
+            "Grasp of Ro",                 -- Level 86
+            "Sun's Corona",                -- Level 67
+            "Ro's Illumination",           -- Level 62
+            "Ro's Smoldering Disjunction", -- Level 56
+            "Fixation of Ro",              -- Level 42
+            "Ro's Fiery Sundering",        -- Level 37
         },
         ['RoDebuffAE'] = {
             -- Ro AE Debuff Series -- >= 97LVL -- AA Starts at LVL
-            "Pillar of Ro VII",
-            "Visage of Ro",
-            "Scrutiny of Ro",
-            "Glare of Ro",
-            "Gaze of Ro",
-            "Column of Ro",
-            "Pillar of Ro",
+            "Pillar of Ro VII", -- Level 127
+            "Visage of Ro",     -- Level 122
+            "Scrutiny of Ro",   -- Level 117
+            "Glare of Ro",      -- Level 112
+            "Gaze of Ro",       -- Level 107
+            "Column of Ro",     -- Level 102
+            "Pillar of Ro",     -- Level 97
         },
         ['IceBreathDebuff'] = {
             -- Ice Breath Series >= 63LVL -- On Bar
-            "Glacier Breath XIV",
-            "Algid Breath",
-            "Twilight Breath",
-            "Icerend Breath",
-            "Frostreave Breath",
-            "Blizzard Breath",
-            "Frosthowl Breath",
-            "Encompassing Breath",
-            "Bracing Breath",
-            "Coldwhisper Breath",
-            "Chillvapor Breath",
-            "Icefall Breath",
-            "Glacier Breath",
-            "E`ci's Frosty Breath",
+            "Glacier Breath XIV",   -- Level 127
+            "Algid Breath",         -- Level 122
+            "Twilight Breath",      -- Level 117
+            "Icerend Breath",       -- Level 112
+            "Frostreave Breath",    -- Level 107
+            "Blizzard Breath",      -- Level 102
+            "Frosthowl Breath",     -- Level 97
+            "Encompassing Breath",  -- Level 92
+            "Bracing Breath",       -- Level 87
+            "Coldwhisper Breath",   -- Level 82
+            "Chillvapor Breath",    -- Level 77
+            "Icefall Breath",       -- Level 72
+            "Glacier Breath",       -- Level 67
+            "E`ci's Frosty Breath", -- Level 63
         },
         ['SkinDebuff'] = {
             -- Skin Debuff Series >= 73LVL -- On Bar
-            "Skin to Lichen",
-            "Skin to Sumac",
-            "Skin to Seedlings",
-            "Skin to Foliage",
-            "Skin to Leaves",
-            "Skin to Flora",
-            "Skin to Mulch",
-            "Skin to Vines",
+            "Skin to Lichen",    -- Level 118
+            "Skin to Sumac",     -- Level 108
+            "Skin to Seedlings", -- Level 98
+            "Skin to Foliage",   -- Level 93
+            "Skin to Leaves",    -- Level 88
+            "Skin to Flora",     -- Level 83
+            "Skin to Mulch",     -- Level 78
+            "Skin to Vines",     -- Level 73
         },
         ['ReptileCombatInnate'] = {
             -- Reptile Combat Innate >= 68LVL -- On Bar
-            "Skin of the Reptile XII",
-            "Chitin of the Reptile",
-            "Bulwark of the Reptile",
-            "Defense of the Reptile",
-            "Guard of the Reptile",
-            "Pellicle of the Reptile",
-            "Husk of the Reptile",
-            "Hide of the Reptile",
-            "Shell of the Reptile",
-            "Carapace of the Reptile",
-            "Scales of the Reptile",
-            "Skin of the Reptile",
+            "Skin of the Reptile XII", -- Level 129
+            "Chitin of the Reptile",   -- Level 124
+            "Bulwark of the Reptile",  -- Level 119
+            "Defense of the Reptile",  -- Level 114
+            "Guard of the Reptile",    -- Level 109
+            "Pellicle of the Reptile", -- Level 104
+            "Husk of the Reptile",     -- Level 99
+            "Hide of the Reptile",     -- Level 94
+            "Shell of the Reptile",    -- Level 89
+            "Carapace of the Reptile", -- Level 84
+            "Scales of the Reptile",   -- Level 79
+            "Skin of the Reptile",     -- Level 68
         },
         ['NaturesWrathDot'] = {
             -- Natures Wrath DOT Line >= 75LVL -- On Bar
-            "Nature's Blazing Wrath XII",
-            "Nature's Fervid Wrath",
-            "Nature's Blistering Wrath",
-            "Nature's Fiery Wrath",
-            "Nature's Withering Wrath",
-            "Nature's Scorching Wrath",
-            "Nature's Incinerating Wrath",
-            "Nature's Searing Wrath",
-            "Nature's Burning Wrath",
-            "Nature's Blazing Wrath",
-            "Nature's Sweltering Wrath",
-            "Nature's Boiling Wrath",
+            "Nature's Blazing Wrath XII",  -- Level 130
+            "Nature's Boiling Wrath",      -- Level 125
+            "Nature's Sweltering Wrath",   -- Level 120
+            "Nature's Fervid Wrath",       -- Level 115
+            "Nature's Blistering Wrath",   -- Level 110
+            "Nature's Fiery Wrath",        -- Level 105
+            "Nature's Withering Wrath",    -- Level 100
+            "Nature's Scorching Wrath",    -- Level 95
+            "Nature's Incinerating Wrath", -- Level 90
+            "Nature's Searing Wrath",      -- Level 85
+            "Nature's Burning Wrath",      -- Level 80
+            "Nature's Blazing Wrath",      -- Level 75
         },
         ['HordeDot'] = {
-            "Horde of Spitewasps",
-            "Horde of Hotaria",
-            "Horde of Duskwigs",
-            "Horde of Hyperboreads",
-            "Horde of Polybiads",
-            "Horde of Aculeids",
-            "Horde of Mutillids",
-            "Horde of Vespids",
-            "Horde of Scoriae",
-            "Horde of the Hive",
-            "Horde of Fireants",
-            "Swarm of Fireants",
-            "Wasp Swarm",
-            "Swarming Death",
-            "Winged Death",
-            "Drifting Death",
-            "Drones of Doom",
-            "Creeping Crud",
-            "Stinging Swarm",
+            "Horde of Spitewasps",   -- Level 128
+            "Horde of Hotaria",      -- Level 123
+            "Horde of Duskwigs",     -- Level 118
+            "Horde of Hyperboreads", -- Level 113
+            "Horde of Polybiads",    -- Level 108
+            "Horde of Aculeids",     -- Level 103
+            "Horde of Mutillids",    -- Level 98
+            "Horde of Vespids",      -- Level 93
+            "Horde of Scoriae",      -- Level 88
+            "Horde of the Hive",     -- Level 83
+            "Horde of Fireants",     -- Level 78
+            "Swarm of Fireants",     -- Level 73
+            "Wasp Swarm",            -- Level 68
+            "Swarming Death",        -- Level 63
+            "Winged Death",          -- Level 53
+            "Drifting Death",        -- Level 40
+            "Drones of Doom",        -- Level 32
+            "Creeping Crud",         -- Level 24
+            "Stinging Swarm",        -- Level 10
         },
         ['SunDot'] = {
             -- SUN Dot Line >= 49LVL -- On Bar
-            "Sunscorch XII",
-            "Sunscald",
-            "Sunpyre",
-            "Sunshock",
-            "Sunflame",
-            "Sunflash",
-            "Sunblaze",
-            "Sunscorch",
-            "Sunbrand",
-            "Sunsinge",
-            "Sunsear",
-            "Sunscorch",
-            "Vengeance of the Sun",
-            "Vengeance of Tunare",
-            "Vengeance of Nature",
-            "Vengeance of the Wild",
+            "Sunscorch XII",         -- Level 129
+            "Sunscald",              -- Level 124
+            "Sunpyre",               -- Level 119
+            "Sunshock",              -- Level 114
+            "Sunflame",              -- Level 109
+            "Sunflash",              -- Level 104
+            "Sunblaze",              -- Level 99
+            "Sunbrand",              -- Level 89
+            "Sunsinge",              -- Level 84
+            "Sunsear",               -- Level 79
+            "Sunscorch",             -- Level 74
+            "Sunscorch",             -- Level 74
+            "Vengeance of the Sun",  -- Level 69
+            "Vengeance of Tunare",   -- Level 64
+            "Vengeance of Nature",   -- Level 55
+            "Vengeance of the Wild", -- Level 49
         },
         ['MoonbeamDot'] = {
-            "Gelid Moonbeam IX",
-            "Mythical Moonbeam",
-            "Onyx Moonbeam",
-            "Opaline Moonbeam",
-            "Pearlescent Moonbeam",
-            "Argent Moonbeam",
-            "Frigid Moonbeam",
-            "Algid Moonbeam",
-            "Gelid Moonbeam",
+            "Gelid Moonbeam IX",    -- Level 129
+            "Mythical Moonbeam",    -- Level 124
+            "Onyx Moonbeam",        -- Level 119
+            "Opaline Moonbeam",     -- Level 114
+            "Pearlescent Moonbeam", -- Level 109
+            "Argent Moonbeam",      -- Level 104
+            "Frigid Moonbeam",      -- Level 99
+            "Algid Moonbeam",       -- Level 94
+            "Gelid Moonbeam",       -- Level 89
         },
         ['SunrayDot'] = {
-            "Blistering Sunray XII",
-            "Searing Sunray",
-            "Tenebrous Sunray",
-            "Erupting Sunray",
-            "Overwhelming Sunray",
-            "Consuming Sunray",
-            "Incinerating Sunray",
-            "Blazing Sunray",
-            "Scorching Sunray",
-            "Withering Sunray",
-            "Torrid Sunray",
-            "Blistering Sunray",
-            "Immolation of the Sun",
-            "Sylvan Embers",
-            "Immolation of Ro",
-            "Breath of Ro",
-            "Immolate",
-            "Flame Lick",
+            "Blistering Sunray XII", -- Level 126
+            "Searing Sunray",        -- Level 121
+            "Tenebrous Sunray",      -- Level 116
+            "Erupting Sunray",       -- Level 111
+            "Overwhelming Sunray",   -- Level 106
+            "Consuming Sunray",      -- Level 101
+            "Incinerating Sunray",   -- Level 96
+            "Blazing Sunray",        -- Level 91
+            "Scorching Sunray",      -- Level 86
+            "Withering Sunray",      -- Level 81
+            "Torrid Sunray",         -- Level 76
+            "Blistering Sunray",     -- Level 71
+            "Immolation of the Sun", -- Level 67
+            "Sylvan Embers",         -- Level 65
+            "Immolation of Ro",      -- Level 62
+            "Breath of Ro",          -- Level 52
+            "Immolate",              -- Level 25
+            "Flame Lick",            -- Level 1
         },
         ['RemoteMoonDD'] = {
             -- Remote Moon DD >= 99LVL
-            "Remote Moonfire VII",
-            "Remote Moonshiver",
-            "Remote Moonchill",
-            "Remote Moonrake",
-            "Remote Moonflash",
-            "Remote Moonflame",
-            "Remote Moonfire",
+            "Remote Moonfire VII", -- Level 129
+            "Remote Moonshiver",   -- Level 124
+            "Remote Moonchill",    -- Level 119
+            "Remote Moonrake",     -- Level 114
+            "Remote Moonflash",    -- Level 109
+            "Remote Moonflame",    -- Level 104
+            "Remote Moonfire",     -- Level 99
         },
         ['RemoteSunDD'] = {
             -- Remote Sun DD >= 83LVL
-            "Remote Sunflare X",
-            "Remote Sunscorch",
-            "Remote Sunbolt",
-            "Remote Sunshock",
-            "Remote Sunblaze",
-            "Remote Sunflash",
-            "Remote Sunfire",
-            "Remote Sunburst",
-            "Remote Sunflare",
-            "Remote Manaflux",
+            "Remote Sunflare X", -- Level 130
+            "Remote Sunscorch",  -- Level 123
+            "Remote Sunbolt",    -- Level 118
+            "Remote Sunshock",   -- Level 113
+            "Remote Sunblaze",   -- Level 108
+            "Remote Sunflash",   -- Level 103
+            "Remote Sunfire",    -- Level 98
+            "Remote Sunburst",   -- Level 93
+            "Remote Sunflare",   -- Level 88
+            "Remote Manaflux",   -- Level 83
         },
         ['RoarDD'] = {
             -- Roar DD >= 93LVL
-            "Katabatic Roar VIII",
-            "Tempest Roar",
-            "Bloody Roar",
-            "Typhonic Roar",
-            "Cyclonic Roar",
-            "Anabatic Roar",
-            "Katabatic Roar",
-            "Roar of Kolos",
+            "Katabatic Roar VIII", -- Level 128
+            "Tempest Roar",        -- Level 123
+            "Bloody Roar",         -- Level 118
+            "Typhonic Roar",       -- Level 113
+            "Cyclonic Roar",       -- Level 108
+            "Anabatic Roar",       -- Level 103
+            "Katabatic Roar",      -- Level 98
+            "Roar of Kolos",       -- Level 93
         },
         ['QuickRoarDD'] = {
             -- Quick Cast Roar Series -- will be replaced by roar at lvl 93
-            "Shattering of the Stormborn",
-            "Revelry of the Stormborn",
-            "Bedlam of the Sotrmborn",
-            "Maelstrom of the Stormborn",
-            "Thunderbolt of the Stormborn",
-            "Typhoon of the Stormborn",
-            "Whirlwind of the Stormborn",
-            "Cyclone of the Stormborn",
-            "Shear of the Stormborn",
-            "Squall of the Stormborn",
-            "Tempest of the Stormborn",
-            "Gale of the Stormborn",
-            "Stormwatch",
-            "Storm's Fury",
-            "Dustdevil",
-            "Fury of Air",
+            "Shattering of the Stormborn",  -- Level 126
+            "Revelry of the Stormborn",     -- Level 121
+            "Bedlam of the Stormborn",      -- Level 116
+            "Maelstrom of the Stormborn",   -- Level 111
+            "Thunderbolt of the Stormborn", -- Level 106
+            "Typhoon of the Stormborn",     -- Level 101
+            "Whirlwind of the Stormborn",   -- Level 96
+            "Cyclone of the Stormborn",     -- Level 91
+            "Shear of the Stormborn",       -- Level 86
+            "Squall of the Stormborn",      -- Level 81
+            "Tempest of the Stormborn",     -- Level 76
+            "Gale of the Stormborn",        -- Level 71
+            "Stormwatch",                   -- Level 66
+            "Storm's Fury",                 -- Level 61
+            "Dustdevil",                    -- Level 43
+            "Fury of Air",                  -- Level 30
         },
         ['DichoSpell'] = {
             -- Dicho Spell >= 101LVL
-            "Ecliptic Winds",
-            "Composite Winds",
-            "Dissident Winds",
-            "Dichotomic Winds",
-            "Reciprocal Winds",
+            "Reciprocal Winds", -- Level 121
+            "Ecliptic Winds",   -- Level 116
+            "Composite Winds",  -- Level 111
+            "Dissident Winds",  -- Level 106
+            "Dichotomic Winds", -- Level 101
         },
         ['WinterFireDD'] = {
             -- Winters Fire DD Line >= 73LVL -- Using for Low level Fire DD as well
-            "Winder's Wildflame XII",
-            "Winder's Wildgale",
-            "Winter's Wildbrume",
-            "Winter's Wildshock",
-            "Winter's Wildblaze",
-            "Winter's Wildflame",
-            "Winter's Wildfire",
-            "Winter's Sear",
-            "Winter's Pyre",
-            "Winter's Flare",
-            "Winter's Blaze",
-            "Winter's Flame",
-            "Solstice Strike",
-            "Sylvan Fire",
-            "Summer's Flame",
-            "Wildfire",
-            "Scoriae",
-            "Starfire",
-            "Firestrike",
-            "Combust",
-            "Ignite",
-            "Burst of Fire",
-            "Burst of Flame",
+            "Winter's Wildflame XII", -- Level 128
+            "Winter's Wildgale",      -- Level 123
+            "Winter's Wildbrume",     -- Level 118
+            "Winter's Wildshock",     -- Level 113
+            "Winter's Wildblaze",     -- Level 108
+            "Winter's Wildflame",     -- Level 103
+            "Winter's Wildfire",      -- Level 98
+            "Winter's Sear",          -- Level 93
+            "Winter's Pyre",          -- Level 88
+            "Winter's Flare",         -- Level 83
+            "Winter's Blaze",         -- Level 78
+            "Winter's Flame",         -- Level 73
+            "Solstice Strike",        -- Level 69
+            "Sylvan Fire",            -- Level 65
+            "Summer's Flame",         -- Level 64
+            "Wildfire",               -- Level 59
+            "Scoriae",                -- Level 54
+            "Starfire",               -- Level 48
+            "Firestrike",             -- Level 38
+            "Combust",                -- Level 28
+            "Ignite",                 -- Level 8
+            "Burst of Fire",          -- Level 3
+            "Burst of Flame",         -- Level 1
         },
         ['ChillDot'] = {
             -- Chill DOT Line -- >= 95LVL -- Used for Burns
-            "Chill of the Grovetender",
-            "Chill of the Ferntender",
-            "Chill of the Dusksage Tender",
-            "Chill of the Arbor Tender",
-            "Chill of the Wildtender",
-            "Chill of the Copsetender",
-            "Chill of the Visionary",
-            "Chill of the Natureward",
+            "Chill of the Grovetender",     -- Level 130
+            "Chill of the Ferntender",      -- Level 125
+            "Chill of the Dusksage Tender", -- Level 120
+            "Chill of the Arbor Tender",    -- Level 115
+            "Chill of the Wildtender",      -- Level 110
+            "Chill of the Copsetender",     -- Level 105
+            "Chill of the Visionary",       -- Level 100
+            "Chill of the Natureward",      -- Level 95
         },
         ['RootSpells'] = {
             -- Root Spells
-            "Vinelash Assault",
-            "Vinelash Cascade",
-            "Spore Spiral",
-            "Savage Roots",
-            "Earthen Roots",
-            "Entrapping Roots",
-            "Engorging Roots",
-            "Engulfing Roots",
-            "Enveloping Roots",
-            "Ensnaring Roots",
-            "Grasping Roots",
+            "Vinelash Assault", -- Level 97
+            "Vinelash Cascade", -- Level 72
+            "Spore Spiral",     -- Level 69
+            "Savage Roots",     -- Level 64
+            "Earthen Roots",    -- Level 61
+            "Entrapping Roots", -- Level 60
+            "Engorging Roots",  -- Level 56
+            "Engulfing Roots",  -- Level 45
+            "Enveloping Roots", -- Level 36
+            "Ensnaring Roots",  -- Level 21
+            "Grasping Roots",   -- Level 2
         },
         ['SnareSpell'] = {
             -- Snare Spells
-            "Thornmaw Vines",
-            "Serpent Vines",
-            "Entangle",
-            "Mire Thorns",
-            "Bonds of Tunare",
-            "Ensnare",
-            "Snare",
-            "Tangling Weeds",
+            "Thornmaw Vines",  -- Level 97
+            "Serpent Vines",   -- Level 69
+            "Entangle",        -- Level 61
+            "Mire Thorns",     -- Level 61
+            "Bonds of Tunare", -- Level 57
+            "Ensnare",         -- Level 26
+            "Snare",           -- Level 1
+            "Tangling Weeds",  -- Level 1
         },
         ['TwinHealNuke'] = {
-            "Sundew Blessing X",
-            "Sunbliss Blessing",
-            "Sundew Blessing",
-            "Sunrise Blessing",
-            "Sunbreeze Blessing",
-            "Sunbeam Blessing",
-            "Sunfire Blessing",
-            "Sunflash Blessing",
-            "Sunrake Blessing",
-            "Sunwarmth Blessing",
+            "Sundew Blessing X",  -- Level 128
+            "Sunbliss Blessing",  -- Level 123
+            "Sunwarmth Blessing", -- Level 119
+            "Sunrake Blessing",   -- Level 114
+            "Sunflash Blessing",  -- Level 109
+            "Sunfire Blessing",   -- Level 104
+            "Sunbeam Blessing",   -- Level 99
+            "Sunbreeze Blessing", -- Level 94
+            "Sunrise Blessing",   -- Level 89
+            "Sundew Blessing",    -- Level 84
         },
         ['IceNuke'] = {
-            "Rime Crystals XII",
-            "Ice",
-            "Frost",
-            "Moonfire",
-            "Winter's Frost",
-            "Glitterfrost",
-            "Rime Crystals",
-            "Hoar Crystals",
-            "Glaciating Crystals",
-            "Argent Crystals",
-            "Sterlingfrost Crystals",
-            "Gelid Crystals",
-            "Frostweave Crystals",
-            "Frostreave Crystals",
-            "Icerend Crystals",
-            "Moonwhisper Crystals",
-            "Coldbite Crystals",
+            "Rime Crystals XII",      -- Level 130
+            "Coldbite Crystals",      -- Level 125
+            "Moonwhisper Crystals",   -- Level 120
+            "Icerend Crystals",       -- Level 115
+            "Frostreave Crystals",    -- Level 110
+            "Frostweave Crystals",    -- Level 105
+            "Gelid Crystals",         -- Level 100
+            "Sterlingfrost Crystals", -- Level 95
+            "Argent Crystals",        -- Level 90
+            "Glaciating Crystals",    -- Level 85
+            "Hoar Crystals",          -- Level 80
+            "Rime Crystals",          -- Level 75
+            "Glitterfrost",           -- Level 70
+            "Winter's Frost",         -- Level 65
+            "Moonfire",               -- Level 60
+            "Frost",                  -- Level 55
+            "Ice",                    -- Level 47
         },
         ['IceRainNuke'] = {
-            "Cascade of Hail XVIII",
-            "Cascade of Hail",
-            "Pogonip",
-            "Avalanche",
-            "Blizzard",
-            "Winter's Storm",
-            "Tempest Wind",
-            "Cloudburst Hail",
-            "Torrential Hail",
-            "Cascading Hail",
-            "Cyclonic Hail",
-            "Crashing Hail",
-            "Hailstorm",
-            "Plummeting Hail",
-            "Plunging Hail",
-            "Tempestuous Hail",
-            "Howling Hail",
-            "Unrelenting Hail",
+            "Cascade of Hail XVIII", -- Level 127
+            "Unrelenting Hail",      -- Level 121
+            "Howling Hail",          -- Level 116
+            "Tempestuous Hail",      -- Level 111
+            "Plunging Hail",         -- Level 106
+            "Plummeting Hail",       -- Level 101
+            "Hailstorm",             -- Level 96
+            "Crashing Hail",         -- Level 91
+            "Cyclonic Hail",         -- Level 86
+            "Cascading Hail",        -- Level 81
+            "Torrential Hail",       -- Level 76
+            "Cloudburst Hail",       -- Level 71
+            "Tempest Wind",          -- Level 66
+            "Winter's Storm",        -- Level 61
+            "Blizzard",              -- Level 54
+            "Avalanche",             -- Level 37
+            "Pogonip",               -- Level 22
+            "Cascade of Hail",       -- Level 12
         },
         ['ShroomPet'] = {
             --Druid Mushroom DOT Pet Line >= 84LVL --used for mana savings
-            "Mycelid Assault",
-            "Saprophyte Assault",
-            "Chytrid Assault",
-            "Fungusoid Assault",
-            "Sporali Storm",
-            "Sporali Assault",
-            "Myconid Assault",
-            "Polyporous Assault",
-            "Blast of Hypergrowth",
+            "Mycelid Assault",      -- Level 124
+            "Saprophyte Assault",   -- Level 119
+            "Chytrid Assault",      -- Level 114
+            "Fungusoid Assault",    -- Level 109
+            "Sporali Storm",        -- Level 104
+            "Sporali Assault",      -- Level 99
+            "Myconid Assault",      -- Level 94
+            "Polyporous Assault",   -- Level 89
+            "Blast of Hypergrowth", -- Level 84
         },
         ['IceDD'] = {
             -- Ice Nuke DD --Gap Filler
-            "Moonfire",
-            "Frost",
+            "Moonfire", -- Level 60
+            "Frost",    -- Level 55
         },
         ['SelfShield'] = {
             -- Self Shield Buff
-            "Brackenbriar Coat",
-            "Bramblespike Coat",
-            "Shadespine Coat",
-            "Icebriar Coat",
-            "Daggerspike Coat",
-            "Daggerspur Coat",
-            "Spikethistle Coat",
-            "Spineburr Coat",
-            "Bonebriar Coat",
-            "Brierbloom Coat",
-            "Viridithorn Coat",
-            "Viridicoat",
-            "Nettlecoat",
-            "Brackencoat",
-            "Bladecoat",
-            "Thorncoat",
-            "Spikecoat",
-            "Bramblecoat",
-            "Barbcoat",
-            "Thistlecoat",
+            "Brackenbriar Coat", -- Level 128
+            "Bramblespike Coat", -- Level 123
+            "Shadespine Coat",   -- Level 118
+            "Icebriar Coat",     -- Level 113
+            "Daggerspike Coat",  -- Level 108
+            "Daggerspur Coat",   -- Level 103
+            "Spikethistle Coat", -- Level 98
+            "Spineburr Coat",    -- Level 93
+            "Bonebriar Coat",    -- Level 88
+            "Brierbloom Coat",   -- Level 83
+            "Viridithorn Coat",  -- Level 78
+            "Viridicoat",        -- Level 73
+            "Nettlecoat",        -- Level 68
+            "Brackencoat",       -- Level 64
+            "Bladecoat",         -- Level 56
+            "Thorncoat",         -- Level 47
+            "Spikecoat",         -- Level 37
+            "Bramblecoat",       -- Level 27
+            "Barbcoat",          -- Level 17
+            "Thistlecoat",       -- Level 7
         },
         ['SelfManaRegen'] = {
             -- Self mana Regen Buff
-            "Mask of the Grovetender",
-            "Mask of the Ferntender",
-            "Mask of the Dusksage Tender",
-            "Mask of the Arbor Tender",
-            "Mask of the Wildtender",
-            "Mask of the Copsetender",
-            "Mask of the Bosquetender",
-            "Mask of the Thicket Dweller",
-            "Mask of the Arboreal",
-            "Mask of the Raptor",
-            "Mask of the Shadowcat",
-            "Mask of the Wild",
-            "Mask of the Forest",
-            "Mask of the Stalker",
-            "Mask of the Hunter",
+            "Mask of the Grovetender",     -- Level 130
+            "Mask of the Ferntender",      -- Level 125
+            "Mask of the Dusksage Tender", -- Level 120
+            "Mask of the Arbor Tender",    -- Level 115
+            "Mask of the Wildtender",      -- Level 110
+            "Mask of the Copsetender",     -- Level 105
+            "Mask of the Bosquetender",    -- Level 100
+            "Mask of the Thicket Dweller", -- Level 95
+            "Mask of the Arboreal",        -- Level 90
+            "Mask of the Raptor",          -- Level 85
+            "Mask of the Shadowcat",       -- Level 80
+            "Mask of the Wild",            -- Level 70
+            "Mask of the Forest",          -- Level 65
+            "Mask of the Stalker",         -- Level 60
+            "Mask of the Hunter",          -- Level 60
         },
         ['HPTypeOneGroup'] = {
-            "Grovewood Blessing",
-            "Emberquartz Blessing",
-            "Luclinite Blessing",
-            "Opaline Blessing",
-            "Arcronite Blessing",
-            "Shieldstone Blessing",
-            "Granitebark Blessing",
-            "Stonebark Blessing",
-            "Blessing of the Timbercore",
-            "Blessing of the Heartwood",
-            "Blessing of the Ironwood",
-            "Blessing of the Direwild",
-            "Blessing of Steeloak",
-            "Blessing of the Nine",
-            "Protection of the Glades",
-            "Protection of Nature",
-            "Protection of Diamond",
-            "Protection of Steel",
-            "Protection of Rock",
-            "Protection of Wood",
-            'Skin like Wood',
+            "Grovewood Blessing",         -- Level 127
+            "Emberquartz Blessing",       -- Level 125
+            "Luclinite Blessing",         -- Level 120
+            "Opaline Blessing",           -- Level 115
+            "Arcronite Blessing",         -- Level 110
+            "Shieldstone Blessing",       -- Level 105
+            "Granitebark Blessing",       -- Level 100
+            "Stonebark Blessing",         -- Level 95
+            "Blessing of the Timbercore", -- Level 90
+            "Blessing of the Heartwood",  -- Level 85
+            "Blessing of the Ironwood",   -- Level 80
+            "Blessing of the Direwild",   -- Level 75
+            "Blessing of Steeloak",       -- Level 70
+            "Blessing of the Nine",       -- Level 65
+            "Protection of the Glades",   -- Level 60
+            "Protection of Nature",       -- Level 49
+            "Protection of Diamond",      -- Level 39
+            "Protection of Steel",        -- Level 27
+            "Protection of Rock",         -- Level 19
+            "Protection of Wood",         -- Level 9
         },
         ['TempHPBuff'] = {
             -- Temp Health -- Focus on Tank
-            "Wild Growth X",
-            "Overwhelming Growth",
-            "Fervent Growth",
-            "Frenzied Growth",
-            "Savage Growth",
-            "Ferocious Growth",
-            "Rampant Growth",
-            "Unfettered Growth",
-            "Untamed Growth",
-            "Wild Growth",
+            "Wild Growth X",       -- Level 127
+            "Overwhelming Growth", -- Level 122
+            "Fervent Growth",      -- Level 117
+            "Frenzied Growth",     -- Level 112
+            "Savage Growth",       -- Level 107
+            "Ferocious Growth",    -- Level 102
+            "Rampant Growth",      -- Level 97
+            "Unfettered Growth",   -- Level 92
+            "Untamed Growth",      -- Level 87
+            "Wild Growth",         -- Level 82
         },
         ['GroupRegenBuff'] = {
             -- Group Regen BuffAll Have Long Duration HP Regen Buffs. Not Short term Heal.
-            "Talisman of Perseverance XV",
-            "Talisman of the Unforgettable",
-            "Talisman of the Tenacious",
-            "Talisman of the Enduring",
-            "Talisman of the Unwavering",
-            "Talisman of the Faithful",
-            "Talisman of the Steadfast",
-            "Talisman of the Indomitable",
-            "Talisman of the Relentless",
-            "Talisman of the Resolute",
-            "Talisman of the Stalwart",
-            "Talisman of Perseverance",
-            "Pack Regeneration",
-            "Pack Chloroplast",
-            "Regrowth of the Grove",
-            "Blessing of Oak",
-            "Blessing of Replenishment",
+            "Talisman of Perseverance XV",   -- Level 126
+            "Talisman of the Unforgettable", -- Level 124
+            "Talisman of the Tenacious",     -- Level 119
+            "Talisman of the Enduring",      -- Level 114
+            "Talisman of the Unwavering",    -- Level 109
+            "Talisman of the Faithful",      -- Level 104
+            "Talisman of the Steadfast",     -- Level 99
+            "Talisman of the Indomitable",   -- Level 94
+            "Talisman of the Relentless",    -- Level 89
+            "Talisman of the Resolute",      -- Level 84
+            "Talisman of the Stalwart",      -- Level 79
+            "Blessing of Oak",               -- Level 69
+            "Blessing of Replenishment",     -- Level 63
+            "Regrowth of the Grove",         -- Level 58
+            "Pack Chloroplast",              -- Level 45
+            "Pack Regeneration",             -- Level 39
         },
         ['AtkBuff'] = {
             -- Single Target Attack Buff for MeleeGuard
-            "Mammoth's Force",
-            "Mammoth's Strength",
-            "Lion's Strength",
-            "Nature's Might",
-            "Girdle of Karana",
-            "Storm Strength",
-            "Strength of Stone",
-            "Strength of Earth",
+            "Mammoth's Force",    -- Level 86
+            "Mammoth's Strength", -- Level 71
+            "Lion's Strength",    -- Level 67
+            "Nature's Might",     -- Level 62
+            "Girdle of Karana",   -- Level 55
+            "Storm Strength",     -- Level 44
+            "Strength of Stone",  -- Level 34
+            "Strength of Earth",  -- Level 7
         },
         ['GroupDmgShield'] = {
             -- Group Damage Shield -- Focus on the tank
-            "Legacy of Brackenbriars",
-            "Legacy of Bramblespikes",
-            "Legacy of Bloodspikes",
-            "Legacy of Icebriars",
-            "Legacy of Daggerspikes",
-            "Legacy of Daggerspurs",
-            "Legacy of Spikethistles",
-            "Legacy of Spineburrs",
-            "Legacy of Bonebriar",
-            "Legacy of Brierbloom",
-            "Legacy of Viridithorns",
-            "Legacy of Viridiflora",
-            "Legacy of Nettles",
-            "Legacy of Bracken",
-            "Legacy of Thorn",
-            "Legacy of Spike",
+            "Legacy of Brackenbriars", -- Level 127
+            "Legacy of Bramblespikes", -- Level 125
+            "Legacy of Bloodspikes",   -- Level 120
+            "Legacy of Icebriars",     -- Level 115
+            "Legacy of Daggerspikes",  -- Level 110
+            "Legacy of Daggerspurs",   -- Level 105
+            "Legacy of Spikethistles", -- Level 100
+            "Legacy of Spineburrs",    -- Level 95
+            "Legacy of Bonebriar",     -- Level 90
+            "Legacy of Brierbloom",    -- Level 85
+            "Legacy of Viridithorns",  -- Level 80
+            "Legacy of Viridiflora",   -- Level 75
+            "Legacy of Nettles",       -- Level 70
+            "Legacy of Bracken",       -- Level 65
+            "Legacy of Thorn",         -- Level 59
+            "Legacy of Spike",         -- Level 49
         },
         ['MoveSpells'] = {
-            "Spirit of Wolf",
-            "Pack Spirit",
-            "Spirit of Eagle",
-            "Flight of Eagles",
-            "Spirit of Falcons",
-            "Flight of Falcons",
+            "Flight of Falcons", -- Level 91
+            "Spirit of Falcons", -- Level 74
+            "Flight of Eagles",  -- Level 62
+            "Spirit of Eagle",   -- Level 54
+            "Pack Spirit",       -- Level 35
+            "Spirit of Wolf",    -- Level 10
         },
         ['ManaBear'] = {
             --Druid Mana Bear Growth Line
-            "Nurturing Growth",
-            "Nourishing Growth",
-            "Sustaining Growth",
-            "Bolstered Growth",
-            "Emboldened Growth",
+            "Emboldened Growth", -- Level 121
+            "Bolstered Growth",  -- Level 116
+            "Sustaining Growth", -- Level 111
+            "Nourishing Growth", -- Level 106
+            "Nurturing Growth",  -- Level 96
         },
         ['PetSpell'] = {
-            "Nature Walker's Behest",
+            "Nature Walker's Behest", -- Level 55
         },
         -- ['SingleDS'] = {
         --     -- Updated to 125
         --     --Single Target Damage Shield
-        --     "Shield of Thistles",
-        --     "Shield of Barbs",
-        --     "Shield of Brambles",
-        --     "Shield of Spikes",
-        --     "Shield of Thorns",
-        --     "Shield of Blades",
-        --     "Shield of Bracken",
-        --     "Nettle Shield",
-        --     "Viridifloral Shield",
-        --     "Viridifloral Bulwark",
-        --     "Brierbloom Bulwark",
-        --     "Bonebriar Bulwark",
-        --     "Spineburr Bulwark",
-        --     "Spikethistle Bulwark",
-        --     "Daggerspur Bulwark",
-        --     "Daggerspike Bulwark",
-        --     "Icebriar Bulwark",
-        --     "Nightspire Bulwark",
-        --     "Bramblespike Bulwark",
+        --     "Bramblespike Bulwark", -- Level 122
+        --     "Nightspire Bulwark",   -- Level 117
+        --     "Icebriar Bulwark",     -- Level 112
+        --     "Daggerspike Bulwark",  -- Level 107
+        --     "Daggerspur Bulwark",   -- Level 102
+        --     "Spikethistle Bulwark", -- Level 97
+        --     "Spineburr Bulwark",    -- Level 92
+        --     "Bonebriar Bulwark",    -- Level 87
+        --     "Brierbloom Bulwark",   -- Level 82
+        --     "Viridifloral Bulwark", -- Level 77
+        --     "Viridifloral Shield",  -- Level 72
+        --     "Nettle Shield",        -- Level 67
+        --     "Shield of Bracken",    -- Level 63
+        --     "Shield of Blades",     -- Level 58
+        --     "Shield of Thorns",     -- Level 47
+        --     "Shield of Spikes",     -- Level 37
+        --     "Shield of Brambles",   -- Level 27
+        --     "Shield of Barbs",      -- Level 17
+        --     "Shield of Thistles",   -- Level 7
         -- },
     },
     ['HealRotationOrder'] = {

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -88,785 +88,784 @@ local _ClassConfig    = {
     },
     ['AbilitySets']   = {
         ['TwincastAura'] = {
-            "Twincast Aura",
+            "Twincast Aura", -- Level 84
         },
         ['SpellProcAura'] = {
-            "Mana Recursion Aura XI",
-            "Mana Ripple Aura",
-            "Mana Radix Aura",
-            "Mana Replication Aura",
-            "Mana Repetition Aura",
-            "Mana Reciprocation Aura",
-            "Mana Reverberation Aura",
-            "Mana Repercussion Aura",
-            "Mana Reiteration Aura",
-            "Mana Reiterate Aura",
-            "Mana Resurgence Aura",
+            "Mana Recursion Aura XI",  -- Level 130
+            "Mana Ripple Aura",        -- Level 125
+            "Mana Radix Aura",         -- Level 120
+            "Mana Replication Aura",   -- Level 115
+            "Mana Repetition Aura",    -- Level 110
+            "Mana Reciprocation Aura", -- Level 105
+            "Mana Reverberation Aura", -- Level 100
+            "Mana Repercussion Aura",  -- Level 95
+            "Mana Reiteration Aura",   -- Level 90
+            "Mana Reiterate Aura",     -- Level 85
+            "Mana Resurgence Aura",    -- Level 80
             -- Use mana regen aura until spell proc is available
-            "Mystifier's Aura",
-            "Entrancer's Aura",
-            "Illusionist's Aura",
-            "Beguiler's Aura",
+            "Mystifier's Aura",        -- Level 77
+            "Entrancer's Aura",        -- Level 72
+            "Illusionist's Aura",      -- Level 70
+            "Beguiler's Aura",         -- Level 55
         },
         ['LearnersAura'] = {
-            "Learner's Aura",
+            "Learner's Aura", -- Level 76
         },
         ['HasteBuff'] = {
-            "Hastening of Elluria",
-            "Hastening of Margator",
-            "Hastening of Jharin",
-            "Hastening of Cekenar",
-            "Hastening of Milyex",
-            "Hastening of Prokev",
-            "Hastening of Sviir",
-            "Hastening of Aransir",
-            "Hastening of Novak",
-            "Hastening of Erradien",
-            "Hastening of Ellowind",
-            "Hastening of Salik",
-            "Vallon's Quickening",
-            "Speed of the Brood",
-            "Speed of Cekenar",
-            "Speed of Milyex",
-            "Speed of Prokev",
-            "Speed of Sviir",
-            "Speed of Aransir",
-            "Speed of Novak",
-            "Speed of Erradien",
-            "Speed of Ellowind",
-            "Speed of Salik",
-            "Speed of Vallon",
-            "Visions of Grandeur",
-            "Wondrous Rapidity",
-            "Aanya's Quickening",
-            "Swift Like the Wind",
-            "Celerity",
-            "Augmentation",
-            "Alacrity",
-            "Quickness",
+            "Hastening of Elluria",  -- Level 126
+            "Hastening of Margator", -- Level 124
+            "Hastening of Jharin",   -- Level 119
+            "Hastening of Cekenar",  -- Level 114
+            "Speed of Cekenar",      -- Level 111
+            "Hastening of Milyex",   -- Level 109
+            "Speed of Milyex",       -- Level 106
+            "Hastening of Prokev",   -- Level 104
+            "Speed of Prokev",       -- Level 101
+            "Hastening of Sviir",    -- Level 100
+            "Speed of Sviir",        -- Level 96
+            "Hastening of Aransir",  -- Level 95
+            "Speed of Aransir",      -- Level 91
+            "Hastening of Novak",    -- Level 90
+            "Speed of Novak",        -- Level 86
+            "Hastening of Erradien", -- Level 80
+            "Speed of Erradien",     -- Level 77
+            "Hastening of Ellowind", -- Level 75
+            "Speed of Ellowind",     -- Level 72
+            "Hastening of Salik",    -- Level 70
+            "Speed of Salik",        -- Level 67
+            "Vallon's Quickening",   -- Level 65
+            "Speed of Vallon",       -- Level 62
+            "Speed of the Brood",    -- Level 60
+            "Visions of Grandeur",   -- Level 60
+            "Wondrous Rapidity",     -- Level 58
+            "Aanya's Quickening",    -- Level 53
+            "Swift Like the Wind",   -- Level 47
+            "Celerity",              -- Level 39
+            "Augmentation",          -- Level 28
+            "Alacrity",              -- Level 21
+            "Quickness",             -- Level 15
         },
         ['ManaRegen'] = {
-            "Voice of Clairvoyance XVIII",
-            "Voice of Preordination",
-            "Voice of Perception",
-            "Voice of Sagacity",
-            "Voice of Perspicacity",
-            "Voice of Precognition",
-            "Voice of Foresight",
-            "Voice of Premeditation",
-            "Voice of Forethought",
-            "Voice of Prescience",
-            "Voice of Cognizance",
-            "Voice of Intuition",
-            "Voice of Clairvoyance",
-            "Voice of Quellious",
-            "Tranquility",
-            -- [] = ["Gift of Brilliance", -- Removed because the Map Defaults to it Instead of Koadics
-            "Koadic's Endless Intellect",
-            "Gift of Pure Thought",
-            "Sagacity",
-            "Perspicacity",
-            "Precognition",
-            "Foresight",
-            "Premeditation",
-            "Forethought",
-            "Prescience",
-            "Seer's Cognizance",
-            "Seer's Intuition",
-            "Clairvoyance",
-            "Gift of Insight",
-            "Clarity II",
-            "Clarity",
-            "Breeze",
+            "Voice of Clairvoyance XVIII", -- Level 128
+            "Voice of Preordination",      -- Level 125
+            "Voice of Perception",         -- Level 120
+            "Voice of Sagacity",           -- Level 115
+            "Sagacity",                    -- Level 113
+            "Voice of Perspicacity",       -- Level 110
+            "Perspicacity",                -- Level 108
+            "Voice of Precognition",       -- Level 105
+            "Precognition",                -- Level 103
+            "Voice of Foresight",          -- Level 100
+            "Foresight",                   -- Level 98
+            "Voice of Premeditation",      -- Level 95
+            "Premeditation",               -- Level 93
+            "Voice of Forethought",        -- Level 90
+            "Forethought",                 -- Level 88
+            "Voice of Prescience",         -- Level 85
+            "Prescience",                  -- Level 83
+            "Voice of Cognizance",         -- Level 80
+            "Seer's Cognizance",           -- Level 78
+            "Voice of Intuition",          -- Level 75
+            "Seer's Intuition",            -- Level 73
+            "Voice of Clairvoyance",       -- Level 70
+            "Clairvoyance",                -- Level 68
+            "Voice of Quellious",          -- Level 65
+            "Tranquility",                 -- Level 63
+            -- "Gift of Brilliance",       -- Level 60, Removed because the Map Defaults to it Instead of Koadics
+            "Koadic's Endless Intellect",  -- Level 60
+            "Gift of Pure Thought",        -- Level 56
+            "Gift of Insight",             -- Level 55
+            "Clarity II",                  -- Level 52
+            "Clarity",                     -- Level 26
+            "Breeze",                      -- Level 14
         },
         ['MezBuff'] = {
-            "Ward of Bedazzlement XII",
-            "Ward of the Stupefier",
-            "Ward of the Beguiler",
-            "Ward of the Deviser",
-            "Ward of the Transfixer",
-            "Ward of the Enticer",
-            "Ward of the Mastermind",
-            "Ward of Arctending",
-            "Ward of Bafflement",
-            "Ward of Befuddlement",
-            "Ward of Mystifying",
-            "Ward of Bewilderment",
-            "Ward of Bedazzlement",
+            "Ward of Bedazzlement XII", -- Level 130
+            "Ward of the Stupefier",    -- Level 125
+            "Ward of the Beguiler",     -- Level 120
+            "Ward of the Deviser",      -- Level 115
+            "Ward of the Transfixer",   -- Level 110
+            "Ward of the Enticer",      -- Level 105
+            "Ward of the Mastermind",   -- Level 100
+            "Ward of Arctending",       -- Level 95
+            "Ward of Bafflement",       -- Level 90
+            "Ward of Befuddlement",     -- Level 85
+            "Ward of Mystifying",       -- Level 80
+            "Ward of Bewilderment",     -- Level 75
+            "Ward of Bedazzlement",     -- Level 70
         },
         ['NdtBuff'] = {
-            "Night's Eternal Terror",
-            "Night's Perpetual Terror",
-            "Night's Endless Terror",
-            "Night's Dark Terror",
-            "Boon of the Garou",
+            "Night's Eternal Terror",   -- Level 125
+            "Night's Perpetual Terror", -- Level 115
+            "Night's Endless Terror",   -- Level 103
+            "Night's Dark Terror",      -- Level 63
+            "Boon of the Garou",        -- Level 40
         },
         ['SelfHPBuff'] = {
-            "Shielding XXIII",
-            "Shield of Memories",
-            "Shield of Shadow",
-            "Shield of Restless Ice",
-            "Shield of Scales",
-            "Shield of the Pellarus",
-            "Shield of the Dauntless",
-            "Shield of Bronze",
-            "Shield of Dreams",
-            "Shield of the Void",
-            "Spellbound Shield",
-            "Sorcerous Shield",
-            "Mystic Shield",
-            "Shield of Maelin",
-            "Shield of the Arcane",
-            "Shield of the Magi",
-            "Arch Shielding",
-            "Greater Shielding",
-            "Major Shielding",
-            "Shielding",
-            "Lesser Shielding",
-            "Minor Shielding",
+            "Shielding XXIII",         -- Level 126
+            "Shield of Memories",      -- Level 121
+            "Shield of Shadow",        -- Level 116
+            "Shield of Restless Ice",  -- Level 111
+            "Shield of Scales",        -- Level 106
+            "Shield of the Pellarus",  -- Level 101
+            "Shield of the Dauntless", -- Level 96
+            "Shield of Bronze",        -- Level 91
+            "Shield of Dreams",        -- Level 86
+            "Shield of the Void",      -- Level 81
+            "Spellbound Shield",       -- Level 76
+            "Sorcerous Shield",        -- Level 71
+            "Mystic Shield",           -- Level 66
+            "Shield of Maelin",        -- Level 64
+            "Shield of the Arcane",    -- Level 61
+            "Shield of the Magi",      -- Level 54
+            "Arch Shielding",          -- Level 40
+            "Greater Shielding",       -- Level 31
+            "Major Shielding",         -- Level 23
+            "Shielding",               -- Level 16
+            "Lesser Shielding",        -- Level 6
+            "Minor Shielding",         -- Level 1
         },
         ['SelfRune1'] = {
-            "Arcane Rune XIII",
-            "Esoteric Rune",
-            "Marvel's Rune",
-            "Deviser's Rune",
-            "Transfixer's Rune",
-            "Enticer's Rune",
-            "Mastermind's Rune",
-            "Arcanaward's Rune",
-            "Spectral Rune",
-            "Pearlescent Rune",
-            "Opalescent Rune",
-            "Draconic Rune",
-            "Ethereal Rune",
-            "Arcane Rune",
+            "Arcane Rune XIII",  -- Level 126
+            "Esoteric Rune",     -- Level 121
+            "Marvel's Rune",     -- Level 116
+            "Deviser's Rune",    -- Level 111
+            "Transfixer's Rune", -- Level 106
+            "Enticer's Rune",    -- Level 101
+            "Mastermind's Rune", -- Level 96
+            "Arcanaward's Rune", -- Level 91
+            "Spectral Rune",     -- Level 86
+            "Pearlescent Rune",  -- Level 81
+            "Opalescent Rune",   -- Level 76
+            "Draconic Rune",     -- Level 71
+            "Ethereal Rune",     -- Level 66
+            "Arcane Rune",       -- Level 61
         },
         ['SelfRune2'] = {
-            "Polychromatic Rune XII",
-            "Polyradiant Rune",
-            "Polyluminous Rune",
-            "Polycascading Rune",
-            "Polyfluorescent Rune",
-            "Polyrefractive Rune",
-            "Polyiridescent Rune",
-            "Polyarcanic Rune",
-            "Polyspectral Rune",
-            "Polychaotic Rune",
-            "Multichromatic Rune",
-            "Polychromatic Rune",
+            "Polychromatic Rune XII", -- Level 130
+            "Polyradiant Rune",       -- Level 125
+            "Polyluminous Rune",      -- Level 120
+            "Polycascading Rune",     -- Level 115
+            "Polyfluorescent Rune",   -- Level 110
+            "Polyrefractive Rune",    -- Level 105
+            "Polyiridescent Rune",    -- Level 100
+            "Polyarcanic Rune",       -- Level 95
+            "Polyspectral Rune",      -- Level 90
+            "Polychaotic Rune",       -- Level 85
+            "Multichromatic Rune",    -- Level 80
+            "Polychromatic Rune",     -- Level 75
         },
         ['UnityRune'] = {
-            "Enticer's Unity IX",
-            "Esoteric Unity",
-            "Deviser's Unity",
-            "Marvel's Unity",
+            "Enticer's Unity IX", -- Level 130
+            "Esoteric Unity",     -- Level 125
+            "Marvel's Unity",     -- Level 120
+            "Deviser's Unity",    -- Level 115
         },
         ['SingleRune'] = {
-            "Rune XIX",
-            "Rune of Zoraxmen",
-            "Rune of Tearc",
-            "Rune of Kildrukaun",
-            "Rune of Skrizix",
-            "Rune of Lucem",
-            "Rune of Xolok",
-            "Rune of Tonmek",
-            "Rune of Novak",
-            "Rune of Yozan",
-            "Rune of Erradien",
-            "Rune of Ellowind",
-            "Rune of Salik",
-            "Rune of Zebuxoruk",
-            "Rune V",
-            "Rune IV",
-            "Rune III",
-            "Rune II",
-            "Rune I",
+            "Rune XIX",           -- Level 126
+            "Rune of Zoraxmen",   -- Level 121
+            "Rune of Tearc",      -- Level 116
+            "Rune of Kildrukaun", -- Level 111
+            "Rune of Skrizix",    -- Level 106
+            "Rune of Lucem",      -- Level 101
+            "Rune of Xolok",      -- Level 96
+            "Rune of Tonmek",     -- Level 91
+            "Rune of Novak",      -- Level 86
+            "Rune of Yozan",      -- Level 81
+            "Rune of Erradien",   -- Level 76
+            "Rune of Ellowind",   -- Level 71
+            "Rune of Salik",      -- Level 67
+            "Rune of Zebuxoruk",  -- Level 61
+            "Rune V",             -- Level 52
+            "Rune IV",            -- Level 40
+            "Rune III",           -- Level 33
+            "Rune II",            -- Level 22
+            "Rune I",             -- Level 13
         },
         ['GroupRune'] = {
-            "Rune of the Vortex",
-            "Gloaming Rune",
-            "Eclipsed Rune",
-            "Crepuscular Rune",
-            "Tenebrous Rune",
-            "Darkened Rune",
-            "Umbral Rune",
-            "Shadowed Rune",
-            "Twilight Rune",
-            "Rune of the Void",
-            "Rune of the Deep",
-            "Rune of the Kedge",
-            "Rune of Rikkukin",
-            "Rune of the Scale",
+            "Rune of the Vortex", -- Level 129
+            "Gloaming Rune",      -- Level 124
+            "Eclipsed Rune",      -- Level 119
+            "Crepuscular Rune",   -- Level 114
+            "Tenebrous Rune",     -- Level 109
+            "Darkened Rune",      -- Level 104
+            "Umbral Rune",        -- Level 99
+            "Shadowed Rune",      -- Level 94
+            "Twilight Rune",      -- Level 89
+            "Rune of the Void",   -- Level 84
+            "Rune of the Deep",   -- Level 79
+            "Rune of the Kedge",  -- Level 74
+            "Rune of Rikkukin",   -- Level 69
+            "Rune of the Scale",  -- Level 61
         },
         ['AggroRune'] = {
-            "Horrifying Rune VIII",
-            "Disquieting Rune",
-            "Ghastly Rune",
-            "Horrendous Rune",
-            "Dreadful Rune",
-            "Frightening Rune",
-            "Terrifying Rune",
-            "Horrifying Rune",
+            "Horrifying Rune VIII", -- Level 129
+            "Disquieting Rune",     -- Level 123
+            "Ghastly Rune",         -- Level 118
+            "Horrendous Rune",      -- Level 113
+            "Dreadful Rune",        -- Level 108
+            "Frightening Rune",     -- Level 103
+            "Terrifying Rune",      -- Level 98
+            "Horrifying Rune",      -- Level 93
         },
         ['AggroBuff'] = {
-            "Horrifying Visage",
-            "Haunting Visage",
+            "Horrifying Visage", -- Level 56
+            "Haunting Visage",   -- Level 26
         },
         ['SingleSpellShield'] = {
-            "Aegis of Elmara",
-            "Aegis of Sefra",
-            "Aegis of Omica",
-            "Aegis of Nureya",
-            "Aegis of Gordianus",
-            "Aegis of Xorbb",
-            "Aegis of Soliadal",
-            "Aegis of Zykean",
-            "Aegis of Xadrith",
-            "Aegis of Qandieal",
-            "Aegis of Alendar",
-            "Wall of Alendar",
-            "Bulwark of Alendar",
-            "Protection of Alendar",
-            "Guard of Alendar",
-            "Ward of Alendar",
+            "Aegis of Elmara",       -- Level 123
+            "Aegis of Sefra",        -- Level 118
+            "Aegis of Omica",        -- Level 113
+            "Aegis of Nureya",       -- Level 108
+            "Aegis of Gordianus",    -- Level 103
+            "Aegis of Xorbb",        -- Level 98
+            "Aegis of Soliadal",     -- Level 93
+            "Aegis of Zykean",       -- Level 88
+            "Aegis of Xadrith",      -- Level 83
+            "Aegis of Qandieal",     -- Level 78
+            "Aegis of Alendar",      -- Level 73
+            "Wall of Alendar",       -- Level 68
+            "Bulwark of Alendar",    -- Level 63
+            "Protection of Alendar", -- Level 55
+            "Guard of Alendar",      -- Level 44
+            "Ward of Alendar",       -- Level 29
         },
         ['GroupSpellShield'] = {
-            "Legion of Feish",
-            "Legion of Boberstler",
-            "Legion of Ogna",
-            "Legion of Liako",
-            "Legion of Kildrukaun",
-            "Legion of Skrizix",
-            "Legion of Lucem",
-            "Legion of Xolok",
-            "Legion of Tonmek",
-            "Legion of Zykean",
-            "Legion of Xadrith",
-            "Legion of Qandieal",
-            "Legion of Alendar",
-            "Circle of Alendar",
+            "Legion of Feish",      -- Level 128
+            "Legion of Boberstler", -- Level 126
+            "Legion of Ogna",       -- Level 124
+            "Legion of Liako",      -- Level 119
+            "Legion of Kildrukaun", -- Level 114
+            "Legion of Skrizix",    -- Level 109
+            "Legion of Lucem",      -- Level 104
+            "Legion of Xolok",      -- Level 99
+            "Legion of Tonmek",     -- Level 94
+            "Legion of Zykean",     -- Level 89
+            "Legion of Xadrith",    -- Level 84
+            "Legion of Qandieal",   -- Level 79
+            "Legion of Alendar",    -- Level 74
+            "Circle of Alendar",    -- Level 70
         },
         ['SingleDotShield'] = {
-            "Aegis of Xetheg",
-            "Aegis of Cekenar",
-            "Aegis of Milyex",
-            "Aegis of the Indagator",
-            "Aegis of the Keeper",
+            "Aegis of Xetheg",        -- Level 116
+            "Aegis of Cekenar",       -- Level 111
+            "Aegis of Milyex",        -- Level 106
+            "Aegis of the Indagator", -- Level 101
+            "Aegis of the Keeper",    -- Level 98
         },
         ['GroupDotShield'] = {
-            "Legion of Dhakka",
-            "Legion of Xetheg",
-            "Legion of Cekenar",
-            "Legion of Milyex",
-            "Legion of the Indagator",
-            "Legion of the Keeper",
+            "Legion of Dhakka",        -- Level 121
+            "Legion of Xetheg",        -- Level 117
+            "Legion of Cekenar",       -- Level 112
+            "Legion of Milyex",        -- Level 107
+            "Legion of the Indagator", -- Level 102
+            "Legion of the Keeper",    -- Level 100
         },
         ['SingleMeleeShield'] = {
-            "Umbral Auspice VII",
-            "Gloaming Auspice",
-            "Eclipsed Auspice",
-            "Crepuscular Auspice",
-            "Tenebrous Auspice",
-            "Darkened Auspice",
-            "Umbral Auspice",
+            "Umbral Auspice VII",  -- Level 129
+            "Gloaming Auspice",    -- Level 124
+            "Eclipsed Auspice",    -- Level 119
+            "Crepuscular Auspice", -- Level 114
+            "Tenebrous Auspice",   -- Level 109
+            "Darkened Auspice",    -- Level 104
+            "Umbral Auspice",      -- Level 99
         },
         ['SelfGuardShield'] = {
-            "Shield of Fate VII",
-            "Shield of Inevitability",
-            "Shield of Inescapability",
-            "Shield of Destiny",
-            "Shield of Order",
-            "Shield of Consequence",
-            "Shield of Fate",
+            "Shield of Fate VII",       -- Level 127
+            "Shield of Inescapability", -- Level 122
+            "Shield of Inevitability",  -- Level 117
+            "Shield of Destiny",        -- Level 112
+            "Shield of Order",          -- Level 107
+            "Shield of Consequence",    -- Level 102
+            "Shield of Fate",           -- Level 97
         },
         ['GroupAuspiceBuff'] = {
-            "Marvel's Auspice",
-            "Deviser's Auspice",
-            "Transfixer's Auspice",
-            "Enticer's Auspice",
-            "Stupefier's Auspice",
+            "Stupefier's Auspice",  -- Level 122
+            "Marvel's Auspice",     -- Level 117
+            "Deviser's Auspice",    -- Level 112
+            "Transfixer's Auspice", -- Level 107
+            "Enticer's Auspice",    -- Level 102
         },
         ['SpellProcBuff'] = {
-            "Mana Recursion XI",
-            "Mana Reproduction",
-            "Mana Rebirth",
-            "Mana Replication",
-            "Mana Repetition",
-            "Mana Reciprocation",
-            "Mana Reverberation",
-            "Mana Repercussion",
-            "Mana Reiteration",
-            "Mana Reiterate",
-            "Mana Resurgence",
-            "Mana Recursion",
-            "Mana Flare",
+            "Mana Recursion XI",  -- Level 128
+            "Mana Reproduction",  -- Level 123
+            "Mana Rebirth",       -- Level 118
+            "Mana Replication",   -- Level 113
+            "Mana Repetition",    -- Level 108
+            "Mana Reciprocation", -- Level 103
+            "Mana Reverberation", -- Level 98
+            "Mana Repercussion",  -- Level 93
+            "Mana Reiteration",   -- Level 88
+            "Mana Reiterate",     -- Level 83
+            "Mana Resurgence",    -- Level 78
+            "Mana Recursion",     -- Level 73
+            "Mana Flare",         -- Level 70
         },
         ['AllianceSpell'] = {
-            "Chromatic Covariance",
-            "Chromatic Conjunction",
-            "Chromatic Coalition",
-            "Chromatic Covenant",
-            "Chromatic Alliance",
+            "Chromatic Covariance",  -- Level 123
+            "Chromatic Conjunction", -- Level 118
+            "Chromatic Coalition",   -- Level 113
+            "Chromatic Covenant",    -- Level 108
+            "Chromatic Alliance",    -- Level 101
         },
         ['TwinCastMez'] = {
-            "Chaotic Enticement X",
-            "Chaotic Deception",
-            "Chaotic Delusion",
-            "Chaotic Bewildering",
-            "Chaotic Confounding",
-            "Chaotic Confusion",
-            "Chaotic Baffling",
-            "Chaotic Befuddling",
-            "Chaotic Puzzlement",
-            "Chaotic Conundrum",
+            "Chaotic Enticement X", -- Level 128
+            "Chaotic Conundrum",    -- Level 123
+            "Chaotic Puzzlement",   -- Level 118
+            "Chaotic Deception",    -- Level 113
+            "Chaotic Delusion",     -- Level 108
+            "Chaotic Bewildering",  -- Level 103
+            "Chaotic Confounding",  -- Level 98
+            "Chaotic Confusion",    -- Level 93
+            "Chaotic Baffling",     -- Level 88
+            "Chaotic Befuddling",   -- Level 83
         },
         ['PBAEStunSpell'] = {
-            "Color Flux XVIII",
-            "Color Calibration",
-            "Color Conflagration",
-            "Color Cascade",
-            "Color Congruence",
-            "Color Concourse",
-            "Color Confluence",
-            "Color Convergence",
-            "Color Clash",
-            "Color Conflux",
-            "Color Cataclysm",
-            "Color Collapse",
-            "Color Snap",
-            "Color Cloud",
-            "Color Slant",
-            "Color Skew",
-            "Color Shift",
-            "Color Flux",
+            "Color Flux XVIII",    -- Level 129
+            "Color Calibration",   -- Level 124
+            "Color Conflagration", -- Level 119
+            "Color Cascade",       -- Level 114
+            "Color Congruence",    -- Level 109
+            "Color Concourse",     -- Level 104
+            "Color Confluence",    -- Level 99
+            "Color Convergence",   -- Level 94
+            "Color Clash",         -- Level 89
+            "Color Conflux",       -- Level 84
+            "Color Cataclysm",     -- Level 79
+            "Color Collapse",      -- Level 74
+            "Color Snap",          -- Level 69
+            "Color Cloud",         -- Level 63
+            "Color Slant",         -- Level 52
+            "Color Skew",          -- Level 43
+            "Color Shift",         -- Level 20
+            "Color Flux",          -- Level 3
         },
         ['TargetAEStun'] = {
-            "Remote Color Flux XVIII",
-            "Remote Color Calibration",
-            "Remote Color Conflagration",
-            "Remote Color Cascade",
-            "Remote Color Congruence",
-            "Remote Color Concourse",
-            "Remote Color Confluence",
-            "Remote Color Convergence",
+            "Remote Color Flux XVIII",    -- Level 127
+            "Remote Color Calibration",   -- Level 122
+            "Remote Color Conflagration", -- Level 117
+            "Remote Color Cascade",       -- Level 112
+            "Remote Color Congruence",    -- Level 107
+            "Remote Color Concourse",     -- Level 102
+            "Remote Color Confluence",    -- Level 97
+            "Remote Color Convergence",   -- Level 92
         },
         ['SingleStunSpell1'] = {
-            "Dizzying Helix XII",
-            "Dizzying Spindle",
-            "Dizzying Vortex",
-            "Dizzying Coil",
-            "Dizzying Wheel",
-            "Dizzying Storm",
-            "Dizzying Squall",
-            "Dizzying Gyre",
-            "Dizzying Helix",
-            "The Downward Spiral",
-            "Whirling into the Hollow",
-            "Spinning into the Void",
-            "Largarn's Lamentation",
-            "Dyn's Dizzying Draught",
-            "Whirl till you hurl",
+            "Dizzying Helix XII",       -- Level 129
+            "Dizzying Spindle",         -- Level 124
+            "Dizzying Vortex",          -- Level 119
+            "Dizzying Coil",            -- Level 114
+            "Dizzying Wheel",           -- Level 109
+            "Dizzying Storm",           -- Level 104
+            "Dizzying Squall",          -- Level 99
+            "Dizzying Gyre",            -- Level 94
+            "Dizzying Helix",           -- Level 89
+            "The Downward Spiral",      -- Level 84
+            "Whirling into the Hollow", -- Level 79
+            "Spinning into the Void",   -- Level 74
+            "Largarn's Lamentation",    -- Level 55
+            "Dyn's Dizzying Draught",   -- Level 28
+            "Whirl till you hurl",      -- Level 9
         },
         ['CharmSpell'] = {
-            "Enticer's Command XV",
-            "Charm XVII",
-            "Stupefier's Demand",
-            "Esoteric Command",
-            "Marvel's Demand",
-            "Marvel's Command",
-            "Inveigle",
-            "Deviser's Demand",
-            "Deviser's Command",
-            "Transfixer's Command",
-            "Spellbinding",
-            "Enticer's Command",
-            "Enticer's Demand",
-            "Captivation",
-            "Impose",
-            "Temptation",
-            "Enforce",
-            "Compelling Edict",
-            "Subjugate",
-            "Deception",
-            "Dominate",
-            "Seduction",
-            "Haunting Whispers",
-            "Cajole",
-            "Dyn`leth's Whispers",
-            "Coax",
-            -- [] = "Ancient Voice of Muram",
-            "True Name",
-            "Compel",
-            "Command of Druzzil",
-            "Beckon",
-            "Dictate",
-            "Boltran's Agacerie",
-            "Ordinance",
-            "Allure",
-            "Cajoling Whispers",
-            "Beguile",
-            "Charm",
+            "Enticer's Command XV", -- Level 130
+            "Charm XVII",           -- Level 127
+            "Esoteric Command",     -- Level 125
+            "Stupefier's Demand",   -- Level 124
+            "Marvel's Command",     -- Level 120
+            "Marvel's Demand",      -- Level 119
+            "Inveigle",             -- Level 117
+            "Deviser's Command",    -- Level 115
+            "Deviser's Demand",     -- Level 114
+            "Transfixer's Command", -- Level 110
+            "Spellbinding",         -- Level 107
+            "Enticer's Command",    -- Level 105
+            "Enticer's Demand",     -- Level 104
+            "Captivation",          -- Level 102
+            "Impose",               -- Level 100
+            "Temptation",           -- Level 97
+            "Enforce",              -- Level 95
+            "Compelling Edict",     -- Level 92
+            "Subjugate",            -- Level 90
+            "Deception",            -- Level 87
+            "Dominate",             -- Level 85
+            "Seduction",            -- Level 82
+            "Haunting Whispers",    -- Level 80
+            "Cajole",               -- Level 77
+            "Dyn`leth's Whispers",  -- Level 75
+            "Coax",                 -- Level 72
+            -- "Ancient: Voice of Muram", -- Level 70
+            "True Name",            -- Level 70
+            "Compel",               -- Level 68
+            "Command of Druzzil",   -- Level 64
+            "Beckon",               -- Level 62
+            "Dictate",              -- Level 60
+            "Boltran's Agacerie",   -- Level 53
+            "Ordinance",            -- Level 52
+            "Allure",               -- Level 46
+            "Cajoling Whispers",    -- Level 37
+            "Beguile",              -- Level 23
+            "Charm",                -- Level 11
         },
         ['CrippleSpell'] = {
-            "Splintered Consciousness",
-            "Fragmented Consciousness",
-            "Shattered Consciousness",
-            "Fractured Consciousness",
-            "Synapsis Spasm",
-            "Cripple",
-            "Incapacitate",
-            "Listless Power",
-            "Disempower",
-            "Enfeeblement",
+            "Splintered Consciousness", -- Level 86
+            "Fragmented Consciousness", -- Level 81
+            "Shattered Consciousness",  -- Level 76
+            "Fractured Consciousness",  -- Level 71
+            "Synapsis Spasm",           -- Level 66
+            "Cripple",                  -- Level 53
+            "Incapacitate",             -- Level 40
+            "Listless Power",           -- Level 25
+            "Disempower",               -- Level 16
+            "Enfeeblement",             -- Level 4
         },
         ['SlowSpell'] = {
             -- Slow - lvl88 and above this is also cripple spell Starting @ Level 88  Combines With Cripple.
-            "Desolate Deeds",
-            "Dreary Deeds",
-            "Forlorn Deeds",
-            "Shiftless Deeds",
-            "Tepid Deeds",
-            "Languid Pace",
+            "Desolate Deeds",  -- Level 69
+            "Dreary Deeds",    -- Level 65
+            "Forlorn Deeds",   -- Level 57
+            "Shiftless Deeds", -- Level 41
+            "Tepid Deeds",     -- Level 23
+            "Languid Pace",    -- Level 9
         },
         ['Dispel'] = {
-            "Eradicate Magic",
-            "Recant Magic",
-            "Pillage Enchantment",
-            "Nullify Magic",
-            "Strip Enchantment",
-            "Cancel Magic",
-            "Taper Enchantment",
+            "Recant Magic",        -- Level 53
+            "Pillage Enchantment", -- Level 42
+            "Nullify Magic",       -- Level 28
+            "Strip Enchantment",   -- Level 22
+            "Cancel Magic",        -- Level 7
+            "Taper Enchantment",   -- Level 1
         },
         ['TashSpell'] = {
-            "Tashan XVII",
-            "Roar of Tashan",
-            "Edict of Tashan",
-            "Proclamation of Tashan",
-            "Order of Tashan",
-            "Decree of Tashan",
-            "Enunciation of Tashan",
-            "Declaration of Tashan",
-            "Clamor of Tashan",
-            "Bark of Tashan",
-            "Din of Tashan",
-            "Echo of Tashan",
-            "Howl of Tashan",
-            "Tashanian",
-            "Tashania",
-            "Tashani",
-            "Tashina",
+            "Tashan XVII",            -- Level 127
+            "Roar of Tashan",         -- Level 122
+            "Edict of Tashan",        -- Level 117
+            "Proclamation of Tashan", -- Level 112
+            "Order of Tashan",        -- Level 107
+            "Decree of Tashan",       -- Level 102
+            "Enunciation of Tashan",  -- Level 97
+            "Declaration of Tashan",  -- Level 92
+            "Clamor of Tashan",       -- Level 87
+            "Bark of Tashan",         -- Level 82
+            "Din of Tashan",          -- Level 77
+            "Echo of Tashan",         -- Level 72
+            "Howl of Tashan",         -- Level 61
+            "Tashanian",              -- Level 57
+            "Tashania",               -- Level 41
+            "Tashani",                -- Level 18
+            "Tashina",                -- Level 2
         },
         ['ManaDrainNuke'] = {
-            "Tears of Kasha",
-            "Tears of Xenacious",
-            "Tears of Aaryonar",
-            "Tears of Skrizix",
-            "Tears of Visius",
-            "Tears of Syrkl",
-            "Tears of Wreliard",
-            "Tears of Zykean",
-            "Tears of Xadrith",
-            "Tears of Qandieal",
-            "Torment of Scio",
-            "Torment of Argli",
-            "Scryer's Trespass",
-            "Wandering Mind",
-            "Mana Sieve",
+            "Tears of Kasha",     -- Level 121
+            "Tears of Xenacious", -- Level 116
+            "Tears of Aaryonar",  -- Level 111
+            "Tears of Skrizix",   -- Level 106
+            "Tears of Visius",    -- Level 101
+            "Tears of Syrkl",     -- Level 100
+            "Tears of Wreliard",  -- Level 95
+            "Tears of Zykean",    -- Level 90
+            "Tears of Xadrith",   -- Level 85
+            "Tears of Qandieal",  -- Level 80
+            "Torment of Scio",    -- Level 63
+            "Torment of Argli",   -- Level 56
+            "Scryer's Trespass",  -- Level 52
+            "Wandering Mind",     -- Level 38
+            "Mana Sieve",         -- Level 30
         },
         ['DichoSpell'] = {
-            "Ecliptic Reinforcement",
-            "Composite Reinforcement",
-            "Dissident Reinforcement",
-            "Dichotomic Reinforcement",
-            "Reciprocal Reinforcement",
+            "Reciprocal Reinforcement", -- Level 121
+            "Ecliptic Reinforcement",   -- Level 116
+            "Composite Reinforcement",  -- Level 111
+            "Dissident Reinforcement",  -- Level 106
+            "Dichotomic Reinforcement", -- Level 101
         },
         ['StrangleDot'] = {
             ---DoT 1 -- >=LVL1
-            "Strangle XVII",
-            "Asphyxiating Grasp",
-            "Throttling Grip",
-            "Pulmonary Grip",
-            "Strangulate",
-            "Drown",
-            "Stifle",
-            "Suffocation",
-            "Constrict",
-            "Smother",
-            "Strangling Air",
-            "Thin Air",
-            "Arcane Noose",
-            "Strangle",
-            "Asphyxiate",
-            "Gasping Embrace",
-            "Suffocate",
-            "Choke",
-            "Suffocating Sphere",
-            "Shallow Breath",
+            "Strangle XVII",      -- Level 128
+            "Asphyxiating Grasp", -- Level 123
+            "Throttling Grip",    -- Level 118
+            "Pulmonary Grip",     -- Level 113
+            "Strangulate",        -- Level 108
+            "Drown",              -- Level 103
+            "Stifle",             -- Level 98
+            "Suffocation",        -- Level 93
+            "Constrict",          -- Level 88
+            "Smother",            -- Level 83
+            "Strangling Air",     -- Level 78
+            "Thin Air",           -- Level 73
+            "Arcane Noose",       -- Level 69
+            "Strangle",           -- Level 62
+            "Asphyxiate",         -- Level 59
+            "Gasping Embrace",    -- Level 47
+            "Suffocate",          -- Level 26
+            "Choke",              -- Level 11
+            "Suffocating Sphere", -- Level 4
+            "Shallow Breath",     -- Level 1
         },
         ['MindDot'] = {
             -- DoT 2 --  >= LVL70
-            "Mind Shatter XV",
-            "Mind Whirl",
-            "Mind Vortex",
-            "Mind Coil",
-            "Mind Tempest",
-            "Mind Storm",
-            "Mind Squall",
-            "Mind Spiral",
-            "Mind Helix",
-            "Mind Twist",
-            "Mind Oscillate",
-            "Mind Phobiate",
-            "Mind Shatter",
+            "Mind Shatter XV", -- Level 130
+            "Mind Whirl",      -- Level 125
+            "Mind Vortex",     -- Level 120
+            "Mind Coil",       -- Level 115
+            "Mind Tempest",    -- Level 110
+            "Mind Storm",      -- Level 105
+            "Mind Squall",     -- Level 100
+            "Mind Spiral",     -- Level 95
+            "Mind Helix",      -- Level 90
+            "Mind Twist",      -- Level 85
+            "Mind Oscillate",  -- Level 80
+            "Mind Phobiate",   -- Level 75
+            "Mind Shatter",    -- Level 70
         },
         ['ConstrictionDot'] = {
             ---DoT 3 -- >= LVL89
-            "Dismaying Constriction",
-            "Perplexing Constriction",
-            "Deceiving Constriction",
-            "Deluding Constriction",
-            "Bewildering Constriction",
-            "Confounding Constriction",
-            "Confusing Constriction",
-            "Baffling Constriction",
+            "Dismaying Constriction",   -- Level 124
+            "Perplexing Constriction",  -- Level 119
+            "Deceiving Constriction",   -- Level 114
+            "Deluding Constriction",    -- Level 109
+            "Bewildering Constriction", -- Level 104
+            "Confounding Constriction", -- Level 99
+            "Confusing Constriction",   -- Level 94
+            "Baffling Constriction",    -- Level 89
         },
         ['MagicNuke'] = {
             --- Nuke 1 -- >= LVL7
-            "Mindblade IX",
-            "Mindrend",
-            "Mindreap",
-            "Mindrift",
-            "Mindslash",
-            "Mindsunder",
-            "Mindcleave",
-            "Mindscythe",
-            "Mindblade",
-            "Spectral Assault",
-            "Polychaotic Assault",
-            "Multichromatic Assault",
-            "Polychromatic Assault",
-            "Colored Chaos",
-            "Psychosis",
-            "Madness of Ikkibi",
-            "Insanity",
-            "Dementing Visions",
-            "Dementia",
-            "Discordant Mind",
-            "Anarchy",
-            "Chaos Flux",
-            "Sanity Warp",
-            "Chaotic Feedback",
-            "Chromarcana",
-            "Ancient: Neurosis",
-            "Ancient: Chaos Madness",
-            "Ancient: Chaotic Visions",
+            "Mindblade IX",             -- Level 130
+            "Mindrend",                 -- Level 125
+            "Mindreap",                 -- Level 120
+            "Mindrift",                 -- Level 115
+            "Mindslash",                -- Level 110
+            "Mindsunder",               -- Level 105
+            "Mindcleave",               -- Level 100
+            "Mindscythe",               -- Level 95
+            "Mindblade",                -- Level 90
+            "Spectral Assault",         -- Level 88
+            "Chromarcana",              -- Level 87
+            "Polychaotic Assault",      -- Level 83
+            "Multichromatic Assault",   -- Level 78
+            "Polychromatic Assault",    -- Level 73
+            "Ancient: Neurosis",        -- Level 70
+            "Colored Chaos",            -- Level 69
+            "Psychosis",                -- Level 68
+            "Madness of Ikkibi",        -- Level 65
+            "Ancient: Chaos Madness",   -- Level 65
+            "Insanity",                 -- Level 64
+            "Ancient: Chaotic Visions", -- Level 60
+            "Dementing Visions",        -- Level 58
+            "Dementia",                 -- Level 54
+            "Discordant Mind",          -- Level 43
+            "Anarchy",                  -- Level 32
+            "Chaos Flux",               -- Level 21
+            "Sanity Warp",              -- Level 16
+            "Chaotic Feedback",         -- Level 7
         },
         ['RuneNuke'] = {
             --- RUNE - Nuke Fast >=LVL86
-            "Chromatic Jab IX",
-            "Chromatic Spike",
-            "Chromatic Flare",
-            "Chromatic Stab",
-            "Chromatic Flicker",
-            "Chromatic Blink",
-            "Chromatic Percussion",
-            "Chromatic Flash",
-            "Chromatic Jab",
+            "Chromatic Jab IX",     -- Level 126
+            "Chromatic Spike",      -- Level 121
+            "Chromatic Flare",      -- Level 116
+            "Chromatic Stab",       -- Level 111
+            "Chromatic Flicker",    -- Level 106
+            "Chromatic Blink",      -- Level 101
+            "Chromatic Percussion", -- Level 96
+            "Chromatic Flash",      -- Level 91
+            "Chromatic Jab",        -- Level 86
         },
         ['ManaTapNuke'] = {
             --- Mana Drain Nuke - Fast -- >=LVL96
-            "Mental Appropriation VII",
-            "Psychological Appropriation",
-            "Ideological Appropriation",
-            "Psychic Appropriation",
-            "Intellectual Appropriation",
-            "Mental Appropriation",
-            "Cognitive Appropriation",
+            "Mental Appropriation VII",    -- Level 126
+            "Cognitive Appropriation",     -- Level 121
+            "Psychological Appropriation", -- Level 116
+            "Ideological Appropriation",   -- Level 111
+            "Psychic Appropriation",       -- Level 106
+            "Intellectual Appropriation",  -- Level 101
+            "Mental Appropriation",        -- Level 96
         },
         --Unused table, temporarily removed - was causing conflicts while resolving MagicNuke action maps (will revisit nukes later)
         -- ['ChromaNuke'] = {
         --- Chromatic Lowest Nuke - Normal -- >=LVL73
-        -- "Polycascading Assault",
-        -- "Polyfluorescent Assault",
-        -- "Polyrefractive Assault",
-        -- "Phantasmal Assault",
-        -- "Arcane Assault",
-        -- "Spectral Assault",
-        -- "Polychaotic Assault",
-        -- "Multichromatic Assault",
-        -- "Polychromatic Assault",
+        --     "Polycascading Assault",   -- Level 113
+        --     "Polyfluorescent Assault", -- Level 108
+        --     "Polyrefractive Assault",  -- Level 103
+        --     "Phantasmal Assault",      -- Level 98
+        --     "Arcane Assault",          -- Level 93
+        --     "Spectral Assault",        -- Level 88
+        --     "Polychaotic Assault",     -- Level 83
+        --     "Multichromatic Assault",  -- Level 78
+        --     "Polychromatic Assault",   -- Level 73
         -- },
         ['CripSlowSpell'] = {
             --- Slow Cripple Combo Spell - Beginning @ Level 88
-            "Constraining Coil",
-            "Constraining Helix",
-            "Undermining Helix",
-            "Diminishing Helix",
-            "Attenuating Helix",
-            "Curtailing Helix",
-            "Inhibiting Helix",
+            "Inhibiting Helix",   -- Level 123
+            "Constraining Coil",  -- Level 113
+            "Constraining Helix", -- Level 108
+            "Undermining Helix",  -- Level 103
+            "Diminishing Helix",  -- Level 98
+            "Attenuating Helix",  -- Level 93
+            "Curtailing Helix",   -- Level 88
         },
         ['PetSpell'] = {
-            "Arkahn's Animation",
-            "Flariton's Animation",
-            "Constance's Animation",
-            "Omica's Animation",
-            "Nureya's Animation",
-            "Gordianus' Animation",
-            "Xorlex's Animation",
-            "Seronvall's Animation",
-            "Novak's Animation",
-            "Yozan's Animation",
-            "Erradien's Animation",
-            "Ellowind's Animation",
-            "Salik's Animation",
-            "Aeldorb's Animation",
-            "Zumaik's Animation",
-            "Kintaz's Animation",
-            "Yegoreff's Animation",
-            "Aanya's Animation",
-            "Boltran's Animation",
-            "Uleen's Animation",
-            "Sagar's Animation",
-            "Sisna's Animation",
-            "Shalee's Animation",
-            "Kilan's Animation",
-            "Mircyl's Animation",
-            "Juli's Animation",
-            "Pendril's Animation",
+            "Arkahn's Animation",    -- Level 126
+            "Flariton's Animation",  -- Level 121
+            "Constance's Animation", -- Level 116
+            "Omica's Animation",     -- Level 111
+            "Nureya's Animation",    -- Level 106
+            "Gordianus' Animation",  -- Level 101
+            "Xorlex's Animation",    -- Level 96
+            "Seronvall's Animation", -- Level 91
+            "Novak's Animation",     -- Level 86
+            "Yozan's Animation",     -- Level 81
+            "Erradien's Animation",  -- Level 76
+            "Ellowind's Animation",  -- Level 71
+            "Salik's Animation",     -- Level 66
+            "Aeldorb's Animation",   -- Level 62
+            "Zumaik's Animation",    -- Level 55
+            "Kintaz's Animation",    -- Level 48
+            "Yegoreff's Animation",  -- Level 41
+            "Aanya's Animation",     -- Level 37
+            "Boltran's Animation",   -- Level 31
+            "Uleen's Animation",     -- Level 29
+            "Sagar's Animation",     -- Level 22
+            "Sisna's Animation",     -- Level 17
+            "Shalee's Animation",    -- Level 14
+            "Kilan's Animation",     -- Level 9
+            "Mircyl's Animation",    -- Level 7
+            "Juli's Animation",      -- Level 2
+            "Pendril's Animation",   -- Level 1
         },
         ['PetBuffSpell'] = {
-            "Empowered Minion IV",
-            "Infused Minion",
-            "Empowered Minion",
-            "Invigorated Minion",
+            "Empowered Minion IV", -- Level 128
+            "Invigorated Minion",  -- Level 117
+            "Infused Minion",      -- Level 107
+            "Empowered Minion",    -- Level 97
         },
         ['MezAESpell'] = {
-            "Mesmerizing Wave XV",
-            "Neutralizing Wave",
-            "Perplexing Wave",
-            "Deadening Wave",
-            "Slackening Wave",
-            "Peaceful Wave",
-            "Serene Wave",
-            "Ensorcelling Wave",
-            "Quelling Wave",
-            "Wake of Subdual",
-            "Wake of Felicity",
-            "Bliss of the Nihil",
-            "Fascination",
-            "Mesmerization",
-            "Bewildering Wave",
-            "Stupefying Wave",
+            "Mesmerizing Wave XV", -- Level 129
+            "Stupefying Wave",     -- Level 124
+            "Bewildering Wave",    -- Level 119
+            "Neutralizing Wave",   -- Level 114
+            "Perplexing Wave",     -- Level 109
+            "Deadening Wave",      -- Level 104
+            "Slackening Wave",     -- Level 99
+            "Peaceful Wave",       -- Level 94
+            "Serene Wave",         -- Level 89
+            "Ensorcelling Wave",   -- Level 84
+            "Quelling Wave",       -- Level 79
+            "Wake of Subdual",     -- Level 74
+            "Wake of Felicity",    -- Level 69
+            "Bliss of the Nihil",  -- Level 65
+            "Fascination",         -- Level 52
+            "Mesmerization",       -- Level 16
         },
         ['MezAESpellFast'] = {
-            "Vexing Glance",
-            "Confounding Glance",
-            "Neutralizing Glance",
-            "Perplexing Glance",
-            "Slackening Glance",
+            "Vexing Glance",       -- Level 124
+            "Confounding Glance",  -- Level 119
+            "Neutralizing Glance", -- Level 114
+            "Perplexing Glance",   -- Level 109
+            "Slackening Glance",   -- Level 99
         },
         ['MezPBAESpell'] = {
-            "Docility XII",
-            "Neutralize",
-            "Perplex",
-            "Bafflement",
-            "Disorientation",
-            "Confusion",
-            "Serenity",
-            "Docility",
-            "Visions of Kirathas",
-            "Dreams of Veldyn",
-            "Circle of Dreams",
-            "Word of Morell",
-            "Entrancing Lights",
-            "Bewilderment",
-            "Wonderment",
+            "Docility XII",        -- Level 128
+            "Wonderment",          -- Level 123
+            "Neutralize",          -- Level 113
+            "Perplex",             -- Level 108
+            "Bafflement",          -- Level 103
+            "Disorientation",      -- Level 98
+            "Confusion",           -- Level 93
+            "Serenity",            -- Level 88
+            "Docility",            -- Level 83
+            "Visions of Kirathas", -- Level 78
+            "Dreams of Veldyn",    -- Level 73
+            "Bewilderment",        -- Level 72
+            "Circle of Dreams",    -- Level 68
+            "Word of Morell",      -- Level 62
+            "Entrancing Lights",   -- Level 30
         },
         ['MezSpell'] = {
-            "Mesmerize XX",
-            "Flummox",
-            "Addle",
-            "Deceive",
-            "Delude",
-            "Bewilder",
-            "Confound",
-            "Mislead",
-            "Baffle",
-            "Befuddle",
-            "Mystify",
-            "Bewilderment",
-            "Euphoria",
-            "Felicity",
-            "Bliss",
-            "Sleep",
-            "Apathy",
-            "Ancient: Eternal Rapture",
-            "Rapture",
-            "Glamour of Kintaz",
-            "Enthrall",
-            "Mesmerize",
+            "Mesmerize XX",             -- Level 126
+            "Flummox",                  -- Level 121
+            "Addle",                    -- Level 116
+            "Deceive",                  -- Level 111
+            "Delude",                   -- Level 106
+            "Bewilder",                 -- Level 101
+            "Confound",                 -- Level 96
+            "Mislead",                  -- Level 92
+            "Baffle",                   -- Level 87
+            "Befuddle",                 -- Level 82
+            "Mystify",                  -- Level 77
+            "Bewilderment",             -- Level 72
+            "Euphoria",                 -- Level 69
+            "Felicity",                 -- Level 67
+            "Bliss",                    -- Level 64
+            "Sleep",                    -- Level 63
+            "Apathy",                   -- Level 61
+            "Ancient: Eternal Rapture", -- Level 60
+            "Rapture",                  -- Level 59
+            "Glamour of Kintaz",        -- Level 54
+            "Enthrall",                 -- Level 13
+            "Mesmerize",                -- Level 2
         },
         ['MezSpellFast'] = {
-            "Deceiving Flash",
-            "Deluding Flash",
-            "Bewildering Flash",
-            "Confounding Flash",
-            "Misleading Flash",
-            "Baffling Flash",
-            "Befuddling Flash",
-            "Mystifying Flash",
-            "Perplexing Flash",
-            "Addling Flash",
-            "Flummoxing Flash",
+            "Flummoxing Flash",  -- Level 122
+            "Addling Flash",     -- Level 117
+            "Deceiving Flash",   -- Level 112
+            "Deluding Flash",    -- Level 107
+            "Bewildering Flash", -- Level 102
+            "Confounding Flash", -- Level 97
+            "Misleading Flash",  -- Level 91
+            "Baffling Flash",    -- Level 86
+            "Befuddling Flash",  -- Level 81
+            "Mystifying Flash",  -- Level 76
+            "Perplexing Flash",  -- Level 71
         },
         ['BlurSpell'] = {
-            "Memory Flux",
-            "Reoccurring Amnesia",
-            "Memory Blur",
+            "Memory Flux",         -- Level 55
+            "Reoccurring Amnesia", -- Level 45
+            "Memory Blur",         -- Level 10
         },
         ['AEBlurSpell'] = {
-            "Blanket of Forgetfulness",
-            "Mind Wipe",
+            "Blanket of Forgetfulness", -- Level 46
+            "Mind Wipe",                -- Level 36
         },
         ['CalmSpell'] = {
             ---Calm Spell -- >= LVL1
-            "Quiet Mind XIII",
-            "Docile Mind",
-            "Still Mind",
-            "Serene Mind",
-            "Mollified Mind",
-            "Pacified Mind",
-            "Quiescent Mind",
-            "Halcyon Mind",
-            "Bucolic Mind",
-            "Hushed Mind",
-            "Silent Mind",
-            "Quiet Mind",
-            "Placate",
-            "Pacification",
-            "Pacify",
-            "Calm",
-            "Soothe",
-            "Lull",
+            "Quiet Mind XIII", -- Level 127
+            "Docile Mind",     -- Level 122
+            "Still Mind",      -- Level 117
+            "Serene Mind",     -- Level 112
+            "Mollified Mind",  -- Level 107
+            "Pacified Mind",   -- Level 102
+            "Quiescent Mind",  -- Level 97
+            "Halcyon Mind",    -- Level 92
+            "Bucolic Mind",    -- Level 87
+            "Hushed Mind",     -- Level 82
+            "Silent Mind",     -- Level 77
+            "Quiet Mind",      -- Level 72
+            "Placate",         -- Level 67
+            "Pacification",    -- Level 62
+            "Pacify",          -- Level 35
+            "Calm",            -- Level 18
+            "Soothe",          -- Level 6
+            "Lull",            -- Level 1
         },
         ['FearSpell'] = {
             ---Fear Spell * Var Name:, string outer >= LVL3
-            "Anxiety Attack",
-            "Jitterskin",
-            "Phobia",
-            "Trepidation",
-            "Invoke Fear",
-            "Chase the Moon",
-            "Fear",
+            "Anxiety Attack", -- Level 67
+            "Jitterskin",     -- Level 62
+            "Phobia",         -- Level 57
+            "Trepidation",    -- Level 56
+            "Invoke Fear",    -- Level 35
+            "Chase the Moon", -- Level 16
+            "Fear",           -- Level 3
         },
         ['RootSpell'] = {
-            "Greater Fetter",
-            "Fetter",
-            "Paralyzing Earth",
-            "Immobilize",
-            "Instill",
-            "Root",
+            "Greater Fetter",   -- Level 61
+            "Fetter",           -- Level 58
+            "Paralyzing Earth", -- Level 45
+            "Immobilize",       -- Level 39
+            "Instill",          -- Level 25
+            "Root",             -- Level 6
         },
     },
     ['RotationOrder'] = {

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -87,370 +87,370 @@ _ClassConfig    = {
         --- Nukes
         ['SwarmPet'] = {
             -- Swarm Pet* >= LVL 70
-            "Raging Servant XIII",
-            "Ravening Servant",
-            "Roiling Servant",
-            "Riotous Servant",
-            "Reckless Servant",
-            "Remorseless Servant",
-            "Relentless Servant",
-            "Ruthless Servant",
-            "Ruinous Servant",
-            "Rumbling Servant",
-            "Rancorous Servant",
-            "Rampaging Servant",
-            "Raging Servant",
-            "Rage of Zomm",
+            "Raging Servant XIII", -- Level 130
+            "Ravening Servant",    -- Level 125
+            "Roiling Servant",     -- Level 120
+            "Riotous Servant",     -- Level 115
+            "Reckless Servant",    -- Level 110
+            "Remorseless Servant", -- Level 105
+            "Relentless Servant",  -- Level 100
+            "Ruthless Servant",    -- Level 95
+            "Ruinous Servant",     -- Level 90
+            "Rumbling Servant",    -- Level 85
+            "Rancorous Servant",   -- Level 80
+            "Rampaging Servant",   -- Level 75
+            "Raging Servant",      -- Level 70
+            "Rage of Zomm",        -- Level 55
         },
         ['SpearNuke'] = {
             -- Spear Nuke* >= LVL 70
-            "Spear of Ro X",
-            "Spear of Molten Dacite",
-            "Spear of Molten Luclinite",
-            "Spear of Molten Komatiite",
-            "Spear of Molten Arcronite",
-            "Spear of Molten Shieldstone",
-            "Spear of Blistersteel",
-            "Spear of Molten Steel",
-            "Spear of Magma",
-            "Bolt of Molten Slag", -- Added for TLP without spear unlocked yet
-            "Spear of Ro",
+            "Spear of Ro X",               -- Level 130
+            "Spear of Molten Dacite",      -- Level 125
+            "Spear of Molten Luclinite",   -- Level 120
+            "Spear of Molten Komatiite",   -- Level 115
+            "Spear of Molten Arcronite",   -- Level 110
+            "Spear of Molten Shieldstone", -- Level 105
+            "Spear of Blistersteel",       -- Level 100
+            "Spear of Molten Steel",       -- Level 95
+            "Spear of Magma",              -- Level 90
+            "Bolt of Molten Slag",         -- Level 71, Added for TLP without spear unlocked yet
+            "Spear of Ro",                 -- Level 70
         },
         ['ChaoticNuke'] = {
             -- Chaotic Nuke with Beneficial Effect >= LVL69
-            "Chaotic Fire VI",
-            "Chaotic Magma",
-            "Chaotic Calamity",
-            "Chaotic Pyroclasm",
-            "Chaotic Inferno",
-            "Chaotic Fire",
-            "Fickle Magma",
-            "Fickle Flames",
-            "Fickle Flare",
-            "Fickle Blaze",
-            "Fickle Pyroclasm",
-            "Fickle Inferno",
-            "Fickle Fire",
+            "Chaotic Fire VI",   -- Level 130
+            "Chaotic Magma",     -- Level 125
+            "Chaotic Calamity",  -- Level 120
+            "Chaotic Pyroclasm", -- Level 115
+            "Chaotic Inferno",   -- Level 110
+            "Chaotic Fire",      -- Level 105
+            "Fickle Magma",      -- Level 100
+            "Fickle Flames",     -- Level 95
+            "Fickle Flare",      -- Level 90
+            "Fickle Blaze",      -- Level 85
+            "Fickle Pyroclasm",  -- Level 80
+            "Fickle Inferno",    -- Level 75
+            "Fickle Fire",       -- Level 69
         },
         -- ['FireNuke'] = {
         --     -- Fire Nuke 1 <= LVL <= 70
-        --     "Burning Sands XIV",
-        --     "Cremating Sands",
-        --     "Ravaging Sands",
-        --     "Incinerating Sands",
-        --     "Crash of Sand",
-        --     "Blistering Sands",
-        --     "Searing Sands",
-        --     "Broiling Sands",
-        --     "Blast of Sand",
-        --     "Burning Sands",
-        --     "Burst of Sand",
-        --     "Strike of Sand",
-        --     "Torrid Sands",
-        --     "Scorching Sands",
-        --     "Scalding Sands",
-        --     "Sun Vortex",
-        --     "Star Strike",
-        --     "Ancient: Nova Strike",
-        --     "Burning Sand",
-        --     "Shock of Fiery Blades",
-        --     "Char",
-        --     "Blaze",
-        --     "Shock of Flame",
-        --     "Burn",
-        --     "Burst of Flame",
+        --     "Burning Sands XIV",     -- Level 129
+        --     "Cremating Sands",       -- Level 124
+        --     "Ravaging Sands",        -- Level 118
+        --     "Incinerating Sands",    -- Level 113
+        --     "Crash of Sand",         -- Level 111
+        --     "Blistering Sands",      -- Level 108
+        --     "Searing Sands",         -- Level 103
+        --     "Broiling Sands",        -- Level 98
+        --     "Blast of Sand",         -- Level 96
+        --     "Burning Sands",         -- Level 93
+        --     "Burst of Sand",         -- Level 91
+        --     "Strike of Sand",        -- Level 86
+        --     "Torrid Sands",          -- Level 83
+        --     "Scorching Sands",       -- Level 78
+        --     "Scalding Sands",        -- Level 73
+        --     "Star Strike",           -- Level 70
+        --     "Ancient: Nova Strike",  -- Level 70
+        --     "Sun Vortex",            -- Level 65
+        --     "Burning Sand",          -- Level 62
+        --     "Shock of Fiery Blades", -- Level 60
+        --     "Char",                  -- Level 52
+        --     "Blaze",                 -- Level 31
+        --     "Shock of Flame",        -- Level 15
+        --     "Burn",                  -- Level 4
+        --     "Burst of Flame",        -- Level 1
         -- },
         -- ['FireBoltNuke'] = {
-        --     "Bolt of Flame XVIII",
-        --     "Bolt of Molten Dacite",
-        --     "Bolt of Molten Olivine",
-        --     "Bolt of Molten Komatiite",
-        --     "Bolt of Skyfire",
-        --     "Bolt of Molten Shieldstone",
-        --     "Bolt of Molten Magma",
-        --     "Bolt of Molten Steel",
-        --     "Bolt of Rhyolite",
-        --     "Bolt of Molten Scoria",
-        --     "Bolt of Molten Dross",
-        --     "Bolt of Molten Slag",
-        --     "Bolt of Jerikor",
-        --     "Firebolt of Tallon",
-        --     "Seeking Flame of Seukor",
-        --     "Scars of Sigil",
-        --     "Lava Bolt",
-        --     "Cinder Bolt",
-        --     "Bolt of Flame",
-        --     "Flame Bolt",
+        --     "Bolt of Flame XVIII",        -- Level 126
+        --     "Bolt of Molten Dacite",      -- Level 121
+        --     "Bolt of Molten Olivine",     -- Level 116
+        --     "Bolt of Molten Komatiite",   -- Level 111
+        --     "Bolt of Skyfire",            -- Level 106
+        --     "Bolt of Molten Shieldstone", -- Level 101
+        --     "Bolt of Molten Magma",       -- Level 96
+        --     "Bolt of Molten Steel",       -- Level 91
+        --     "Bolt of Rhyolite",           -- Level 86
+        --     "Bolt of Molten Scoria",      -- Level 81
+        --     "Bolt of Molten Dross",       -- Level 76
+        --     "Bolt of Molten Slag",        -- Level 71
+        --     "Bolt of Jerikor",            -- Level 66
+        --     "Firebolt of Tallon",         -- Level 61
+        --     "Seeking Flame of Seukor",    -- Level 59
+        --     "Scars of Sigil",             -- Level 54
+        --     "Lava Bolt",                  -- Level 47
+        --     "Cinder Bolt",                -- Level 33
+        --     "Bolt of Flame",              -- Level 18
+        --     "Flame Bolt",                 -- Level 5
         -- },
         -- ['MagicNuke'] = {
         --     -- Nuke 1 <= LVL <= 69
-        --     "Shock of Blades XIX",
-        --     "Shock of Memorial Steel",
-        --     "Shock of Carbide Steel",
-        --     "Shock of Burning Steel",
-        --     "Shock of Arcronite Steel",
-        --     "Shock of Darksteel",
-        --     "Shock of Blistersteel",
-        --     "Shock of Argathian Steel",
-        --     "Shock of Ethereal Steel",
-        --     "Shock of Discordant Steel",
-        --     "Shock of Cineral Steel",
-        --     "Shock of Silvered Steel",
-        --     "Blade Strike",
-        --     "Rock of Taelosia",
-        --     "Black Steel",
-        --     "Shock of Steel",
-        --     "Shock of Swords",
-        --     "Shock of Spikes",
-        --     "Shock of Blades",
+        --     "Shock of Blades XIX",       -- Level 127
+        --     "Shock of Memorial Steel",   -- Level 122
+        --     "Shock of Carbide Steel",    -- Level 117
+        --     "Shock of Burning Steel",    -- Level 112
+        --     "Shock of Arcronite Steel",  -- Level 107
+        --     "Shock of Darksteel",        -- Level 102
+        --     "Shock of Blistersteel",     -- Level 97
+        --     "Shock of Argathian Steel",  -- Level 92
+        --     "Shock of Ethereal Steel",   -- Level 87
+        --     "Shock of Discordant Steel", -- Level 82
+        --     "Shock of Cineral Steel",    -- Level 77
+        --     "Shock of Silvered Steel",   -- Level 72
+        --     "Blade Strike",              -- Level 68
+        --     "Rock of Taelosia",          -- Level 65
+        --     "Black Steel",               -- Level 63
+        --     "Shock of Steel",            -- Level 57
+        --     "Shock of Swords",           -- Level 41
+        --     "Shock of Spikes",           -- Level 23
+        --     "Shock of Blades",           -- Level 7
         -- },
         -- ['MagicBolt'] = {
         --     -- Magic Bolt Nukes
-        --     "Voidstone Bolt",
-        --     "Luclinite Bolt",
-        --     "Komatiite Bolt",
-        --     "Korascian Bolt",
-        --     "Meteoric Bolt",
-        --     "Iron Bolt",
+        --     "Voidstone Bolt", -- Level 123
+        --     "Luclinite Bolt", -- Level 118
+        --     "Komatiite Bolt", -- Level 113
+        --     "Korascian Bolt", -- Level 108
+        --     "Meteoric Bolt",  -- Level 103
+        --     "Iron Bolt",      -- Level 98
         -- },
-        ['FireDD'] = { --Mix of Fire Nukes and Bolts appropriate for use at lower levels.
-            "Scalding Sands",
-            "Burning Earth",
-            "Burning Sand",
-            "Scars of Sigil",
-            "Lava Bolt",
-            "Cinder Bolt",
-            "Bolt of Flame",
-            "Shock of Flame",
-            "Flame Bolt",
-            "Burn",
-            "Burst of Flame",
+        ['FireDD'] = {                 --Mix of Fire Nukes and Bolts appropriate for use at lower levels.
+            "Scalding Sands",          -- Level 73
+            "Burning Earth",           -- Level 69
+            "Burning Sand",            -- Level 62
+            "Scars of Sigil",          -- Level 54
+            "Lava Bolt",               -- Level 47
+            "Cinder Bolt",             -- Level 33
+            "Bolt of Flame",           -- Level 18
+            "Shock of Flame",          -- Level 15
+            "Flame Bolt",              -- Level 5
+            "Burn",                    -- Level 4
+            "Burst of Flame",          -- Level 1
         },
-        ['BigFireDD'] = { -- Longer cast time bolts we can use when mobs are at higher health.
-            "Bolt of Jerikor",
-            "Firebolt of Tallon",
-            "Seeking Flame of Seukor",
+        ['BigFireDD'] = {              -- Longer cast time bolts we can use when mobs are at higher health.
+            "Bolt of Jerikor",         -- Level 66
+            "Firebolt of Tallon",      -- Level 61
+            "Seeking Flame of Seukor", -- Level 59
         },
-        ['MagicDD'] = { -- Magic does not have any faster casts like Fire, we have only these.
-            "Blade Strike",
-            "Rock of Taelosia",
-            "Black Steel",
-            "Shock of Steel",
-            "Shock of Swords",
-            "Shock of Spikes",
-            "Shock of Blades",
+        ['MagicDD'] = {                -- Magic does not have any faster casts like Fire, we have only these.
+            "Blade Strike",            -- Level 68
+            "Rock of Taelosia",        -- Level 65
+            "Black Steel",             -- Level 63
+            "Shock of Steel",          -- Level 57
+            "Shock of Swords",         -- Level 41
+            "Shock of Spikes",         -- Level 23
+            "Shock of Blades",         -- Level 7
         },
         ['TwinCast'] = {
-            "Twincast",
+            "Twincast", -- Level 85
         },
         ['BeamNuke'] = {
             -- Beam Frontal AOE Spell*
-            "Beam of Molten Slag XII",
-            "Beam of Molten Dacite",
-            "Beam of Molten Olivine",
-            "Beam of Molten Komatiite",
-            "Beam of Molten Rhyolite",
-            "Beam of Molten Shieldstone",
-            "Beam of Brimstone",
-            "Beam of Molten Steel",
-            "Beam of Rhyolite",
-            "Beam of Molten Scoria",
-            "Beam of Molten Dross",
-            "Beam of Molten Slag",
+            "Beam of Molten Slag XII",    -- Level 127
+            "Beam of Molten Dacite",      -- Level 122
+            "Beam of Molten Olivine",     -- Level 117
+            "Beam of Molten Komatiite",   -- Level 112
+            "Beam of Molten Rhyolite",    -- Level 107
+            "Beam of Molten Shieldstone", -- Level 102
+            "Beam of Brimstone",          -- Level 97
+            "Beam of Molten Steel",       -- Level 92
+            "Beam of Rhyolite",           -- Level 87
+            "Beam of Molten Scoria",      -- Level 82
+            "Beam of Molten Dross",       -- Level 77
+            "Beam of Molten Slag",        -- Level 72
         },
         ['RainNuke'] = {
             --- Rain AOE Spell*
-            "Rain of Fire XVI",
-            "Rain of Molten Dacite",
-            "Rain of Molten Olivine",
-            "Rain of Molten Komatiite",
-            "Rain of Molten Rhyolite",
-            "Coronal Rain",
-            "Rain of Blistersteel",
-            "Rain of Molten Steel",
-            "Rain of Rhyolite",
-            "Rain of Molten Scoria",
-            "Rain of Molten Dross",
-            "Rain of Molten Slag",
-            "Rain of Jerikor",
-            "Sun Storm",
-            "Sirocco",
-            "Rain of Lava",
-            "Rain of Fire",
+            "Rain of Fire XVI",         -- Level 128
+            "Rain of Molten Dacite",    -- Level 123
+            "Rain of Molten Olivine",   -- Level 118
+            "Rain of Molten Komatiite", -- Level 113
+            "Rain of Molten Rhyolite",  -- Level 108
+            "Coronal Rain",             -- Level 103
+            "Rain of Blistersteel",     -- Level 97
+            "Rain of Molten Steel",     -- Level 92
+            "Rain of Rhyolite",         -- Level 87
+            "Rain of Molten Scoria",    -- Level 82
+            "Rain of Molten Dross",     -- Level 77
+            "Rain of Molten Slag",      -- Level 72
+            "Rain of Jerikor",          -- Level 67
+            "Sun Storm",                -- Level 62
+            "Sirocco",                  -- Level 55
+            "Rain of Lava",             -- Level 35
+            "Rain of Fire",             -- Level 17
         },
         ['MagicRainNuke'] = {
-            "Rain of Blades XVII",
-            "Rain of Kukris",
-            "Rain of Falchions",
-            "Rain of Blades",
-            "Rain of Spikes",
-            "Rain Of Swords",
-            "ManaStorm",
-            "Maelstrom of Electricity",
-            "Maelstrom of Thunder",
+            "Rain of Blades XVII",      -- Level 129
+            "Rain of Kukris",           -- Level 124
+            "Rain of Falchions",        -- Level 119
+            "Maelstrom of Thunder",     -- Level 64
+            "Maelstrom of Electricity", -- Level 60
+            "ManaStorm",                -- Level 59
+            "Rain Of Swords",           -- Level 49
+            "Rain of Spikes",           -- Level 26
+            "Rain of Blades",           -- Level 10
         },
         ['VolleyNuke'] = {
             -- Volley Nuke - Pet buff*
-            "Shock of Many XI",
-            "Fusillade of Many",
-            "Barrage of Many",
-            "Shockwave of Many",
-            "Volley of Many",
-            "Storm of Many",
-            "Salvo of Many",
-            "Strike of Many",
-            "Clash of Many",
-            "Jolt of Many",
-            "Shock of Many",
+            "Shock of Many XI",  -- Level 127
+            "Fusillade of Many", -- Level 122
+            "Barrage of Many",   -- Level 117
+            "Shockwave of Many", -- Level 112
+            "Volley of Many",    -- Level 107
+            "Storm of Many",     -- Level 102
+            "Salvo of Many",     -- Level 97
+            "Strike of Many",    -- Level 92
+            "Clash of Many",     -- Level 87
+            "Jolt of Many",      -- Level 82
+            "Shock of Many",     -- Level 77
         },
         ['SummonedNuke'] = {
             -- Unnatural Nukes >70
-            "Expunge the Unnatural",
-            "Dismantle the Unnatural",
-            "Unmend the Unnatural",
-            "Obliterate the Unnatural",
-            "Repudiate the Unnatural",
-            "Eradicate the Unnatural",
-            "Exterminate the Unnatural",
-            "Abolish the Divergent",
-            "Annihilate the Divergent",
-            "Annihilate the Anomalous",
-            "Annihilate the Aberrant",
-            "Annihilate the Unnatural",
+            "Expunge the Unnatural",     -- Level 129
+            "Dismantle the Unnatural",   -- Level 124
+            "Unmend the Unnatural",      -- Level 118
+            "Obliterate the Unnatural",  -- Level 113
+            "Repudiate the Unnatural",   -- Level 108
+            "Eradicate the Unnatural",   -- Level 103
+            "Exterminate the Unnatural", -- Level 98
+            "Abolish the Divergent",     -- Level 93
+            "Annihilate the Divergent",  -- Level 88
+            "Annihilate the Anomalous",  -- Level 83
+            "Annihilate the Aberrant",   -- Level 78
+            "Annihilate the Unnatural",  -- Level 73
         },
         ['MaloNuke'] = {
             -- Shock/Malo Combo Line
-            "Shock of Malaise VII",
-            "Memorial Steel Malosinera",
-            "Carbide Malosinetra",
-            "Blistersteel Malosenia",
-            "Darksteel Malosenete",
-            "Arcronite Malosinata",
-            "Burning Malosinara",
+            "Shock of Malaise VII",      -- Level 129
+            "Memorial Steel Malosinera", -- Level 124
+            "Carbide Malosinetra",       -- Level 119
+            "Burning Malosinara",        -- Level 114
+            "Arcronite Malosinata",      -- Level 109
+            "Darksteel Malosenete",      -- Level 104
+            "Blistersteel Malosenia",    -- Level 100
         },
         --- Buffs
         ['SelfShield'] = {
-            "Shielding XXIII",
-            "Shield of Memories",
-            "Shield of Shadow",
-            "Shield of Restless Ice",
-            "Shield of Scales",
-            "Shield of the Pellarus",
-            "Shield of the Dauntless",
-            "Shield of Bronze",
-            "Shield of Dreams",
-            "Shield of the Void",
-            "Prime Guard",
-            "Prime Shielding",
-            "Elemental Aura",
-            "Shield of Maelin",
-            "Shield of the Arcane",
-            "Shield of the Magi",
-            "Arch Shielding",
-            "Greater Shielding",
-            "Major Shielding",
-            "Shielding",
-            "Lesser Shielding",
-            "Minor Shielding",
+            "Shielding XXIII",         -- Level 126
+            "Shield of Memories",      -- Level 121
+            "Shield of Shadow",        -- Level 116
+            "Shield of Restless Ice",  -- Level 111
+            "Shield of Scales",        -- Level 106
+            "Shield of the Pellarus",  -- Level 101
+            "Shield of the Dauntless", -- Level 96
+            "Shield of Bronze",        -- Level 91
+            "Shield of Dreams",        -- Level 86
+            "Shield of the Void",      -- Level 81
+            "Prime Guard",             -- Level 76
+            "Prime Shielding",         -- Level 71
+            "Elemental Aura",          -- Level 66
+            "Shield of Maelin",        -- Level 64
+            "Shield of the Arcane",    -- Level 61
+            "Shield of the Magi",      -- Level 54
+            "Arch Shielding",          -- Level 43
+            "Greater Shielding",       -- Level 32
+            "Major Shielding",         -- Level 24
+            "Shielding",               -- Level 16
+            "Lesser Shielding",        -- Level 5
+            "Minor Shielding",         -- Level 1
         },
         ['SkinDS'] = {
             -- Use at the start of the DPS loop
-            "Searing Skin XI",
-            "Boiling Skin",
-            "Scorching Skin",
-            "Burning Skin",
-            "Blistering Skin",
-            "Coronal Skin",
-            "Infernal Skin",
-            "Molten Skin",
-            "Blazing Skin",
-            "Torrid Skin",
-            "Brimstoneskin",
-            "Searing Skin",
-            "Scorching Skin",
-            "Ancient: Veil of Pyrilonus",
-            "Pyrilen Skin",
+            "Searing Skin XI",            -- Level 128
+            "Boiling Skin",               -- Level 123
+            "Burning Skin",               -- Level 113
+            "Blistering Skin",            -- Level 108
+            "Coronal Skin",               -- Level 103
+            "Infernal Skin",              -- Level 98
+            "Molten Skin",                -- Level 93
+            "Blazing Skin",               -- Level 88
+            "Torrid Skin",                -- Level 83
+            "Brimstoneskin",              -- Level 81
+            "Searing Skin",               -- Level 78
+            "Scorching Skin",             -- Level 73
+            "Scorching Skin",             -- Level 73
+            "Ancient: Veil of Pyrilonus", -- Level 70
+            "Pyrilen Skin",               -- Level 68
         },
         ['LongDurDmgShield'] = {
             -- Preferring group buffs for ease. Included all Single target Now as well.
-            "Circle of Fireskin XVI",
-            "Circle of Forgefire Coat",
-            "Forgefire Coat",
-            "Circle of Emberweave Coat",
-            "Emberweave Coat",
-            "Circle of Igneous Skin",
-            "Igneous Coat",
-            "Circle of the Inferno",
-            "Inferno Coat",
-            "Circle of Flameweaving",
-            "Flameweave Coat",
-            "Circle of Flameskin",
-            "Flameskin",
-            "Circle of Embers",
-            "Embercoat",
-            "Circle of Dreamfire",
-            "Dreamfire Coat",
-            "Circle of Brimstoneskin",
-            "Brimstoneskin",
-            "Circle of Lavaskin",
-            "Lavaskin",
-            "Circle of Magmaskin",
-            "Magmaskin",
-            "Circle of Fireskin",
-            "Fireskin",
-            "Maelstrom of Ro",
-            "FlameShield of Ro",
-            "Aegis of Ro",
-            "Cadeau of Flame",
-            "Boon of Immolation",
-            "Shield of Lava",
-            "Barrier of Combustion",
-            "Inferno Shield",
-            "Shield of Flame",
-            "Shield of Fire",
+            "Circle of Fireskin XVI",    -- Level 126
+            "Circle of Forgefire Coat",  -- Level 124
+            "Forgefire Coat",            -- Level 121
+            "Circle of Emberweave Coat", -- Level 119
+            "Emberweave Coat",           -- Level 116
+            "Circle of Igneous Skin",    -- Level 114
+            "Igneous Coat",              -- Level 111
+            "Circle of the Inferno",     -- Level 109
+            "Inferno Coat",              -- Level 106
+            "Circle of Flameweaving",    -- Level 104
+            "Flameweave Coat",           -- Level 101
+            "Circle of Flameskin",       -- Level 99
+            "Flameskin",                 -- Level 96
+            "Circle of Embers",          -- Level 94
+            "Embercoat",                 -- Level 91
+            "Circle of Dreamfire",       -- Level 89
+            "Dreamfire Coat",            -- Level 86
+            "Circle of Brimstoneskin",   -- Level 84
+            "Brimstoneskin",             -- Level 81
+            "Circle of Lavaskin",        -- Level 79
+            "Lavaskin",                  -- Level 76
+            "Circle of Magmaskin",       -- Level 74
+            "Magmaskin",                 -- Level 71
+            "Circle of Fireskin",        -- Level 70
+            "Fireskin",                  -- Level 66
+            "Maelstrom of Ro",           -- Level 63
+            "FlameShield of Ro",         -- Level 61
+            "Aegis of Ro",               -- Level 60
+            "Cadeau of Flame",           -- Level 56
+            "Boon of Immolation",        -- Level 53
+            "Shield of Lava",            -- Level 45
+            "Barrier of Combustion",     -- Level 38
+            "Inferno Shield",            -- Level 28
+            "Shield of Flame",           -- Level 19
+            "Shield of Fire",            -- Level 7
         },
         ['ManaRegenBuff'] = {
             -- LVL58 (Transon's Phantasmal Protection) and up to avoid reagent usage
-            "Eidolic Guardian XVII",
-            "Courageous Guardian",
-            "Relentless Guardian",
-            "Restless Guardian",
-            "Burning Guardian",
-            "Praetorian Guardian",
-            "Phantasmal Guardian",
-            "Splendrous Guardian",
-            "Cognitive Guardian",
-            "Empyrean Guardian",
-            "Eidolic Guardian",
-            "Phantasmal Warden",
-            "Phantom Shield",
-            "Xegony's Phantasmal Guard",
-            "Transon's Phantasmal Protection",
+            "Eidolic Guardian XVII",           -- Level 127
+            "Courageous Guardian",             -- Level 122
+            "Relentless Guardian",             -- Level 117
+            "Restless Guardian",               -- Level 112
+            "Burning Guardian",                -- Level 107
+            "Praetorian Guardian",             -- Level 102
+            "Phantasmal Guardian",             -- Level 97
+            "Splendrous Guardian",             -- Level 92
+            "Cognitive Guardian",              -- Level 87
+            "Empyrean Guardian",               -- Level 82
+            "Eidolic Guardian",                -- Level 77
+            "Phantasmal Warden",               -- Level 72
+            "Phantom Shield",                  -- Level 68
+            "Xegony's Phantasmal Guard",       -- Level 62
+            "Transon's Phantasmal Protection", -- Level 58
         },
         ['AllianceBuff'] = {
-            "Firebound Covariance",
-            "Firebound Conjunction",
-            "Firebound Coalition",
-            "Firebound Covenant",
-            "Firebound Alliance",
+            "Firebound Covariance",  -- Level 125
+            "Firebound Conjunction", -- Level 120
+            "Firebound Coalition",   -- Level 115
+            "Firebound Covenant",    -- Level 110
+            "Firebound Alliance",    -- Level 101
         },
         ['SurgeDS1'] = {
             -- ShortDuration DS (Slot 4)
-            "Surge of Shadow",
-            "Surge of Arcanum",
-            "Surge of Shadowflares",
-            "Surge of Thaumacretion",
+            "Surge of Shadow",        -- Level 100
+            "Surge of Arcanum",       -- Level 95
+            "Surge of Shadowflares",  -- Level 90
+            "Surge of Thaumacretion", -- Level 85
         },
         ['SurgeDS2'] = {
             -- ShortDuration DS (Slot 4)
-            "Surge of Shadow",
-            "Surge of Arcanum",
-            "Surge of Shadowflares",
-            "Surge of Thaumacretion",
+            "Surge of Shadow",        -- Level 100
+            "Surge of Arcanum",       -- Level 95
+            "Surge of Shadowflares",  -- Level 90
+            "Surge of Thaumacretion", -- Level 85
         },
         ['PetAura'] = {
             -- Mage Pet Aura
-            "Arcane Distillect",
+            "Arcane Distillect", -- Level 85
         },
         --not used
         --[[ ['SingleDS'] = {
@@ -477,426 +477,426 @@ _ClassConfig    = {
         },]] --
         ['FireShroud'] = {
             -- Defensive Proc 3-6m Buff
-            "Burning Veil X",
-            "Igneous Veil",
-            "Volcanic Veil",
-            "Exothermic Veil",
-            "Skyfire Veil",
-            "Magmatic Veil",
-            "Molten Veil",
-            "Burning Veil",
-            "Burning Pyroshroud",
-            "Burning Brimbody",
-            "Burning Aura",
+            "Burning Veil X",     -- Level 129
+            "Igneous Veil",       -- Level 124
+            "Volcanic Veil",      -- Level 119
+            "Exothermic Veil",    -- Level 114
+            "Skyfire Veil",       -- Level 109
+            "Magmatic Veil",      -- Level 99
+            "Molten Veil",        -- Level 94
+            "Burning Veil",       -- Level 89
+            "Burning Pyroshroud", -- Level 84
+            "Burning Brimbody",   -- Level 79
+            "Burning Aura",       -- Level 68
         },
         ['PetBodyGuard'] = {
-            "Hulking Bodyguard X",
-            "ValorForged Bodyguard",
-            "Ophiolite Bodyguard",
-            "Pyroxenite Bodyguard",
-            "Rhyolitic Bodyguard",
-            "Shieldstone Bodyguard",
-            "Groundswell Bodyguard",
-            "Steelbound Bodyguard",
-            "Tellurian Bodyguard",
-            "Hulking Bodyguard",
+            "Hulking Bodyguard X",   -- Level 126
+            "ValorForged Bodyguard", -- Level 121
+            "Ophiolite Bodyguard",   -- Level 116
+            "Pyroxenite Bodyguard",  -- Level 115
+            "Rhyolitic Bodyguard",   -- Level 110
+            "Shieldstone Bodyguard", -- Level 105
+            "Groundswell Bodyguard", -- Level 100
+            "Steelbound Bodyguard",  -- Level 95
+            "Tellurian Bodyguard",   -- Level 90
+            "Hulking Bodyguard",     -- Level 85
         },
         ['GatherMana'] = {
-            "Gather Potential VIII",
-            "Gather Zeal",
-            "Gather Vigor",
-            "Gather Potency",
-            "Gather Capability",
-            "Gather Magnitude",
-            "Gather Capacity",
-            "Gather Potential",
+            "Gather Potential VIII", -- Level 130
+            "Gather Zeal",           -- Level 125
+            "Gather Vigor",          -- Level 120
+            "Gather Potency",        -- Level 115
+            "Gather Capability",     -- Level 110
+            "Gather Magnitude",      -- Level 100
+            "Gather Capacity",       -- Level 95
+            "Gather Potential",      -- Level 90
         },
         -- Pet Spells Pets & Spells Affecting them
         ['MeleeGuard  '] = {
-            "Shield of Fate VII",
-            "Shield of Inescapability",
-            "Shield of Inevitability",
-            "Shield of Destiny",
-            "Shield of Order",
-            "Shield of Consequence",
-            "Shield of Fate",
+            "Shield of Fate VII",       -- Level 127
+            "Shield of Inescapability", -- Level 122
+            "Shield of Inevitability",  -- Level 117
+            "Shield of Destiny",        -- Level 112
+            "Shield of Order",          -- Level 107
+            "Shield of Consequence",    -- Level 102
+            "Shield of Fate",           -- Level 97
         },
         ['DichoSpell'] = {
             -- Dicho Spell*
-            "Reciprocal Companion",
-            "Ecliptic Companion",
-            "Composite Companion",
-            "Dissident Companion",
-            "Dichotomic Companion",
+            "Reciprocal Companion", -- Level 121
+            "Ecliptic Companion",   -- Level 116
+            "Composite Companion",  -- Level 111
+            "Dissident Companion",  -- Level 106
+            "Dichotomic Companion", -- Level 101
         },
         ['PetHealSpell'] = {
             -- Pet Heal*
-            "Renewal of Magmath",
-            "Renewal of Shoru",
-            "Renewal of Iilivina ",
-            "Renewal of Evreth",
-            "Renewal of Ioulin",
-            "Renewal of Calix",
-            "Renewal of Hererra",
-            "Renewal of Sirqo",
-            "Renewal of Volark",
-            "Renewal of Cadwin",
-            "Revival of Aenro",
-            "Renewal of Aenda",
-            "Renewal of Jerikor",
-            "Planar Renewal",
-            "Transon's Elemental Renewal",
-            "Transon's Elemental Infusion",
-            "Refresh Summoning",
-            "Renew Summoning",
-            "Renew Elements",
+            "Renewal of Magmath",           -- Level 128
+            "Renewal of Shoru",             -- Level 123
+            "Renewal of Iilivina ",         -- Level 118
+            "Renewal of Evreth",            -- Level 113
+            "Renewal of Ioulin",            -- Level 108
+            "Renewal of Calix",             -- Level 103
+            "Renewal of Hererra",           -- Level 98
+            "Renewal of Sirqo",             -- Level 93
+            "Renewal of Volark",            -- Level 88
+            "Renewal of Cadwin",            -- Level 83
+            "Revival of Aenro",             -- Level 78
+            "Renewal of Aenda",             -- Level 73
+            "Renewal of Jerikor",           -- Level 69
+            "Planar Renewal",               -- Level 64
+            "Transon's Elemental Renewal",  -- Level 60
+            "Transon's Elemental Infusion", -- Level 52
+            "Refresh Summoning",            -- Level 34
+            "Renew Summoning",              -- Level 18
+            "Renew Elements",               -- Level 7
         },
         ['PetPromisedSpell'] = {
             ---Pet Promised*
-            "Promised Mending XII",
-            "Promised Reconstitution",
-            "Promised Relief",
-            "Promised Healing",
-            "Promised Alleviation",
-            "Promised Invigoration",
-            "Promised Amelioration",
-            "Promised Amendment",
-            "Promised Wardmending",
-            "Promised Rejuvenation",
-            "Promised Recovery",
+            "Promised Mending XII",    -- Level 128
+            "Promised Reconstitution", -- Level 123
+            "Promised Relief",         -- Level 118
+            "Promised Healing",        -- Level 113
+            "Promised Alleviation",    -- Level 108
+            "Promised Invigoration",   -- Level 103
+            "Promised Amelioration",   -- Level 98
+            "Promised Amendment",      -- Level 93
+            "Promised Wardmending",    -- Level 88
+            "Promised Rejuvenation",   -- Level 83
+            "Promised Recovery",       -- Level 78
         },
         ['PetStanceSpell'] = {
             ---Pet Stance*
-            "Omphacite Stance",
-            "Kanoite Stance",
-            "Pyroxene Stance",
-            "Rhyolite Stance",
-            "Shieldstone Stance",
-            "Groundswell Stance",
-            "Steelstance",
-            "Tellurian Stance",
-            "Earthen Stance",
-            "Grounded Stance",
-            "Granite Stance",
+            "Omphacite Stance",   -- Level 123
+            "Kanoite Stance",     -- Level 118
+            "Pyroxene Stance",    -- Level 113
+            "Rhyolite Stance",    -- Level 108
+            "Shieldstone Stance", -- Level 103
+            "Groundswell Stance", -- Level 98
+            "Steelstance",        -- Level 93
+            "Tellurian Stance",   -- Level 88
+            "Earthen Stance",     -- Level 83
+            "Grounded Stance",    -- Level 78
+            "Granite Stance",     -- Level 73
         },
         ['PetManaConv'] = {
-            "Valiant Symbiosis",
-            "Relentless Symbiosis",
-            "Restless Symbiosis",
-            "Burning Symbiosis",
-            "Dark Symbiosis",
-            "Phantasmal Symbiosis",
-            "Arcane Symbiosis",
-            "Spectral Symbiosis",
-            "Ethereal Symbiosis",
-            "Prime Symbiosis",
-            "Elemental Symbiosis",
-            "Elemental Simulacrum",
-            "Elemental Siphon",
-            "Elemental Draw",
+            "Valiant Symbiosis",    -- Level 122
+            "Relentless Symbiosis", -- Level 117
+            "Restless Symbiosis",   -- Level 115
+            "Burning Symbiosis",    -- Level 110
+            "Dark Symbiosis",       -- Level 105
+            "Phantasmal Symbiosis", -- Level 100
+            "Arcane Symbiosis",     -- Level 95
+            "Spectral Symbiosis",   -- Level 90
+            "Ethereal Symbiosis",   -- Level 85
+            "Prime Symbiosis",      -- Level 80
+            "Elemental Symbiosis",  -- Level 75
+            "Elemental Simulacrum", -- Level 70
+            "Elemental Siphon",     -- Level 65
+            "Elemental Draw",       -- Level 54
         },
         ['PetHaste'] = {
-            "Burnout XVII",
-            "Burnout XVI",
-            "Burnout XV",
-            "Burnout XIV",
-            "Burnout XIII",
-            "Burnout XII",
-            "Burnout XI",
-            "Burnout XI",
-            "Burnout IX",
-            "Burnout VIII",
-            "Burnout VII",
-            "Burnout VI",
-            "Elemental Fury",
-            "Burnout V",
-            "Burnout IV",
-            "Elemental Empathy",
-            "Burnout III",
-            "Burnout II",
-            "Burnout",
+            "Burnout XVII",      -- Level 126
+            "Burnout XVI",       -- Level 121
+            "Burnout XV",        -- Level 116
+            "Burnout XIV",       -- Level 111
+            "Burnout XIII",      -- Level 106
+            "Burnout XII",       -- Level 101
+            "Burnout XI",        -- Level 96
+            "Burnout XI",        -- Level 96
+            "Burnout IX",        -- Level 86
+            "Burnout VIII",      -- Level 81
+            "Burnout VII",       -- Level 76
+            "Burnout VI",        -- Level 71
+            "Elemental Fury",    -- Level 69
+            "Burnout V",         -- Level 62
+            "Burnout IV",        -- Level 55
+            "Elemental Empathy", -- Level 52
+            "Burnout III",       -- Level 47
+            "Burnout II",        -- Level 29
+            "Burnout",           -- Level 11
         },
         ['PetIceFlame'] = {
-            "Iceflame Guard XII",
-            "IceFlame Palisade",
-            "Iceflame Barricade ",
-            "Iceflame Rampart",
-            "Iceflame Keep",
-            "Iceflame Armaments",
-            "Iceflame Eminence",
-            "Iceflame Armor",
-            "Iceflame Ward",
-            "Iceflame Efflux",
-            "Iceflame Tenement",
-            "Iceflame Body",
-            "Iceflame Guard",
+            "Iceflame Guard XII",  -- Level 129
+            "IceFlame Palisade",   -- Level 124
+            "Iceflame Barricade ", -- Level 119
+            "Iceflame Rampart",    -- Level 114
+            "Iceflame Keep",       -- Level 109
+            "Iceflame Armaments",  -- Level 104
+            "Iceflame Eminence",   -- Level 99
+            "Iceflame Armor",      -- Level 94
+            "Iceflame Ward",       -- Level 89
+            "Iceflame Efflux",     -- Level 84
+            "Iceflame Tenement",   -- Level 79
+            "Iceflame Body",       -- Level 74
+            "Iceflame Guard",      -- Level 70
         },
         ['EarthPetSpell'] = {
-            "Earth Elemental XXVI",
-            "Recruitment of Earth",
-            "Conscription of Earth",
-            "Manifestation of Earth",
-            "Embodiment of Earth",
-            "Convocation of Earth",
-            "Shard of Earth",
-            "Facet of Earth",
-            "Construct of Earth",
-            "Aspect of Earth",
-            "Core of Earth",
-            "Essence of Earth",
-            "Child of Earth",
-            "Greater Vocaration: Earth",
-            "Vocarate: Earth",
-            "Greater Conjuration: Earth",
-            "Conjuration: Earth",
-            "Lesser Conjuration: Earth",
-            "Minor Conjuration: Earth",
-            "Greater Summoning: Earth",
-            "Summoning: Earth",
-            "Lesser Summoning: Earth",
-            "Minor Summoning: Earth",
-            "Elemental: Earth",
-            "Elementaling: Earth",
-            "Elementalkin: Earth",
+            "Earth Elemental XXVI",       -- Level 129
+            "Recruitment of Earth",       -- Level 124
+            "Conscription of Earth",      -- Level 119
+            "Manifestation of Earth",     -- Level 114
+            "Embodiment of Earth",        -- Level 109
+            "Convocation of Earth",       -- Level 104
+            "Shard of Earth",             -- Level 99
+            "Facet of Earth",             -- Level 94
+            "Construct of Earth",         -- Level 89
+            "Aspect of Earth",            -- Level 84
+            "Core of Earth",              -- Level 79
+            "Essence of Earth",           -- Level 74
+            "Child of Earth",             -- Level 70
+            "Greater Vocaration: Earth",  -- Level 57
+            "Vocarate: Earth",            -- Level 51
+            "Greater Conjuration: Earth", -- Level 46
+            "Conjuration: Earth",         -- Level 44
+            "Lesser Conjuration: Earth",  -- Level 39
+            "Minor Conjuration: Earth",   -- Level 34
+            "Greater Summoning: Earth",   -- Level 29
+            "Summoning: Earth",           -- Level 25
+            "Lesser Summoning: Earth",    -- Level 21
+            "Minor Summoning: Earth",     -- Level 17
+            "Elemental: Earth",           -- Level 13
+            "Elementaling: Earth",        -- Level 9
+            "Elementalkin: Earth",        -- Level 5
         },
         ['WaterPetSpell'] = {
-            "Water Elemental XXVI",
-            "Recruitment of Water",
-            "Conscription of Water",
-            "Manifestation of Water",
-            "Embodiment of Water",
-            "Convocation of Water",
-            "Shard of Water",
-            "Facet of Water",
-            "Construct of Water",
-            "Aspect of Water",
-            "Core of Water",
-            "Essence of Water",
-            "Child of Water",
-            "Servant of Marr",
-            "Greater Vocaration: Water",
-            "Vocarate: Water",
-            "Greater Conjuration: Water",
-            "Conjuration: Water",
-            "Lesser Conjuration: Water",
-            "Minor Conjuration: Water",
-            "Greater Summoning: Water",
-            "Summoning: Water",
-            "Lesser Summoning: Water",
-            "Minor Summoning: Water",
-            "Elemental: Water",
-            "Elementaling: Water",
-            "Elementalkin: Water",
+            "Water Elemental XXVI",       -- Level 127
+            "Recruitment of Water",       -- Level 122
+            "Conscription of Water",      -- Level 117
+            "Manifestation of Water",     -- Level 112
+            "Embodiment of Water",        -- Level 107
+            "Convocation of Water",       -- Level 102
+            "Shard of Water",             -- Level 97
+            "Facet of Water",             -- Level 92
+            "Construct of Water",         -- Level 87
+            "Aspect of Water",            -- Level 82
+            "Core of Water",              -- Level 77
+            "Essence of Water",           -- Level 72
+            "Child of Water",             -- Level 67
+            "Servant of Marr",            -- Level 62
+            "Greater Vocaration: Water",  -- Level 60
+            "Vocarate: Water",            -- Level 54
+            "Greater Conjuration: Water", -- Level 49
+            "Conjuration: Water",         -- Level 41
+            "Lesser Conjuration: Water",  -- Level 36
+            "Minor Conjuration: Water",   -- Level 31
+            "Greater Summoning: Water",   -- Level 26
+            "Summoning: Water",           -- Level 22
+            "Lesser Summoning: Water",    -- Level 18
+            "Minor Summoning: Water",     -- Level 14
+            "Elemental: Water",           -- Level 10
+            "Elementaling: Water",        -- Level 6
+            "Elementalkin: Water",        -- Level 2
         },
         ['AirPetSpell'] = {
-            "Air Elemental XXVI",
-            "Recruitment of Air",
-            "Conscription of Air",
-            "Manifestation of Air",
-            "Embodiment of Air",
-            "Convocation of Air",
-            "Shard of Air",
-            "Facet of Air",
-            "Construct of Air",
-            "Aspect of Air",
-            "Core of Air",
-            "Essence of Air",
-            "Child of Wind",
-            "Ward of Xegony",
-            "Greater Vocaration: Air",
-            "Vocarate: Air",
-            "Greater Conjuration: Air",
-            "Conjuration: Air",
-            "Lesser Conjuration: Air",
-            "Minor Conjuration: Air",
-            "Greater Summoning: Air",
-            "Summoning: Air",
-            "Lesser Summoning: Air",
-            "Minor Summoning: Air",
-            "Elemental: Air",
-            "Elementaling: Air",
-            "Elementalkin: Air",
+            "Air Elemental XXVI",       -- Level 126
+            "Recruitment of Air",       -- Level 121
+            "Conscription of Air",      -- Level 116
+            "Manifestation of Air",     -- Level 111
+            "Embodiment of Air",        -- Level 106
+            "Convocation of Air",       -- Level 101
+            "Shard of Air",             -- Level 96
+            "Facet of Air",             -- Level 91
+            "Construct of Air",         -- Level 86
+            "Aspect of Air",            -- Level 81
+            "Core of Air",              -- Level 76
+            "Essence of Air",           -- Level 71
+            "Child of Wind",            -- Level 66
+            "Ward of Xegony",           -- Level 61
+            "Greater Vocaration: Air",  -- Level 59
+            "Vocarate: Air",            -- Level 53
+            "Greater Conjuration: Air", -- Level 48
+            "Conjuration: Air",         -- Level 43
+            "Lesser Conjuration: Air",  -- Level 38
+            "Minor Conjuration: Air",   -- Level 33
+            "Greater Summoning: Air",   -- Level 28
+            "Summoning: Air",           -- Level 24
+            "Lesser Summoning: Air",    -- Level 20
+            "Minor Summoning: Air",     -- Level 16
+            "Elemental: Air",           -- Level 12
+            "Elementaling: Air",        -- Level 8
+            "Elementalkin: Air",        -- Level 4
         },
         ['FirePetSpell'] = {
-            "Fire Elemental XXVI",
-            "Recruitment of Fire",
-            "Conscription of Fire",
-            "Manifestation of Fire",
-            "Embodiment of Fire",
-            "Convocation of Fire",
-            "Shard of Fire",
-            "Facet of Fire",
-            "Construct of Fire",
-            "Aspect of Fire",
-            "Core of Fire",
-            "Essence of Fire",
-            "Child of Fire",
-            "Child of Ro",
-            "Greater Vocaration: Fire",
-            "Vocarate: Fire",
-            "Greater Conjuration: Fire",
-            "Conjuration: Fire",
-            "Lesser Conjuration: Fire",
-            "Minor Conjuration: Fire",
-            "Greater Summoning: Fire",
-            "Summoning: Fire",
-            "Lesser Summoning: Fire",
-            "Minor Summoning: Fire",
-            "Elemental: Fire",
-            "Elementaling: Fire",
-            "Elementalkin: Fire",
+            "Fire Elemental XXVI",       -- Level 128
+            "Recruitment of Fire",       -- Level 123
+            "Conscription of Fire",      -- Level 118
+            "Manifestation of Fire",     -- Level 113
+            "Embodiment of Fire",        -- Level 108
+            "Convocation of Fire",       -- Level 103
+            "Shard of Fire",             -- Level 98
+            "Facet of Fire",             -- Level 93
+            "Construct of Fire",         -- Level 88
+            "Aspect of Fire",            -- Level 83
+            "Core of Fire",              -- Level 78
+            "Essence of Fire",           -- Level 73
+            "Child of Fire",             -- Level 68
+            "Child of Ro",               -- Level 63
+            "Greater Vocaration: Fire",  -- Level 58
+            "Vocarate: Fire",            -- Level 52
+            "Greater Conjuration: Fire", -- Level 47
+            "Conjuration: Fire",         -- Level 42
+            "Lesser Conjuration: Fire",  -- Level 37
+            "Minor Conjuration: Fire",   -- Level 32
+            "Greater Summoning: Fire",   -- Level 27
+            "Summoning: Fire",           -- Level 23
+            "Lesser Summoning: Fire",    -- Level 19
+            "Minor Summoning: Fire",     -- Level 15
+            "Elemental: Fire",           -- Level 11
+            "Elementaling: Fire",        -- Level 7
+            "Elementalkin: Fire",        -- Level 3
         },
         ['AegisBuff'] = {
             ---Pet Aegis Shield Buff (Short Duration)*
-            "Auspice of Usira",
-            "Aegis of Valorforged",
-            "Auspice of Valia",
-            "Aegis of Rumblecrush",
-            "Auspice of Kildrukaun",
-            "Aegis of Orfur",
-            "Auspice of Esianti",
-            "Aegis of Zeklor",
-            "Aegis of Japac",
-            "Auspice of Eternity",
-            "Aegis of Nefori",
-            "Auspice of Shadows",
-            "Aegis of Kildrukaun",
-            "Aegis of Calliav",
-            "Bulwark of Calliav",
-            "Protection of Calliav",
-            "Guard of Calliav",
-            "Ward of Calliav",
+            "Aegis of Valorforged",  -- Level 124
+            "Auspice of Usira",      -- Level 122
+            "Aegis of Rumblecrush",  -- Level 119
+            "Auspice of Valia",      -- Level 117
+            "Aegis of Orfur",        -- Level 114
+            "Auspice of Kildrukaun", -- Level 112
+            "Aegis of Zeklor",       -- Level 109
+            "Auspice of Esianti",    -- Level 107
+            "Aegis of Japac",        -- Level 104
+            "Auspice of Eternity",   -- Level 102
+            "Aegis of Nefori",       -- Level 99
+            "Auspice of Shadows",    -- Level 96
+            "Aegis of Kildrukaun",   -- Level 79
+            "Aegis of Calliav",      -- Level 74
+            "Bulwark of Calliav",    -- Level 69
+            "Protection of Calliav", -- Level 64
+            "Guard of Calliav",      -- Level 58
+            "Ward of Calliav",       -- Level 46
         },
         ['PetManaNuke'] = {
             --- PetManaNuke
-            "Thaumatize Pet",
+            "Thaumatize Pet", -- Level 83
         },
         -- ['PetArmorSummon'] = {
         --     -- >=LVL71
-        --     "Grant Arcane Plate",
-        --     "Grant The Alloy's Plate",
-        --     "Grant the Centien's Plate",
-        --     "Grant Ocoenydd's Plate",
-        --     "Grant Wirn's Plate",
-        --     "Grant Thassis' Plate",
-        --     "Grant Frightforged Plate",
-        --     "Grant Manaforged Plate",
-        --     "Grant Spectral Plate",
-        --     "Summon Plate of the Prime",
-        --     "Summon Plate of the Elements",
+        --     "Grant Arcane Plate",           -- Level 127
+        --     "Grant The Alloy's Plate",      -- Level 121
+        --     "Grant the Centien's Plate",    -- Level 116
+        --     "Grant Ocoenydd's Plate",       -- Level 111
+        --     "Grant Wirn's Plate",           -- Level 106
+        --     "Grant Thassis' Plate",         -- Level 101
+        --     "Grant Frightforged Plate",     -- Level 96
+        --     "Grant Manaforged Plate",       -- Level 91
+        --     "Grant Spectral Plate",         -- Level 86
+        --     "Summon Plate of the Prime",    -- Level 76
+        --     "Summon Plate of the Elements", -- Level 71
         -- },
         -- ['PetWeaponSummon'] = {
-        --     "Grant Arcane Armaments",
-        --     "Grant Goliath's Armaments",
-        --     "Grant Shak Dathor's Armaments",
-        --     "Grant Yalrek's Armaments",
-        --     "Grant Wirn's Armaments",
-        --     "Grant Thassis' Armaments",
-        --     "Grant Frightforged Armaments",
-        --     "Grant Manaforged Armaments",
-        --     "Grant Spectral Armaments",
-        --     "Summon Ethereal Armaments",
-        --     "Summon Prime Armaments",
-        --     "Summon Elemental Armaments",
+        --     "Grant Arcane Armaments",        -- Level 128
+        --     "Grant Goliath's Armaments",     -- Level 123
+        --     "Grant Shak Dathor's Armaments", -- Level 118
+        --     "Grant Yalrek's Armaments",      -- Level 113
+        --     "Grant Wirn's Armaments",        -- Level 108
+        --     "Grant Thassis' Armaments",      -- Level 103
+        --     "Grant Frightforged Armaments",  -- Level 98
+        --     "Grant Manaforged Armaments",    -- Level 93
+        --     "Grant Spectral Armaments",      -- Level 88
+        --     "Summon Ethereal Armaments",     -- Level 83
+        --     "Summon Prime Armaments",        -- Level 78
+        --     "Summon Elemental Armaments",    -- Level 73
         -- },
         -- ['PetHeirloomSummon'] = {
-        --     "Grant Arcane Heirlooms",
-        --     "Grant Ankexfen's Heirlooms",
-        --     "Grant the Diabo's Heirlooms",
-        --     "Summon Nastel's Heirlooms",
-        --     "Summon Zabella's Heirlooms",
-        --     "Grant Enibik's Heirlooms",
-        --     "Grant Atleris' Heirlooms",
-        --     "Grant Nint's Heirlooms",
-        --     "Grant Calix's Heirlooms",
-        --     "Grant Ioulin's Heirlooms",
-        --     "Grant Crystasia's Heirlooms",
+        --     "Grant Arcane Heirlooms",      -- Level 126
+        --     "Grant Ankexfen's Heirlooms",  -- Level 121
+        --     "Grant the Diabo's Heirlooms", -- Level 116
+        --     "Grant Crystasia's Heirlooms", -- Level 111
+        --     "Grant Ioulin's Heirlooms",    -- Level 106
+        --     "Grant Calix's Heirlooms",     -- Level 101
+        --     "Grant Nint's Heirlooms",      -- Level 96
+        --     "Grant Atleris' Heirlooms",    -- Level 91
+        --     "Grant Enibik's Heirlooms",    -- Level 86
+        --     "Summon Zabella's Heirlooms",  -- Level 81
+        --     "Summon Nastel's Heirlooms",   -- Level 76
         -- },
         ['IceOrbSummon'] = {
-            "Grant Frostbound Paradox",
-            "Grant Icebound Paradox",
-            "Grant Frostrift Paradox",
-            "Grant Glacial Paradox",
-            "Summon Frigid Paradox",
-            "Summon Gelid Paradox",
-            "Summon Wintry Paradox",
+            "Grant Frostbound Paradox", -- Level 109
+            "Grant Icebound Paradox",   -- Level 99
+            "Grant Frostrift Paradox",  -- Level 94
+            "Grant Glacial Paradox",    -- Level 89
+            "Summon Frigid Paradox",    -- Level 84
+            "Summon Gelid Paradox",     -- Level 79
+            "Summon Wintry Paradox",    -- Level 74
         },
         ['FireOrbSummon'] = {
-            "Summon Molten Dacite Orb",
-            "Summon Molten Komatiite Orb",
-            "Summon Firebound Orb",
-            "Summon Blazing Orb",
-            "Summon: Molten Orb",
-            "Summon: Lava Orb",
+            "Summon Molten Dacite Orb",    -- Level 125
+            "Summon Molten Komatiite Orb", -- Level 114
+            "Summon Firebound Orb",        -- Level 102
+            "Summon Blazing Orb",          -- Level 94
+            "Summon: Molten Orb",          -- Level 69
+            "Summon: Lava Orb",            -- Level 61
         },
         ['EarthPetItemSummon'] = {
-            "Summon Arcane Servant",
-            "Summon Valorous Servant",
-            "Summon Forbearing Servant",
-            "Summon Imperative Servant",
-            "Summon Insurgent Servant",
-            "Summon Mutinous Servant",
-            "Summon Imperious Servant",
-            "Summon Exigent Servant",
+            "Summon Arcane Servant",     -- Level 128
+            "Summon Valorous Servant",   -- Level 123
+            "Summon Forbearing Servant", -- Level 118
+            "Summon Imperative Servant", -- Level 113
+            "Summon Insurgent Servant",  -- Level 108
+            "Summon Mutinous Servant",   -- Level 103
+            "Summon Imperious Servant",  -- Level 98
+            "Summon Exigent Servant",    -- Level 93
         },
         ['FirePetItemSummon'] = {
-            "Summon Arcane Minion",
-            "Summon Valorous Minion",
-            "Summon Forbearing Minion",
-            "Summon Imperative Minion",
-            "Summon Insurgent Minion",
-            "Summon Mutinous Minion",
-            "Summon Imperious Minion",
-            "Summon Exigent Minion",
+            "Summon Arcane Minion",         -- Level 130
+            "Summon Valorous Minion",       -- Level 125
+            "Summon Forbearing Minion",     -- Level 120
+            "Summon Imperative Minion",     -- Level 115
+            "Summon Insurgent Minion",      -- Level 110
+            "Summon Mutinous Minion",       -- Level 105
+            "Summon Imperious Minion",      -- Level 100
+            "Summon Exigent Minion",        -- Level 95
         },
-        ['ManaRodSummon'] = { -- Level 44 - 105
+        ['ManaRodSummon'] = {               -- Level 44 - 105
             --- ManaRodSummon - Focuses on group mana rod summon for ease.
-            "Mass Dark Transvergence",
-            "Mass Arcane Transvergence",
-            "Mass Spectral Transvergence",
-            "Mass Ethereal Transvergence",
-            "Mass Prime Transvergence",
-            "Mass Elemental Transvergence",
-            "Mass Mystical Transvergence",
-            "Modulating Rod",
+            "Mass Dark Transvergence",      -- Level 105
+            "Mass Arcane Transvergence",    -- Level 95
+            "Mass Spectral Transvergence",  -- Level 90
+            "Mass Ethereal Transvergence",  -- Level 85
+            "Mass Prime Transvergence",     -- Level 80
+            "Mass Elemental Transvergence", -- Level 75
+            "Mass Mystical Transvergence",  -- Level 56
+            "Modulating Rod",               -- Level 44
         },
         ['SelfManaRodSummon'] = {
             ---, - Focuses on self mana rod summon separate from other timers. >95
-            "Rod of Shattered Modulation",
-            "Rod of Courageous Modulation",
-            "Sickle of Umbral Modulation",
-            "Wand of Frozen Modulation",
-            "Wand of Burning Modulation",
-            "Wand of Dark Modulation",
-            "Wand of Phantasmal Modulation",
+            "Rod of Shattered Modulation",   -- Level 127
+            "Rod of Courageous Modulation",  -- Level 122
+            "Sickle of Umbral Modulation",   -- Level 117
+            "Wand of Frozen Modulation",     -- Level 112
+            "Wand of Burning Modulation",    -- Level 107
+            "Wand of Dark Modulation",       -- Level 102
+            "Wand of Phantasmal Modulation", -- Level 97
         },
         -- - Debuffs
         ['MaloDebuff'] = {
             -- line < LVL 75 @ LVL75 use the AA
-            "Malaise XVI",
-            "Malosinera",
-            "Malosinetra",
-            "Malosinara",
-            "Malosinata",
-            "Malosenete",
-            "Malosenia",
-            "Maloseneta",
-            "Malosene",
-            "Malosenea",
-            "Malosinatia",
-            "Malosinise",
-            "Malosinia",
-            "Mala",
-            "Malosini",
-            "Malosi",
-            "Malaisement",
-            "Malaise",
+            "Malaise XVI", -- Level 126
+            "Malosinera",  -- Level 121
+            "Malosinetra", -- Level 116
+            "Malosinara",  -- Level 111
+            "Malosinata",  -- Level 106
+            "Malosenete",  -- Level 101
+            "Malosenia",   -- Level 96
+            "Maloseneta",  -- Level 91
+            "Malosene",    -- Level 86
+            "Malosenea",   -- Level 81
+            "Malosinatia", -- Level 76
+            "Malosinise",  -- Level 71
+            "Malosinia",   -- Level 63
+            "Mala",        -- Level 60
+            "Malosini",    -- Level 58
+            "Malosi",      -- Level 51
+            "Malaisement", -- Level 44
+            "Malaise",     -- Level 22
         },
         ['SingleCotH'] = {
-            "Call of the Hero",
+            "Call of the Hero", -- Level 55
         },
         ['GroupCotH'] = {
-            "Call of the Heroes",
+            "Call of the Heroes", -- Level 97
         },
     },
     ['HealRotationOrder'] = {

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -47,201 +47,201 @@ local _ClassConfig = {
     ['AbilitySets']   = {
         ['EndRegen'] = {
             --Timer 13, can't be used in combat
+            "Breather",    -- Level 101
+            "Rest",        -- Level 96
+            "Reprieve",    -- Level 91
+            "Respite",     -- Level 86
+            "Fourth Wind", -- Level 82
+            "Third Wind",  -- Level 77
             "Second Wind", -- Level 72
-            "Third Wind",
-            "Fourth Wind",
-            "Respite",
-            "Reprieve",
-            "Rest",
-            "Breather", --Level 101
         },
         ['CombatEndRegen'] = {
             --Timer 13, can be used in combat.
-            "Hiatus V",
-            "Hiatus", --Level 106
-            "Relax",
-            "Night's Calming",
-            "Convalesce",
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Relax",           -- Level 111
+            "Hiatus",          -- Level 106
         },
         ['MonkAura'] = {
-            "Disciple's Aura",
-            "Master's Aura",
+            "Master's Aura",   -- Level 70
+            "Disciple's Aura", -- Level 55
         },
         ['Dicho'] = {
-            "Dichotomic Form",
-            "Dissident Form",
-            "Composite Form",
-            "Ecliptic Form",
-            "Reciprocal Form",
+            "Reciprocal Form", -- Level 121
+            "Ecliptic Form",   -- Level 116
+            "Composite Form",  -- Level 111
+            "Dissident Form",  -- Level 106
+            "Dichotomic Form", -- Level 101
         },
         ['Drunken'] = {
-            "Drunken Monkey Style",
+            "Drunken Monkey Style", -- Level 85
         },
         ['Curse'] = {
             -- Curse Line - Alternating expansions
-            "Curse of the Thirteen Fingers", -- 103 TBM
-            "Curse of Fourteen Fists",       -- 108 TBM
-            "Curse of Fifteen Strikes",      -- 113 COV
-            "Curse of Sixteen Shadows",      -- 118 NOS
-            "Curse of Seventeen Facets",     -- 123 TOB
+            "Curse of Seventeen Facets",     -- Level 123, TOB
+            "Curse of Sixteen Shadows",      -- Level 118, NOS
+            "Curse of Fifteen Strikes",      -- Level 113, COV
+            "Curse of Fourteen Fists",       -- Level 108, TBM
+            "Curse of the Thirteen Fingers", -- Level 103, TBM
         },
         ['Fang'] = {
-            "Dragon Fang",
-            "Zalikor's Fang",
-            "Hoshkar's Fang",
-            "Zlexak's Fang",
-            "Uncia's Fang",
+            "Uncia's Fang",   -- Level 124
+            "Zlexak's Fang",  -- Level 114
+            "Hoshkar's Fang", -- Level 109
+            "Zalikor's Fang", -- Level 99
+            "Dragon Fang",    -- Level 69
         },
         ['Fists'] = {
-            "Wheel of Fists XII",
-            "Buffeting of Fists",
-            "Wheel of Fists",
-            "Whorl of Fists",
-            "Torrent of Fists",
-            "Firestorm of Fists",
-            "Barrage of Fists",
-            "Flurry of Fists",
+            "Wheel of Fists XII", -- Level 130
+            "Flurry of Fists",    -- Level 125
+            "Buffeting of Fists", -- Level 120
+            "Barrage of Fists",   -- Level 115
+            "Firestorm of Fists", -- Level 110
+            "Torrent of Fists",   -- Level 104
+            "Whorl of Fists",     -- Level 84
+            "Wheel of Fists",     -- Level 79
         },
         ['Precision1'] = {
-            "Doomwalker's Precision Strike",
-            "Firewalker's Precision Strike",
-            "Icewalker's Precision Strike",
-            "Bloodwalker's Precision Strike",
-            "Fatewalker's Precision Strike",
+            "Fatewalker's Precision Strike",  -- Level 124
+            "Bloodwalker's Precision Strike", -- Level 119
+            "Icewalker's Precision Strike",   -- Level 114
+            "Firewalker's Precision Strike",  -- Level 109
+            "Doomwalker's Precision Strike",  -- Level 104
         },
         ['Precision2'] = {
-            "Doomwalker's Precision Strike",
-            "Firewalker's Precision Strike",
-            "Icewalker's Precision Strike",
-            "Bloodwalker's Precision Strike",
-            "Fatewalker's Precision Strike",
+            "Fatewalker's Precision Strike",  -- Level 124
+            "Bloodwalker's Precision Strike", -- Level 119
+            "Icewalker's Precision Strike",   -- Level 114
+            "Firewalker's Precision Strike",  -- Level 109
+            "Doomwalker's Precision Strike",  -- Level 104
         },
         ['Precision3'] = {
-            "Doomwalker's Precision Strike",
-            "Firewalker's Precision Strike",
-            "Icewalker's Precision Strike",
-            "Bloodwalker's Precision Strike",
-            "Fatewalker's Precision Strike",
+            "Fatewalker's Precision Strike",  -- Level 124
+            "Bloodwalker's Precision Strike", -- Level 119
+            "Icewalker's Precision Strike",   -- Level 114
+            "Firewalker's Precision Strike",  -- Level 109
+            "Doomwalker's Precision Strike",  -- Level 104
         },
         ['Precision4'] = {
-            "Doomwalker's Precision Strike",
-            "Firewalker's Precision Strike",
-            "Icewalker's Precision Strike",
-            "Bloodwalker's Precision Strike",
-            "Fatewalker's Precision Strike",
+            "Fatewalker's Precision Strike",  -- Level 124
+            "Bloodwalker's Precision Strike", -- Level 119
+            "Icewalker's Precision Strike",   -- Level 114
+            "Firewalker's Precision Strike",  -- Level 109
+            "Doomwalker's Precision Strike",  -- Level 104
         },
         ['Precision5'] = {
-            "Doomwalker's Precision Strike",
-            "Firewalker's Precision Strike",
-            "Icewalker's Precision Strike",
-            "Bloodwalker's Precision Strike",
-            "Fatewalker's Precision Strike",
+            "Fatewalker's Precision Strike",  -- Level 124
+            "Bloodwalker's Precision Strike", -- Level 119
+            "Icewalker's Precision Strike",   -- Level 114
+            "Firewalker's Precision Strike",  -- Level 109
+            "Doomwalker's Precision Strike",  -- Level 104
         },
         ['Shuriken'] = {
-            "Vigorous Shuriken",
+            "Vigorous Shuriken", -- Level 83
         },
         ['CraneStance'] = {
-            "Crane Stance",
-            "Heron Stance",
+            "Heron Stance", -- Level 112
+            "Crane Stance", -- Level 93
         },
         ['Synergy'] = {
-            "Lifewalker's Synergy",
-            "Fatewalker's Synergy",  -- LS 125
-            "Bloodwalker's Synergy", -- TOL 120
-            "Calanin's Synergy",
-            "Dreamwalker's Synergy",
-            "Veilwalker's Synergy",
-            "Shadewalker's Synergy",
-            "Doomwalker's Synergy",
-            "Firewalker's Synergy",
-            "Icewalker's Synergy",
+            "Lifewalker's Synergy",  -- Level 126
+            "Fatewalker's Synergy",  -- Level 121, LS 125
+            "Bloodwalker's Synergy", -- Level 116, TOL 120
+            "Icewalker's Synergy",   -- Level 111
+            "Firewalker's Synergy",  -- Level 106
+            "Doomwalker's Synergy",  -- Level 101
+            "Shadewalker's Synergy", -- Level 96
+            "Veilwalker's Synergy",  -- Level 91
+            "Dreamwalker's Synergy", -- Level 86
+            "Calanin's Synergy",     -- Level 81
         },
         ['Alliance'] = {
             -- Alliance line - Alternates expansions
-            "Doomwalker's Alliance",
-            "Firewalker's Covenant",
-            "Icewalker's Coalition",     -- COV
-            "Bloodwalker's Conjunction", -- NOS
-            "Fatewalker's Covariance",   -- TOB
+            "Fatewalker's Covariance",   -- Level 122, TOB
+            "Bloodwalker's Conjunction", -- Level 117, NOS
+            "Icewalker's Coalition",     -- Level 112, COV
+            "Firewalker's Covenant",     -- Level 107
+            "Doomwalker's Alliance",     -- Level 102
         },
         ['Storm'] = {
-            "Eye of the Storm",
+            "Eye of the Storm", -- Level 98
         },
         ['Breaths'] = {
             --- Breaths Endurance Line
-            "Five Breaths",
-            "Six Breaths",
-            "Seven Breaths",
-            "Eight Breaths",
-            "Nine Breaths",
-            "Breath of Tranquility",
-            "Breath of Stillness",
-            "Moment of Stillness",
+            "Moment of Stillness",   -- Level 123
+            "Breath of Stillness",   -- Level 118
+            "Breath of Tranquility", -- Level 113
+            "Nine Breaths",          -- Level 108
+            "Eight Breaths",         -- Level 105
+            "Seven Breaths",         -- Level 100
+            "Six Breaths",           -- Level 95
+            "Five Breaths",          -- Level 90
         },
         ['FistsOfWu'] = {
             --- Fists of Wu - Double Attack
-            "Fists Of Wu",
+            "Fists Of Wu", -- Level 68
         },
         ['EarthDisc'] = {
             -- EarthDisc - Melee Mitigation
-            "Earthwalk Discipline",
-            "Earthforce Discipline",
+            "Earthforce Discipline", -- Level 96
+            "Earthwalk Discipline",  -- Level 65
         },
         ['ShadedStep'] = {
             -- ShadedStep - Dodge Bonus 18 Seconds
-            "Void Step",
-            "Shaded Step",
+            "Shaded Step", -- Level 97
+            "Void Step",   -- Level 92
         },
         ['RejectDeath'] = {
-            "Delay Death XI",
-            "Repeal Death",
-            "Delay Death",
-            "Defer Death",
-            "Deny Death",
-            "Decry Death",
-            "Forestall Death",
-            "Refuse Death",
-            "Reject Death",
-            "Rescind Death",
-            "Defy Death",
+            "Delay Death XI",  -- Level 130
+            "Defy Death",      -- Level 125
+            "Repeal Death",    -- Level 120
+            "Rescind Death",   -- Level 115
+            "Reject Death",    -- Level 110
+            "Refuse Death",    -- Level 105
+            "Forestall Death", -- Level 100
+            "Decry Death",     -- Level 95
+            "Deny Death",      -- Level 90
+            "Defer Death",     -- Level 85
+            "Delay Death",     -- Level 80
         },
         ['DodgeBody'] = {
-            "Void Body",
-            "Veiled Body",
+            "Veiled Body", -- Level 94
+            "Void Body",   -- Level 89
         },
         ['MezSpell'] = {
-            "Echo of Disorientation",
-            "Echo of Flinching",
-            "Echo of Diversion",
+            "Echo of Diversion",      -- Level 123
+            "Echo of Flinching",      -- Level 118
+            "Echo of Disorientation", -- Level 113
         },
         ['FistDisc'] = {
-            "Ashenhand Discipline",
-            "Scaledfist Discipline",
-            "Ironfist Discipline",
+            "Ironfist Discipline",   -- Level 88
+            "Scaledfist Discipline", -- Level 74
+            "Ashenhand Discipline",  -- Level 60
         },
         ['Heel'] = {
-            "Rapid Kick Discipline",
-            "Heel of Kanji",
-            "Heel of Kai",
-            "Heel of Kojai",
-            "Heel of Zagali",
+            "Heel of Zagali",        -- Level 100
+            "Heel of Kojai",         -- Level 95
+            "Heel of Kai",           -- Level 90
+            "Rapid Kick Discipline", -- Level 70
+            "Heel of Kanji",         -- Level 70
         },
         ['Speed'] = {
-            "Hundred Fists Discipline",
-            "Speed Focus Discipline",
+            "Speed Focus Discipline",   -- Level 63
+            "Hundred Fists Discipline", -- Level 57
         },
         ['Palm'] = {
-            "Innerflame Discipline",
-            "Crystalpalm Discipline",
-            "Diamondpalm Discipline",
-            "Terrorpalm Discipline",
+            "Terrorpalm Discipline",  -- Level 99
+            "Diamondpalm Discipline", -- Level 94
+            "Crystalpalm Discipline", -- Level 79
+            "Innerflame Discipline",  -- Level 56
         },
         ['Poise'] = {
-            "Eagles's Symmetry",
-            "Dragon's Poise",
-            "Tiger's Poise",
-            "Eagle's Poise",
-            "Tiger's Symmetry",
+            "Eagle's Symmetry", -- Level 127
+            "Tiger's Symmetry", -- Level 122
+            "Dragon's Poise",   -- Level 117
+            "Eagle's Poise",    -- Level 112
+            "Tiger's Poise",    -- Level 107
         },
     },
     ['Helpers']       = {

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -84,231 +84,219 @@ local _ClassConfig = {
     },
     ['AbilitySets']     = {
         ['SelfHPBuff'] = {
-            "Shielding XXIII",
-            "Shield of Memories",
-            "Shield of Shadow",
-            "Shield of Restless Ice",
-            "Shield of Scales",
-            "Shield of the Pellarus",
-            "Shield of the Dauntless",
-            "Shield of Bronze",
-            "Shield of Dreams",
-            "Shield of the Void",
-            "Bulwark of the Crystalwing",
-            "Shield of the Crystalwing",
-            "Ether Shield",
-            "Shield of Maelin",
-            "Shield of the Arcane",
-            "Shield of the Magi",
-            "Arch Shielding",
-            "Greater Shielding",
-            "Major Shielding",
-            "Shielding",
-            "Lesser Shielding",
+            "Shielding XXIII",         -- Level 126
+            "Shield of Memories",      -- Level 121
+            "Shield of Shadow",        -- Level 116
+            "Shield of Restless Ice",  -- Level 111
+            "Shield of Scales",        -- Level 106
+            "Shield of the Pellarus",  -- Level 101
+            "Shield of the Dauntless", -- Level 96
+            "Shield of Bronze",        -- Level 91
+            "Shield of Dreams",        -- Level 86
+            "Shield of the Void",      -- Level 81
+            "Shield of Maelin",        -- Level 64
+            "Shield of the Arcane",    -- Level 61
+            "Shield of the Magi",      -- Level 54
+            "Arch Shielding",          -- Level 41
+            "Greater Shielding",       -- Level 33
+            "Major Shielding",         -- Level 24
+            "Shielding",               -- Level 16
+            "Lesser Shielding",        -- Level 8
         },
         ['Levitate'] = {
-            "Dead Men Floating",
+            "Dead Men Floating", -- Level 45
         },
         ['SelfRune1'] = {
-            "Wraithskin XIII",
-            "Golemskin",
-            "Carrion Skin",
-            "Frozen Skin",
-            "Ashen Skin",
-            "Deadskin",
-            "Zombieskin",
-            "Ghoulskin",
-            "Grimskin",
-            "Corpseskin",
-            "Shadowskin",
-            "Wraithskin",
-            "Dull Pain",
-            "Force Shield",
-            "Manaskin",
-            "Diamondskin",
-            "Steelskin",
-            "Leatherskin",
-            "Shieldskin",
+            "Wraithskin XIII", -- Level 128
+            "Golemskin",       -- Level 123
+            "Carrion Skin",    -- Level 118
+            "Frozen Skin",     -- Level 113
+            "Ashen Skin",      -- Level 108
+            "Deadskin",        -- Level 103
+            "Zombieskin",      -- Level 98
+            "Ghoulskin",       -- Level 93
+            "Grimskin",        -- Level 88
+            "Corpseskin",      -- Level 83
+            "Shadowskin",      -- Level 78
+            "Wraithskin",      -- Level 73
+            "Dull Pain",       -- Level 69
+            "Force Shield",    -- Level 63
+            "Manaskin",        -- Level 52
+            "Diamondskin",     -- Level 43
+            "Steelskin",       -- Level 32
+            "Leatherskin",     -- Level 22
+            "Shieldskin",      -- Level 14
         },
         ['SelfSpellShield1'] = {
-            "Shield of Fate VII",
-            "Shield of Inescapability",
-            "Shield of Inevitability",
-            "Shield of Destiny",
-            "Shield of Order",
-            "Shield of Consequence",
-            "Shield of Fate",
+            "Shield of Fate VII",       -- Level 127
+            "Shield of Inescapability", -- Level 122
+            "Shield of Inevitability",  -- Level 117
+            "Shield of Destiny",        -- Level 112
+            "Shield of Order",          -- Level 107
+            "Shield of Consequence",    -- Level 102
+            "Shield of Fate",           -- Level 97
         },
         ['FDSpell'] = {
             -- Fd Spell
-            "Death Peace",
+            "Death Peace", -- Level 60
         },
         ['CharmSpell'] = {
             -- Charm Spells >= 20
-            "Enslave Death",
-            "Thrall of Bones",
-            "Cajole Undead",
-            "Beguile Undead",
-            "Dominate Undead",
+            "Enslave Death",   -- Level 60
+            "Thrall of Bones", -- Level 54
+            "Cajole Undead",   -- Level 47
+            "Beguile Undead",  -- Level 31
+            "Dominate Undead", -- Level 18
         },
         ---DPS
         ['AllianceSpell'] = {
             -- Alliance Spells
-            "Malevolent Covariance",
-            "Malevolent Conjunction",
-            "Malevolent Coalition",
-            "Malevolent Covenant",
-            "Malevolent Alliance",
+            "Malevolent Covariance",  -- Level 122
+            "Malevolent Conjunction", -- Level 117
+            "Malevolent Coalition",   -- Level 114
+            "Malevolent Covenant",    -- Level 107
+            "Malevolent Alliance",    -- Level 102
         },
         ['DichoDot'] = {
             ---DichoSpell >= LVL101
-            "Ecliptic Paroxysm",
-            "Composite Paroxysm",
-            "Dissident Paroxysm",
-            "Dichotomic Paroxysm",
-            "Reciprocal Paroxysm",
+            "Reciprocal Paroxysm", -- Level 121
+            "Ecliptic Paroxysm",   -- Level 116
+            "Composite Paroxysm",  -- Level 111
+            "Dissident Paroxysm",  -- Level 106
+            "Dichotomic Paroxysm", -- Level 101
         },
         ['SwarmPet'] = {
             ---SwarmPet >= LVL85
-            "Call Raging Skeleton X",
-            "Call Ravening Skeleton",
-            "Call Roiling Skeleton",
-            "Call Riotous Skeleton",
-            "Call Reckless Skeleton",
-            "Call Remorseless Skeleton",
-            "Call Relentless Skeleton",
-            "Call Ruthless Skeleton",
-            "Call Ruinous Skeleton",
-            "Call Rumbling Skeleton",
-            "Call Skeleton Thrall",
-            "Call Skeleton Mass",
-            "Call Skeleton Horde",
-            "Call Skeleton Army",
-            "Call Skeleton Mob",
-            "Call Skeleton Throng",
-            "Call Skeleton Host",
-            "Call Skeleton Crush",
-            "Call Skeleton Swarm",
+            "Call Raging Skeleton X",    -- Level 130
+            "Call Ravening Skeleton",    -- Level 125
+            "Call Roiling Skeleton",     -- Level 120
+            "Call Riotous Skeleton",     -- Level 115
+            "Call Reckless Skeleton",    -- Level 110
+            "Call Remorseless Skeleton", -- Level 105
+            "Call Relentless Skeleton",  -- Level 100
+            "Call Ruthless Skeleton",    -- Level 95
+            "Call Ruinous Skeleton",     -- Level 90
+            "Call Rumbling Skeleton",    -- Level 85
         },
         ['Lifetap'] = {
             ---HealthTaps >= LVL1
-            "Soulrip VII",
-            "Drain Essence XXIII",
-            "Soullash",
-            "Extort Essence",
-            "Soulflay",
-            "Maraud Essence",
-            "Soulgouge",
-            "Draw Essence",
-            "Soulsiphon",
-            "Consume Essence",
-            "Soulrend",
-            "Hemorrhage Essence",
-            "Plunder Essence",
-            "Bleed Essence",
-            "Divert Essence",
-            "Drain Essence",
-            "Siphon Essence",
-            "Drain Life",
-            -- [] =["Ancient: Touch of Orshilak",
-            "Soulspike",
-            "Touch of Mujaki",
-            "Touch of Night",
-            "Deflux",
-            "Drain Soul",
-            "Drain Spirit",
-            "Spirit Tap",
-            "Siphon Life",
-            "Lifedraw",
-            "Lifespike",
-            "Lifetap",
+            "Soulrip VII",         -- Level 128
+            "Drain Essence XXIII", -- Level 126
+            "Soullash",            -- Level 123
+            "Extort Essence",      -- Level 121
+            "Soulflay",            -- Level 118
+            "Maraud Essence",      -- Level 116
+            "Soulgouge",           -- Level 113
+            "Draw Essence",        -- Level 111
+            "Soulsiphon",          -- Level 108
+            "Consume Essence",     -- Level 106
+            "Soulrend",            -- Level 103
+            "Hemorrhage Essence",  -- Level 101
+            "Plunder Essence",     -- Level 96
+            "Bleed Essence",       -- Level 91
+            "Divert Essence",      -- Level 86
+            "Drain Essence",       -- Level 81
+            "Siphon Essence",      -- Level 76
+            "Drain Life",          -- Level 71
+            -- "Ancient: Touch of Orshilak", -- Level 70
+            "Soulspike",           -- Level 67
+            "Touch of Mujaki",     -- Level 61
+            "Touch of Night",      -- Level 59
+            "Deflux",              -- Level 54
+            "Drain Soul",          -- Level 48
+            "Drain Spirit",        -- Level 39
+            "Spirit Tap",          -- Level 26
+            "Siphon Life",         -- Level 20
+            "Lifedraw",            -- Level 12
+            "Lifespike",           -- Level 3
+            "Lifetap",             -- Level 1
         },
         ['DurationTap'] = {
             ---DurationTap >= LVL9
-            "Sharosh's Grasp",
-            "Helmsbane's Grasp",
-            "The Protector's Grasp",
-            "Tserrina's Grasp",
-            "Bomoda's Grasp",
-            "Plexipharia's Grasp",
-            "Halstor's Grasp",
-            "Ivrikdal's Grasp",
-            "Arachne's Grasp",
-            "Fellid's Grasp",
-            "Visziaj's Grasp",
-            "Dyn`leth's Grasp",
-            "Fang of Death",
-            "Night's Beckon",
-            "Saryrn's Kiss",
-            "Vexing Mordinia",
-            "Bond of Death",
-            "Auspice",
-            "Vampiric Curse",
-            "Leech",
+            "Sharosh's Grasp",       -- Level 127
+            "Helmsbane's Grasp",     -- Level 122
+            "The Protector's Grasp", -- Level 117
+            "Tserrina's Grasp",      -- Level 112
+            "Bomoda's Grasp",        -- Level 107
+            "Plexipharia's Grasp",   -- Level 102
+            "Halstor's Grasp",       -- Level 97
+            "Ivrikdal's Grasp",      -- Level 92
+            "Arachne's Grasp",       -- Level 87
+            "Fellid's Grasp",        -- Level 82
+            "Visziaj's Grasp",       -- Level 77
+            "Dyn`leth's Grasp",      -- Level 72
+            "Fang of Death",         -- Level 68
+            "Night's Beckon",        -- Level 65
+            "Saryrn's Kiss",         -- Level 62
+            "Vexing Mordinia",       -- Level 57
+            "Bond of Death",         -- Level 49
+            "Auspice",               -- Level 45
+            "Vampiric Curse",        -- Level 29
+            "Leech",                 -- Level 9
         },
         ['GroupLeech'] = {
             ---GroupLeech >= LVL60
-            "Dark Leech VIII",
-            "Ghastly Leech",
-            "Twilight Leech",
-            "Frozen Leech",
-            "Ashen Leech",
-            "Dark Leech",
-            "Night Stalker",
-            "Zevfeer's Theft of Vitae",
+            "Dark Leech VIII",          -- Level 126
+            "Ghastly Leech",            -- Level 121
+            "Twilight Leech",           -- Level 120
+            "Frozen Leech",             -- Level 115
+            "Ashen Leech",              -- Level 110
+            "Dark Leech",               -- Level 100
+            "Night Stalker",            -- Level 65
+            "Zevfeer's Theft of Vitae", -- Level 60
         },
         ['ManaDrain'] = {
             --Mana Drain with Group Mana Recourse
-            "Mind Wrack XIV",
-            "Mind Disintegrate",
-            "Mind Atrophy",
-            "Mind Erosion",
-            "Mind Exorciation",
-            "Mind Extraction",
-            "Mind Strip",
-            "Mind Abrasion",
-            "Thought Flay",
-            "Mind Decomposition",
-            "Mental Vivisection",
-            "Mind Dissection",
-            "Mind Flay",
-            "Mind Wrack",
+            "Mind Wrack XIV",     -- Level 129
+            "Mind Disintegrate",  -- Level 124
+            "Mind Atrophy",       -- Level 119
+            "Mind Erosion",       -- Level 114
+            "Mind Excoriation",   -- Level 109
+            "Mind Extraction",    -- Level 104
+            "Mind Strip",         -- Level 99
+            "Mind Abrasion",      -- Level 94
+            "Thought Flay",       -- Level 89
+            "Mind Decomposition", -- Level 84
+            "Mental Vivisection", -- Level 79
+            "Mind Dissection",    -- Level 74
+            "Mind Flay",          -- Level 70
+            "Mind Wrack",         -- Level 58
         },
         ['PoisonNuke1'] = {
             ---PoisonNuke >=LVL21
-            "Schisming Venin",
-            "Necrotizing Venin",
-            "Embalming Venin",
-            "Searing Venin",
-            "Effluvial Venin",
-            "Liquefying Venin",
-            "Dissolving Venin",
-            "Blighted Venin",
-            "Withering Venin",
-            "Ruinous Venin",
-            "Venin",
-            "Acikin",
-            "Neurotoxin",
-            "Torbas' Venom Blast",
-            "Torbas' Poison Blast",
-            "Torbas' Acid Blast",
-            "Shock of Poison",
+            "Schisming Venin",      -- Level 126
+            "Necrotizing Venin",    -- Level 121
+            "Embalming Venin",      -- Level 116
+            "Searing Venin",        -- Level 111
+            "Effluvial Venin",      -- Level 106
+            "Liquefying Venin",     -- Level 101
+            "Dissolving Venin",     -- Level 96
+            "Blighted Venin",       -- Level 86
+            "Withering Venin",      -- Level 81
+            "Ruinous Venin",        -- Level 76
+            "Venin",                -- Level 71
+            "Acikin",               -- Level 66
+            "Neurotoxin",           -- Level 61
+            "Torbas' Venom Blast",  -- Level 54
+            "Torbas' Poison Blast", -- Level 49
+            "Torbas' Acid Blast",   -- Level 32
+            "Shock of Poison",      -- Level 21
         },
         ['PoisonNuke2'] = {
             ---PoisonNuke2  >=LVL 75 (DD Increase chance)
-            "Call for Blood XIII",
-            "Decree for Blood",
-            "Proclamation for Blood",
-            "Assert for Blood",
-            "Refute for Blood",
-            "Impose for Blood",
-            "Impel for Blood",
-            --"Provocation for Blood",
-            "Compel for Blood",
-            "Exigency for Blood",
-            "Supplication of Blood",
-            "Demand for Blood",
-            "Call for Blood",
+            "Call for Blood XIII",    -- Level 130
+            "Decree for Blood",       -- Level 125
+            "Proclamation for Blood", -- Level 120
+            "Assert for Blood",       -- Level 115
+            "Refute for Blood",       -- Level 110
+            "Impose for Blood",       -- Level 105
+            "Impel for Blood",        -- Level 100
+            -- "Provocation for Blood", -- Level 95
+            "Compel for Blood",       -- Level 90
+            "Exigency for Blood",     -- Level 85
+            "Supplication of Blood",  -- Level 80
+            "Demand for Blood",       -- Level 75
+            "Call for Blood",         -- Level 68
         },
         ['FireNuke'] = {
             ---Fire Nuke, undead conversion and short stun, 90+
@@ -324,485 +312,485 @@ local _ClassConfig = {
         },
         ['SearingDot'] = {
             ---FireDot1 >= LVL80
-            "Searing Shadow XI",
-            "Raging Shadow",
-            "Scalding Shadow",
-            "Broiling Shadow",
-            "Burning Shadow",
-            "Smouldering Shadow",
-            "Coruscating Shadow",
-            "Blazing Shadow",
-            "Blistering Shadow",
-            "Scorching Shadow",
-            "Searing Shadow",
+            "Searing Shadow XI",  -- Level 130
+            "Raging Shadow",      -- Level 125
+            "Scalding Shadow",    -- Level 120
+            "Broiling Shadow",    -- Level 115
+            "Burning Shadow",     -- Level 110
+            "Smouldering Shadow", -- Level 105
+            "Coruscating Shadow", -- Level 100
+            "Blazing Shadow",     -- Level 95
+            "Blistering Shadow",  -- Level 90
+            "Scorching Shadow",   -- Level 85
+            "Searing Shadow",     -- Level 80
         },
         ['DreadDot'] = {
             ---FireDot2 >= LVL10
-            "Dread Pyre XIII",
-            "Pyre of Illandrin",
-            "Pyre of Va Xakra",
-            "Pyre of Klraggek",
-            "Pyre of the Shadewarden",
-            "Pyre of Jorobb",
-            "Pyre of Marnek",
-            "Pyre of Hazarak",
-            "Pyre of Nos",
-            "Soul Reaper's Pyre",
-            "Reaver's Pyre",
-            "Ashengate Pyre",
-            "Dread Pyre",
-            "Night Fire",
-            "Funeral Pyre of Kelador",
-            "Pyrocruor",
-            "Ignite Blood",
-            "Boil Blood",
-            "Heat Blood",
+            "Dread Pyre XIII",         -- Level 129
+            "Pyre of Illandrin",       -- Level 124
+            "Pyre of Va Xakra",        -- Level 119
+            "Pyre of Klraggek",        -- Level 114
+            "Pyre of the Shadewarden", -- Level 109
+            "Pyre of Jorobb",          -- Level 104
+            "Pyre of Marnek",          -- Level 99
+            "Pyre of Hazarak",         -- Level 94
+            "Pyre of Nos",             -- Level 89
+            "Soul Reaper's Pyre",      -- Level 84
+            "Reaver's Pyre",           -- Level 79
+            "Ashengate Pyre",          -- Level 74
+            "Dread Pyre",              -- Level 70
+            "Night Fire",              -- Level 65
+            "Funeral Pyre of Kelador", -- Level 60
+            "Pyrocruor",               -- Level 58
+            "Ignite Blood",            -- Level 47
+            "Boil Blood",              -- Level 28
+            "Heat Blood",              -- Level 10
         },
         ['DreadDot2'] = {
             ---FireDot2 >= LVL10
-            "Dread Pyre XIII",
-            "Pyre of Illandrin",
-            "Pyre of Va Xakra",
-            "Pyre of Klraggek",
-            "Pyre of the Shadewarden",
-            "Pyre of Jorobb",
-            "Pyre of Marnek",
-            "Pyre of Hazarak",
-            "Pyre of Nos",
-            "Soul Reaper's Pyre",
-            "Reaver's Pyre",
-            "Ashengate Pyre",
-            "Dread Pyre",
-            "Night Fire",
-            "Funeral Pyre of Kelador",
-            "Pyrocruor",
-            "Ignite Blood",
-            "Boil Blood",
-            "Heat Blood",
+            "Dread Pyre XIII",         -- Level 129
+            "Pyre of Illandrin",       -- Level 124
+            "Pyre of Va Xakra",        -- Level 119
+            "Pyre of Klraggek",        -- Level 114
+            "Pyre of the Shadewarden", -- Level 109
+            "Pyre of Jorobb",          -- Level 104
+            "Pyre of Marnek",          -- Level 99
+            "Pyre of Hazarak",         -- Level 94
+            "Pyre of Nos",             -- Level 89
+            "Soul Reaper's Pyre",      -- Level 84
+            "Reaver's Pyre",           -- Level 79
+            "Ashengate Pyre",          -- Level 74
+            "Dread Pyre",              -- Level 70
+            "Night Fire",              -- Level 65
+            "Funeral Pyre of Kelador", -- Level 60
+            "Pyrocruor",               -- Level 58
+            "Ignite Blood",            -- Level 47
+            "Boil Blood",              -- Level 28
+            "Heat Blood",              -- Level 10
         },
         ['FlashDot'] = {
             ---FireDot3 >= LVL88 (QuickDOT)
-            "Marith's Flashblaze",
-            "Arcanaforged's Flashblaze",
-            "Thall Va Kelun's Flashblaze",
-            "Otatomik's Flashblaze",
-            "Azeron's Flashblaze",
-            "Mazub's Flashblaze",
-            "Osalur's Flashblaze",
-            "Brimtav's Flashblaze",
-            "Tenak's Flashblaze",
+            "Marith's Flashblaze",         -- Level 128
+            "Arcanaforged's Flashblaze",   -- Level 123
+            "Thall Va Kelun's Flashblaze", -- Level 118
+            "Otatomik's Flashblaze",       -- Level 113
+            "Azeron's Flashblaze",         -- Level 108
+            "Mazub's Flashblaze",          -- Level 103
+            "Osalur's Flashblaze",         -- Level 98
+            "Brimtav's Flashblaze",        -- Level 93
+            "Tenak's Flashblaze",          -- Level 88
         },
         ['MoriDot'] = {
             ---FireDot4 >= LVL73 DOT
-            "Pyre of Mori XIX",
-            "Pyre of the Abandoned",
-            "Pyre of the Neglected",
-            "Pyre of the Wretched",
-            "Pyre of the Fereth",
-            "Pyre of the Lost",
-            "Pyre of the Forsaken",
-            "Pyre of the Piq'a",
-            "Pyre of the Bereft",
-            "Pyre of the Forgotten",
-            "Pyre of the Lifeless",
-            "Pyre of the Fallen",
+            "Pyre of Mori XIX",      -- Level 128
+            "Pyre of the Abandoned", -- Level 123
+            "Pyre of the Neglected", -- Level 118
+            "Pyre of the Wretched",  -- Level 113
+            "Pyre of the Fereth",    -- Level 108
+            "Pyre of the Lost",      -- Level 103
+            "Pyre of the Forsaken",  -- Level 98
+            "Pyre of the Piq'a",     -- Level 93
+            "Pyre of the Bereft",    -- Level 88
+            "Pyre of the Forgotten", -- Level 83
+            "Pyre of the Lifeless",  -- Level 78
+            "Pyre of the Fallen",    -- Level 73
         },
         ['WoundDot'] = {
             ---Magic1 >= LVL51 SlowDot
-            "Necrotizing Wounds VIII",
-            "Putrefying Wounds",
-            "Infected Wounds",
-            "Septic Wounds",
-            "Cytotoxic Wounds",
-            "Mortiferous Wounds",
-            "Pernicious Wounds",
-            "Necrotizing Wounds",
-            "Splirt",
-            "Splart",
-            "Splort",
-            "Splurt",
+            "Necrotizing Wounds VIII", -- Level 130
+            "Putrefying Wounds",       -- Level 125
+            "Infected Wounds",         -- Level 120
+            "Septic Wounds",           -- Level 115
+            "Cytotoxic Wounds",        -- Level 110
+            "Mortiferous Wounds",      -- Level 105
+            "Pernicious Wounds",       -- Level 100
+            "Necrotizing Wounds",      -- Level 95
+            "Splirt",                  -- Level 90
+            "Splart",                  -- Level 85
+            "Splort",                  -- Level 80
+            "Splurt",                  -- Level 51
         },
         ['HorrorDot'] = {
             ---Magic2 >=LVL67 DOT
-            "Horror XV",
-            "Extermination",
-            "Extinction",
-            "Oblivion",
-            "Inevitable End",
-            "Annihilation",
-            "Termination",
-            "Doom",
-            "Demise",
-            "Mortal Coil",
-            "Anathema of Life",
-            "Curse of Mortality",
-            "Ancient: Curse of Mori",
-            "Dark Nightmare",
-            "Horror",
+            "Horror XV",              -- Level 127
+            "Extermination",          -- Level 122
+            "Extinction",             -- Level 117
+            "Oblivion",               -- Level 112
+            "Inevitable End",         -- Level 107
+            "Annihilation",           -- Level 102
+            "Termination",            -- Level 97
+            "Doom",                   -- Level 92
+            "Demise",                 -- Level 87
+            "Mortal Coil",            -- Level 82
+            "Anathema of Life",       -- Level 77
+            "Curse of Mortality",     -- Level 72
+            "Ancient: Curse of Mori", -- Level 70
+            "Dark Nightmare",         -- Level 67
+            "Horror",                 -- Level 63
         },
         ['HorrorDot2'] = {
             ---Magic2 >=LVL67 DOT
-            "Horror XV",
-            "Extermination",
-            "Extinction",
-            "Oblivion",
-            "Inevitable End",
-            "Annihilation",
-            "Termination",
-            "Doom",
-            "Demise",
-            "Mortal Coil",
-            "Anathema of Life",
-            "Curse of Mortality",
-            "Ancient: Curse of Mori",
-            "Dark Nightmare",
-            "Horror",
+            "Horror XV",              -- Level 127
+            "Extermination",          -- Level 122
+            "Extinction",             -- Level 117
+            "Oblivion",               -- Level 112
+            "Inevitable End",         -- Level 107
+            "Annihilation",           -- Level 102
+            "Termination",            -- Level 97
+            "Doom",                   -- Level 92
+            "Demise",                 -- Level 87
+            "Mortal Coil",            -- Level 82
+            "Anathema of Life",       -- Level 77
+            "Curse of Mortality",     -- Level 72
+            "Ancient: Curse of Mori", -- Level 70
+            "Dark Nightmare",         -- Level 67
+            "Horror",                 -- Level 63
         },
         ['DeconDot'] = {
             ---Magic3 >=LVL87 QuickDot
-            "Xirrim's Swift Deconstruction",
-            "Blevak's Swift Deconstruction",
-            "Xetheg's Swift Deconstruction",
-            "Lexelan's Swift Deconstruction",
-            "Adalora's Swift Deconstruction",
-            "Marmat's Swift Deconstruction",
-            "Itkari's Swift Deconstruction",
-            "Hral's Swift Deconstruction",
-            "Ninavero's Swift Deconstruction",
+            "Xirrim's Swift Deconstruction",   -- Level 127
+            "Blevak's Swift Deconstruction",   -- Level 122
+            "Xetheg's Swift Deconstruction",   -- Level 117
+            "Lexelan's Swift Deconstruction",  -- Level 112
+            "Adalora's Swift Deconstruction",  -- Level 107
+            "Marmat's Swift Deconstruction",   -- Level 102
+            "Itkari's Swift Deconstruction",   -- Level 97
+            "Hral's Swift Deconstruction",     -- Level 92
+            "Ninavero's Swift Deconstruction", -- Level 87
         },
         ['ScourgeDot'] = {
             ---Magic4 >=LVL 97 DOT
-            "Scourge of Eternity", -- Level 123 TOB
-            "Scourge of Destiny",
-            "Scourge of Fates",
+            "Scourge of Eternity",      -- Level 123, TOB
+            "Scourge of Destiny",       -- Level 108
+            "Scourge of Fates",         -- Level 97
         },
-        ['ComboDot'] = { ---Combines GripDot and DecayDot
-            "Goremand's Grip of Decay",
-            "Fleshrot's Grip of Decay",
-            "Danvid's Grip of Decay",
-            "Mourgis' Grip of Decay",
-            "Livianus' Grip of Decay",
+        ['ComboDot'] = {                ---Combines GripDot and DecayDot
+            "Goremand's Grip of Decay", -- Level 125
+            "Fleshrot's Grip of Decay", -- Level 120
+            "Danvid's Grip of Decay",   -- Level 115
+            "Mourgis' Grip of Decay",   -- Level 110
+            "Livianus' Grip of Decay",  -- Level 104
         },
         ['DecayDot'] = {
             ---Decay Line of Disease Spells >=LVL56 Slow DOT
-            "Pustim's Decay",
-            "Goremand's Decay",
-            "Fleshrot's Decay",
-            "Danvid's Decay",
-            "Mourgis' Decay",
-            "Livianus' Decay",
-            "Wuran's Decay",
-            "Ulork's Decay",
-            "Folasar's Decay",
-            "Megrima's Decay",
-            "Eranon's Decay",
-            "Severan's Rot",
-            "Chaos Plague",
-            "Dark Plague",
-            "Cessation of Cor",
+            "Pustim's Decay",   -- Level 126
+            "Goremand's Decay", -- Level 121
+            "Fleshrot's Decay", -- Level 116
+            "Danvid's Decay",   -- Level 111
+            "Mourgis' Decay",   -- Level 106
+            "Livianus' Decay",  -- Level 101
+            "Wuran's Decay",    -- Level 96
+            "Ulork's Decay",    -- Level 91
+            "Folasar's Decay",  -- Level 86
+            "Megrima's Decay",  -- Level 81
+            "Eranon's Decay",   -- Level 76
+            "Severan's Rot",    -- Level 71
+            "Chaos Plague",     -- Level 66
+            "Dark Plague",      -- Level 61
+            "Cessation of Cor", -- Level 56
         },
         ['GripDot'] = {
             ---Grip Line of Disease Spells =LVL1 HAS DEBUFF
-            "Grip of Pustim",
-            "Grip of Quietus",
-            "Grip of Zorglim",
-            "Grip of Kraz",
-            "Grip of Jabaum",
-            "Grip of Zalikor",
-            "Grip of Zargo",
-            "Grip of Mori",
-            "Plague",
-            "Asystole",
-            "Scourge",
-            -- "Infectious Cloud",
-            "Heart Flutter",
-            "Disease Cloud",
+            "Grip of Pustim",  -- Level 126
+            "Grip of Quietus", -- Level 116
+            "Grip of Zorglim", -- Level 111
+            "Grip of Kraz",    -- Level 106
+            "Grip of Jabaum",  -- Level 101
+            "Grip of Zalikor", -- Level 96
+            "Grip of Zargo",   -- Level 91
+            "Grip of Mori",    -- Level 67
+            "Plague",          -- Level 52
+            "Asystole",        -- Level 40
+            "Scourge",         -- Level 35
+            -- "Infectious Cloud", -- Level 15
+            "Heart Flutter",   -- Level 13
+            "Disease Cloud",   -- Level 1
         },
         ['SwiftDiseaseDot'] = {
             ---Sickness Life of Disease Spells >=LVL89 QuickDOT
-            "Wremms's Swift Sickness",
-            "Ogna's Swift Sickness",
-            "Diabo Tatrua's Swift Sickness",
-            "Lairsaf's Swift Sickness",
-            "Hoshkar's Swift Sickness",
-            "Ilsaria's Swift Sickness",
-            "Bora's Swift Sickness",
-            "Prox's Swift Sickness",
-            "Rilfed's Swift Sickness",
+            "Wremm's Swift Sickness",        -- Level 129
+            "Ogna's Swift Sickness",         -- Level 124
+            "Diabo Tatrua's Swift Sickness", -- Level 119
+            "Lairsaf's Swift Sickness",      -- Level 114
+            "Hoshkar's Swift Sickness",      -- Level 109
+            "Ilsaria's Swift Sickness",      -- Level 104
+            "Bora's Swift Sickness",         -- Level 99
+            "Prox's Swift Sickness",         -- Level 94
+            "Rilfed's Swift Sickness",       -- Level 89
         },
         ['SwiftPoisonDot'] = {
             ---Poison1 >= LVL86 (QuickDOT)
-            "Lherre's Swift Venom",
-            "Dotal's Swift Venom",
-            "Xenacious' Swift Venom",
-            "Vilefang's Swift Venom",
-            "Nexona's Swift Venom",
-            "Serisaria's Swift Venom",
-            "Slaunk's Swift Venom",
-            "Hyboram's Swift Venom",
-            "Burlabis' Swift Venom",
+            "Lherre's Swift Venom",    -- Level 126
+            "Dotal's Swift Venom",     -- Level 121
+            "Xenacious' Swift Venom",  -- Level 116
+            "Vilefang's Swift Venom",  -- Level 111
+            "Nexona's Swift Venom",    -- Level 106
+            "Serisaria's Swift Venom", -- Level 101
+            "Slaunk's Swift Venom",    -- Level 96
+            "Hyboram's Swift Venom",   -- Level 91
+            "Burlabis' Swift Venom",   -- Level 86
         },
         ['VenomDot'] = {
             ---Poison2 >=LVL1 (DOT)
-            "Silkwhisper Venom",
-            "Luggald Venom",
-            "Hemorrhagic Venom",
-            "Crystal Crawler Venom",
-            "Polybiad Venom",
-            "Glistenwing Venom",
-            "Binaesa Venom",
-            "Naeya Venom",
-            "Argendev's Venom",
-            "Slitheren Venom",
-            "Venonscale Venom",
-            "Vakk`dra's Sickly Mists",
-            "Blood of Thule",
-            "Envenomed Bolt",
-            "Chilling Embrace",
-            "Venom of the Snake",
-            "Poison Bolt",
+            "Silkwhisper Venom",       -- Level 130
+            "Luggald Venom",           -- Level 125
+            "Hemorrhagic Venom",       -- Level 120
+            "Crystal Crawler Venom",   -- Level 115
+            "Polybiad Venom",          -- Level 110
+            "Glistenwing Venom",       -- Level 105
+            "Binaesa Venom",           -- Level 100
+            "Naeya Venom",             -- Level 95
+            "Argendev's Venom",        -- Level 90
+            "Slitheren Venom",         -- Level 85
+            "Venonscale Venom",        -- Level 80
+            "Vakk`dra's Sickly Mists", -- Level 74
+            "Blood of Thule",          -- Level 65
+            "Envenomed Bolt",          -- Level 50
+            "Chilling Embrace",        -- Level 36
+            "Venom of the Snake",      -- Level 34
+            "Poison Bolt",             -- Level 4
         },
         ['VenomDot2'] = {
             ---Poison2 >=LVL1 (DOT)
-            "Silkwhisper Venom",
-            "Luggald Venom",
-            "Hemorrhagic Venom",
-            "Crystal Crawler Venom",
-            "Polybiad Venom",
-            "Glistenwing Venom",
-            "Binaesa Venom",
-            "Naeya Venom",
-            "Argendev's Venom",
-            "Slitheren Venom",
-            "Venonscale Venom",
-            "Vakk`dra's Sickly Mists",
-            "Blood of Thule",
-            "Envenomed Bolt",
-            "Chilling Embrace",
-            "Venom of the Snake",
-            "Poison Bolt",
+            "Silkwhisper Venom",       -- Level 130
+            "Luggald Venom",           -- Level 125
+            "Hemorrhagic Venom",       -- Level 120
+            "Crystal Crawler Venom",   -- Level 115
+            "Polybiad Venom",          -- Level 110
+            "Glistenwing Venom",       -- Level 105
+            "Binaesa Venom",           -- Level 100
+            "Naeya Venom",             -- Level 95
+            "Argendev's Venom",        -- Level 90
+            "Slitheren Venom",         -- Level 85
+            "Venonscale Venom",        -- Level 80
+            "Vakk`dra's Sickly Mists", -- Level 74
+            "Blood of Thule",          -- Level 65
+            "Envenomed Bolt",          -- Level 50
+            "Chilling Embrace",        -- Level 36
+            "Venom of the Snake",      -- Level 34
+            "Poison Bolt",             -- Level 4
         },
         ['HazeDot'] = {
             ---Poison3 >= LVL79 DOT
-            "Khrosik's Pallid Haze",
-            "Uncia's Pallid Haze",
-            "Zelnithak's Pallid Haze",
-            "Dracnia's Pallid Haze",
-            "Bomoda's Pallid Haze",
-            "Plexipharia's Pallid Haze",
-            "Halstor's Pallid Haze",
-            "Ivrikdal's Pallid Haze",
-            "Arachne's Pallid Haze",
-            "Fellid's Pallid Haze",
-            "Visziaj's Pallid Haze",
-            "Chaos Venom",
+            "Khrosik's Pallid Haze",     -- Level 129
+            "Uncia's Pallid Haze",       -- Level 124
+            "Zelnithak's Pallid Haze",   -- Level 119
+            "Dracnia's Pallid Haze",     -- Level 114
+            "Bomoda's Pallid Haze",      -- Level 109
+            "Plexipharia's Pallid Haze", -- Level 104
+            "Halstor's Pallid Haze",     -- Level 99
+            "Ivrikdal's Pallid Haze",    -- Level 94
+            "Arachne's Pallid Haze",     -- Level 89
+            "Fellid's Pallid Haze",      -- Level 84
+            "Visziaj's Pallid Haze",     -- Level 79
+            "Chaos Venom",               -- Level 70
         },
         ['PutrefactionDot'] = {
             ---Corruption1 >= LVL77
-            "Putrefaction XI",
-            "Deterioration",
-            "Decomposition",
-            "Miasma",
-            "Effluvium",
-            "Liquefaction",
-            "Dissolution",
-            "Mortification",
-            "Fetidity",
-            "Putrescence",
-            "Putrefaction",
+            "Putrefaction XI", -- Level 127
+            "Deterioration",   -- Level 122
+            "Decomposition",   -- Level 117
+            "Miasma",          -- Level 112
+            "Effluvium",       -- Level 107
+            "Liquefaction",    -- Level 102
+            "Dissolution",     -- Level 97
+            "Mortification",   -- Level 92
+            "Fetidity",        -- Level 87
+            "Putrescence",     -- Level 82
+            "Putrefaction",    -- Level 77
         },
         ['CripplingTap'] = {
             -- >= LVL56 Crippling Claudication
-            "Crippling Paraplegia",
-            "Crippling Incapacity",
-            "Crippling Claudication",
+            "Crippling Paraplegia",   -- Level 106
+            "Crippling Incapacity",   -- Level 96
+            "Crippling Claudication", -- Level 56
         },
         ['ChaoticDebuff'] = {
             -- >= LVL93
             -- Chaotic Contgion
-            "Chaotic Fetor",
-            "Chaotic Acridness",
-            "Chaotic Miasma",
-            "Chaotic Effluvium",
-            "Chaotic Liquefaction",
-            "Chaotic Corruption",
-            "Chaotic Contagion",
+            "Chaotic Fetor",        -- Level 123
+            "Chaotic Acridness",    -- Level 118
+            "Chaotic Miasma",       -- Level 113
+            "Chaotic Effluvium",    -- Level 108
+            "Chaotic Liquefaction", -- Level 103
+            "Chaotic Corruption",   -- Level 98
+            "Chaotic Contagion",    -- Level 93
         },
         ['SnareDot'] = {
             -- LVL4 -> <= LVL70
-            "Clinging Darkness XIX",
-            "Afflicted Darkness",
-            "Harrowing Darkness",
-            "Tormenting Darkness",
-            "Gnawing Darkness",
-            "Grasping Darkness",
-            "Clutching Darkness",
-            "Viscous Darkness",
-            "Tenuous Darkness",
-            "Clawing Darkness",
-            "Auroral Darkness",
-            "Coruscating Darkness",
-            "Desecrating Darkness",
-            "Embracing Darkness",
-            "Devouring Darkness",
-            "Cascading Darkness",
-            "Scent of Darkness",
-            "Dooming Darkness",
-            "Engulfing Darkness",
-            "Clinging Darkness",
+            "Clinging Darkness XIX", -- Level 129
+            "Afflicted Darkness",    -- Level 124
+            "Harrowing Darkness",    -- Level 119
+            "Tormenting Darkness",   -- Level 114
+            "Gnawing Darkness",      -- Level 109
+            "Grasping Darkness",     -- Level 104
+            "Clutching Darkness",    -- Level 99
+            "Viscous Darkness",      -- Level 94
+            "Tenuous Darkness",      -- Level 89
+            "Clawing Darkness",      -- Level 84
+            "Auroral Darkness",      -- Level 79
+            "Coruscating Darkness",  -- Level 74
+            "Desecrating Darkness",  -- Level 68
+            "Embracing Darkness",    -- Level 63
+            "Devouring Darkness",    -- Level 59
+            "Cascading Darkness",    -- Level 47
+            "Scent of Darkness",     -- Level 37
+            "Dooming Darkness",      -- Level 27
+            "Engulfing Darkness",    -- Level 11
+            "Clinging Darkness",     -- Level 4
         },
         ['ScentDebuff'] = {
             -- line needed till >= LVL10 <= LVL85
-            "Scent of Dusk XIII",
-            "Scent of The Realm",
-            "Scent of The Grave",
-            "Scent of Mortality",
-            "Scent of Extinction",
-            "Scent of Dread",
-            "Scent of Nightfall",
-            "Scent of Doom",
-            "Scent of Gloom",
-            "Scent of Afterlight",
-            "Scent of Twilight",
-            "Scent of Midnight",
-            "Scent of Terris",
-            "Scent of Darkness",
-            "Scent of Shadow",
-            "Scent of Dusk",
+            "Scent of Dusk XIII",  -- Level 127
+            "Scent of The Realm",  -- Level 122
+            "Scent of The Grave",  -- Level 117
+            "Scent of Mortality",  -- Level 112
+            "Scent of Extinction", -- Level 107
+            "Scent of Dread",      -- Level 97
+            "Scent of Nightfall",  -- Level 92
+            "Scent of Doom",       -- Level 87
+            "Scent of Gloom",      -- Level 82
+            "Scent of Afterlight", -- Level 77
+            "Scent of Twilight",   -- Level 72
+            "Scent of Midnight",   -- Level 68
+            "Scent of Terris",     -- Level 52
+            "Scent of Darkness",   -- Level 37
+            "Scent of Shadow",     -- Level 21
+            "Scent of Dusk",       -- Level 10
         },
         ['LichSpell'] = {
             -- LichForm Spell
-            "Otherside XX",
-            "Realmside",
-            "Lunaside",
-            "Gloomside",
-            "Contraside",
-            "Forgottenside",
-            "Forsakenside",
-            "Shadowside",
-            "Darkside",
-            "Netherside",
-            "Spectralside",
-            "Otherside",
-            "Dark Possession",
-            "Grave Pact",
-            "Seduction of Saryrn",
-            "Arch Lich",
-            "Demi Lich",
-            "Lich",
-            "Call of Bones",
-            "Allure of Death",
-            "Dark Pact",
+            "Otherside XX",        -- Level 129
+            "Realmside",           -- Level 124
+            "Lunaside",            -- Level 119
+            "Gloomside",           -- Level 114
+            "Contraside",          -- Level 109
+            "Forgottenside",       -- Level 104
+            "Forsakenside",        -- Level 99
+            "Shadowside",          -- Level 94
+            "Darkside",            -- Level 89
+            "Netherside",          -- Level 84
+            "Spectralside",        -- Level 79
+            "Otherside",           -- Level 74
+            "Dark Possession",     -- Level 70
+            "Grave Pact",          -- Level 70
+            "Seduction of Saryrn", -- Level 64
+            "Arch Lich",           -- Level 60
+            "Demi Lich",           -- Level 56
+            "Lich",                -- Level 48
+            "Call of Bones",       -- Level 31
+            "Allure of Death",     -- Level 18
+            "Dark Pact",           -- Level 6
         },
         ['BestowBuff'] = {
-            "Bestow Undeath X",
-            "Bestow Ruin",
-            "Bestow Rot",
-            "Bestow Dread",
-            "Bestow Relife",
-            "Bestow Doom",
-            "Bestow Mortality",
-            "Bestow Decay",
-            "Bestow Unlife",
-            "Bestow Undeath",
+            "Bestow Undeath X", -- Level 128
+            "Bestow Ruin",      -- Level 123
+            "Bestow Rot",       -- Level 118
+            "Bestow Dread",     -- Level 113
+            "Bestow Relife",    -- Level 108
+            "Bestow Doom",      -- Level 103
+            "Bestow Mortality", -- Level 98
+            "Bestow Decay",     -- Level 93
+            "Bestow Unlife",    -- Level 88
+            "Bestow Undeath",   -- Level 83
         },
         ['RogPetSpell'] = {
-            "Dark Assassin XVI",
-            "Merciless Assassin",
-            "Unrelenting Assassin",
-            "Restless Assassin",
-            "Reliving Assassin",
-            "Restless Assassin",
-            "Revived Assassin",
-            "Unearthed Assassin",
-            "Reborn Assassin",
-            "Raised Assassin",
-            "Unliving Murderer",
-            "Noxious Servant",
-            "Putrescent Servant",
-            "Dark Assassin",
-            "Saryrn's Companion",
-            "Minion of Shadows",
+            "Dark Assassin XVI",    -- Level 130
+            "Merciless Assassin",   -- Level 125
+            "Unrelenting Assassin", -- Level 120
+            "Restless Assassin",    -- Level 115
+            "Restless Assassin",    -- Level 115
+            "Reliving Assassin",    -- Level 110
+            "Revived Assassin",     -- Level 105
+            "Unearthed Assassin",   -- Level 100
+            "Reborn Assassin",      -- Level 95
+            "Raised Assassin",      -- Level 90
+            "Unliving Murderer",    -- Level 85
+            "Noxious Servant",      -- Level 80
+            "Putrescent Servant",   -- Level 75
+            "Dark Assassin",        -- Level 70
+            "Saryrn's Companion",   -- Level 63
+            "Minion of Shadows",    -- Level 53
         },
         ['WarPetSpell'] = {
-            "Rasivimun's Shade",
-            "Margator's Shade",
-            "Luclin's Conqueror",
-            "Tserrina's Shade",
-            "Adalora's Shade",
-            "Miktokla's Shade",
-            "Zalifur's Shade",
-            "Vak`Ridel's Shade",
-            "Aziad's Shade",
-            "Bloodreaper's Shade",
-            "Relamar's Shade",
-            "Riza`farr's Shadow",
-            "Lost Soul",
-            "Child of Bertoxxulous",
-            "Emissary of Thule",
-            "Servant of Bones",
-            "Invoke Death",
-            "Cackling Bones",
-            "Malignant Dead",
-            "Invoke Shadow",
-            "Summon Dead",
-            "Haunting Corpse",
-            "Animate Dead",
-            "Restless Bones",
-            "Convoke Shadow",
-            "Bone Walk",
-            "Leering Corpse",
-            "Cavorting Bones",
+            "Rasvimun's Shade",      -- Level 127
+            "Margator's Shade",      -- Level 122
+            "Luclin's Conqueror",    -- Level 117
+            "Tserrina's Shade",      -- Level 112
+            "Adalora's Shade",       -- Level 107
+            "Miktokla's Shade",      -- Level 102
+            "Zalifur's Shade",       -- Level 97
+            "Vak`Ridel's Shade",     -- Level 92
+            "Aziad's Shade",         -- Level 87
+            "Bloodreaper's Shade",   -- Level 82
+            "Relamar's Shade",       -- Level 77
+            "Riza`farr's Shadow",    -- Level 72
+            "Lost Soul",             -- Level 67
+            "Child of Bertoxxulous", -- Level 65
+            "Emissary of Thule",     -- Level 59
+            "Servant of Bones",      -- Level 56
+            "Invoke Death",          -- Level 48
+            "Cackling Bones",        -- Level 44
+            "Malignant Dead",        -- Level 39
+            "Invoke Shadow",         -- Level 33
+            "Summon Dead",           -- Level 29
+            "Haunting Corpse",       -- Level 24
+            "Animate Dead",          -- Level 20
+            "Restless Bones",        -- Level 16
+            "Convoke Shadow",        -- Level 12
+            "Bone Walk",             -- Level 8
+            "Leering Corpse",        -- Level 4
+            "Cavorting Bones",       -- Level 1
         },
         ['PetBuff'] = {
-            "Necrotize Ally X",
-            "Instill Ally",
-            "Inspire Ally",
-            "Incite Ally",
-            "Infuse Ally",
-            "Imbue Ally",
+            "Necrotize Ally X", -- Level 130
+            "Instill Ally",     -- Level 125
+            "Inspire Ally",     -- Level 120
+            "Incite Ally",      -- Level 115
+            "Infuse Ally",      -- Level 110
+            "Imbue Ally",       -- Level 105
             --The below spells deal PBAE damage on fade and should not be casually used (later spells drop this effect)
-            --"Sanction Ally",
-            --"Empower Ally",
-            --"Energize Ally",
-            --"Necrotize Ally",
+            -- "Sanction Ally",  -- Level 100
+            -- "Empower Ally",   -- Level 95
+            -- "Energize Ally",  -- Level 90
+            -- "Necrotize Ally", -- Level 85
         },
         ['PetHaste'] = {
-            "Sigil of Death XV",
-            "Sigil of Putrefaction",
-            "Sigil of Undeath",
-            "Sigil of Decay",
-            "Sigil of the Arcron",
-            "Sigil of the Doomscale",
-            "Sigil of the Sundered",
-            "Sigil of the Preternatural",
-            "Sigil of the Moribund",
-            "Sigil of the Aberrant",
-            "Sigil of the Unnatural",
-            "Glyph of Darkness",
-            "Rune of Death",
-            "Augmentation of Death",
-            "Augment Death",
-            "Intensify Death",
-            "Focus Death",
+            "Sigil of Death XV",          -- Level 127
+            "Sigil of Putrefaction",      -- Level 122
+            "Sigil of Undeath",           -- Level 117
+            "Sigil of Decay",             -- Level 112
+            "Sigil of the Arcron",        -- Level 107
+            "Sigil of the Doomscale",     -- Level 102
+            "Sigil of the Sundered",      -- Level 97
+            "Sigil of the Preternatural", -- Level 92
+            "Sigil of the Moribund",      -- Level 87
+            "Sigil of the Aberrant",      -- Level 77
+            "Sigil of the Unnatural",     -- Level 72
+            "Glyph of Darkness",          -- Level 67
+            "Rune of Death",              -- Level 62
+            "Augmentation of Death",      -- Level 55
+            "Augment Death",              -- Level 35
+            "Intensify Death",            -- Level 23
+            "Focus Death",                -- Level 11
         },
         ['PetHealSpell'] = {
-            "Chilling Renewal XVI",
-            "Bracing Revival",
-            "Frigid Salubrity",
-            "Icy Revival",
-            "Algid Renewal",
-            "Icy Mending",
-            "Algid Mending",
-            "Chilled Mending",
-            "Gelid Mending",
-            "Icy Stitches",
-            "Wintry Revival",
-            "Chilling Renewal",
-            "Dark Salve",
-            "Touch of Death",
-            "Renew Bones",
-            "Mend Bones",
+            "Chilling Renewal XVI", -- Level 128
+            "Bracing Revival",      -- Level 123
+            "Frigid Salubrity",     -- Level 118
+            "Icy Revival",          -- Level 113
+            "Algid Renewal",        -- Level 108
+            "Icy Mending",          -- Level 103
+            "Algid Mending",        -- Level 98
+            "Chilled Mending",      -- Level 93
+            "Gelid Mending",        -- Level 88
+            "Icy Stitches",         -- Level 83
+            "Wintry Revival",       -- Level 78
+            "Chilling Renewal",     -- Level 73
+            "Dark Salve",           -- Level 69
+            "Touch of Death",       -- Level 64
+            "Renew Bones",          -- Level 26
+            "Mend Bones",           -- Level 7
         },
         ['FleshBuff'] = {
             "Flesh to Toxin",  -- Level 119
@@ -1372,14 +1360,14 @@ local _ClassConfig = {
             {
                 name = "Dead Man Floating",
                 type = "AA",
-                load_cond = function(self) return Config:GetSettings('DoLevitate') and Casting.CanUseAA("Dead Man Floating") end,
+                load_cond = function(self) return Config:GetSetting('DoLevitate') and Casting.CanUseAA("Dead Man Floating") end,
                 active_cond = function(self, aaName) return Casting.IHaveBuff(aaName) end,
                 cond = function(self, aaName) return Casting.SelfBuffAACheck(aaName) end,
             },
             {
                 name = "Levitate",
                 type = "Spell",
-                load_cond = function(self) return Config:GetSettings('DoLevitate') and not Casting.CanUseAA("Dead Man Floating") end,
+                load_cond = function(self) return Config:GetSetting('DoLevitate') and not Casting.CanUseAA("Dead Man Floating") end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell) return Casting.SelfBuffCheck(spell) end,
             },

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -132,466 +132,465 @@ local _ClassConfig = {
     ['AbilitySets']       = {
         ['CrushTimer6'] = {
             "Crush of Eminence",     -- Level 129
-            "Crush of Compunction",  -- Level 85
-            "Crush of Repentance",   -- Level 90
-            "Crush of Tides",        -- Level 95
-            "Crush of Tarew",        -- Level 100
-            "Crush of Povar",        -- Level 105
-            "Crush of E'Ci",         -- Level 110
-            "Crush of Restless Ice", -- Level 115
-            "Crush of the Umbra",    -- Level 120
             "Crush of the Heroic",   -- Level 124
+            "Crush of the Umbra",    -- Level 120
+            "Crush of Restless Ice", -- Level 115
+            "Crush of E'Ci",         -- Level 110
+            "Crush of Povar",        -- Level 105
+            "Crush of Tarew",        -- Level 100
+            "Crush of Tides",        -- Level 95
+            "Crush of Repentance",   -- Level 90
+            "Crush of Compunction",  -- Level 85
         },
         ['CrushTimer5'] = {
             "Crush of the Crying Seas X", -- Level 127
-            "Crush of the Crying Seas",   -- Level 82
-            "Crush of Marr",              -- Level 87
-            "Crush of Oseka",             -- Level 92
-            "Crush of the Iceclad",       -- Level 97
-            "Crush of the Darkened Sea",  -- Level 102
-            "Crush of the Timorous Deep", -- Level 107
-            "Crush of the Grotto",        -- Level 112
-            "Crush of the Twilight Sea",  -- Level 117
             "Crush of the Wayunder",      -- Level 122
+            "Crush of the Twilight Sea",  -- Level 117
+            "Crush of the Grotto",        -- Level 112
+            "Crush of the Timorous Deep", -- Level 107
+            "Crush of the Darkened Sea",  -- Level 102
+            "Crush of the Iceclad",       -- Level 97
+            "Crush of Oseka",             -- Level 92
+            "Crush of Marr",              -- Level 87
+            "Crush of the Crying Seas",   -- Level 82
         },
         ['TwinHealNuke'] = {
             "Brilliant Expurgation",  -- Level 130
-            "Glorious Vindication",   -- Level 85
-            "Glorious Exoneration",   -- Level 90
-            "Glorious Exculpation",   -- Level 95
-            "Glorious Expurgation",   -- Level 100
-            "Brilliant Vindication",  -- Level 105
-            "Brilliant Exoneration",  -- Level 110
-            "Brilliant Exculpation",  -- Level 115
-            "Brilliant Acquittal",    -- Level 120
             "Brilliant Denouncement", -- Level 125
+            "Brilliant Acquittal",    -- Level 120
+            "Brilliant Exculpation",  -- Level 115
+            "Brilliant Exoneration",  -- Level 110
+            "Brilliant Vindication",  -- Level 105
+            "Glorious Expurgation",   -- Level 100
+            "Glorious Exculpation",   -- Level 95
+            "Glorious Exoneration",   -- Level 90
+            "Glorious Vindication",   -- Level 85
         },
         ['TempHP'] = {
-            "Unyielding Stance",
-            "Steely Stance",
-            "Stubborn Stance",
-            "Stoic Stance",
-            "Staunch Stance",
-            "Steadfast Stance",
-            "Defiant Stance",
-            "Stormwall Stance",
-            "Adamant Stance",
-            "Unwavering Stance",
+            "Unyielding Stance", -- Level 129
+            "Unwavering Stance", -- Level 124
+            "Adamant Stance",    -- Level 119
+            "Stormwall Stance",  -- Level 114
+            "Defiant Stance",    -- Level 109
+            "Staunch Stance",    -- Level 104
+            "Steadfast Stance",  -- Level 99
+            "Stoic Stance",      -- Level 94
+            "Stubborn Stance",   -- Level 89
+            "Steely Stance",     -- Level 84
         },
         ['Preservation'] = {
             "Preservation of Quellious",    -- Level 130
-            "Ward of Tunare",               -- Level 70
-            "Sustenance of Tunare",         -- Level 80
-            "Preservation of Tunare",       -- Level 85
-            "Preservation of Marr",         -- Level 90
-            "Preservation of Oseka",        -- Level 95
-            "Preservation of the Iceclad",  -- Level 100
-            "Preservation of Rodcet",       -- Level 110
-            "Preservation of the Grotto",   -- Level 115
-            "Preservation of the Basilica", -- Level 120
             "Preservation of the Fern",     -- Level 125
+            "Preservation of the Basilica", -- Level 120
+            "Preservation of the Grotto",   -- Level 115
+            "Preservation of Rodcet",       -- Level 110
+            "Preservation of the Iceclad",  -- Level 100
+            "Preservation of Oseka",        -- Level 95
+            "Preservation of Marr",         -- Level 90
+            "Preservation of Tunare",       -- Level 85
+            "Sustenance of Tunare",         -- Level 80
+            "Ward of Tunare",               -- Level 70
         },
         ['HealNuke'] = {
-            "Denouncement IX",
-            "Denouncement",
-            "Reprimand",
-            "Ostracize",
-            "Admonish",
-            "Censure",
-            "Remonstrate",
-            "Upbraid",
-            "Chastise",
+            "Denouncement IX", -- Level 127
+            "Chastise",        -- Level 122
+            "Upbraid",         -- Level 117
+            "Remonstrate",     -- Level 112
+            "Censure",         -- Level 107
+            "Admonish",        -- Level 102
+            "Ostracize",       -- Level 97
+            "Reprimand",       -- Level 92
+            "Denouncement",    -- Level 87
         },
         ['BlessingProc'] = {
-            "Harmonious Blessing",
-            "Concordant Blessing",
-            "Confluent Blessing",
-            "Penumbral Blessing",
-            "Paradoxical Blessing",
+            "Paradoxical Blessing", -- Level 123
+            "Penumbral Blessing",   -- Level 118
+            "Confluent Blessing",   -- Level 113
+            "Concordant Blessing",  -- Level 108
+            "Harmonious Blessing",  -- Level 103
         },
         ['DebuffNuke'] = {
-            "Committal",    -- Level 126
-            "Last Rites",   -- Level 68 - Timer 7
-            "Burial Rites", -- Level 71 - Timer 7
-            "Benediction",  -- Level 76
-            "Eulogy",       -- Level 81
-            "Elegy",        -- Level 86
-            "Paean",        -- Level 91
-            "Laudation",    -- Level 96
-            "Consecration", -- Level 101
-            "Remembrance",  -- Level 106
-            "Requiem",      -- Level 111
-            "Hymnal",       -- Level 116
-            "Revelation",   -- Level 121
+            "Committal",              -- Level 126
+            "Revelation",             -- Level 121
+            "Hymnal",                 -- Level 116
+            "Requiem",                -- Level 111
+            "Remembrance",            -- Level 106
+            "Consecration",           -- Level 101
+            "Laudation",              -- Level 96
+            "Paean",                  -- Level 91
+            "Elegy",                  -- Level 86
+            "Eulogy",                 -- Level 81
+            "Benediction",            -- Level 76
+            "Burial Rites",           -- Level 71, - Timer 7
+            "Last Rites",             -- Level 68, - Timer 7
         },
-        ['SteelProc'] = {   --Proc Heal ToT
-            "Rejuvenating Steel VII",
-            "Restoring Steel",
-            "Regenerating Steel",
-            "Rejuvenating Steel",
-            "Reinvigorating Steel",
-            "Revitalizating Steel",
-            "Renewing Steel",
+        ['SteelProc'] = {             --Proc Heal ToT
+            "Rejuvenating Steel VII", -- Level 129
+            "Restoring Steel",        -- Level 124
+            "Regenerating Steel",     -- Level 119
+            "Renewing Steel",         -- Level 114
+            "Revitalizating Steel",   -- Level 109
+            "Reinvigorating Steel",   -- Level 99
+            "Rejuvenating Steel",     -- Level 94
         },
         ['FuryProc'] = {
             "Eminent Fury",   -- Level 130
-            "Divine Might",   -- Level 45, 65pt
-            "Pious Might",    -- Level 63, 150pt
-            "Holy Order",     -- Level 65, 180pt
-            "Pious Fury",     -- Level 68, 190pt
-            "Righteous Fury", -- Level 80, 268pt --For simplicity of coding and conflict prevention, once fury is rolled into DPU at 80, we will no longer use the undead proc.
-            "Devout Fury",    -- Level 85
-            "Earnest Fury",   -- Level 90
-            "Zealous Fury",   -- Level 95
-            "Reverent Fury",  -- Level 100
-            "Ardent Fury",    -- Level 105
-            "Merciful Fury",  -- Level 110
-            "Sincere Fury",   -- Level 115
-            "Wrathful Fury",  -- Level 120
             "Avowed Fury",    -- Level 125
+            "Wrathful Fury",  -- Level 120
+            "Sincere Fury",   -- Level 115
+            "Merciful Fury",  -- Level 110
+            "Ardent Fury",    -- Level 105
+            "Reverent Fury",  -- Level 100
+            "Zealous Fury",   -- Level 95
+            "Earnest Fury",   -- Level 90
+            "Devout Fury",    -- Level 85
+            "Righteous Fury", -- Level 80, 268pt --For simplicity of coding and conflict prevention, once fury is rolled into DPU at 80, we will no longer use the undead proc.
+            "Pious Fury",     -- Level 68, 190pt
+            "Holy Order",     -- Level 65, 180pt
+            "Pious Might",    -- Level 63, 150pt
+            "Divine Might",   -- Level 45, 65pt
         },
         ['UndeadProc'] = {
             --- Undead Proc Strike : does not stack with Fury Proc, will be used until Fury is available even if setting not enabled.
-            "Instrument of Nife", -- Level 26, 243pt
-            "Ward of Nife",       -- Level 62, 300pt
             "Silvered Fury",      -- Level 67, 390pt
+            "Ward of Nife",       -- Level 62, 300pt
+            "Instrument of Nife", -- Level 26, 243pt
         },
         ['Aurora'] = {
-            "Aurora of Sunlight XI",
-            "Aurora of Dawning",
-            "Aurora of Dawnlight",
-            "Aurora of Daybreak",
-            "Aurora of Splendor",
-            "Aurora of Sunrise",
-            "Aurora of Dayspring",
-            "Aurora of Morninglight",
-            "Aurora of Wakening",
-            "Aurora of Realizing",
+            "Aurora of Sunlight XI",  -- Level 130
+            "Aurora of Realizing",    -- Level 125
+            "Aurora of Dawning",      -- Level 120
+            "Aurora of Wakening",     -- Level 115
+            "Aurora of Morninglight", -- Level 110
+            "Aurora of Dayspring",    -- Level 105
+            "Aurora of Sunrise",      -- Level 100
+            "Aurora of Splendor",     -- Level 95
+            "Aurora of Daybreak",     -- Level 90
+            "Aurora of Dawnlight",    -- Level 85
         },
         ['StunTimer5'] = {
             "Force of Akera XV",          -- Level 130
-            "Desist",                     -- Level 13 - Not Timer 5, use for TLP Low Level Stun
-            "Stun",                       -- Level 28
-            "Force of Akera",             -- Level 53
-            "Ancient: Force of Chaos",    -- Level 65
-            "Ancient: Force of Jeron",    -- Level 70
-            "Force of Prexus",            -- Level 75
-            "Force of Timorous",          -- Level 80
-            "Force of the Crying Seas",   -- Level 85
-            "Force of Marr",              -- Level 90
-            "Force of Oseka",             -- Level 95
-            "Force of the Iceclad",       -- Level 100
-            "Force of the Darkened Sea",  -- Level 105
-            "Force of the Timorous Deep", -- Level 110
-            "Force of the Grotto",        -- Level 115
-            "Force of the Umbra",         -- Level 120
             "Force of the Wayunder",      -- Level 125
+            "Force of the Umbra",         -- Level 120
+            "Force of the Grotto",        -- Level 115
+            "Force of the Timorous Deep", -- Level 110
+            "Force of the Darkened Sea",  -- Level 105
+            "Force of the Iceclad",       -- Level 100
+            "Force of Oseka",             -- Level 95
+            "Force of Marr",              -- Level 90
+            "Force of the Crying Seas",   -- Level 85
+            "Force of Timorous",          -- Level 80
+            "Force of Prexus",            -- Level 75
+            "Ancient: Force of Jeron",    -- Level 70
+            "Ancient: Force of Chaos",    -- Level 65
+            "Force of Akera",             -- Level 53
+            "Stun",                       -- Level 28
+            "Desist",                     -- Level 13, - Not Timer 5, use for TLP Low Level Stun
         },
         ['StunTimer4'] = {
             "Eminent Force",   -- Level 126
-            "Cease",           -- Level 7 - Not Timer 4, use for TLP Low Level Stun
-            "Force of Akilae", -- Level 62
-            "Force of Piety",  -- Level 66
-            "Sacred Force",    -- Level 71
-            "Devout Force",    -- Level 81
-            "Solemn Force",    -- Level 83
-            "Earnest Force",   -- Level 86
-            "Zealous Force",   -- Level 91
-            "Reverent Force",  -- Level 96
-            "Ardent Force",    -- Level 101
-            "Merciful Force",  -- Level 106
-            "Sincere Force",   -- Level 111
-            "Pious Force",     -- Level 116
             "Avowed Force",    -- Level 121
+            "Pious Force",     -- Level 116
+            "Sincere Force",   -- Level 111
+            "Merciful Force",  -- Level 106
+            "Ardent Force",    -- Level 101
+            "Reverent Force",  -- Level 96
+            "Zealous Force",   -- Level 91
+            "Earnest Force",   -- Level 86
+            "Devout Force",    -- Level 81
+            "Solemn Force",    -- Level 76
+            "Sacred Force",    -- Level 71
+            "Force of Piety",  -- Level 66
+            "Force of Akilae", -- Level 62
+            "Cease",           -- Level 7, - Not Timer 4, use for TLP Low Level Stun
         },
         ['HealStun'] = {
-            "Force of Eminence",   -- Level 129
-            "Force of the Avowed", --Level 124
-            "Force of Generosity",
-            "Force of Reverence",
-            "Force of Ardency",
-            "Force of Mercy",
-            "Force of Sincerity",
+            "Force of Eminence",       -- Level 129
+            "Force of the Avowed",     -- Level 124
+            "Force of Generosity",     -- Level 119
+            "Force of Sincerity",      -- Level 114
+            "Force of Mercy",          -- Level 109
+            "Force of Ardency",        -- Level 104
+            "Force of Reverence",      -- Level 99
         },
-        ['HealWard'] = { -- Heal ToT, Ward on Self
-            "Protective Confession X",
-            "Protective Acceptance",
-            "Protective Revelation",
-            "Protective Confession",
-            "Protective Devotion",
-            "Protective Dedication",
-            "Protective Allegiance",
-            "Protective Proclamation",
-            "Protective Devotion",
-            "Protective Consecration",
+        ['HealWard'] = {               -- Heal ToT, Ward on Self
+            "Protective Confession X", -- Level 130
+            "Protective Acceptance",   -- Level 125
+            "Protective Revelation",   -- Level 120
+            "Protective Consecration", -- Level 115
+            "Protective Proclamation", -- Level 105
+            "Protective Allegiance",   -- Level 100
+            "Protective Dedication",   -- Level 95
+            "Protective Devotion",     -- Level 90
+            "Protective Devotion",     -- Level 90
+            "Protective Confession",   -- Level 85
         },
         ['Aego'] = {
-            "Hand of Austerity XVII",        -- Level 127 - Group
-            "Austerity",                     -- Level 55
-            "Blessing of Austerity",         -- Level 58 - Group
-            "Guidance",                      -- Level 65
-            "Affirmation",                   -- Level 70
-            "Sworn Protector",               -- Level 75
-            "Oathbound Protector",           -- Level 80
-            "Sworn Keeper",                  -- Level 85
-            "Oathbound Keeper",              -- Level 90
-            "Avowed Keeper",                 -- Level 92
-            "Hand of the Avowed Keeper",     -- Level 95 - Group
-            "Pledged Keeper",                -- Level 97
-            "Hand of the Pledged Keeper",    -- Level 100 - Group
-            "Stormbound Keeper",             -- Level 102
-            "Hand of the Stormbound Keeper", -- Level 105 - Group
-            "Ashbound Keeper",               -- Level 107
-            "Hand of the Ashbound Keeper",   -- Level 110 - Group
-            "Stormwall Keeper",              -- Level 112
-            "Hand of the Stormwall Keeper",  -- Level 115 - Group
-            "Shadewell Keeper",              -- Level 117
-            "Hand of the Dreaming Keeper",   -- Level 120 - Group
+            "Hand of Austerity XVII",        -- Level 127, - Group
+            "Hand of the Fernshade Keeper",  -- Level 125, - Group
             "Fernshade Keeper",              -- Level 122
-            "Hand of the Fernshade Keeper",  -- Level 125 - Group
+            "Hand of the Dreaming Keeper",   -- Level 120, - Group
+            "Shadewell Keeper",              -- Level 117
+            "Hand of the Stormwall Keeper",  -- Level 115, - Group
+            "Stormwall Keeper",              -- Level 112
+            "Hand of the Ashbound Keeper",   -- Level 110, - Group
+            "Ashbound Keeper",               -- Level 107
+            "Hand of the Stormbound Keeper", -- Level 105, - Group
+            "Stormbound Keeper",             -- Level 102
+            "Hand of the Pledged Keeper",    -- Level 100, - Group
+            "Pledged Keeper",                -- Level 97
+            "Hand of the Avowed Keeper",     -- Level 95, - Group
+            "Avowed Keeper",                 -- Level 92
+            "Oathbound Keeper",              -- Level 90
+            "Sworn Keeper",                  -- Level 85
+            "Oathbound Protector",           -- Level 80
+            "Sworn Protector",               -- Level 75
+            "Affirmation",                   -- Level 70
+            "Guidance",                      -- Level 65
+            "Blessing of Austerity",         -- Level 58, - Group
+            "Austerity",                     -- Level 55
         },
         ['Brells'] = {
-            "Brell's Mountainous Barrior XVI",
-            "Brell's Tenacious Barrier",
-            "Brell's Loamy Ward",
-            "Brell's Tellurian Rampart",
-            "Brell's Adamantine Armor",
-            "Brell's Steadfast Bulwark",
-            "Brell's Stalwart Bulwark",
-            "Brell's Blessed Bastion",
-            "Brell's Blessed Barrier",
-            "Brell's Earthen Aegis",
-            "Brell's Stony Guard",
-            "Brell's Brawny Bulwark",
-            "Brell's Stalwart Shield",
-            "Brell's Mountainous Barrier",
-            "Brell's Steadfast Aegis",
-            "Brell's Unbreakable Palisade",
+            "Brell's Mountainous Barrier XVI", -- Level 129
+            "Brell's Unbreakable Palisade",    -- Level 124
+            "Brell's Tenacious Barrier",       -- Level 119
+            "Brell's Blessed Barrier",         -- Level 114
+            "Brell's Blessed Bastion",         -- Level 109
+            "Brell's Stalwart Bulwark",        -- Level 104
+            "Brell's Steadfast Bulwark",       -- Level 99
+            "Brell's Adamantine Armor",        -- Level 94
+            "Brell's Tellurian Rampart",       -- Level 89
+            "Brell's Loamy Ward",              -- Level 84
+            "Brell's Earthen Aegis",           -- Level 79
+            "Brell's Stony Guard",             -- Level 74
+            "Brell's Brawny Bulwark",          -- Level 70
+            "Brell's Stalwart Shield",         -- Level 65
+            "Brell's Mountainous Barrier",     -- Level 60
+            "Brell's Steadfast Aegis",         -- Level 49
         },
         ['SplashHeal'] = {
-            "Splash of Eminence",
-            "Splash of Heroism",
-            "Splash of Repentance",
-            "Splash of Sanctification",
-            "Splash of Purification",
-            "Splash of Cleansing",
-            "Splash of Atonement",
-            "Splash of Depuration",
-            "Splash of Exaltation",
+            "Splash of Eminence",       -- Level 128
+            "Splash of Heroism",        -- Level 123
+            "Splash of Repentance",     -- Level 118
+            "Splash of Exaltation",     -- Level 113
+            "Splash of Depuration",     -- Level 108
+            "Splash of Atonement",      -- Level 103
+            "Splash of Cleansing",      -- Level 98
+            "Splash of Purification",   -- Level 93
+            "Splash of Sanctification", -- Level 83
         },
         ['HealTaunt'] = {
-            "Valiant Defiance",
-            "Valiant Disruption",
-            "Valiant Deflection",
-            "Valiant Defense",
-            "Valiant Diversion",
-            "Valiant Deterrence",
+            "Valiant Defiance",          -- Level 124
+            "Valiant Disruption",        -- Level 119
+            "Valiant Deterrence",        -- Level 115
+            "Valiant Diversion",         -- Level 110
+            "Valiant Defense",           -- Level 105
+            "Valiant Deflection",        -- Level 98
         },
-        ['Affirmation'] = { --- Improved Super Taunt - Gets you Aggro for X seconds and reduces other Haters generation.
-            "Unquestioned Affirmation",
-            "Unconditional Affirmation",
-            "Unending Affirmation",
-            "Unrelenting Affirmation",
-            "Undivided Affirmation",
-            "Unbroken Affirmation",
-            "Unflinching Affirmation",
-            "Unyielding Affirmation",
+        ['Affirmation'] = {              --- Improved Super Taunt - Gets you Aggro for X seconds and reduces other Haters generation.
+            "Unquestioned Affirmation",  -- Level 129
+            "Unconditional Affirmation", -- Level 124
+            "Unrelenting Affirmation",   -- Level 119
+            "Unending Affirmation",      -- Level 114
+            "Unyielding Affirmation",    -- Level 109
+            "Unflinching Affirmation",   -- Level 104
+            "Unbroken Affirmation",      -- Level 99
+            "Undivided Affirmation",     -- Level 94
         },
-        ['WaveHeal'] = { -- Group Heal
-            "Wave of Inspiriation",
-            "Wave of Regret",
-            "Wave of Bereavement",
-            "Wave of Propitiation",
-            "Wave of Expiation",
-            "Wave of Grief",
-            "Wave of Sorrow",
-            "Wave of Contrition",
-            "Wave of Penitence",
-            "Wave of Remitment",
-            "Wave of Absolution",
-            "Wave of Forgiveness",
-            "Wave of Piety",
-            "Wave of Marr",
-            "Wave of Trushar",
-            "Healing Wave of Prexus",
-            "Wave of Healing",
-            "Wave of Life",
+        ['WaveHeal'] = {                 -- Group Heal
+            "Wave of Inspiration",       -- Level 129
+            "Wave of Regret",            -- Level 124
+            "Wave of Bereavement",       -- Level 119
+            "Wave of Propitiation",      -- Level 114
+            "Wave of Expiation",         -- Level 109
+            "Wave of Grief",             -- Level 104
+            "Wave of Sorrow",            -- Level 99
+            "Wave of Contrition",        -- Level 94
+            "Wave of Penitence",         -- Level 89
+            "Wave of Remitment",         -- Level 84
+            "Wave of Absolution",        -- Level 79
+            "Wave of Forgiveness",       -- Level 74
+            "Wave of Piety",             -- Level 70
+            "Wave of Marr",              -- Level 65
+            "Wave of Trushar",           -- Level 65
+            "Healing Wave of Prexus",    -- Level 58
+            "Wave of Healing",           -- Level 55
+            "Wave of Life",              -- Level 39
         },
         ['SelfHeal'] = {
-            "Penitence IX",
-            "Penitence",
-            "Contrition",
-            "Sorrow",
-            "Grief",
-            "Exaltation",
-            "Propitiation",
-            "Culpability",
-            "Angst",
+            "Penitence IX", -- Level 129
+            "Angst",        -- Level 124
+            "Culpability",  -- Level 119
+            "Propitiation", -- Level 114
+            "Grief",        -- Level 104
+            "Sorrow",       -- Level 99
+            "Contrition",   -- Level 94
+            "Penitence",    -- Level 89
         },
         ['ReverseDS'] = {
-            "Mark of Sharash",
-            "Mark of the Saint",
-            "Mark of the Crusader",
-            "Mark of the Pious",
-            "Mark of the Pure",
-            "Mark of the Defender",
-            "Mark of the Reverent",
-            "Mark of the Exemplar",
-            "Mark of the Commander",
-            "Mark of the Jade Cohort",
-            "Mark of the Eclipsed Cohort",
-            "Mark of the Forgotten Hero",
+            "Mark of Sharosh",             -- Level 126
+            "Mark of the Forgotten Hero",  -- Level 122
+            "Mark of the Eclipsed Cohort", -- Level 119
+            "Mark of the Jade Cohort",     -- Level 114
+            "Mark of the Commander",       -- Level 104
+            "Mark of the Exemplar",        -- Level 99
+            "Mark of the Reverent",        -- Level 94
+            "Mark of the Defender",        -- Level 89
+            "Mark of the Pure",            -- Level 86
+            "Mark of the Pious",           -- Level 84
+            "Mark of the Crusader",        -- Level 81
+            "Mark of the Saint",           -- Level 79
         },
         -- ['Cleansing'] = {           -- ST HoT
-        --     "Ethereal Cleansing",   -- Level 44
-        --     "Celestial Cleansing",  -- Level 59
-        --     "Supernal Cleansing",   -- Level 64
-        --     "Pious Cleansing",      -- Level 69
-        --     "Sacred Cleansing",     -- Level 73
-        --     "Solemn Cleansing",     -- Level 78
-        --     "Devout Cleansing",     -- Level 93
-        --     "Earnest Cleansing",    -- Level 88
-        --     "Zealous Cleansing",    -- Level 93
-        --     "Reverent Cleansing",   -- Level 98
-        --     "Ardent Cleansing",     -- Level 103
-        --     "Merciful Cleansing",   -- Level 108
-        --     "Sincere Cleansing",    -- Level 113
-        --     "Forthright Cleansing", -- Level 118
         --     "Avowed Cleansing",     -- Level 123
+        --     "Forthright Cleansing", -- Level 118
+        --     "Sincere Cleansing",    -- Level 113
+        --     "Merciful Cleansing",   -- Level 108
+        --     "Ardent Cleansing",     -- Level 103
+        --     "Reverent Cleansing",   -- Level 98
+        --     "Zealous Cleansing",    -- Level 93
+        --     "Earnest Cleansing",    -- Level 88
+        --     "Devout Cleansing",     -- Level 83
+        --     "Solemn Cleansing",     -- Level 78
+        --     "Sacred Cleansing",     -- Level 73
+        --     "Pious Cleansing",      -- Level 69
+        --     "Supernal Cleansing",   -- Level 64
+        --     "Celestial Cleansing",  -- Level 59
+        --     "Ethereal Cleansing",   -- Level 44
         -- },
-        ['BurstHeal'] = { -- Smart Heal, Target or ToT
-            "Burst of Sunlight XII",
-            "Burst of Sunlight",
-            "Burst of Morrow",
-            "Burst of Dawnlight",
-            "Burst of Daybreak",
-            "Burst of Splendor",
-            "Burst of Sunrise",
-            "Burst of Dayspring",
-            "Burst of Morninglight",
-            "Burst of Wakening",
-            "Burst of Dawnbreak",
-            "Burst of Sunspring",
+        ['BurstHeal'] = {            -- Smart Heal, Target or ToT
+            "Burst of Sunlight XII", -- Level 128
+            "Burst of Sunspring",    -- Level 123
+            "Burst of Dawnbreak",    -- Level 118
+            "Burst of Wakening",     -- Level 113
+            "Burst of Morninglight", -- Level 108
+            "Burst of Dayspring",    -- Level 103
+            "Burst of Sunrise",      -- Level 98
+            "Burst of Splendor",     -- Level 93
+            "Burst of Daybreak",     -- Level 88
+            "Burst of Dawnlight",    -- Level 83
+            "Burst of Morrow",       -- Level 78
+            "Burst of Sunlight",     -- Level 73
         },
         ['ArmorSelfBuff'] = {
             "Armor of Unyielding Faith",  -- Level 128
-            "Aura of the Crusader",       -- Level 64
-            "Armor of the Champion",      -- Level 69
-            "Armor of Unrelenting Faith", -- Level 73
-            "Armor of Inexorable Faith",  -- Level 78
-            "Armor of Unwavering Faith",  -- Level 83
-            "Armor of Implacable Faith",  -- Level 88
-            "Armor of Formidable Faith",  -- Level 93
-            "Armor of Formidable Grace",  -- Level 98
-            "Armor of Formidable Spirit", -- Level 103
-            "Armor of Steadfast Faith",   -- Level 108
-            "Armor of Steadfast Grace",   -- Level 113
+            "Armor of Heroic Faith",      -- Level 123
             "Armor of Unyielding Grace",  -- Level 118
-            "Armor of Heroic Faith",      -- Level 118
+            "Armor of Steadfast Grace",   -- Level 113
+            "Armor of Steadfast Faith",   -- Level 108
+            "Armor of Formidable Spirit", -- Level 103
+            "Armor of Formidable Grace",  -- Level 98
+            "Armor of Formidable Faith",  -- Level 93
+            "Armor of Implacable Faith",  -- Level 88
+            "Armor of Unwavering Faith",  -- Level 83
+            "Armor of Inexorable Faith",  -- Level 78
+            "Armor of Unrelenting Faith", -- Level 73
+            "Armor of the Champion",      -- Level 69
+            "Aura of the Crusader",       -- Level 64
         },
         ['RighteousStrike'] = {
-            "Righteous Indignation VIII",
-            "Righteous Antipathy",
-            "Righteous Fury",
-            "Righteous Indignation",
-            "Righteous Vexation",
-            "Righteous Umbrage",
-            "Righteous Condemnation",
-            "Righteous Antipathy",
-            "Righteous Censure",
-            "Righteous Disdain",
+            "Righteous Indignation VIII", -- Level 126
+            "Righteous Disdain",          -- Level 121
+            "Righteous Censure",          -- Level 118
+            "Righteous Antipathy",        -- Level 113
+            "Righteous Antipathy",        -- Level 113
+            "Righteous Condemnation",     -- Level 108
+            "Righteous Umbrage",          -- Level 98
+            "Righteous Vexation",         -- Level 93
+            "Righteous Indignation",      -- Level 88
+            "Righteous Fury",             -- Level 80
         },
         ['Symbol'] = {
-            "Symbol of Liako",
-            "Symbol of Jeneca",
-            "Symbol of Jyleel",
-            "Symbol of Erillion",
-            "Symbol of Burim",
-            "Symbol of Niparson",
-            "Symbol of Teralov",
-            "Symbol of Sevalak",
-            "Symbol of Bthur",
-            "Symbol of Jeron",
-            "Symbol of Marzin",
-            "Symbol of Naltron",
-            "Symbol of Pinzarn",
-            "Symbol of Ryltan",
-            "Symbol of Transal",
-            "Symbol of Sevalak",
-            "Symbol of Thormir",
+            "Symbol of Thormir",              -- Level 122
+            "Symbol of Liako",                -- Level 117
+            "Symbol of Sevalak",              -- Level 112
+            "Symbol of Sevalak",              -- Level 112
+            "Symbol of Teralov",              -- Level 107
+            "Symbol of Niparson",             -- Level 102
+            "Symbol of Burim",                -- Level 97
+            "Symbol of Erillion",             -- Level 92
+            "Symbol of Jyleel",               -- Level 87
+            "Symbol of Jeneca",               -- Level 82
+            "Symbol of Bthur",                -- Level 77
+            "Symbol of Jeron",                -- Level 67
+            "Symbol of Marzin",               -- Level 63
+            "Symbol of Naltron",              -- Level 58
+            "Symbol of Pinzarn",              -- Level 46
+            "Symbol of Ryltan",               -- Level 33
+            "Symbol of Transal",              -- Level 24
         },
         ['StunTimer6'] = {                    -- Timer 6, less damage than timer 6 crush, but inlcudes stun. Has Push.
             "Lesson of Penitence XV",         -- Level 127
-            "Quellious' Word of Tranquility", -- Level 54
-            "Quellious' Word of Serenity",    -- Level 64
-            "Serene Command",                 -- Level 68
-            "Lesson of Penitence",            -- Level 72
-            "Lesson of Contrition",           -- Level 77
-            "Lesson of Compunction",          -- Level 82
-            "Lesson of Repentance",           -- Level 87
-            "Lesson of Remorse",              -- Level 92
-            "Lesson of Sorrow",               -- Level 97
-            "Lesson of Grief",                -- Level 102
-            "Lesson of Expiation",            -- Level 107
-            "Lesson of Propitiation",         -- Level 112
-            "Lesson of Guilt",                -- Level 117
             "Lesson of Remembrance",          -- Level 122
+            "Lesson of Guilt",                -- Level 117
+            "Lesson of Propitiation",         -- Level 112
+            "Lesson of Expiation",            -- Level 107
+            "Lesson of Grief",                -- Level 102
+            "Lesson of Sorrow",               -- Level 97
+            "Lesson of Remorse",              -- Level 92
+            "Lesson of Repentance",           -- Level 87
+            "Lesson of Compunction",          -- Level 82
+            "Lesson of Contrition",           -- Level 77
+            "Lesson of Penitence",            -- Level 72
+            "Serene Command",                 -- Level 68
+            "Quellious' Word of Serenity",    -- Level 64
+            "Quellious' Word of Tranquility", -- Level 54
         },
         ['Audacity'] = {                      -- Magic Resist debuff, Hate over time
-            "Impassioned Audacity",
-            "Fanatical Audacity",
-            "Ardent Audacity",
-            "Fervent Audacity",
-            "Sanctimonious Audacity",
-            "Devout Audacity",
-            "Righteous Audacity",
+            "Impassioned Audacity",           -- Level 127
+            "Fanatical Audacity",             -- Level 122
+            "Ardent Audacity",                -- Level 117
+            "Fervent Audacity",               -- Level 112
+            "Sanctimonious Audacity",         -- Level 107
+            "Devout Audacity",                -- Level 97
+            "Righteous Audacity",             -- Level 92
         },
-        ['LightHeal'] = {      --ToT Heal
-            "Eminent Light",   -- Level 127
-            "Light of Life",   -- Level 52
-            "Light of Nife",   -- Level 63
-            "Light of Order",  -- Level 65
-            "Light of Piety",  -- Level 68
-            "Gleaming Light",  -- Level 72
-            "Radiant Light",   -- Level 77
-            "Shining Light",   -- Level 82
-            "Joyous Light",    -- Level 87
-            "Brilliant Light", -- Level 92
-            "Dazzling Light",  -- Level 97
-            "Blessed Light",   -- Level 102
-            "Merciful Light",  -- Level 107
-            "Sincere Light",   -- Level 112
-            "Raptured Light",  -- Level 117
-            "Avowed Light",    -- Level 122
+        ['LightHeal'] = {                     --ToT Heal
+            "Eminent Light",                  -- Level 127
+            "Avowed Light",                   -- Level 122
+            "Raptured Light",                 -- Level 117
+            "Sincere Light",                  -- Level 112
+            "Merciful Light",                 -- Level 107
+            "Blessed Light",                  -- Level 102
+            "Dazzling Light",                 -- Level 97
+            "Brilliant Light",                -- Level 92
+            "Joyous Light",                   -- Level 87
+            "Shining Light",                  -- Level 82
+            "Radiant Light",                  -- Level 77
+            "Gleaming Light",                 -- Level 72
+            "Light of Piety",                 -- Level 68
+            "Light of Order",                 -- Level 65
+            "Light of Nife",                  -- Level 63
+            "Light of Life",                  -- Level 52
         },
         -- ['Pacify'] = {
-        --     "Assuring Words",
-        --     "Placating Words",
-        --     "Tranquil Words",
-        --     "Propitiate",
-        --     "Mollify",
-        --     "Reconcile",
-        --     "Dulcify",
-        --     "Soothe",
-        --     "Pacify",
-        --     "Calm",
-        --     "Lull",
+        --     "Assuring Words",  -- Level 121
+        --     "Tranquil Words",  -- Level 116
+        --     "Placating Words", -- Level 111
+        --     "Dulcify",         -- Level 101
+        --     "Reconcile",       -- Level 96
+        --     "Mollify",         -- Level 91
+        --     "Propitiate",      -- Level 86
+        --     "Pacify",          -- Level 49
+        --     "Calm",            -- Level 43
+        --     "Soothe",          -- Level 25
+        --     "Lull",            -- Level 10
         -- },
         ['TouchHeal'] = {
-            "Eminent Touch",
-            "Touch of Nife",
-            "Touch of Piety",
-            "Sacred Touch",
-            "Solemn Touch",
-            "Devout Touch",
-            "Earnest Touch",
-            "Zealous Touch",
-            "Reverent Touch",
-            "Ardent Touch",
-            "Merciful Touch",
-            "Sincere Touch",
-            "Soothing Touch",
-            "Avowed Touch",
+            "Eminent Touch",    -- Level 126
+            "Avowed Touch",     -- Level 121
+            "Soothing Touch",   -- Level 116
+            "Sincere Touch",    -- Level 111
+            "Merciful Touch",   -- Level 106
+            "Ardent Touch",     -- Level 101
+            "Reverent Touch",   -- Level 96
+            "Zealous Touch",    -- Level 91
+            "Earnest Touch",    -- Level 86
+            "Devout Touch",     -- Level 81
+            "Solemn Touch",     -- Level 76
+            "Sacred Touch",     -- Level 71
+            "Touch of Piety",   -- Level 66
+            "Touch of Nife",    -- Level 61
             "Superior Healing", -- Level 48
             "Healing",          -- Level 27
             "Light Healing",    -- Level 12
@@ -600,185 +599,174 @@ local _ClassConfig = {
         },
         ['Dicho'] = {
             --- Dissident Stun
-            "Dichotomic Force",
-            "Dissident Force",
-            "Composite Force",
-            "Ecliptic Force",
-            "Reciprocal Force",
+            "Reciprocal Force",         -- Level 121
+            "Ecliptic Force",           -- Level 116
+            "Composite Force",          -- Level 111
+            "Dissident Force",          -- Level 106
+            "Dichotomic Force",         -- Level 101
         },
-        ['PurityCure'] = { --- Purity Cure Poison/Diease Cure Half Power to curse
-            "Mastery: Balanced Purity",
-            "Balanced Purity",
-            "Devoted Purity",
-            "Earnest Purity",
-            "Zealous Purity",
-            "Reverent Purity",
-            "Ardent Purity",
-            "Merciful Purity",
+        ['PurityCure'] = {              --- Purity Cure Poison/Diease Cure Half Power to curse
+            "Mastery: Balanced Purity", -- Level 126
+            "Balanced Purity",          -- Level 116
+            "Merciful Purity",          -- Level 106
+            "Ardent Purity",            -- Level 101
+            "Reverent Purity",          -- Level 96
+            "Zealous Purity",           -- Level 91
+            "Earnest Purity",           -- Level 86
+            "Devoted Purity",           -- Level 81
         },
         -- ['CureCurse'] = {
-        --     "Remove Minor Curse",
-        --     "Remove Lesser Curse",
-        --     "Remove Curse",
-        --     "Remove Greater Curse",
-        --     "Eradicate Curse",
+        --     "Remove Greater Curse", -- Level 60
+        --     "Eradicate Curse",      -- Level 60
+        --     "Remove Curse",         -- Level 45
+        --     "Remove Lesser Curse",  -- Level 34
+        --     "Remove Minor Curse",   -- Level 19
         -- },
         ['CureCorrupt'] = {
-            "Mastery: Consecrate",
-            "Consecrate",
-            "Sanctify",
-            "Depurate",
-            "Expurgate",
-            "Purify",
-            "Cleanse",
-            "Cure Corruption",
+            "Mastery: Consecrate",      -- Level 126
+            "Consecrate",               -- Level 116
+            "Sanctify",                 -- Level 106
+            "Depurate",                 -- Level 101
+            "Expurgate",                -- Level 96
+            "Purify",                   -- Level 91
+            "Cleanse",                  -- Level 86
+            "Cure Corruption",          -- Level 65
         },
-        ['ForHonor'] = { --- Challenge Taunt Over time Debuff
-            "Duel for Honor",
-            "Challenge for Honor",
-            "Trial For Honor",
-            "Charge for Honor",
-            "Confrontation for Honor",
-            "Provocation for Honor",
-            "Demand for Honor",
-            "Impose for Honor",
-            "Refute for Honor",
-            "Protest for Honor",
-            "Parlay for Honor",
-            "Petition for Honor",
+        ['ForHonor'] = {                --- Challenge Taunt Over time Debuff
+            "Duel for Honor",           -- Level 127
+            "Petition for Honor",       -- Level 122
+            "Parlay for Honor",         -- Level 117
+            "Protest for Honor",        -- Level 112
+            "Refute for Honor",         -- Level 107
+            "Impose for Honor",         -- Level 102
+            "Demand for Honor",         -- Level 97
+            "Provocation for Honor",    -- Level 92
+            "Confrontation for Honor",  -- Level 87
+            "Charge for Honor",         -- Level 82
+            "Trial For Honor",          -- Level 77
+            "Challenge for Honor",      -- Level 72
         },
-        ['Piety'] = { -- Spell Resist Buff
-            "Silent Piety",
+        ['Piety'] = {                   -- Spell Resist Buff
+            "Silent Piety",             -- Level 69
         },
-        ['Remorse'] = { -- Killshot buff
-            "Penitence for the Fallen",
-            "Remorse for the Fallen",
+        ['Remorse'] = {                 -- Killshot buff
+            "Penitence for the Fallen", -- Level 120
+            "Remorse for the Fallen",   -- Level 75
         },
         ['HealAura'] = {
-            "Blessed Aura",
-            "Holy Aura",
+            "Blessed Aura", -- Level 70
+            "Holy Aura",    -- Level 55
         },
         ['UndeadNuke'] = {
             "Doctrine of Revocation",  -- Level 128
             "Doctrine of Repudiation", -- Level 121
-            "Ward Undead",             -- Level 14
-            "Expulse Undead",          -- Level 30
-            "Dismiss Undead",          -- Level 46
-            "Expel Undead",            -- Level 54
-            "Deny Undead",             -- Level 62 - Timer 7
-            "Spurn Undead",            -- Level 67 - Timer 7
-            --[] = "Wraithguard's Vengeance",  -- Level 75 - Unobtainable?
-            "Annihilate the Undead",   -- Level 86 - Res Debuff / Extra Damage
-            "Abolish the Undead",      -- Level 91 - Res Debuff / Extra Damage
-            "Doctrine of Abrogation",  -- Level 96
-            "Abrogate the Undead",     -- Level 96 - Res Debuff / Extra Damage
-            "Doctrine of Rescission",  -- Level 101
-            "Doctrine of Exculpation", -- Level 106
-            "Doctrine of Abolishment", -- Level 111
             "Doctrine of Annulment",   -- Level 116
+            "Doctrine of Abolishment", -- Level 111
+            "Doctrine of Exculpation", -- Level 106
+            "Doctrine of Rescission",  -- Level 101
+            "Doctrine of Abrogation",  -- Level 96
+            "Abrogate the Undead",     -- Level 96, - Res Debuff / Extra Damage
+            "Abolish the Undead",      -- Level 91, - Res Debuff / Extra Damage
+            "Annihilate the Undead",   -- Level 86, - Res Debuff / Extra Damage
+            -- "Wraithguard's Vengeance", -- Level 75, - Unobtainable?
+            "Spurn Undead",            -- Level 67, - Timer 7
+            "Deny Undead",             -- Level 62, - Timer 7
+            "Expel Undead",            -- Level 54
+            "Dismiss Undead",          -- Level 46
+            "Expulse Undead",          -- Level 30
+            "Ward Undead",             -- Level 14
         },
         ['AllianceNuke'] = {
-            "Holy Alliance",
-            "Stormwall Coalition",
-            "Aureate Covariance",
+            "Aureate Covariance",  -- Level 125
+            "Stormwall Coalition", -- Level 114
+            "Holy Alliance",       -- Level 104
         },
         ['EndRegen'] = {
             --Timer 13, can't be used in combat
-            "Second Wind",
-            "Third Wind",
-            "Fourth Wind",
-            "Respite",
-            "Reprieve",
-            "Rest",
-            "Breather", --Level 101
+            "Breather", -- Level 101
+            "Rest",     -- Level 96
+            "Reprieve", -- Level 91
+            "Respite",  -- Level 86
         },
         ['CombatEndRegen'] = {
             --Timer 13, can be used in combat.
-            "Hiatus V",
-            "Hiatus", --Level 106
-            "Relax",
-            "Night's Calming",
-            "Convalesce",
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Relax",           -- Level 111
+            "Hiatus",          -- Level 106
         },
         ['MeleeMit'] = {
-            "Impede",
-            -- "Withstand",
-            "Defy",
-            "Renounce",
-            "Reprove",
-            "Repel",
-            "Spurn",
-            "Thwart",
-            "Repudiate",
-            "Gird",
+            "Impede",    -- Level 128
+            "Gird",      -- Level 123
+            "Repudiate", -- Level 118
+            "Thwart",    -- Level 113
+            "Spurn",     -- Level 108
+            "Repel",     -- Level 103
+            "Reprove",   -- Level 98
+            "Renounce",  -- Level 93
+            "Defy",      -- Level 88
+            -- "Withstand", -- Level 83
         },
         ['ArmorDisc'] = {
             --- Armor Timer 11
-            "Armor of Eminence",
-            "Armor of Avowal",
-            "Armor of the Forthright",
-            "Armor of Sincerity",
-            "Armor of Mercy",
-            "Armor of Ardency",
-            "Armor of Reverence",
-            "Armor of Zeal",
-            "Armor of Courage",
+            "Armor of Eminence",       -- Level 128
+            "Armor of Avowal",         -- Level 123
+            "Armor of the Forthright", -- Level 118
+            "Armor of Sincerity",      -- Level 113
+            "Armor of Mercy",          -- Level 108
+            "Armor of Ardency",        -- Level 103
+            "Armor of Reverence",      -- Level 98
+            "Armor of Zeal",           -- Level 93
+            "Armor of Courage",        -- Level 88
         },
         ['Undeadburn'] = {
-            "Holyforge Discipline",
+            "Holyforge Discipline", -- Level 55
         },
         ['Penitent'] = {
             -- Penitent Armor Discipline Timer 11
-            "Avowed Penitence",
-            "Fervent Penitence",
-            "Reverent Penitence",
-            "Devout Penitence",
-            "Merciful Penitence",
-            "Sincere Penitence",
+            "Avowed Penitence",   -- Level 122
+            "Fervent Penitence",  -- Level 117
+            "Sincere Penitence",  -- Level 112
+            "Merciful Penitence", -- Level 107
+            "Devout Penitence",   -- Level 102
+            "Reverent Penitence", -- Level 97
         },
         ['Mantle'] = {
-            "Mantle of Eminence",
-            "Supernal Mantle",
-            "Mantle of the Sapphire Cohort",
-            "Kar`Zok Mantle",
-            "Skalber Mantle",
-            "Brightwing Mantle",
-            "Prominent Mantle",
-            "Exalted Mantle",
-            "Honorific Mantle",
-            "Armor of Decorum",
-            "Armor of Righteousness",
-            "Guard of Righteousness",
-            "Guard of Humility",
-            "Guard of Piety",
+            "Mantle of Eminence",            -- Level 128
+            "Supernal Mantle",               -- Level 118
+            "Mantle of the Sapphire Cohort", -- Level 113
+            "Kar`Zok Mantle",                -- Level 108
+            "Skalber Mantle",                -- Level 103
+            "Brightwing Mantle",             -- Level 98
+            "Prominent Mantle",              -- Level 93
+            "Exalted Mantle",                -- Level 88
+            "Honorific Mantle",              -- Level 83
+            "Armor of Decorum",              -- Level 78
+            "Armor of Righteousness",        -- Level 73
+            "Guard of Righteousness",        -- Level 69
+            "Guard of Humility",             -- Level 61
+            "Guard of Piety",                -- Level 56
         },
         ['Guardian'] = {
-            "Holy Guardian Discipline IV",
-            "Revered Guardian Discipline",
-            "Blessed Guardian Discipline",
-            "Holy Guardian Discipline",
+            "Holy Guardian Discipline IV", -- Level 127
+            "Revered Guardian Discipline", -- Level 117
+            "Blessed Guardian Discipline", -- Level 107
+            "Holy Guardian Discipline",    -- Level 97
         },
         ['Spellblock'] = {
-            "Sanctification Discipline",
+            "Sanctification Discipline", -- Level 60
         },
         ['Deflection'] = {
-            'Deflection Discipline',
         },
         ['ReflexStrike'] = {
             --- Reflexive Strike Heal
-            "Reflexive Resolution",
-            "Reflexive Redemption",
-            "Reflexive Righteousness",
-            "Reflexive Reverence",
+            "Reflexive Resolution",    -- Level 121
+            "Reflexive Redemption",    -- Level 111
+            "Reflexive Reverence",     -- Level 105
+            "Reflexive Righteousness", -- Level 100
         },
         ['RezSpell'] = {
-            'Resurrection',
-            'Restoration',
-            'Renewal',
-            'Revive',
-            'Reparation',
-            'Reconstitution',
-            'Reanimation',
         },
     },
     ['AASets']            = {

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -283,556 +283,553 @@ local _ClassConfig = {
     },
     ['AbilitySets']       = {
         ['ArrowOpener'] = {
-            "Concealed Shot",
-            "Stealthy Shot",
-            "Silent Shot",
+            "Concealed Shot", -- Level 125
+            "Stealthy Shot",  -- Level 111
+            "Silent Shot",    -- Level 103
         },
         ['PullOpener'] = {
-            "Deadfall",
-            "Heartpierce",
-            "Heartrend",
-            "Heartrip",
-            "Heartspike",
+            "Heartspike",  -- Level 98
+            "Heartrip",    -- Level 93
+            "Heartrend",   -- Level 88
+            "Heartpierce", -- Level 83
+            "Deadfall",    -- Level 78
         },
         ['CalledShotsArrow'] = {
-            "Called Shots IX",
-            "Called Shots",
-            "Announced Shots",
-            "Forecasted Shots",
-            "Anticipated Shots",
-            "Foreseen Shots",
-            "Marked Shots",
-            "Claimed Shots",
-            "Inevitable Shots",
+            "Called Shots IX",   -- Level 126
+            "Inevitable Shots",  -- Level 121
+            "Claimed Shots",     -- Level 116
+            "Marked Shots",      -- Level 111
+            "Foreseen Shots",    -- Level 106
+            "Anticipated Shots", -- Level 101
+            "Forecasted Shots",  -- Level 96
+            "Announced Shots",   -- Level 91
+            "Called Shots",      -- Level 86
         },
         ['FocusedArrows'] = {
-            "Focused Hail of Arrows XII",
-            "Focused Frenzy of Arrows",
-            "Focused Storm of Arrows",
-            "Focused Tempest of Arrows",
-            "Focused Arrow Swarm",
-            "Focused Rain of Arrows",
-            "Focused Arrowrain",
-            "Focused Arrowgale",
-            "Focused Blizzard of Arrows",
-            "Focused Whirlwind of Arrows",
+            "Focused Hail of Arrows XII",  -- Level 130
+            "Focused Frenzy of Arrows",    -- Level 125
+            "Focused Whirlwind of Arrows", -- Level 120
+            "Focused Blizzard of Arrows",  -- Level 115
+            "Focused Arrowgale",           -- Level 110
+            "Focused Arrowrain",           -- Level 105
+            "Focused Rain of Arrows",      -- Level 100
+            "Focused Arrow Swarm",         -- Level 95
+            "Focused Tempest of Arrows",   -- Level 90
+            "Focused Storm of Arrows",     -- Level 85
         },
         ['DichoSpell'] = {
-            "Dichotomic Fusillade",
-            "Dissident Fusillade",
-            "Composite Fusillade",
-            "Ecliptic Fusillade",
-            "Reciprocal Fusillade",
+            "Reciprocal Fusillade", -- Level 121
+            "Ecliptic Fusillade",   -- Level 116
+            "Composite Fusillade",  -- Level 111
+            "Dissident Fusillade",  -- Level 106
+            "Dichotomic Fusillade", -- Level 101
         },
         ['SummerNuke'] = {
-            "Summer's Dew XII",
-            "Summer's Deluge",
-            "Summer's Torrent",
-            "Summer's Viridity",
-            "Summer's Mist",
-            "Summer's Storm",
-            "Summer's Squall",
-            "Summer's Gale",
-            "Summer's Cyclone",
-            "Summer's Tempest",
-            "Summer's Sleet",
+            "Summer's Dew XII",  -- Level 129
+            "Summer's Deluge",   -- Level 124
+            "Summer's Torrent",  -- Level 119
+            "Summer's Sleet",    -- Level 114
+            "Summer's Tempest",  -- Level 109
+            "Summer's Cyclone",  -- Level 104
+            "Summer's Gale",     -- Level 99
+            "Summer's Squall",   -- Level 94
+            "Summer's Storm",    -- Level 89
+            "Summer's Mist",     -- Level 84
+            "Summer's Viridity", -- Level 79
         },
         ['SwarmDot'] = {
-            "Spitestinger Swarm",
-            "Stinging Swarm",
-            "Swarm of Pain",
-            "Drones of Doom",
-            "Fire Swarm",
-            "Drifting Death",
-            "Locust Swarm",
-            "Wasp Swarm",
-            "Hornet Swarm",
-            "Beetle Swarm",
-            "Scarab Swarm",
-            "Vespid Swarm",
-            "Dreadbeetle Swarm",
-            "Blisterbeetle Swarm",
-            "Bonecrawler Swarm",
-            "Ice Burrower Swarm",
-            "Bloodbeetle Swarm",
-            "Hotaria Swarm",
+            "Spitestinger Swarm",  -- Level 126
+            "Hotaria Swarm",       -- Level 121
+            "Bloodbeetle Swarm",   -- Level 116
+            "Ice Burrower Swarm",  -- Level 111
+            "Bonecrawler Swarm",   -- Level 106
+            "Blisterbeetle Swarm", -- Level 101
+            "Dreadbeetle Swarm",   -- Level 96
+            "Vespid Swarm",        -- Level 91
+            "Scarab Swarm",        -- Level 86
+            "Beetle Swarm",        -- Level 81
+            "Hornet Swarm",        -- Level 76
+            "Wasp Swarm",          -- Level 71
+            "Locust Swarm",        -- Level 67
+            "Drifting Death",      -- Level 62
+            "Fire Swarm",          -- Level 55
+            "Drones of Doom",      -- Level 54
+            "Swarm of Pain",       -- Level 40
+            "Stinging Swarm",      -- Level 25
         },
         ['ShortSwarmDot'] = {
-            "Swarm of Spitemidges",
-            "Swarm of Fernflies",
-            "Swarm of Bloodflies",
-            "Swarm of Hyperboreads",
-            "Swarm of Glistenwings",
-            "Swarm of Vespines",
-            "Swarm of Sand Wasps",
-            "Swarm of Hornets",
-            "Swarm of Bees",
+            "Swarm of Spitemidges",  -- Level 128
+            "Swarm of Fernflies",    -- Level 123
+            "Swarm of Bloodflies",   -- Level 118
+            "Swarm of Hyperboreads", -- Level 113
+            "Swarm of Glistenwings", -- Level 103
+            "Swarm of Vespines",     -- Level 98
+            "Swarm of Sand Wasps",   -- Level 93
+            "Swarm of Hornets",      -- Level 88
+            "Swarm of Bees",         -- Level 83
         },
         ['UnityBuff'] = {
-            "Bosquetender's Unity",
-            "Copsestalker's Unity",
-            "Wildstalker's Unity",
+            "Wildstalker's Unity",  -- Level 110
+            "Copsestalker's Unity", -- Level 105
+            "Bosquetender's Unity", -- Level 100
         },
         ['Protectionbuff'] = {
-            "Protection of the Grove",
-            "Force of Nature",
-            "Warder's Protection",
-            "Protection of the Wild",
-            "Protection of the Minohten",
-            "Protection of the Kirkoten",
-            "Protection of the Paw",
-            "Protection of the Vale",
-            "Protection of the Copse",
-            "Protection of the Bosque",
-            "Protection of the Forest",
-            "Protection of the Woodlands",
-            "Protection of the Wakening Land",
-            "Protection of the Valley",
+            "Protection of the Grove",         -- Level 130
+            "Protection of the Valley",        -- Level 120
+            "Protection of the Wakening Land", -- Level 115
+            "Protection of the Woodlands",     -- Level 110
+            "Protection of the Forest",        -- Level 105
+            "Protection of the Bosque",        -- Level 100
+            "Protection of the Copse",         -- Level 95
+            "Protection of the Vale",          -- Level 90
+            "Protection of the Paw",           -- Level 85
+            "Protection of the Kirkoten",      -- Level 80
+            "Protection of the Minohten",      -- Level 75
+            "Protection of the Wild",          -- Level 65
+            "Warder's Protection",             -- Level 60
+            "Force of Nature",                 -- Level 48
         },
         ['ShoutBuff'] = {
-            "Shout of the Grovestalker",
-            "Shout of the Fernstalker",
-            "Shout of the Predator",
-            "Shout of the Bosquestalker",
-            "Shout of the Copsestalker",
-            "Shout of the Wildstalker",
-            "Shout of the Arbor Stalker",
-            "Shout of the Dusksage Stalker",
+            "Shout of the Grovestalker",     -- Level 129
+            "Shout of the Fernstalker",      -- Level 124
+            "Shout of the Dusksage Stalker", -- Level 119
+            "Shout of the Arbor Stalker",    -- Level 114
+            "Shout of the Wildstalker",      -- Level 109
+            "Shout of the Copsestalker",     -- Level 104
+            "Shout of the Bosquestalker",    -- Level 100
+            "Shout of the Predator",         -- Level 98
         },
         ['AggroBuff'] = {
-            "Devastating Blades XII",
-            "Devastating Blades",
-            "Devastating Edges",
-            "Devastating Slashes",
-            "Devastating Impact",
-            "Devastating Swords",
-            "Devastating Steel",
-            "Devastating Velium",
-            "Devastating Barrage",
+            "Devastating Blades XII", -- Level 129
+            "Devastating Barrage",    -- Level 119
+            "Devastating Velium",     -- Level 114
+            "Devastating Steel",      -- Level 109
+            "Devastating Swords",     -- Level 104
+            "Devastating Impact",     -- Level 99
+            "Devastating Slashes",    -- Level 94
+            "Devastating Edges",      -- Level 89
+            "Devastating Blades",     -- Level 84
         },
         ['AggroReducerBuff'] = {
-            "Jolting Blades",
-            "Jolting Strikes",
-            "Jolting Swings",
-            "Jolting Edges",
-            "Jolting Impact",
-            "Jolting Shock",
-            "Jolting Swords",
-            "Jolting Steel",
-            "Jolting Velium",
-            "Jolting Luclinite",
+            "Jolting Luclinite", -- Level 117
+            "Jolting Velium",    -- Level 112
+            "Jolting Steel",     -- Level 107
+            "Jolting Swords",    -- Level 102
+            "Jolting Shock",     -- Level 97
+            "Jolting Impact",    -- Level 92
+            "Jolting Edges",     -- Level 87
+            "Jolting Swings",    -- Level 82
+            "Jolting Strikes",   -- Level 77
+            "Jolting Blades",    -- Level 54
         },
         ['AggroKick'] = {
-            "Enraging Kicks XII",
-            "Enraging Roundhouse Kicks",
-            "Enraging Axe Kicks",
-            "Enraging Wheel Kicks",
-            "Enraging Cut Kicks",
-            "Enraging Heel Kicks",
-            "Enraging Crescent Kicks",
+            "Enraging Kicks XII",        -- Level 127
+            "Enraging Roundhouse Kicks", -- Level 117
+            "Enraging Axe Kicks",        -- Level 112
+            "Enraging Wheel Kicks",      -- Level 107
+            "Enraging Cut Kicks",        -- Level 102
+            "Enraging Heel Kicks",       -- Level 97
+            "Enraging Crescent Kicks",   -- Level 92
         },
         ['ParryProcBuff'] = {
-            "Thundering Blades",
-            "Crackling Blades",
-            "Crackling Edges",
-            "Deafening Edges",
-            "Deafening Weapons",
-            "Roaring Weapons",
-            "Roaring Blades",
-            "Howling Blades",
-            "Vociferous Blades",
+            "Vociferous Blades", -- Level 120
+            "Howling Blades",    -- Level 115
+            "Roaring Blades",    -- Level 110
+            "Roaring Weapons",   -- Level 105
+            "Deafening Weapons", -- Level 100
+            "Deafening Edges",   -- Level 95
+            "Crackling Edges",   -- Level 90
+            "Crackling Blades",  -- Level 85
+            "Thundering Blades", -- Level 75
         },
         ['Eyes'] = {
-            "Eyes of the Grove",
-            "Hawk Eye",
-            "Falcon Eye",
-            "Eagle Eye",
-            "Eyes of the Owl",
-            "Eyes of the Peregrine",
-            "Eyes of the Nocturnal",
-            "Eyes of the Wolf",
-            "Eyes of the Raptor",
-            "Eyes of the Howler",
-            "Eyes of the Harrier",
-            "Eyes of the Sabertooth",
-            "Eyes of the Visionary",
-            "Eyes of the Senshali",
-            "Eyes of the Phoenix",
+            "Eyes of the Grove",      -- Level 130
+            "Eyes of the Phoenix",    -- Level 124
+            "Eyes of the Senshali",   -- Level 119
+            "Eyes of the Visionary",  -- Level 114
+            "Eyes of the Sabertooth", -- Level 109
+            "Eyes of the Harrier",    -- Level 104
+            "Eyes of the Howler",     -- Level 99
+            "Eyes of the Raptor",     -- Level 94
+            "Eyes of the Wolf",       -- Level 89
+            "Eyes of the Nocturnal",  -- Level 84
+            "Eyes of the Peregrine",  -- Level 79
+            "Eyes of the Owl",        -- Level 74
+            "Eagle Eye",              -- Level 58
+            "Falcon Eye",             -- Level 52
+            "Hawk Eye",               -- Level 11
         },
         ['GroupStrengthBuff'] = {
-            "Strength of the Grovestalker",
-            "Nature's Precision",
-            "Strength of Nature",
-            "Strength of Tunare",
-            "Strength of the Hunter",
-            "Strength of the Forest Stalker",
-            "Strength of the Gladewalker",
-            "Strength of the Tracker",
-            "Strength of the Thicket Stalker",
-            "Strength of the Gladetender",
-            "Strength of the Bosquestalker",
-            "Strength of the Copsestalker",
-            "Strength of the Wildstalker",
-            "Strength of the Arbor Stalker",
+            "Strength of the Grovestalker",    -- Level 127
+            "Strength of the Arbor Stalker",   -- Level 112
+            "Strength of the Wildstalker",     -- Level 107
+            "Strength of the Copsestalker",    -- Level 102
+            "Strength of the Bosquestalker",   -- Level 97
+            "Strength of the Gladetender",     -- Level 92
+            "Strength of the Thicket Stalker", -- Level 87
+            "Strength of the Tracker",         -- Level 82
+            "Strength of the Gladewalker",     -- Level 77
+            "Strength of the Forest Stalker",  -- Level 72
+            "Strength of the Hunter",          -- Level 67
+            "Strength of Tunare",              -- Level 62
+            "Strength of Nature",              -- Level 51
+            "Nature's Precision",              -- Level 37
         },
         ['GroupPredatorBuff'] = {
-            "Call of the Predator XVI",
-            "Mark of the Predator",
-            "Call of the Predator",
-            "Spirit of the Predator",
-            "Howl of the Predator",
-            "Snarl of the Predator",
-            "Gnarl of the Predator",
-            "Yowl of the Predator",
-            "Roar of the Predator",
-            "Cry of the Predator",
-            "Shout of the Predator",
-            "Shout of the Bosquestalker",
-            "Bellow of the Predator",
-            "Wail of the Predator",
-            "Frostroar of the Predator",
-            "Shout of the Dusksage Stalker",
-            "Shout of the Fernstalker",
+            "Call of the Predator XVI",      -- Level 127
+            "Shout of the Fernstalker",      -- Level 124
+            "Shout of the Dusksage Stalker", -- Level 119
+            "Frostroar of the Predator",     -- Level 112
+            "Wail of the Predator",          -- Level 107
+            "Bellow of the Predator",        -- Level 102
+            "Shout of the Bosquestalker",    -- Level 100
+            "Shout of the Predator",         -- Level 98
+            "Cry of the Predator",           -- Level 93
+            "Roar of the Predator",          -- Level 88
+            "Yowl of the Predator",          -- Level 83
+            "Gnarl of the Predator",         -- Level 78
+            "Snarl of the Predator",         -- Level 73
+            "Howl of the Predator",          -- Level 69
+            "Spirit of the Predator",        -- Level 64
+            "Call of the Predator",          -- Level 60
+            "Mark of the Predator",          -- Level 56
         },
         ['GroupEnrichmentBuff'] = {
-            "Arbor Stalker's Enrichment",
-            "Copsestalker's Enrichment",
-            "Wildstalker's Enrichment",
-            "Fernstalker's Enrichment",
+            "Fernstalker's Enrichment",   -- Level 125
+            "Arbor Stalker's Enrichment", -- Level 115
+            "Wildstalker's Enrichment",   -- Level 110
+            "Copsestalker's Enrichment",  -- Level 105
         },
         ['Rathe'] = {
-            "Cloak of Underbrush",
-            "Cloak of Needlespikes",
-            "Cloak of Bloodbarbs",
-            "Cloak of Rimespurs",
-            "Cloak of Needlebarbs",
-            "Cloak of Nettlespears",
-            "Cloak of Spurs",
-            "Cloak of Burrs",
-            "Cloak of Quills",
-            "Cloak of Feathers",
-            "Cloak of Scales",
-            "Guard of the Earth",
-            "Call of the Rathe",
-            "Call of Earth",
-            "Riftwind's Protection",
+            "Cloak of Underbrush",   -- Level 127
+            "Cloak of Needlespikes", -- Level 122
+            "Cloak of Bloodbarbs",   -- Level 117
+            "Cloak of Rimespurs",    -- Level 112
+            "Cloak of Needlebarbs",  -- Level 107
+            "Cloak of Nettlespears", -- Level 102
+            "Cloak of Spurs",        -- Level 97
+            "Cloak of Burrs",        -- Level 92
+            "Cloak of Quills",       -- Level 87
+            "Cloak of Feathers",     -- Level 82
+            "Cloak of Scales",       -- Level 77
+            "Guard of the Earth",    -- Level 67
+            "Call of the Rathe",     -- Level 62
+            "Call of Earth",         -- Level 50
+            "Riftwind's Protection", -- Level 29
         },
         ['BowDisc'] = {
-            "Trueshot Discipline",
-            "Aimshot Discipline",
-            "Sureshot Discipline",
-            "Pureshot Discipline",
+            "Pureshot Discipline", -- Level 100
+            "Sureshot Discipline", -- Level 85
+            "Aimshot Discipline",  -- Level 80
+            "Trueshot Discipline", -- Level 55
         },
         ['MeleeDisc'] = {
-            "Grovestalker's Discipline",
-            "Fernstalker's Discipline",
-            "Dusksage Stalker's Discipline",
-            "Bosquestalker's Discipline",
-            "Copsestalker's Discipline",
-            "Wildstalker's Discipline",
-            "Arbor Stalker's Discipline",
+            "Grovestalker's Discipline",     -- Level 130
+            "Fernstalker's Discipline",      -- Level 125
+            "Dusksage Stalker's Discipline", -- Level 120
+            "Arbor Stalker's Discipline",    -- Level 115
+            "Wildstalker's Discipline",      -- Level 110
+            "Copsestalker's Discipline",     -- Level 105
+            "Bosquestalker's Discipline",    -- Level 100
         },
         ['DefenseDisc'] = {
-            "Weapon Shield Discipline",
+            "Weapon Shield Discipline", -- Level 60
         },
         ['Fireboon'] = {
-            "Fernflash Boon",
-            "Lunarflare Boon",
-            "Pyroclastic Boon",
-            "Skyfire Boon",
-            "Wildfire Boon",
-            "Ashcloud Boon",
+            "Fernflash Boon",   -- Level 123
+            "Lunarflare Boon",  -- Level 118
+            "Pyroclastic Boon", -- Level 113
+            "Skyfire Boon",     -- Level 108
+            "Wildfire Boon",    -- Level 103
+            "Ashcloud Boon",    -- Level 98
         },
         ['Firenuke'] = {
-            "Volcanic Ash XVIII",
-            "Flame Lick",
-            "Burst of Fire",
-            "Ignite",
-            "Flaming Arrow",
-            "Burning Arrow",
-            "Call of Flame",
-            "FireStrike",
-            "Brushfire",
-            "Sylvan Burn",
-            "Ancient: Burning Chaos",
-            "Hearth Embers",
-            "Scorched Earth",
-            "Volcanic Ash",
-            "Galvanic Ash",
-            "Cataclysm Ash",
-            "Burning Ash",
-            "Beastwood Ash",
-            "Vileoak Ash",
-            "Wildfire Ash",
-            "Skyfire Ash",
-            "Pyroclastic Ash",
-            "Lunarflare Ash",
+            "Volcanic Ash XVIII",     -- Level 128
+            "Lunarflare Ash",         -- Level 118
+            "Pyroclastic Ash",        -- Level 113
+            "Skyfire Ash",            -- Level 108
+            "Wildfire Ash",           -- Level 103
+            "Vileoak Ash",            -- Level 98
+            "Beastwood Ash",          -- Level 93
+            "Burning Ash",            -- Level 88
+            "Cataclysm Ash",          -- Level 83
+            "Galvanic Ash",           -- Level 78
+            "Volcanic Ash",           -- Level 73
+            "Scorched Earth",         -- Level 70
+            "Hearth Embers",          -- Level 69
+            "Sylvan Burn",            -- Level 65
+            "Ancient: Burning Chaos", -- Level 65
+            "Brushfire",              -- Level 64
+            "FireStrike",             -- Level 52
+            "Call of Flame",          -- Level 49
+            "Burning Arrow",          -- Level 39
+            "Flaming Arrow",          -- Level 29
+            "Ignite",                 -- Level 19
+            "Burst of Fire",          -- Level 14
+            "Flame Lick",             -- Level 3
         },
         ['Iceboon'] = {
-            "Frostsquall Boon",
-            "Nocturnal Boon",
-            "Mistral Boon",
-            "Windshear Boon",
-            "Windgale Boon",
-            "Windblast Boon",
+            "Frostsquall Boon", -- Level 122
+            "Nocturnal Boon",   -- Level 117
+            "Mistral Boon",     -- Level 112
+            "Windshear Boon",   -- Level 107
+            "Windgale Boon",    -- Level 102
+            "Windblast Boon",   -- Level 97
         },
         ['Icenuke'] = {
-            "Frozen Wind XVIII",
-            "Gelid Wind",
-            "Coagulated Wind",
-            "Restless Wind",
-            "Frigid Wind",
-            "Frozen Wind", -- lvl 102. Spell ID: 43478
-            "Bitter Wind",
-            "Biting Wind",
-            "Windwhip Bite",
-            "Rimefall Bite",
-            "Icefall Chill",
-            "Ancient North Wind",
-            "Frost Wind",
-            "Frozen Wind", -- lvl 63. Spell ID: 3418
-            "Icewind",
+            "Frozen Wind XVIII",   -- Level 127
+            "Gelid Wind",          -- Level 122
+            "Coagulated Wind",     -- Level 117
+            "Restless Wind",       -- Level 112
+            "Frigid Wind",         -- Level 107
+            "Bitter Wind",         -- Level 97
+            "Biting Wind",         -- Level 87
+            "Windwhip Bite",       -- Level 82
+            "Rimefall Bite",       -- Level 77
+            "Icefall Chill",       -- Level 72
+            "Ancient: North Wind", -- Level 70
+            "Frost Wind",          -- Level 68
+            "Frozen Wind",         -- Level 63, lvl 102. Spell ID: 43478
+            "Frozen Wind",         -- Level 63, lvl 63. Spell ID: 3418
+            "Icewind",             -- Level 52
         },
         ['Heartshot'] = {
-            "Heartshot",
-            "Heartsting",
-            "Heartsting",
-            "Heartslice",
-            "Heartslash",
-            "Heartsplit",
-            "Heartcleave",
-            "Heartsunder",
-            "Heartruin",
+            "Heartruin",   -- Level 120
+            "Heartsunder", -- Level 115
+            "Heartcleave", -- Level 110
+            "Heartsplit",  -- Level 105
+            "Heartslash",  -- Level 95
+            "Heartslice",  -- Level 90
+            "Heartsting",  -- Level 80
+            "Heartsting",  -- Level 80
+            "Heartshot",   -- Level 75
         },
         ['EndRegenDisc'] = {
-            "Hiatus V",
-            "Second Wind",
-            "Third Wind",
-            "Fourth Wind",
-            "Respite",
-            "Reprieve",
-            "Rest",
-            "Breather",
-            "Hiatus",
-            "Relax",
-            "Night's Calming",
-            "Convalesce",
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Relax",           -- Level 111
+            "Hiatus",          -- Level 106
+            "Breather",        -- Level 101
+            "Rest",            -- Level 96
+            "Reprieve",        -- Level 91
+            "Respite",         -- Level 86
         },
         ['Coat'] = {
-            "Underbrush Coat",
-            "Thistlecoat",
-            "Barbcoat",
-            "Bramblecoat",
-            "Spikecoat",
-            "Thorncoat",
-            "Bladecoat",
-            "Briarcoat",
-            "Spinecoat",
-            "Quillcoat",
-            "Burrcoat",
-            "Spurcoat",
-            "Nettlespear Coat",
-            "Needlebarb Coat",
-            "Rimespur Coat",
-            "Moonthorn Coat",
-            "Needlespike Coat",
+            "Underbrush Coat",  -- Level 128
+            "Needlespike Coat", -- Level 123
+            "Moonthorn Coat",   -- Level 118
+            "Rimespur Coat",    -- Level 113
+            "Needlebarb Coat",  -- Level 108
+            "Nettlespear Coat", -- Level 103
+            "Spurcoat",         -- Level 98
+            "Burrcoat",         -- Level 93
+            "Quillcoat",        -- Level 88
+            "Spinecoat",        -- Level 83
+            "Briarcoat",        -- Level 68
+            "Bladecoat",        -- Level 63
+            "Thorncoat",        -- Level 60
+            "Spikecoat",        -- Level 42
+            "Bramblecoat",      -- Level 34
+            "Barbcoat",         -- Level 30
+            "Thistlecoat",      -- Level 13
         },
         ['Mask'] = {
-            "Mask of the Stalker",
+            "Mask of the Stalker", -- Level 65
         },
         ['Hunt'] = {
-            "Consumed by the Hunt X",
-            "Engulfed by the Hunt",
-            "Steeled by the Hunt",
-            "Provoked by the Hunt",
-            "Spurred by the Hunt",
-            "Energized by the Hunt",
-            "Inspired by the Hunt",
-            "Galvanized by the Hunt",
-            "Invigorated by the Hunt",
-            "Consumed by the Hunt",
+            "Consumed by the Hunt X",  -- Level 130
+            "Engulfed by the Hunt",    -- Level 125
+            "Steeled by the Hunt",     -- Level 120
+            "Provoked by the Hunt",    -- Level 115
+            "Spurred by the Hunt",     -- Level 110
+            "Energized by the Hunt",   -- Level 105
+            "Inspired by the Hunt",    -- Level 100
+            "Galvanized by the Hunt",  -- Level 95
+            "Invigorated by the Hunt", -- Level 90
+            "Consumed by the Hunt",    -- Level 75
         },
         ['Heal'] = {
-            "Lifespring",
-            "Elizerain Spring",
-            "Darkflow Spring",
-            "Meltwater Spring",
-            "Wellspring",
-            "Cloudfont",
-            "Cloudburst",
-            "Purespring",
-            "Purefont",
-            "Oceangreen Aquifer",
-            "Dragonscale Aquifer",
-            "Sunderock Springwater",
-            "Sylvan Water",
-            "Sylvan Light",
-            "Chloroblast",
-            "Greater Healing",
-            "Light Healing",
-            "Healing",
-            "Minor Healing",
-            "Salve",
+            "Lifespring",            -- Level 126
+            "Elizerain Spring",      -- Level 121
+            "Darkflow Spring",       -- Level 116
+            "Meltwater Spring",      -- Level 111
+            "Wellspring",            -- Level 106
+            "Cloudfont",             -- Level 101
+            "Cloudburst",            -- Level 96
+            "Purespring",            -- Level 91
+            "Purefont",              -- Level 86
+            "Oceangreen Aquifer",    -- Level 81
+            "Dragonscale Aquifer",   -- Level 76
+            "Sunderock Springwater", -- Level 71
+            "Sylvan Water",          -- Level 67
+            "Sylvan Light",          -- Level 65
+            "Chloroblast",           -- Level 62
+            "Greater Healing",       -- Level 44
+            "Healing",               -- Level 32
+            "Light Healing",         -- Level 20
+            "Minor Healing",         -- Level 8
+            "Salve",                 -- Level 1
         },
-        ['Fastheal'] = { -- 30s recast. ToT
-            "Desperate Deluge IX",
-            "Desperate Quenching",
-            "Desperate Geyser",
-            "Desperate Meltwater",
-            "Desperate Dewcloud",
-            "Desperate Dousing",
-            "Desperate Drenching",
-            "Desperate Downpour",
-            "Desperate Deluge", -- lvl 89
+        ['Fastheal'] = {             -- 30s recast. ToT
+            "Desperate Deluge IX",   -- Level 129
+            "Desperate Quenching",   -- Level 124
+            "Desperate Geyser",      -- Level 119
+            "Desperate Meltwater",   -- Level 114
+            "Desperate Dewcloud",    -- Level 109
+            "Desperate Dousing",     -- Level 104
+            "Desperate Drenching",   -- Level 99
+            "Desperate Downpour",    -- Level 94
+            "Desperate Deluge",      -- Level 89, lvl 89
         },
         ['Totheal'] = {
-            "Lifespring",
-            "Elizerain Spring",
-            "Darkflow Spring",
-            "Meltwater Spring", -- lvl 111
-            "Wellspring",
-            "Cloundfont",
-            "Cloudburst",
+            "Lifespring",       -- Level 126
+            "Elizerain Spring", -- Level 121
+            "Darkflow Spring",  -- Level 116
+            "Meltwater Spring", -- Level 111, lvl 111
+            "Wellspring",       -- Level 106
+            "Cloudfont",        -- Level 101
+            "Cloudburst",       -- Level 96
         },
         ['RegenSpells'] = {
-            "Grovestalker's Vigor",
-            "Fernstalker's Vigor",
-            "Dusksage Stalker's Vigor",
-            "Arbor Stalker's Vigor",
-            "Wildstalker's Vigor",
-            "Copsestalker's Vigor",
-            "Bosquestalker's Vigor",
-            "Gladewalker's Vigor",
-            "Stalker's Vigor",
-            "Hunter's Vigor",
-            "Regrowth",
-            "Chloroplast",
+            "Grovestalker's Vigor",     -- Level 128
+            "Fernstalker's Vigor",      -- Level 123
+            "Dusksage Stalker's Vigor", -- Level 118
+            "Arbor Stalker's Vigor",    -- Level 113
+            "Wildstalker's Vigor",      -- Level 108
+            "Copsestalker's Vigor",     -- Level 103
+            "Bosquestalker's Vigor",    -- Level 98
+            "Gladewalker's Vigor",      -- Level 93
+            "Stalker's Vigor",          -- Level 88
+            "Hunter's Vigor",           -- Level 68
+            "Regrowth",                 -- Level 64
+            "Chloroplast",              -- Level 55
         },
         ['SnareSpells'] = {
-            "Snare",
-            "Tangling Weeds",
-            "Ensnare",
-            "Earthen Embrace",
-            "Earthen Shackles",
+            "Earthen Shackles", -- Level 69
+            "Earthen Embrace",  -- Level 61
+            "Ensnare",          -- Level 51
+            "Snare",            -- Level 6
+            "Tangling Weeds",   -- Level 5
         },
         ['FireFist'] = {
-            "Nature's Precision",
-            "Wolf Form",
-            "Greater Wolf Form",
-            "Feral Form",
-            "Firefist",
+            "Feral Form",         -- Level 64
+            "Greater Wolf Form",  -- Level 56
+            "Wolf Form",          -- Level 48
+            "Nature's Precision", -- Level 37
+            "Firefist",           -- Level 17
         },
         ['DsBuff'] = {
-            "Shield of Underbrush",
-            "Shield of Thistles",
-            "Shield of Brambles",
-            "Shield of Spikes",
-            "Shield of Thorns",
-            "Shield of Briar",
-            "Shield of Needles",
-            "Shield of Spurs",
-            "Shield of DrySpines",
-            "Shield of Nettlespikes",
-            "Shield of Bramblespikes",
-            "Shield of Nettlespines",
-            "Shield of Nettlespears",
-            "Shield of Needlebarbs",
-            "Shield of Rimespurs",
-            "Shield of Shadethorns",
-            "Shield of Needlespikes",
+            "Shield of Underbrush",    -- Level 126
+            "Shield of Needlespikes",  -- Level 121
+            "Shield of Shadethorns",   -- Level 116
+            "Shield of Rimespurs",     -- Level 111
+            "Shield of Needlebarbs",   -- Level 106
+            "Shield of Nettlespears",  -- Level 101
+            "Shield of Nettlespines",  -- Level 96
+            "Shield of Bramblespikes", -- Level 91
+            "Shield of Nettlespikes",  -- Level 86
+            "Shield of DrySpines",     -- Level 81
+            "Shield of Spurs",         -- Level 76
+            "Shield of Needles",       -- Level 71
+            "Shield of Briar",         -- Level 66
+            "Shield of Thorns",        -- Level 62
+            "Shield of Spikes",        -- Level 58
+            "Shield of Brambles",      -- Level 43
+            "Shield of Thistles",      -- Level 24
         },
         ['SkinLike'] = {
-            "Skin Like Wood",
-            "Skin Like Rock",
-            "Skin Like Steel",
-            "Skin Like Diamond",
-            "Skin Like Nature",
-            "Natureskin",
+            "Natureskin",        -- Level 65
+            "Skin Like Nature",  -- Level 59
+            "Skin Like Diamond", -- Level 54
+            "Skin Like Steel",   -- Level 38
+            "Skin Like Rock",    -- Level 21
+            "Skin Like Wood",    -- Level 7
         },
         ['MoveSpells'] = {
-            "Spirit of Falcons",
-            "Spirit of Eagle",
-            "Pack Shrew",
-            "Spirit of the Shrew",
-            "Spirit of Wolf",
+            "Spirit of Falcons",   -- Level 85
+            "Spirit of Eagle",     -- Level 65
+            "Pack Shrew",          -- Level 49
+            "Spirit of the Shrew", -- Level 41
+            "Spirit of Wolf",      -- Level 28
         },
         ['Alliance'] = {
-            "Bosquestalker's Alliance",
-            "Wildstalker's Covenant",
-            "Arbor Stalker's Coalition",
-            "Dusksage Stalker's Conjunction",
-            "Fernstalker's Covariance",
+            "Fernstalker's Covariance",       -- Level 123
+            "Dusksage Stalker's Conjunction", -- Level 118
+            "Arbor Stalker's Coalition",      -- Level 113
+            "Wildstalker's Covenant",         -- Level 108
+            "Bosquestalker's Alliance",       -- Level 103
         },
         ['Cloak'] = {
-            "Ro's Burning Cloak VI",
-            "Shalowain's Crucible Cloak",
-            "Luclin's Darkfire Cloak",
-            "Outrider's Ever-Burning Cloak",
-            "Lavastorm Cloak",
-            "Ro's Burning Cloak",
+            "Ro's Burning Cloak VI",         -- Level 128
+            "Shalowain's Crucible Cloak",    -- Level 123
+            "Luclin's Darkfire Cloak",       -- Level 117
+            "Outrider's Ever-Burning Cloak", -- Level 112
+            "Lavastorm Cloak",               -- Level 107
+            "Ro's Burning Cloak",            -- Level 97
         },
         ['Veil'] = {
-            "Shadowveil",
-            "Duskveil",
-            "Frostveil",
-            "Vaporous Veil",
-            "Shimmering Veil",
-            "Arbor Veil",
-            "Veil of Alaris",
-            "Nature Veil",
+            "Shadowveil",      -- Level 125
+            "Duskveil",        -- Level 116
+            "Frostveil",       -- Level 111
+            "Vaporous Veil",   -- Level 106
+            "Shimmering Veil", -- Level 101
+            "Arbor Veil",      -- Level 96
+            "Veil of Alaris",  -- Level 91
+            "Nature Veil",     -- Level 66
         },
         ['JoltingKicks'] = {
-            "Jolting Kicks XII",
-            "Jolting Frontkicks",
-            "Jolting Hook Kicks",
-            "Jolting Crescent Kicks",
-            "Jolting Heel Kicks",
-            "Jolting Cut Kicks",
-            "Jolting Wheel Kicks",
-            "Jolting Axe Kicks",
-            "Jolting Roundhouse Kicks",
-            "Jolting Drop Kicks",
-            "Jolting Kicks",
+            "Jolting Kicks XII",        -- Level 127
+            "Jolting Drop Kicks",       -- Level 122
+            "Jolting Roundhouse Kicks", -- Level 117
+            "Jolting Axe Kicks",        -- Level 112
+            "Jolting Wheel Kicks",      -- Level 107
+            "Jolting Cut Kicks",        -- Level 102
+            "Jolting Heel Kicks",       -- Level 97
+            "Jolting Crescent Kicks",   -- Level 92
+            "Jolting Hook Kicks",       -- Level 87
+            "Jolting Frontkicks",       -- Level 82
+            "Jolting Kicks",            -- Level 72
         },
         ['AEBlades'] = {
-            "Storm of Blades VII",
-            "Storm of Blades",
-            "Squall Of Blades",
-            "Gale of Blades",
-            "Blizzard of Blades",
-            "Tempest of Blades",
-            "Maelstrom of Blades",
+            "Storm of Blades VII", -- Level 126
+            "Maelstrom of Blades", -- Level 121
+            "Tempest of Blades",   -- Level 116
+            "Blizzard of Blades",  -- Level 111
+            "Gale of Blades",      -- Level 106
+            "Squall Of Blades",    -- Level 101
+            "Storm of Blades",     -- Level 96
         },
         ['FocusedBlades'] = {
-            "Focused Storm of Blades",
-            "Focused Squall of Blades",
-            "Focused Gale of Blades",
-            "Focused Blizzard of Blades",
-            "Focused Tempest of Blades",
-            "Focused Maelstrom of Blades",
+            "Focused Maelstrom of Blades", -- Level 124
+            "Focused Tempest of Blades",   -- Level 119
+            "Focused Blizzard of Blades",  -- Level 114
+            "Focused Gale of Blades",      -- Level 109
+            "Focused Squall of Blades",    -- Level 103
+            "Focused Storm of Blades",     -- Level 98
         },
         ['ReflexSlashHeal'] = {
-            "Reflexive Bladespurs",
-            "Reflexive Nettlespears",
-            "Reflexive Rimespurs",
-            "Reflexive Needlespikes",
+            "Reflexive Needlespikes", -- Level 121
+            "Reflexive Rimespurs",    -- Level 111
+            "Reflexive Nettlespears", -- Level 105
+            "Reflexive Bladespurs",   -- Level 100
         },
         ['AEArrows'] = {
-            "Frenzy of Arrows",
-            "Whirlwind of Arrows",
-            "Blizzard of Arrows",
-            "Gale of Arrows",
-            "Cyclone of Arrows",
-            "Rain of Arrows",
-            "Squall of Arrows",
-            "Arrow Swarm",
-            "Swarm of Arrows",
-            "Tempest of Arrows",
-            "Fusillade of Arrows",
-            "Storm of Arrows",
-            "Barrage of Arrows",
-            "Arc of Arrows",
-            "Hail of Arrows",
+            "Frenzy of Arrows",    -- Level 124
+            "Whirlwind of Arrows", -- Level 119
+            "Blizzard of Arrows",  -- Level 114
+            "Gale of Arrows",      -- Level 109
+            "Cyclone of Arrows",   -- Level 104
+            "Rain of Arrows",      -- Level 100
+            "Squall of Arrows",    -- Level 99
+            "Arrow Swarm",         -- Level 95
+            "Swarm of Arrows",     -- Level 94
+            "Tempest of Arrows",   -- Level 90
+            "Fusillade of Arrows", -- Level 89
+            "Storm of Arrows",     -- Level 85
+            "Barrage of Arrows",   -- Level 84
+            "Arc of Arrows",       -- Level 79
+            "Hail of Arrows",      -- Level 68
         },
     },
     -- These are handled differently from normal rotations in that we try to make some intelligent decisions about which spells to use instead

--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -48,8 +48,8 @@ return {
     },
     ['AbilitySets']   = {
         ['Reflex'] = {
-            "Conditioned Reflexes",
-            "Practiced Reflexes",
+            "Practiced Reflexes",   -- Level 115
+            "Conditioned Reflexes", -- Level 97
         },
         ['ThiefBuff'] = {
             "Thief's Sight",  -- Level 117
@@ -163,24 +163,24 @@ return {
         },
         ['EndRegen'] = {
             --Timer 13, can't be used in combat
+            "Breather",    -- Level 101
+            "Rest",        -- Level 96
+            "Reprieve",    -- Level 91
+            "Respite",     -- Level 86
+            "Fourth Wind", -- Level 82
+            "Third Wind",  -- Level 77
             "Second Wind", -- Level 72
-            "Third Wind",
-            "Fourth Wind",
-            "Respite",
-            "Reprieve",
-            "Rest",
-            "Breather", --Level 101
         },
         ['CombatEndRegen'] = {
             --Timer 13, can be used in combat.
-            "Hiatus V", --Level 126
-            "Convalesce",
-            "Night's Calming",
-            "Relax",
-            "Hiatus", --Level 106
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Relax",           -- Level 111
+            "Hiatus",          -- Level 106
         },
         ['CADisc'] = {
-            "Counterattack Discipline",
+            "Counterattack Discipline", -- Level 53
         },
         ['EdgeDisc'] = {
             "Reckless Edge Discipline", -- Level 121
@@ -188,7 +188,7 @@ return {
             "Razor's Edge Discipline",  -- Level 92
         },
         ['AspDisc'] = {
-            "Visapehn Discipline",   -- Level 129
+            "Visaphen Discipline",   -- Level 129
             "Crinotoxin Discipline", -- Level 124
             "Exotoxin Discipline",   -- Level 119
             "Chelicerae Discipline", -- Level 114
@@ -197,11 +197,11 @@ return {
             "Aspbleeder Discipline", -- Level 99
         },
         ['AimDisc'] = {
-            "Fatal Aim Discipline IV", --  Level 130
-            "Baleful Aim Discipline",  --  Level 116
-            "Lethal Aim Discipline",   --  Level 108
-            "Fatal Aim Discipline",    --  Level 98
-            "Deadly Aim Discipline",   --  Level 68
+            "Fatal Aim Discipline IV", -- Level 130
+            "Baleful Aim Discipline",  -- Level 116
+            "Lethal Aim Discipline",   -- Level 108
+            "Fatal Aim Discipline",    -- Level 98
+            "Deadly Aim Discipline",   -- Level 68
         },
         ['MarkDisc'] = {
             "Easy Mark X",       -- Level 126
@@ -211,7 +211,7 @@ return {
             "Dim-Witted Mark",   -- Level 106
             "Wide-Eyed Mark",    -- Level 101
             "Gullible Mark",     -- Level 96
-            "Gullible Mark",     -- Level 91
+            "Gullible Mark",     -- Level 96
             "Easy Mark",         -- Level 86
         },
         ['Jugular'] = {
@@ -248,10 +248,10 @@ return {
         },
         ['Alliance'] = {
             "Poisonous Covariance",  -- Level 123
-            "Poisonous Covenant",    -- Level 118
-            "Poisonous Alliance",    -- Level 113
-            "Poisonous Coalition",   -- Level 108
-            "Poisonous Conjunction", -- Level 103
+            "Poisonous Conjunction", -- Level 118
+            "Poisonous Coalition",   -- Level 113
+            "Poisonous Covenant",    -- Level 108
+            "Poisonous Alliance",    -- Level 103
         },
         ['Knifeplay'] = {
             "Knifeplay Discipline", -- Level 98, Timer 16
@@ -267,7 +267,6 @@ return {
             "Delusion",             -- Level 94
             "Misdirection",         -- Level 89
         },
-
     },
     ['RotationOrder'] = {
         {

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -142,611 +142,609 @@ local _ClassConfig = {
     },
     ['AbilitySets']   = {
         ['Mantle'] = {
-            "Waxwork Mantle",
-            "Ichor Guard", -- Level 56, Timer 5
-            "Soul Guard",
-            "Soul Shield",
-            "Soul Carapace",
-            "Umbral Carapace",
-            "Malarian Mantle",
-            "Gorgon Mantle",
-            "Recondite Mantle",
-            "Bonebrood Mantle",
-            "Doomscale Mantle",
-            "Krellnakor Mantle",
-            "Restless Mantle",
-            "Fyrthek Mantle",
-            "Geomimus Mantle",
+            "Waxwork Mantle",    -- Level 128
+            "Geomimus Mantle",   -- Level 123
+            "Fyrthek Mantle",    -- Level 118
+            "Restless Mantle",   -- Level 113
+            "Krellnakor Mantle", -- Level 108
+            "Doomscale Mantle",  -- Level 103
+            "Bonebrood Mantle",  -- Level 98
+            "Recondite Mantle",  -- Level 93
+            "Gorgon Mantle",     -- Level 88
+            "Malarian Mantle",   -- Level 83
+            "Umbral Carapace",   -- Level 78
+            "Soul Carapace",     -- Level 73
+            "Soul Shield",       -- Level 69
+            "Soul Guard",        -- Level 61
+            "Ichor Guard",       -- Level 56, Timer 5
         },
         ['Carapace'] = {
             -- Added to mantle because we won't use carapace until it becomes Timer 11
-            -- "Soul Carapace", -- Level 73, Timer 5
-            -- "Umbral Carapace",
-            -- "Malarian Carapace", -- much worse than Malarian Mantle and shares a timer
-            "Gorgon Carapace", -- Level 88, Timer 11 from here on
-            "Sholothian Carapace",
-            "Grelleth's Carapace",
-            "Vizat's Carapace",
-            "Tylix's Carapace",
-            "Cadcane's Carapace",
-            "Xetheg's Carapace",
-            "Kanghammer's Carapace",
+            "Kanghammer's Carapace", -- Level 123
+            "Xetheg's Carapace",     -- Level 118
+            "Cadcane's Carapace",    -- Level 113
+            "Tylix's Carapace",      -- Level 108
+            "Vizat's Carapace",      -- Level 103
+            "Grelleth's Carapace",   -- Level 98
+            "Sholothian Carapace",   -- Level 93
+            "Gorgon Carapace",       -- Level 88, Timer 11 from here on
+            -- "Malarian Carapace",  -- Level 83, much worse than Malarian Mantle and shares a timer
+            -- "Umbral Carapace",    -- Level 78
+            -- "Soul Carapace",      -- Level 73, Timer 5
         },
         ['EndRegen'] = {
             --Timer 13, can't be used in combat
-            "Respite", --Level 86
-            "Reprieve",
-            "Rest",
-            "Breather", --Level 101
+            "Breather", -- Level 101
+            "Rest",     -- Level 96
+            "Reprieve", -- Level 91
+            "Respite",  -- Level 86
         },
         ['CombatEndRegen'] = {
             --Timer 13, can be used in combat.
-            "Hiatus V",
-            "Hiatus", --Level 106
-            "Relax",
-            "Night's Calming",
-            "Convalesce",
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Relax",           -- Level 111
+            "Hiatus",          -- Level 106
         },
         ['Blade'] = {
-            "Gouging Blade VIII",
-            "Incapacitating Blade",
-            "Grisly Blade",
-            "Gouging Blade",
-            "Gashing Blade",
-            "Lacerating Blade",
-            "Wounding Blade",
-            "Rending Blade",
+            "Gouging Blade VIII",   -- Level 127
+            "Incapacitating Blade", -- Level 122
+            "Grisly Blade",         -- Level 117
+            "Rending Blade",        -- Level 112
+            "Wounding Blade",       -- Level 107
+            "Lacerating Blade",     -- Level 102
+            "Gashing Blade",        -- Level 97
+            "Gouging Blade",        -- Level 92
         },
         ['Crimson'] = {
-            "Crimson Blade VIII",
-            "Crimson Blade",
-            "Scarlet Blade",
-            "Carmine Blade",
-            "Claret Blade",
-            "Cerise Blade",
-            "Sanguine Blade",
-            "Incarnadine Blade",
+            "Crimson Blade VIII", -- Level 130
+            "Incarnadine Blade",  -- Level 125
+            "Sanguine Blade",     -- Level 120
+            "Cerise Blade",       -- Level 115
+            "Claret Blade",       -- Level 110
+            "Carmine Blade",      -- Level 105
+            "Scarlet Blade",      -- Level 100
+            "Crimson Blade",      -- Level 95
         },
         ['MeleeMit'] = {
-            "Impede",
+            "Impede",    -- Level 128
+            "Gird",      -- Level 123
+            "Repudiate", -- Level 118
+            "Thwart",    -- Level 113
+            "Spurn",     -- Level 108
+            "Repel",     -- Level 103
+            "Reprove",   -- Level 98
+            "Renounce",  -- Level 93
+            "Defy",      -- Level 88
             -- "Withstand", -- Level 83, extreme endurance problems until 86 when we have Respite and Bard Regen Song gives endurance
-            "Defy",
-            "Renounce",
-            "Reprove",
-            "Repel",
-            "Spurn",
-            "Thwart",
-            "Repudiate",
-            "Gird",
         },
         ['Deflection'] = { 'Deflection Discipline', },
         ['LeechCurse'] = { 'Leechcurse Discipline', },
         ['UnholyAura'] = { 'Unholy Aura Discipline', },
-
         ['Guardian'] = {
-            "Unholy Guardian Discipline IV",
-            "Corrupted Guardian Discipline",
-            "Cursed Guardian Discipline",
-            "Unholy Guardian Discipline",
+            "Unholy Guardian Discipline IV", -- Level 127
+            "Corrupted Guardian Discipline", -- Level 117
+            "Cursed Guardian Discipline",    -- Level 107
+            "Unholy Guardian Discipline",    -- Level 97
         },
-
         ['PetSpell'] = {
-            "Minion of Telthel",
-            "Leering Corpse",
-            "Bone Walk",
-            "Convoke Shadow",
-            "Restless Bones",
-            "Animate Dead",
-            "Summon Dead",
-            "Malignant Dead",
-            "Cackling Bones",
-            "Invoke Death",
-            "Son of Decay",
-            "Maladroit Minion",
-            "Minion of Sebilis",
-            "Minion of Fear",
-            "Minion of Sholoth",
-            "Minion of Grelleth",
-            "Minion of Vizat",
-            "Minion of T`Vem",
-            "Minion of Drendar",
-            "Minion of Itzal",
-            "Minion of Fandrel",
+            "Minion of Telthel",  -- Level 128
+            "Minion of Fandrel",  -- Level 123
+            "Minion of Itzal",    -- Level 118
+            "Minion of Drendar",  -- Level 113
+            "Minion of T`Vem",    -- Level 108
+            "Minion of Vizat",    -- Level 103
+            "Minion of Grelleth", -- Level 98
+            "Minion of Sholoth",  -- Level 93
+            "Minion of Fear",     -- Level 88
+            "Minion of Sebilis",  -- Level 83
+            "Maladroit Minion",   -- Level 78
+            "Son of Decay",       -- Level 68
+            "Invoke Death",       -- Level 64
+            "Cackling Bones",     -- Level 58
+            "Malignant Dead",     -- Level 52
+            "Summon Dead",        -- Level 46
+            "Animate Dead",       -- Level 38
+            "Restless Bones",     -- Level 30
+            "Convoke Shadow",     -- Level 22
+            "Bone Walk",          -- Level 14
+            "Leering Corpse",     -- Level 7
         },
         ['PetHaste'] = {
-            "Gift of Telthel",
-            "Gift of Fandrel",
-            "Gift of Itzal",
-            "Gift of Drendar",
-            "Gift of T`Vem",
-            "Gift of Lutzen",
-            "Gift of Urash",
-            "Gift of Dyalgem",
-            "Expatiate Death",
-            "Amplify Death",
-            "Rune of Decay",
-            "Augmentation of Death",
-            "Augment Death",
-            "Strengthen Death",
+            "Gift of Telthel",           -- Level 128
+            "Gift of Fandrel",           -- Level 123
+            "Gift of Itzal",             -- Level 118
+            "Gift of Drendar",           -- Level 113
+            "Gift of T`Vem",             -- Level 108
+            "Gift of Lutzen",            -- Level 103
+            "Gift of Urash",             -- Level 93
+            "Gift of Dyalgem",           -- Level 88
+            "Expatiate Death",           -- Level 78
+            "Amplify Death",             -- Level 73
+            "Rune of Decay",             -- Level 69
+            "Augmentation of Death",     -- Level 64
+            "Augment Death",             -- Level 60
+            "Strengthen Death",          -- Level 29
         },
-        ['Shroud'] = { --Some Shrouds listed under the Horror Line as HP/Mana Proc Choice was shroud vs. mental in buff slot 1 at lower levels.
-            "Shroud of Elonik",
-            "Shroud of the Nightborn",
-            "Shroud of the Gloomborn",
-            "Shroud of the Blightborn",
-            "Shroud of the Plagueborne",
-            "Shroud of the Shadeborne",
-            "Shroud of the Darksworn",
-            "Shroud of the Doomscale",
-            "Shroud of the Krellnakor",
-            "Shroud of the Restless",
-            "Shroud of Zelinstein",
-            "Shroud of Rimeclaw",
+        ['Shroud'] = {                   --Some Shrouds listed under the Horror Line as HP/Mana Proc Choice was shroud vs. mental in buff slot 1 at lower levels.
+            "Shroud of Elonik",          -- Level 127
+            "Shroud of Rimeclaw",        -- Level 122
+            "Shroud of Zelinstein",      -- Level 117
+            "Shroud of the Restless",    -- Level 112
+            "Shroud of the Krellnakor",  -- Level 107
+            "Shroud of the Doomscale",   -- Level 102
+            "Shroud of the Darksworn",   -- Level 97
+            "Shroud of the Shadeborne",  -- Level 92
+            "Shroud of the Plagueborne", -- Level 87
+            "Shroud of the Blightborn",  -- Level 82
+            "Shroud of the Gloomborn",   -- Level 77
+            "Shroud of the Nightborn",   -- Level 72
         },
-        ['Horror'] = {                -- HP Tap Proc
-            "Husk Devourer's Horror", -- Level 126
-            "Shroud of Death",        -- Level 55
-            "Shroud of Chaos",        -- Level 63
-            "Black Shroud",           -- Level 65
-            "Shroud of Discord",      -- Level 67 -- Buff Slot 1 <
-            "Marrowthirst Horror",    -- Level 71 -- Buff Slot 2 >
-            "Soulthirst Horror",      -- Level 76
-            "Mindshear Horror",       -- Level 81
-            "Amygdalan Horror",       -- Level 86
-            "Sholothian Horror",      -- Level 91
-            "Grelleth's Horror",      -- Level 96
-            "Vizat's Horror",         -- Level 101
-            "Tylix's Horror",         -- Level 106
-            "Cadcane's Horror",       -- Level 111
-            "Brightfeld's Horror",    -- Level 116
-            "Mortimus' Horror",       -- Level 121
+        ['Horror'] = {                   -- HP Tap Proc
+            "Husk Devourer's Horror",    -- Level 126
+            "Mortimus' Horror",          -- Level 121
+            "Brightfeld's Horror",       -- Level 116
+            "Cadcane's Horror",          -- Level 111
+            "Tylix's Horror",            -- Level 106
+            "Vizat's Horror",            -- Level 101
+            "Grelleth's Horror",         -- Level 96
+            "Sholothian Horror",         -- Level 91
+            "Amygdalan Horror",          -- Level 86
+            "Mindshear Horror",          -- Level 81
+            "Soulthirst Horror",         -- Level 76
+            "Marrowthirst Horror",       -- Level 71, -- Buff Slot 2 >
+            "Shroud of Discord",         -- Level 67, -- Buff Slot 1 <
+            "Black Shroud",              -- Level 65
+            "Shroud of Chaos",           -- Level 63
+            "Shroud of Death",           -- Level 55
         },
-        ['Mental'] = {                -- Mana Tap Proc
-            "Mental Horror VIII",     -- Level 126
-            "Mental Retchedness",     -- Level 121
-            "Mental Anguish",         -- Level 116
-            "Mental Torment",         -- Level 111
-            "Mental Fright",          -- Level 106
-            "Mental Dread",           -- Level 101
-            "Mental Terror",          -- Level 96 --Buff Slot 2 <
-            "Mental Horror",          -- Level 65 --Buff Slot 1 >
-            "Mental Corruption",      -- Level 52
+        ['Mental'] = {                   -- Mana Tap Proc
+            "Mental Horror VIII",        -- Level 126
+            "Mental Wretchedness",       -- Level 121
+            "Mental Anguish",            -- Level 116
+            "Mental Torment",            -- Level 111
+            "Mental Fright",             -- Level 106
+            "Mental Dread",              -- Level 101
+            "Mental Terror",             -- Level 96, --Buff Slot 2 <
+            "Mental Horror",             -- Level 65, --Buff Slot 1 >
+            "Mental Corruption",         -- Level 52
         },
         ['Skin'] = {
-            "Spitetangle's Skin",
-            "Decrepit Skin", -- Level 70
-            "Umbral Skin",
-            "Malarian Skin",
-            "Gorgon Skin",
-            "Sholothian Skin",
-            "Grelleth's Skin",
-            "Vizat's Skin",
-            "Tylix's Skin",
-            "Cadcane's Skin",
-            "Xenacious' Skin",
-            "Krizad's Skin",
+            "Spitetangle's Skin", -- Level 130
+            "Krizad's Skin",      -- Level 125
+            "Xenacious' Skin",    -- Level 120
+            "Cadcane's Skin",     -- Level 115
+            "Tylix's Skin",       -- Level 110
+            "Vizat's Skin",       -- Level 105
+            "Grelleth's Skin",    -- Level 100
+            "Sholothian Skin",    -- Level 95
+            "Gorgon Skin",        -- Level 90
+            "Malarian Skin",      -- Level 85
+            "Umbral Skin",        -- Level 80
+            "Decrepit Skin",      -- Level 70
         },
         ['SelfDS'] = {
-            "Banshee Skin VIII",
-            "Banshee Aura",
-            "Banshee Skin",
-            "Ghoul Skin",
-            "Zombie Skin",
-            "Helot Skin",
-            "Specter Skin",
-            "Tekuel Skin",
-            "Goblin Skin",
+            "Banshee Skin VIII", -- Level 126
+            "Goblin Skin",       -- Level 121
+            "Tekuel Skin",       -- Level 116
+            "Specter Skin",      -- Level 111
+            "Helot Skin",        -- Level 106
+            "Zombie Skin",       -- Level 96
+            "Ghoul Skin",        -- Level 91
+            "Banshee Skin",      -- Level 86
+            "Banshee Aura",      -- Level 54
         },
         ['Demeanor'] = {
-            "Ruthless Demeanor",
-            "Remorseless Demeanor",
-            "Impenitent Demeanor",
+            "Ruthless Demeanor",    -- Level 130
+            "Impenitent Demeanor",  -- Level 120
+            "Remorseless Demeanor", -- Level 75
         },
         ['HealBurn'] = {
-            "Harmonious Disruption", -- Level 103
-            "Concordant Disruption",
-            "Confluent Disruption",
-            "Penumbral Disruption",
-            "Paradoxical Disruption",
+            "Paradoxical Disruption", -- Level 123
+            "Penumbral Disruption",   -- Level 118
+            "Confluent Disruption",   -- Level 113
+            "Concordant Disruption",  -- Level 108
+            "Harmonious Disruption",  -- Level 103
         },
         ['CloakHP'] = {
-            "Drape of Spite",
-            "Cloak of the Akheva",
-            "Cloak of Luclin",
-            "Cloak of Discord",
-            "Cloak of Corruption",
-            "Drape of Corruption",
-            "Drape of Korafax",
-            "Drape of Fear",
-            "Drape of the Sepulcher",
-            "Drape of the Fallen",
-            "Drape of the Wrathforged",
-            "Drape of the Magmaforged",
-            "Drape of the Iceforged",
-            "Drape of the Akheva",
-            "Drape of the Ankexfen",
+            "Drape of Spite",           -- Level 129
+            "Drape of the Ankexfen",    -- Level 124
+            "Drape of the Akheva",      -- Level 119
+            "Drape of the Iceforged",   -- Level 114
+            "Drape of the Magmaforged", -- Level 109
+            "Drape of the Wrathforged", -- Level 104
+            "Drape of the Fallen",      -- Level 99
+            "Drape of the Sepulcher",   -- Level 94
+            "Drape of Fear",            -- Level 89
+            "Drape of Korafax",         -- Level 84
+            "Drape of Corruption",      -- Level 79
+            "Cloak of Corruption",      -- Level 74
+            "Cloak of Discord",         -- Level 70
+            "Cloak of Luclin",          -- Level 65
+            "Cloak of the Akheva",      -- Level 60
         },
         ['Covenant'] = {
-            "Telthel's Convenant",
-            "Grim Covenant",
-            "Venril's Covenant",
-            "Gixblat's Covenant",
-            "Worag's Covenant",
-            "Falhotep's Covenant",
-            "Livio's Covenant",
-            "Helot Covenant",
-            "Syl`Tor Covenant",
-            "Aten Ha Ra's Covenant",
-            "Kar's Covenant",
+            "Telthel's Covenant",    -- Level 128
+            "Kar's Covenant",        -- Level 123
+            "Aten Ha Ra's Covenant", -- Level 118
+            "Syl`Tor Covenant",      -- Level 113
+            "Helot Covenant",        -- Level 108
+            "Livio's Covenant",      -- Level 103
+            "Falhotep's Covenant",   -- Level 98
+            "Worag's Covenant",      -- Level 93
+            "Gixblat's Covenant",    -- Level 88
+            "Venril's Covenant",     -- Level 83
+            "Grim Covenant",         -- Level 78
         },
         ['CallAtk'] = {
-            "Call of Darkness X",
-            "Call of Darkness",
-            "Call of Dusk",
-            "Call of Shadow",
-            "Call of Gloomhaze",
-            "Call of Nightfall",
-            "Call of Twilight",
-            "Penumbral Call",
-            "Call of Blight",
+            "Call of Darkness X", -- Level 129
+            "Call of Blight",     -- Level 124
+            "Penumbral Call",     -- Level 119
+            "Call of Twilight",   -- Level 114
+            "Call of Nightfall",  -- Level 109
+            "Call of Gloomhaze",  -- Level 99
+            "Call of Shadow",     -- Level 94
+            "Call of Dusk",       -- Level 89
+            "Call of Darkness",   -- Level 54
         },
         ['AETaunt'] = {
-            "Dread Gaze XIII",
-            "Dread Gaze", -- Level 69
-            "Vilify",
-            "Revile",
-            "Burst of Spite",
-            "Loathing",
-            "Abhorrence",
-            "Disgust",
-            "Revulsion",
-            "Contempt",
-            "Antipathy",
-            "Animus",
+            "Dread Gaze XIII", -- Level 129
+            "Animus",          -- Level 124
+            "Antipathy",       -- Level 119
+            "Contempt",        -- Level 114
+            "Revulsion",       -- Level 109
+            "Disgust",         -- Level 104
+            "Abhorrence",      -- Level 94
+            "Loathing",        -- Level 89
+            "Burst of Spite",  -- Level 84
+            "Revile",          -- Level 79
+            "Vilify",          -- Level 74
+            "Dread Gaze",      -- Level 69
         },
         ['PoisonDot'] = {
-            "Blood of Lherre",
-            "Blood of Pain", -- Level 41
-            "Blood of Hate",
-            "Blood of Discord",
-            "Blood of Inruku",
-            "Blood of the Blacktalon",
-            "Blood of the Blackwater",
-            "Blood of Laarthik",
-            "Blood of Malthiasiss",
-            "Blood of Korum",
-            "Blood of Ralstok",
-            "Blood of Bonemaw",
-            "Blood of Drakus",
-            "Blood of Ikatiar",
-            "Blood of Tearc",
-            "Blood of Shoru",
+            "Blood of Lherre",         -- Level 127
+            "Blood of Shoru",          -- Level 122
+            "Blood of Tearc",          -- Level 117
+            "Blood of Ikatiar",        -- Level 112
+            "Blood of Drakus",         -- Level 107
+            "Blood of Bonemaw",        -- Level 102
+            "Blood of Ralstok",        -- Level 97
+            "Blood of Korum",          -- Level 92
+            "Blood of Malthiasiss",    -- Level 87
+            "Blood of Laarthik",       -- Level 82
+            "Blood of the Blackwater", -- Level 77
+            "Blood of the Blacktalon", -- Level 72
+            "Blood of Inruku",         -- Level 68
+            "Blood of Discord",        -- Level 66
+            "Blood of Hate",           -- Level 63
+            "Blood of Pain",           -- Level 41
         },
         ['CorruptionDot'] = {
-            "Insidious Blight IX",
-            "Vitriolic Blight",
-            "Unscrupulous Blight",
-            "Nefarious Blight",
-            "Duplicitous Blight",
-            "Deceitful Blight",
-            "Surreptitious Blight",
-            "Perfidious Blight",
-            "Insidious Blight", -- Level 89
+            "Insidious Blight IX",  -- Level 129
+            "Vitriolic Blight",     -- Level 124
+            "Unscrupulous Blight",  -- Level 119
+            "Nefarious Blight",     -- Level 114
+            "Duplicitous Blight",   -- Level 109
+            "Deceitful Blight",     -- Level 104
+            "Surreptitious Blight", -- Level 99
+            "Perfidious Blight",    -- Level 94
+            "Insidious Blight",     -- Level 89
         },
         ['SpearNuke'] = {
-            "Spear of Wremm",
-            "Spike of Disease", -- Level 1
-            "Spear of Disease",
-            "Spear of Pain",
-            "Spear of Plague",
-            "Spear of Decay",
-            "Miasmic Spear",
-            "Spear of Muram",
-            "Rotroot Spear",
-            "Rotmarrow Spear",
-            "Malarian Spear",
-            "Gorgon Spear",
-            "Spear of Sholoth",
-            "Spear of Grelleth",
-            "Spear of Vizat",
-            "Spear of Tylix",
-            "Spear of Cadcane",
-            "Spear of Bloodwretch",
-            "Spear of Lazam",
+            "Spear of Wremm",       -- Level 129
+            "Spear of Lazam",       -- Level 124
+            "Spear of Bloodwretch", -- Level 119
+            "Spear of Cadcane",     -- Level 114
+            "Spear of Tylix",       -- Level 109
+            "Spear of Vizat",       -- Level 104
+            "Spear of Grelleth",    -- Level 99
+            "Spear of Sholoth",     -- Level 94
+            "Gorgon Spear",         -- Level 89
+            "Malarian Spear",       -- Level 84
+            "Rotmarrow Spear",      -- Level 79
+            "Rotroot Spear",        -- Level 74
+            "Spear of Muram",       -- Level 69
+            "Miasmic Spear",        -- Level 65
+            "Spear of Decay",       -- Level 64
+            "Spear of Plague",      -- Level 54
+            "Spear of Pain",        -- Level 48
+            "Spear of Disease",     -- Level 34
+            "Spike of Disease",     -- Level 1
         },
         ['BondTap'] = {
-            "Bond of the Devourer",
-            "Bond of Tatalros",
-            "Bond of Bynn",
-            "Bond of Vulak",
-            "Bond of Xalgoz",
-            "Bond of Bonemaw",
-            "Bond of Ralstok",
-            "Bond of Korum",
-            "Bond of Malthiasiss",
-            "Bond of Laarthik",
-            "Bond of the Blackwater",
-            "Bond of the Blacktalon",
-            "Bond of Inruku",
-            "Bond of Death",
-            "Vampiric Curse", -- Level 57
+            "Bond of the Devourer",   -- Level 126
+            "Bond of Tatalros",       -- Level 121
+            "Bond of Bynn",           -- Level 116
+            "Bond of Vulak",          -- Level 111
+            "Bond of Xalgoz",         -- Level 106
+            "Bond of Bonemaw",        -- Level 101
+            "Bond of Ralstok",        -- Level 96
+            "Bond of Korum",          -- Level 91
+            "Bond of Malthiasiss",    -- Level 86
+            "Bond of Laarthik",       -- Level 81
+            "Bond of the Blackwater", -- Level 76
+            "Bond of the Blacktalon", -- Level 71
+            "Bond of Inruku",         -- Level 66
+            "Bond of Death",          -- Level 62
+            "Vampiric Curse",         -- Level 57
         },
         ['DireTap'] = {
-            "Dire Implication X",
-            "Dire Implication", -- Level 85
-            "Dire Accusation",
-            "Dire Allegation",
-            "Dire Insinuation",
-            "Dire Declaration",
-            "Dire Testimony",
-            "Dire Indictment",
-            "Dire Censure",
-            "Dire Rebuke",
+            "Dire Implication X", -- Level 130
+            "Dire Rebuke",        -- Level 125
+            "Dire Censure",       -- Level 120
+            "Dire Indictment",    -- Level 115
+            "Dire Testimony",     -- Level 110
+            "Dire Declaration",   -- Level 105
+            "Dire Insinuation",   -- Level 100
+            "Dire Allegation",    -- Level 95
+            "Dire Accusation",    -- Level 90
+            "Dire Implication",   -- Level 85
         },
         ['LifeTap'] = {
-            "Touch of Bonesplinter",
-            "Touch of Flariton",
-            "Touch of Txiki",
-            "Touch of Drendar",
-            "Touch of T`Vem",
-            "Touch of Lutzen",
-            "Touch of Falsin",
-            "Touch of Urash",
-            "Touch of Falsin",
-            "Touch of Dyalgem",
-            "Touch of Tharoff",
-            "Touch of Kildrukaun",
-            "Touch of Severan",
-            "Touch of the Devourer",
-            "Touch of Inruku",
-            "Touch of Innoruuk",
-            "Touch of Volatis",
-            "Drain Soul",
-            "Drain Spirit",
-            "Spirit Tap",
-            "Siphon Life",
-            "Life Leech",
-            "Lifedraw",
-            "Lifespike", -- Level 15
-            "Lifetap",   -- Level 8
+            "Touch of Bonesplinter", -- Level 130
+            "Touch of Flariton",     -- Level 125
+            "Touch of Txiki",        -- Level 120
+            "Touch of Drendar",      -- Level 115
+            "Touch of T`Vem",        -- Level 110
+            "Touch of Lutzen",       -- Level 105
+            "Touch of Falsin",       -- Level 100
+            "Touch of Falsin",       -- Level 100
+            "Touch of Urash",        -- Level 95
+            "Touch of Dyalgem",      -- Level 90
+            "Touch of Tharoff",      -- Level 85
+            "Touch of Kildrukaun",   -- Level 80
+            "Touch of Severan",      -- Level 75
+            "Touch of the Devourer", -- Level 70
+            "Touch of Inruku",       -- Level 67
+            "Touch of Innoruuk",     -- Level 65
+            "Touch of Volatis",      -- Level 62
+            "Drain Soul",            -- Level 60
+            "Drain Spirit",          -- Level 57
+            "Spirit Tap",            -- Level 55
+            "Siphon Life",           -- Level 51
+            "Life Leech",            -- Level 47
+            "Lifedraw",              -- Level 29
+            "Lifespike",             -- Level 15
+            "Lifetap",               -- Level 8
         },
         ['LifeTap2'] = {
-            "Touch of Bonesplinter",
-            "Touch of Flariton",
-            "Touch of Txiki",
-            "Touch of Drendar",
-            "Touch of T`Vem",
-            "Touch of Lutzen",
-            "Touch of Falsin",
-            "Touch of Urash",
-            "Touch of Falsin",
-            "Touch of Dyalgem",
-            "Touch of Tharoff",
-            "Touch of Kildrukaun",
-            "Touch of Severan",
-            "Touch of the Devourer",
-            "Touch of Inruku",
-            "Touch of Innoruuk",
-            "Touch of Volatis",
-            "Drain Soul",
-            "Drain Spirit",
-            "Spirit Tap",
-            "Siphon Life",
-            "Life Leech",
-            "Lifedraw",
-            "Lifespike",
-            "Lifetap",    -- Level 8
+            "Touch of Bonesplinter",    -- Level 130
+            "Touch of Flariton",        -- Level 125
+            "Touch of Txiki",           -- Level 120
+            "Touch of Drendar",         -- Level 115
+            "Touch of T`Vem",           -- Level 110
+            "Touch of Lutzen",          -- Level 105
+            "Touch of Falsin",          -- Level 100
+            "Touch of Falsin",          -- Level 100
+            "Touch of Urash",           -- Level 95
+            "Touch of Dyalgem",         -- Level 90
+            "Touch of Tharoff",         -- Level 85
+            "Touch of Kildrukaun",      -- Level 80
+            "Touch of Severan",         -- Level 75
+            "Touch of the Devourer",    -- Level 70
+            "Touch of Inruku",          -- Level 67
+            "Touch of Innoruuk",        -- Level 65
+            "Touch of Volatis",         -- Level 62
+            "Drain Soul",               -- Level 60
+            "Drain Spirit",             -- Level 57
+            "Spirit Tap",               -- Level 55
+            "Siphon Life",              -- Level 51
+            "Life Leech",               -- Level 47
+            "Lifedraw",                 -- Level 29
+            "Lifespike",                -- Level 15
+            "Lifetap",                  -- Level 8
         },
-        ['AELifeTap'] = { --Lifetap/Hate up to 30 targets, level 98+
-            "Insidious Deflection VII",
-            "Insidious Repudiation",
-            "Insidious Renunciation",
-            "Insidious Rejection",
-            "Insidious Denial",
-            "Deceitful Deflection",
-            "Insidious Deflection",
+        ['AELifeTap'] = {               --Lifetap/Hate up to 30 targets, level 98+
+            "Insidious Deflection VII", -- Level 128
+            "Insidious Repudiation",    -- Level 123
+            "Insidious Renunciation",   -- Level 118
+            "Insidious Rejection",      -- Level 113
+            "Insidious Denial",         -- Level 108
+            "Deceitful Deflection",     -- Level 103
+            "Insidious Deflection",     -- Level 98
         },
         ['MaxHPTap'] = {
-            "Rending of Ulnaa",
-            "Touch of Mortimus",
-            "Touch of Namdrows",
-            "Touch of Zlandicar",
-            "Touch of Hemofax",
-            "Touch of Holmein",
-            "Touch of Klonda",
-            "Touch of Piqiorn",
-            "Touch of Iglum",
-            "Touch of Lanys",
-            "Touch of the Soulbleeder",
-            "Touch of the Wailing Three",
-            "Touch of Draygun", -- Level 69
+            "Rending of Ulnaa",           -- Level 130
+            "Touch of Mortimus",          -- Level 125
+            "Touch of Namdrows",          -- Level 120
+            "Touch of Zlandicar",         -- Level 115
+            "Touch of Hemofax",           -- Level 110
+            "Touch of Holmein",           -- Level 105
+            "Touch of Klonda",            -- Level 100
+            "Touch of Piqiorn",           -- Level 95
+            "Touch of Iglum",             -- Level 90
+            "Touch of Lanys",             -- Level 85
+            "Touch of the Soulbleeder",   -- Level 80
+            "Touch of the Wailing Three", -- Level 75
+            "Touch of Draygun",           -- Level 69
         },
         ['BiteTap'] = {
-            "Wremm's Bite",
-            "Zevfeer's Bite", -- Level 62
-            "Inruku's Bite",
-            "Ancient: Bite of Muram",
-            "Blacktalon Bite",
-            "Blackwater Bite",
-            "Laarthik's Bite",
-            "Malthiasiss's Bite",
-            "Korum's Bite",
-            "Ralstok's Bite",
-            "Bonemaw's Bite",
-            "Xalgoz's Bite",
-            "Vulak's Bite",
-            "Cruor's Bite",
-            "Charka's Bite",
+            "Wremm's Bite",           -- Level 126
+            "Charka's Bite",          -- Level 121
+            "Cruor's Bite",           -- Level 116
+            "Vulak's Bite",           -- Level 111
+            "Xalgoz's Bite",          -- Level 106
+            "Bonemaw's Bite",         -- Level 101
+            "Ralstok's Bite",         -- Level 96
+            "Korum's Bite",           -- Level 91
+            "Malthiasiss's Bite",     -- Level 86
+            "Laarthik's Bite",        -- Level 81
+            "Blackwater Bite",        -- Level 76
+            "Blacktalon Bite",        -- Level 71
+            "Ancient: Bite of Muram", -- Level 70
+            "Inruku's Bite",          -- Level 67
+            "Zevfeer's Bite",         -- Level 62
         },
         ['ForPower'] = {
-            "Duel for Power",
-            "Challenge for Power", -- Level 72
-            "Trial for Power",
-            "Charge for Power",
-            "Confrontation for Power",
-            "Provocation for Power",
-            "Demand for Power",
-            "Impose for Power",
-            "Refute for Power",   -- TBL - 107
-            "Protest for Power",  -- TOV - 112
-            "Parlay for Power",   -- TOL - 117
-            "Petition for Power", -- LS - 122
+            "Duel for Power",          -- Level 127
+            "Petition for Power",      -- Level 122, LS - 122
+            "Parlay for Power",        -- Level 117, TOL - 117
+            "Protest for Power",       -- Level 112, TOV - 112
+            "Refute for Power",        -- Level 107, TBL - 107
+            "Impose for Power",        -- Level 102
+            "Demand for Power",        -- Level 97
+            "Provocation for Power",   -- Level 92
+            "Confrontation for Power", -- Level 87
+            "Charge for Power",        -- Level 82
+            "Trial for Power",         -- Level 77
+            "Challenge for Power",     -- Level 72
         },
         ['Terror'] = {
-            "Terror of Telthel",
-            "Terror of Darkness", -- Level 33
-            "Terror of Shadows",  -- Level 42
-            "Terror of Death",
-            "Terror of Terris",
-            "Terror of Thule",
-            "Terror of Discord",
-            "Terror of Vergalid",
-            "Terror of the Soulbleeder",
-            "Terror of Jelvalak",
-            "Terror of Rerekalen",
-            "Terror of Desalin",
-            "Terror of Poira",
-            "Terror of Narus",
-            "Terror of Kra`Du",
-            "Terror of Mirenilla",
-            "Terror of Ander",
-            "Terror of Tarantis",
+            "Terror of Telthel",         -- Level 126
+            "Terror of Tarantis",        -- Level 121
+            "Terror of Ander",           -- Level 116
+            "Terror of Mirenilla",       -- Level 111
+            "Terror of Kra`Du",          -- Level 106
+            "Terror of Narus",           -- Level 101
+            "Terror of Poira",           -- Level 96
+            "Terror of Desalin",         -- Level 91
+            "Terror of Rerekalen",       -- Level 86
+            "Terror of Jelvalak",        -- Level 81
+            "Terror of the Soulbleeder", -- Level 76
+            "Terror of Vergalid",        -- Level 71
+            "Terror of Discord",         -- Level 67
+            "Terror of Thule",           -- Level 63
+            "Terror of Terris",          -- Level 59
+            "Terror of Death",           -- Level 53
+            "Terror of Shadows",         -- Level 42
+            "Terror of Darkness",        -- Level 33
         },
         ['Terror2'] = {
-            "Terror of Telthel",
-            "Terror of Darkness",
-            "Terror of Shadows",
-            "Terror of Death",
-            "Terror of Terris",
-            "Terror of Thule",
-            "Terror of Discord",
-            "Terror of Vergalid",
-            "Terror of the Soulbleeder",
-            "Terror of Jelvalak",
-            "Terror of Rerekalen",
-            "Terror of Desalin",
-            "Terror of Poira",
-            "Terror of Narus",
-            "Terror of Kra`Du",
-            "Terror of Mirenilla",
-            "Terror of Ander",
-            "Terror of Tarantis",
+            "Terror of Telthel",         -- Level 126
+            "Terror of Tarantis",        -- Level 121
+            "Terror of Ander",           -- Level 116
+            "Terror of Mirenilla",       -- Level 111
+            "Terror of Kra`Du",          -- Level 106
+            "Terror of Narus",           -- Level 101
+            "Terror of Poira",           -- Level 96
+            "Terror of Desalin",         -- Level 91
+            "Terror of Rerekalen",       -- Level 86
+            "Terror of Jelvalak",        -- Level 81
+            "Terror of the Soulbleeder", -- Level 76
+            "Terror of Vergalid",        -- Level 71
+            "Terror of Discord",         -- Level 67
+            "Terror of Thule",           -- Level 63
+            "Terror of Terris",          -- Level 59
+            "Terror of Death",           -- Level 53
+            "Terror of Shadows",         -- Level 42
+            "Terror of Darkness",        -- Level 33
         },
         ['TempHP'] = {
-            "Unyielding Stance",
-            "Unwavering Stance",
-            "Adamant Stance",
-            "Stormwall Stance",
-            "Defiant Stance",
-            "Staunch Stance",
-            "Steadfast Stance",
-            "Stoic Stance",
-            "Stubborn Stance",
-            "Steely Stance", -- Level 84
+            "Unyielding Stance", -- Level 129
+            "Unwavering Stance", -- Level 124
+            "Adamant Stance",    -- Level 119
+            "Stormwall Stance",  -- Level 114
+            "Defiant Stance",    -- Level 109
+            "Staunch Stance",    -- Level 104
+            "Steadfast Stance",  -- Level 99
+            "Stoic Stance",      -- Level 94
+            "Stubborn Stance",   -- Level 89
+            "Steely Stance",     -- Level 84
         },
         ['Dicho'] = {
+            "Reciprocal Fang", -- Level 121
+            "Ecliptic Fang",   -- Level 116
+            "Composite Fang",  -- Level 111
+            "Dissident Fang",  -- Level 106
             "Dichotomic Fang", -- Level 101
-            "Dissident Fang",
-            "Composite Fang",
-            "Ecliptic Fang",
-            "Reciprocal Fang",
         },
         ['PowerTapAC'] = {
-            "Torrent of Pain IX",
-            "Torrent of Desolation",
-            "Torrent of Melancholy",
-            "Torrent of Anguish",
-            "Torrent of Suffering",
-            "Torrent of Misery",
-            "Torrent of Agony", -- Level 100
-            "Theft of Agony",
-            "Theft of Pain",
-            "Aura of Pain",
-            "Torrent of Pain",
-            "Shroud of Pain",
-            "Scream of Pain",
+            "Torrent of Pain IX",    -- Level 130
+            "Torrent of Desolation", -- Level 125
+            "Torrent of Melancholy", -- Level 120
+            "Torrent of Anguish",    -- Level 115
+            "Torrent of Suffering",  -- Level 110
+            "Torrent of Misery",     -- Level 105
+            "Torrent of Agony",      -- Level 100
+            "Theft of Agony",        -- Level 70
+            "Theft of Pain",         -- Level 68
+            "Aura of Pain",          -- Level 63
+            "Torrent of Pain",       -- Level 56
+            "Shroud of Pain",        -- Level 50
+            "Scream of Pain",        -- Level 23
         },
         ['PowerTapAtk'] = {
-            "Theft of Hate",
-            "Aura of Hate",
-            "Torrent of Hate",
-            "Shroud of Hate",
-            "Scream of Hate",
+            "Theft of Hate",   -- Level 70
+            "Aura of Hate",    -- Level 65
+            "Torrent of Hate", -- Level 54
+            "Shroud of Hate",  -- Level 35
+            "Scream of Hate",  -- Level 15
         },
         ['SnareDot'] = {
-            "Festering Darkness XI",
-            "Clinging Darkness", -- Level 11
-            "Engulfing Darkness",
-            "Dooming Darkness",
-            "Cascading Darkness",
-            "Festering Darkness",
-            "Despairing Darkness",
-            "Suppurating Darkness",
-            "Smoldering Darkness",
-            "Spreading Darkness",
-            "Putrefying Darkness",
-            "Pestilent Darkness",
-            "Virulent Darkness",
-            "Vitriolic Darkness",
+            "Festering Darkness XI", -- Level 127
+            "Vitriolic Darkness",    -- Level 122
+            "Virulent Darkness",     -- Level 117
+            "Pestilent Darkness",    -- Level 112
+            "Putrefying Darkness",   -- Level 107
+            "Spreading Darkness",    -- Level 102
+            "Smoldering Darkness",   -- Level 97
+            "Suppurating Darkness",  -- Level 92
+            "Despairing Darkness",   -- Level 87
+            "Festering Darkness",    -- Level 61
+            "Cascading Darkness",    -- Level 59
+            "Dooming Darkness",      -- Level 44
+            "Engulfing Darkness",    -- Level 20
+            "Clinging Darkness",     -- Level 11
         },
         ['Acrimony'] = {
-            "Unquestioned Acrimony",
-            "Undivided Acrimony",
-            "Unbroken Acrimony",
-            "Unflinching Acrimony",
-            "Unyielding Acrimony",
-            "Unending Acrimony",
-            "Unrelenting Acrimony",
-            "Unconditional Acrimony",
+            "Unquestioned Acrimony",  -- Level 129
+            "Unconditional Acrimony", -- Level 124
+            "Unrelenting Acrimony",   -- Level 119
+            "Unending Acrimony",      -- Level 114
+            "Unyielding Acrimony",    -- Level 109
+            "Unflinching Acrimony",   -- Level 104
+            "Unbroken Acrimony",      -- Level 99
+            "Undivided Acrimony",     -- Level 94
         },
         ['SpiteStrike'] = {
-            "Spite of Ronak",
-            "Spite of Kra`Du",
-            "Spite of Mirenilla",
+            "Spite of Mirenilla", -- Level 114
+            "Spite of Kra`Du",    -- Level 109
+            "Spite of Ronak",     -- Level 99
         },
         ['ReflexStrike'] = {
-            "Reflexive Resentment",
-            "Reflexive Rancor",
-            "Reflexive Revulsion",
-            "Reflexive Retribution",
+            "Reflexive Retribution", -- Level 125
+            "Reflexive Resentment",  -- Level 112
+            "Reflexive Revulsion",   -- Level 104
+            "Reflexive Rancor",      -- Level 100
         },
         ['DireDot'] = {
-            "Dire Constriction XI",
-            "Dire Constriction", -- Level 85
-            "Dire Restriction",
-            "Dire Stenosis",
-            "Dire Stricture",
-            "Dire Strangulation",
-            "Dire Coarctation",
-            "Dire Convulsion",
-            "Dire Seizure",
-            "Dire Squelch",
-            "Dark Constriction",
-            "Asystole",
-            "Heart Flutter",
-            "Disease Cloud",
+            "Dire Constriction XI", -- Level 130
+            "Dire Squelch",         -- Level 125
+            "Dire Seizure",         -- Level 120
+            "Dire Convulsion",      -- Level 115
+            "Dire Coarctation",     -- Level 110
+            "Dire Strangulation",   -- Level 105
+            "Dire Stricture",       -- Level 100
+            "Dire Stenosis",        -- Level 95
+            "Dire Restriction",     -- Level 90
+            "Dire Constriction",    -- Level 85
+            "Dark Constriction",    -- Level 66
+            "Asystole",             -- Level 60
+            "Heart Flutter",        -- Level 36
+            "Disease Cloud",        -- Level 5
         },
         ['AllianceNuke'] = {
-            "Bloodletting Coalition",
-            "Bloodletting Alliance",
-            "Bloodletting Covenant",
-            "Bloodletting Conjunction",
-            "Bloodletting Covariance",
+            "Bloodletting Covariance",  -- Level 124
+            "Bloodletting Conjunction", -- Level 119
+            "Bloodletting Coalition",   -- Level 114
+            "Bloodletting Covenant",    -- Level 109
+            "Bloodletting Alliance",    -- Level 104
         },
         ['InfluenceDisc'] = {
-            "Insolent Influence",
-            "Impudent Influence",
-            "Impenitent Influence",
-            "Impertinent Influence",
-            "Ignominious Influence",
-            "Incensive Influence",
+            "Incensive Influence",   -- Level 122
+            "Ignominious Influence", -- Level 117
+            "Impertinent Influence", -- Level 115
+            "Impenitent Influence",  -- Level 110
+            "Impudent Influence",    -- Level 102
+            "Insolent Influence",    -- Level 97
         },
-        ['HateBuff'] = {         --9 minute reuse makes these somewhat ridiculous to gem on the fly.
-            "Voice of Thule",    -- level 60, 12% hate
-            "Voice of Terris",   -- level 55, 10% hate
-            "Voice of Death",    -- level 50, 6% hate
-            "Voice of Shadows",  -- level 46, 4% hate
-            "Voice of Darkness", -- level 39, 2% hate
+        ['HateBuff'] = {             --9 minute reuse makes these somewhat ridiculous to gem on the fly.
+            "Voice of Thule",        -- Level 65, 12% hate
+            "Voice of Terris",       -- Level 60, 10% hate
+            "Voice of Death",        -- Level 55, 6% hate
+            "Voice of Shadows",      -- Level 46, 4% hate
+            "Voice of Darkness",     -- Level 39, 2% hate
         },
     },
     ['Helpers']       = {

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -132,666 +132,664 @@ local _ClassConfig = {
     ['AbilitySets']       = {
         ['GroupFocusSpell'] = {
             -- Focus Spell - Group Spells will be used on everyone
-            "Talisman of Unity X",        -- Level 130 - Group
-            "Khura's Focusing",           -- Level 60 - Group
-            "Focus of the Seventh",       -- Level 65 - Group
-            "Talisman of Wunshi",         -- Level 70 - Group
-            "Talisman of the Dire",       -- Level 75 - Group
-            "Talisman of the Bloodworg",  -- Level 80 - Group
-            "Talisman of Unity",          -- Level 85 - Group
-            "Talisman of Soul's Unity",   -- Level 90 - Group
-            "Talisman of Kolos' Unity",   -- Level 95 - Group
-            "Talisman of the Courageous", -- Level 100 - Group
-            "Talisman of the Doomscale",  -- Level 105 - Group
-            "Talisman of the Wulthan",    -- Level 110 - Group
-            "Talisman of the Ry'Gorr",    -- Level 115 - Group
-            "Talisman of the Usurper",    -- Level 120 - Group
-            "Talisman of the Heroic",     -- Level 125 - Group
+            "Talisman of Unity X",        -- Level 126, - Group
+            "Talisman of the Heroic",     -- Level 125, - Group
+            "Talisman of the Usurper",    -- Level 120, - Group
+            "Talisman of the Ry'Gorr",    -- Level 115, - Group
+            "Talisman of the Wulthan",    -- Level 110, - Group
+            "Talisman of the Doomscale",  -- Level 105, - Group
+            "Talisman of the Courageous", -- Level 100, - Group
+            "Talisman of Kolos' Unity",   -- Level 95, - Group
+            "Talisman of Soul's Unity",   -- Level 90, - Group
+            "Talisman of Unity",          -- Level 85, - Group
+            "Talisman of the Bloodworg",  -- Level 80, - Group
+            "Talisman of the Dire",       -- Level 75, - Group
+            "Talisman of Wunshi",         -- Level 70, - Group
+            "Focus of the Seventh",       -- Level 65, - Group
+            "Khura's Focusing",           -- Level 60, - Group
         },
         ['RunSpeedBuff'] = {
             -- Run Speed Buff - 9 - 74
-            "Spirit of Tala'Tak",
-            "Spirit of Bih`Li",
-            "Pack Shrew",
-            "Spirit of Wolf",
+            "Spirit of Tala'Tak", -- Level 74
+            "Spirit of Bih`Li",   -- Level 36
+            "Pack Shrew",         -- Level 34
+            "Spirit of Wolf",     -- Level 9
         },
         ['HasteBuff'] = {
             -- Haste Buff - 26 - 64
-            "Talisman of Celerity",
-            "Swift Like the Wind",
-            "Celerity",
-            "Quickness",
+            "Talisman of Celerity", -- Level 64
+            "Swift Like the Wind",  -- Level 63
+            "Celerity",             -- Level 56
+            "Quickness",            -- Level 26
         },
         ['TempHPBuff'] = {
             -- Growth Buff 81+
-            "Wild Growth X",
-            "Overwhelming Growth",
-            "Fervent Growth",
-            "Frenzied Growth",
-            "Savage Growth",
-            "Ferocious Growth",
-            "Rampant Growth",
-            "Unfettered Growth",
-            "Untamed Growth",
-            "Wild Growth",
+            "Wild Growth X",       -- Level 126
+            "Overwhelming Growth", -- Level 121
+            "Fervent Growth",      -- Level 116
+            "Frenzied Growth",     -- Level 111
+            "Savage Growth",       -- Level 106
+            "Ferocious Growth",    -- Level 101
+            "Rampant Growth",      -- Level 96
+            "Unfettered Growth",   -- Level 91
+            "Untamed Growth",      -- Level 86
+            "Wild Growth",         -- Level 81
         },
         ['LowLvlStaBuff'] = {
             -- Low Level Stamina Buff --- I guess this may be okay for tanks (but largely a raid thing). Need to scrub which levels. Not currently used.
-            "Spirit of Bear",
-            "Spirit of Ox",
-            "Health",
-            "Stamina",
-            "Riotous Health",
-            "Talisman of the Brute",
-            "Endurance of the Boar",
-            "Talisman of the Boar",
-            "Spirit of Fortitude",
-            "Talisman of Fortitude",
-            "Talisman of Persistence",
-            "Talisman of Vehemence",
-            "Spirit of Vehemence",
+            "Talisman of Vehemence",   -- Level 76
+            "Spirit of Vehemence",     -- Level 76
+            "Talisman of Persistence", -- Level 71
+            "Talisman of Fortitude",   -- Level 69
+            "Spirit of Fortitude",     -- Level 68
+            "Talisman of the Boar",    -- Level 63
+            "Endurance of the Boar",   -- Level 62
+            "Talisman of the Brute",   -- Level 57
+            "Riotous Health",          -- Level 54
+            "Stamina",                 -- Level 43
+            "Health",                  -- Level 30
+            "Spirit of Ox",            -- Level 21
+            "Spirit of Bear",          -- Level 6
         },
         ['LowLvlAtkBuff'] = {
             -- Low Level Attack Buff --- user under level 86. Including Harnessing of Spirit as they will have similar usecases and targets.
-            "Harnessing of Spirit",
-            "Primal Avatar",
-            "Ferine Avatar",
-            "Champion",
+            "Champion",             -- Level 70
+            "Ferine Avatar",        -- Level 65
+            "Primal Avatar",        -- Level 60
+            "Harnessing of Spirit", -- Level 46
         },
         ['LowLvlHPBuff'] = {
-            "Inner Fire",         -- Level 1 - Single
-            "Talisman of Tnarg",  -- Level 32 - Single
-            "Talisman of Altuna", -- Level 40 - Single
-            "Talisman of Kragg",  -- Level 55 - Single
+            "Talisman of Kragg",  -- Level 55, - Single
+            "Talisman of Altuna", -- Level 40, - Single
+            "Talisman of Tnarg",  -- Level 32, - Single
+            "Inner Fire",         -- Level 1, - Single
         },
         ['LowLvlStrBuff'] = {
             -- Low Level Strength Buff -- Below 68 these are only worthwhile on non-live, defiant stat caps too easily. Even then arguable.
-            "Talisman of Might",  -- Level 70, Group
-            "Spirit of Might",    -- Level 68, Single Target
-            "Talisman of the Diaku",
-            "Infusion of Spirit", -- Level 49, Str/Dex/Sta, can use HP buff
-            "Tumultuous Strength",
-            "Raging Strength",
-            "Spirit Strength", -- Level 18, Can't see this as being very worth but keeping for now.
+            "Talisman of Might",     -- Level 70, Group
+            "Spirit of Might",       -- Level 67, Single Target
+            "Talisman of the Diaku", -- Level 64
+            "Infusion of Spirit",    -- Level 49, Str/Dex/Sta, can use HP buff
+            "Tumultuous Strength",   -- Level 35
+            "Raging Strength",       -- Level 28
+            "Spirit Strength",       -- Level 18, Can't see this as being very worth but keeping for now.
         },
         ['LowLvlDexBuff'] = {
             -- Low Level Dex Buff -- This has no real place outside of raids on select tanks. Waste of mana.
-            "Talisman of the Raptor",
-            "Mortal Deftness",
-            "Dexterity",
-            "Deftness",
-            "Rising Dexterity",
-            "Spirit of Monkey",
-            "Dexterous Aura",
+            "Talisman of the Raptor", -- Level 59
+            "Mortal Deftness",        -- Level 58
+            "Dexterity",              -- Level 48
+            "Deftness",               -- Level 39
+            "Rising Dexterity",       -- Level 25
+            "Spirit of Monkey",       -- Level 21
+            "Dexterous Aura",         -- Level 1
         },
         ['LowLvlAgiBuff'] = {
             --- Low Level AGI Buff -- This has no real place outside of raids on select tanks. Waste of mana.
-            "Talisman of Foresight",
-            "Preternatural Foresight",
-            "Talisman of Sense",
-            "Spirit of Sense",
-            "Talisman of the Wrulan",
-            "Agility of the Wrulan",
-            "Talisman of the Cat",
-            "Deliriously Nimble",
-            "Agility",
-            "Nimble",
-            "Spirit of Cat",
-            "Feet like Cat",
+            "Talisman of Foresight",   -- Level 74
+            "Preternatural Foresight", -- Level 71
+            "Talisman of Sense",       -- Level 68
+            "Spirit of Sense",         -- Level 66
+            "Talisman of the Wrulan",  -- Level 62
+            "Agility of the Wrulan",   -- Level 61
+            "Talisman of the Cat",     -- Level 57
+            "Deliriously Nimble",      -- Level 53
+            "Agility",                 -- Level 41
+            "Nimble",                  -- Level 31
+            "Spirit of Cat",           -- Level 18
+            "Feet like Cat",           -- Level 3
         },
         ['AEMaloSpell'] = {
-            "Wind of Malisene",
-            "Wind of Malis",
+            "Wind of Malisene", -- Level 89
+            "Wind of Malis",    -- Level 84
         },
         ['MaloSpell'] = {
             -- AA Starts at LVL 75
-            "Malaise XVI",
-            "Malosinera",
-            "Malosinetra",
-            "Malosinise",
-            "Malos",
-            "Malosinia",
-            "Malo",
-            "Malosini",
+            "Malaise XVI",     -- Level 127
+            "Malosinera",      -- Level 122
+            "Malosinetra",     -- Level 117
+            "Malosinise",      -- Level 72
+            "Malos",           -- Level 65
+            "Malosinia",       -- Level 63
+            "Malo",            -- Level 60
+            "Malosini",        -- Level 57
             --Below this these spells are considered by many to be a waste of mana, but the user can elect to turn this off.
-            "Malosi",
-            "Malaisement",
-            "Malaise",
+            "Malosi",          -- Level 48
+            "Malaisement",     -- Level 32
+            "Malaise",         -- Level 18
         },
-        ['AESlowSpell'] = { --Often considered a waste of mana in group situations, user option.
-            "Tigir's Insects",
+        ['AESlowSpell'] = {    --Often considered a waste of mana in group situations, user option.
+            "Tigir's Insects", -- Level 58
         },
         ['SlowSpell'] = {
-            "Balance of Discord",
-            "Balance of the Nihil",
-            "Turgur's Insects", --Can save mana by continuing to use Togor's on group mobs, but this is problematic for automation. Not worth splitting the entry.
-            "Togor's Insects",
-            "Tagar's Insects",
-            --"Walking Sleep", --Too much mana with little benefit at these levels
-            --"Drowsy", --Too much mana with little benefit at these levels
+            "Balance of Discord",   -- Level 69
+            "Balance of the Nihil", -- Level 65
+            "Turgur's Insects",     -- Level 51, Can save mana by continuing to use Togor's on group mobs, but this is problematic for automation. Not worth splitting the entry.
+            "Togor's Insects",      -- Level 38
+            "Tagar's Insects",      -- Level 27
+            -- "Walking Sleep",     -- Level 13, Too much mana with little benefit at these levels
+            -- "Drowsy",            -- Level 5, Too much mana with little benefit at these levels
         },
         ['DiseaseSlow'] = {
-            "Cloud of Grummus",
-            "Plague of Insects",
+            "Cloud of Grummus",  -- Level 61
+            "Plague of Insects", -- Level 54
         },
-        ['CrippleSpell'] = {   --not currently utilized for groups, gem slots are precious
-            "Crippling Spasm", -- Level 66
-            "Cripple",         -- Level 53, Starts to become worth it, depending on target
-            "Incapacitate",    -- Level 41, Likely not worth
-            "Listless Power",  -- Level 29, Definitely not worth
+        ['CrippleSpell'] = {     --not currently utilized for groups, gem slots are precious
+            "Crippling Spasm",   -- Level 66
+            "Cripple",           -- Level 53, Starts to become worth it, depending on target
+            "Incapacitate",      -- Level 41, Likely not worth
+            "Listless Power",    -- Level 29, Definitely not worth
         },
         ['GroupHealProcBuff'] = {
-            "Mindful Spirit",
-            "Watchful Spirit",
-            "Attentive Spirit",
-            "Responsive Spirit",
+            "Mindful Spirit",    -- Level 122
+            "Watchful Spirit",   -- Level 117
+            "Attentive Spirit",  -- Level 112
+            "Responsive Spirit", -- Level 101
         },
         ['WardBuff'] = {
             -- Self Heal Ward Spells
-            "Ward of Resurgence XI",
-            "Ward of Heroic Deeds",
-            "Ward of Recuperation",
-            "Ward of Remediation",
-            "Ward of Regeneration",
-            "Ward of Rejuvenation",
-            "Ward of Reconstruction",
-            "Ward of Recovery",
-            "Ward of Restoration",
-            "Ward of Resurgence",
-            "Ward of Rebirth",
+            "Ward of Resurgence XI",  -- Level 130
+            "Ward of Heroic Deeds",   -- Level 125
+            "Ward of Rebirth",        -- Level 120
+            "Ward of Recuperation",   -- Level 115
+            "Ward of Remediation",    -- Level 110
+            "Ward of Regeneration",   -- Level 105
+            "Ward of Rejuvenation",   -- Level 100
+            "Ward of Reconstruction", -- Level 95
+            "Ward of Recovery",       -- Level 90
+            "Ward of Restoration",    -- Level 85
+            "Ward of Resurgence",     -- Level 80
         },
         ['DichoSpell'] = {
-            "Reciprocal Roar",
-            "Ecliptic Roar",
-            "Composite Roar",
-            "Dissident Roar",
-            "Roar of the Lion",
+            "Reciprocal Roar",  -- Level 121
+            "Ecliptic Roar",    -- Level 116
+            "Composite Roar",   -- Level 111
+            "Dissident Roar",   -- Level 106
+            "Roar of the Lion", -- Level 101
         },
         ['MeleeProcBuff'] = {
             -- Melee Proc Buff - Level 50 - 111
             -- To be used when the Shaman does not have Dicho
-            "Talisman of the Panther XVI",
-            "Talisman of the Manul",
-            "Talisman of the Kerran",
-            "Talisman of the Lioness",
-            "Talisman of the Sabretooth",
-            "Talisman of the Leopard",
-            "Talisman of the Snow Leopard",
-            "Talisman of the Lion",
-            "Talisman of the Tiger",
-            "Talisman of the Lynx",
-            "Talisman of the Cougar",
-            "Talisman of the Panther",
+            "Talisman of the Panther XVI",  -- Level 126
+            "Talisman of the Manul",        -- Level 121
+            "Talisman of the Kerran",       -- Level 116
+            "Talisman of the Lioness",      -- Level 111
+            "Talisman of the Sabretooth",   -- Level 106
+            "Talisman of the Leopard",      -- Level 101
+            "Talisman of the Snow Leopard", -- Level 96
+            "Talisman of the Lion",         -- Level 91
+            "Talisman of the Tiger",        -- Level 86
+            "Talisman of the Lynx",         -- Level 81
+            "Talisman of the Cougar",       -- Level 76
+            "Talisman of the Panther",      -- Level 71
             -- Below Level 71 This is a single target buff and will be keyed off of the MA
-            "Spirit of the Panther",
-            "Spirit of the Leopard",
-            "Spirit of the Jaguar",
-            "Spirit of the Puma",
+            "Spirit of the Panther",        -- Level 69
+            "Spirit of the Leopard",        -- Level 61
+            "Spirit of the Jaguar",         -- Level 57
+            "Spirit of the Puma",           -- Level 50
         },
         ['SlowProcBuff'] = {
             -- Slow Proc Buff for MA - Level 68 - 122
-            "Lassitude XIII",
-            "Moroseness",
-            "Melancholy",
-            "Ennui",
-            "Incapacity",
-            "Sluggishness",
-            "Fatigue",
-            "Apathy",
-            "Lethargy",
-            "Listlessness",
-            "Languor",
-            "Lassitude",
-            "Lingering Sloth",
+            "Lassitude XIII",  -- Level 127
+            "Moroseness",      -- Level 122
+            "Melancholy",      -- Level 117
+            "Ennui",           -- Level 112
+            "Incapacity",      -- Level 107
+            "Sluggishness",    -- Level 102
+            "Fatigue",         -- Level 97
+            "Apathy",          -- Level 92
+            "Lethargy",        -- Level 87
+            "Listlessness",    -- Level 82
+            "Languor",         -- Level 77
+            "Lassitude",       -- Level 72
+            "Lingering Sloth", -- Level 68
         },
         ['PackSelfBuff'] = {
             -- Pack Self Buff - Level 90 - 115
             --- Ignoring the LVL 85 Call the Pack buff due to the decrease in mana per tick.
-            "Pack of Dire Wolves",
-            "Pack of Ancestral Beasts",
-            "Pack of Lunar Wolves",
-            "Pack of The Black Fang",
-            "Pack of Mirtuk",
-            "Pack of Olesira",
-            "Pack of Kriegas",
-            "Pack of Hilnaah",
-            "Pack of Wurt",
+            "Pack of Dire Wolves",      -- Level 130
+            "Pack of Ancestral Beasts", -- Level 125
+            "Pack of Lunar Wolves",     -- Level 120
+            "Pack of The Black Fang",   -- Level 115
+            "Pack of Mirtuk",           -- Level 110
+            "Pack of Olesira",          -- Level 105
+            "Pack of Kriegas",          -- Level 100
+            "Pack of Hilnaah",          -- Level 95
+            "Pack of Wurt",             -- Level 90
         },
         ['AllianceBuff'] = {
-            "Ancient Alliance",
-            "Ancient Coalition",
-            "Ancient Covariance",
+            "Ancient Covariance", -- Level 123
+            "Ancient Coalition",  -- Level 113
+            "Ancient Alliance",   -- Level 103
         },
         ['RezSpell'] = {
-            'Incarnate Anew', -- Level 59
         },
         ['RecklessHeal1'] = {
-            "Reckless Mending VIII",
-            "Reckless Reinvigoration",
-            "Reckless Resurgence",
-            "Reckless Renewal",
-            "Reckless Rejuvenation",
-            "Reckless Regeneration",
-            "Reckless Restoration",
-            "Reckless Remedy",
-            "Reckless Mending",
-            "Qirik's Mending",
-            "Dannal's Mending",
-            "Gemmi's Mending",
-            "Ahnkaul's Mending",
-            "Ancient: Wilslik's Mending",
-            "Yoppa's Mending",
-            "Daluda's Mending",
-            "Tnarg's Mending",
-            "Chloroblast",
-            "Kragg's Salve",
-            "Superior Healing",
-            "Spirit Salve",
-            "Greater Healing",
-            "Healing",
-            "Light Healing",
-            "Minor Healing",
+            "Reckless Mending VIII",      -- Level 130
+            "Reckless Reinvigoration",    -- Level 125
+            "Reckless Resurgence",        -- Level 120
+            "Reckless Renewal",           -- Level 115
+            "Reckless Rejuvenation",      -- Level 110
+            "Reckless Regeneration",      -- Level 105
+            "Reckless Restoration",       -- Level 100
+            "Reckless Remedy",            -- Level 95
+            "Reckless Mending",           -- Level 90
+            "Qirik's Mending",            -- Level 88
+            "Dannal's Mending",           -- Level 83
+            "Gemmi's Mending",            -- Level 78
+            "Ahnkaul's Mending",          -- Level 73
+            "Ancient: Wilslik's Mending", -- Level 70
+            "Yoppa's Mending",            -- Level 68
+            "Daluda's Mending",           -- Level 65
+            "Tnarg's Mending",            -- Level 62
+            "Chloroblast",                -- Level 55
+            "Kragg's Salve",              -- Level 50
+            "Superior Healing",           -- Level 45
+            "Spirit Salve",               -- Level 40
+            "Greater Healing",            -- Level 29
+            "Healing",                    -- Level 19
+            "Light Healing",              -- Level 9
+            "Minor Healing",              -- Level 1
         },
         ['RecklessHeal2'] = {
             --worthless to mem two mendings because they don't have a recast time, keep Qirik's for when we don't have enough Reckless.
-            "Reckless Mending VIII",
-            "Reckless Reinvigoration",
-            "Reckless Resurgence",
-            "Reckless Renewal",
-            "Reckless Rejuvenation",
-            "Reckless Regeneration",
-            "Reckless Restoration",
-            "Reckless Remedy",
-            "Reckless Mending",
-            "Qirik's Mending",
+            "Reckless Mending VIII",   -- Level 130
+            "Reckless Reinvigoration", -- Level 125
+            "Reckless Resurgence",     -- Level 120
+            "Reckless Renewal",        -- Level 115
+            "Reckless Rejuvenation",   -- Level 110
+            "Reckless Regeneration",   -- Level 105
+            "Reckless Restoration",    -- Level 100
+            "Reckless Remedy",         -- Level 95
+            "Reckless Mending",        -- Level 90
+            "Qirik's Mending",         -- Level 88
         },
         ['RecklessHeal3'] = {
             --fallback just in case we have some other DPS stuff disabled, but 3 reckless is overkill for automation
-            "Reckless Mending VIII",
-            "Reckless Reinvigoration",
-            "Reckless Resurgence",
-            "Reckless Renewal",
-            "Reckless Rejuvenation",
-            "Reckless Regeneration",
-            "Reckless Restoration",
-            "Reckless Remedy",
-            "Reckless Mending",
-            "Qirik's Mending",
+            "Reckless Mending VIII",   -- Level 130
+            "Reckless Reinvigoration", -- Level 125
+            "Reckless Resurgence",     -- Level 120
+            "Reckless Renewal",        -- Level 115
+            "Reckless Rejuvenation",   -- Level 110
+            "Reckless Regeneration",   -- Level 105
+            "Reckless Restoration",    -- Level 100
+            "Reckless Remedy",         -- Level 95
+            "Reckless Mending",        -- Level 90
+            "Qirik's Mending",         -- Level 88
         },
         ['AESpiritualHeal'] = {
             -- Pulsing AE Heal, 100+
-            "Spiritual Shower",
-            "Spiritual Squall",
-            "Spiritual Swell",
-            "Spiritual Surge",
+            "Spiritual Shower", -- Level 118
+            "Spiritual Squall", -- Level 110
+            "Spiritual Swell",  -- Level 105
+            "Spiritual Surge",  -- Level 100
         },
         ['RecourseHeal'] = {
             --- RecourseHeal Level 87+
-            "Baratu's Recourse",
-            "Grayleaf's Recourse",
-            "Rowain's Recourse",
-            "Zrelik's Recourse",
-            "Eyrzekla's Recourse",
-            "Krasir's Recourse",
-            "Blezon's Recourse",
-            "Gotikan's Recourse",
-            "Qirik's Recourse",
+            "Baratu's Recourse",   -- Level 127
+            "Grayleaf's Recourse", -- Level 122
+            "Rowain's Recourse",   -- Level 117
+            "Zrelik's Recourse",   -- Level 112
+            "Eyrzekla's Recourse", -- Level 107
+            "Krasir's Recourse",   -- Level 102
+            "Blezon's Recourse",   -- Level 97
+            "Gotikan's Recourse",  -- Level 92
+            "Qirik's Recourse",    -- Level 87
         },
         ['InterventionHeal'] = {
             -- Intervention Heal 78+
-            "Ancestral Intervention XI",
-            "Immortal Intervention",
-            "Primordial Intervention",
-            "Prehistoric Intervention",
-            "Historian's Intervention",
-            "Antecessor's Intervention",
-            "Progenitor's Intervention",
-            "Ascendant's Intervention",
-            "Antecedent's Intervention",
-            "Ancestral Intervention",
-            "Antediluvian Intervention",
+            "Ancestral Intervention XI", -- Level 128
+            "Immortal Intervention",     -- Level 123
+            "Antediluvian Intervention", -- Level 118
+            "Primordial Intervention",   -- Level 113
+            "Prehistoric Intervention",  -- Level 108
+            "Historian's Intervention",  -- Level 103
+            "Antecessor's Intervention", -- Level 98
+            "Progenitor's Intervention", -- Level 93
+            "Ascendant's Intervention",  -- Level 88
+            "Antecedent's Intervention", -- Level 83
+            "Ancestral Intervention",    -- Level 78
         },
         ['GroupRenewalHoT'] = {
             -- Prior to 70 Breath of Trushar, single HoTs will be used including the
             --- the Torpor/Stoicism line. LVL 44 is the lowest level.
-            "Ghost of Renewal XIII",
-            "Reverie of Renewal",
-            "Spirit of Renewal",
-            "Spectre of Renewal",
-            "Cloud of Renewal",
-            "Shear of Renewal",
-            "Wisp of Renewal",
-            "Phantom of Renewal",
-            "Penumbra of Renewal",
-            "Shadow of Renewal",
-            "Shade of Renewal",
-            "Specter of Renewal",
-            "Ghost of Renewal",
-            "Spiritual Serenity",
-            "Breath of Trushar",
-            "Quiescence",
-            "Torpor",
-            "Stoicism",
+            "Ghost of Renewal XIII", -- Level 128
+            "Reverie of Renewal",    -- Level 125
+            "Spirit of Renewal",     -- Level 120
+            "Spectre of Renewal",    -- Level 115
+            "Cloud of Renewal",      -- Level 110
+            "Shear of Renewal",      -- Level 105
+            "Wisp of Renewal",       -- Level 100
+            "Phantom of Renewal",    -- Level 95
+            "Penumbra of Renewal",   -- Level 90
+            "Shadow of Renewal",     -- Level 85
+            "Shade of Renewal",      -- Level 80
+            "Specter of Renewal",    -- Level 75
+            "Ghost of Renewal",      -- Level 70
+            "Spiritual Serenity",    -- Level 70
+            "Breath of Trushar",     -- Level 65
+            "Quiescence",            -- Level 65
+            "Torpor",                -- Level 60
+            "Stoicism",              -- Level 44
         },
         ['CanniSpell'] = {
             -- Convert Health to Mana - Level  23+
-            "Ancestral Bargain XIV",
-            "Traumatic Exchange",
-            "Hoary Agreement",
-            "Ancient Bargain",
-            "Tribal Bargain",
-            "Tribal Pact",
-            "Ancestral Pact",
-            "Ancestral Arrangement",
-            "Ancestral Covenant",
-            "Ancestral Obligation",
-            "Ancestral Hearkening",
-            "Ancestral Bargain",
-            "Ancient: Ancestral Calling",
-            "Pained Memory",
-            "Ancient: Chaotic Pain",
-            "Cannibalize IV",
-            "Cannibalize III",
-            "Cannibalize II",
-            "Cannibalize",
+            "Ancestral Bargain XIV",      -- Level 129
+            "Traumatic Exchange",         -- Level 124
+            "Hoary Agreement",            -- Level 118
+            "Ancient Bargain",            -- Level 113
+            "Tribal Bargain",             -- Level 108
+            "Tribal Pact",                -- Level 103
+            "Ancestral Pact",             -- Level 98
+            "Ancestral Arrangement",      -- Level 93
+            "Ancestral Covenant",         -- Level 88
+            "Ancestral Obligation",       -- Level 83
+            "Ancestral Hearkening",       -- Level 78
+            "Ancestral Bargain",          -- Level 73
+            "Ancient: Ancestral Calling", -- Level 70
+            "Pained Memory",              -- Level 68
+            "Ancient: Chaotic Pain",      -- Level 65
+            "Cannibalize IV",             -- Level 58
+            "Cannibalize III",            -- Level 54
+            "Cannibalize II",             -- Level 38
+            "Cannibalize",                -- Level 23
         },
         ['CureSpell'] = {
-            "Mastery: Blood of Mayong",
-            "Blood of Mayong",
-            "Blood of Tevik",
-            "Blood of Rivans",
-            "Blood of Sanera",
-            "Blood of Klar",
-            "Blood of Corbeth",
-            "Blood of Avoling",
-            "Blood of Nadox",
+            "Mastery: Blood of Mayong", -- Level 130
+            "Blood of Mayong",          -- Level 120
+            "Blood of Tevik",           -- Level 110
+            "Blood of Rivans",          -- Level 105
+            "Blood of Sanera",          -- Level 100
+            "Blood of Klar",            -- Level 95
+            "Blood of Corbeth",         -- Level 90
+            "Blood of Avoling",         -- Level 85
+            "Blood of Nadox",           -- Level 52
         },
         ['CureCorrupt'] = {
-            "Mastery: Chant of the Zelniak",
-            "Chant of the Zelniak",
-            "Chant of the Wulthan",
-            "Chant of the Kromtus",
-            "Chant of Jaerol",
-            "Chant of the Izon",
-            "Chant of the Tae Ew",
-            "Chant of the Burynai",
-            "Chant of the Darkvine",
-            "Chant of the Napaea",
-            "Cure Corruption",
+            "Mastery: Chant of the Zelniak", -- Level 129
+            "Chant of the Zelniak",          -- Level 119
+            "Chant of the Wulthan",          -- Level 109
+            "Chant of the Kromtus",          -- Level 104
+            "Chant of Jaerol",               -- Level 99
+            "Chant of the Izon",             -- Level 94
+            "Chant of the Tae Ew",           -- Level 89
+            "Chant of the Burynai",          -- Level 84
+            "Chant of the Darkvine",         -- Level 79
+            "Chant of the Napaea",           -- Level 64
+            "Cure Corruption",               -- Level 62
         },
         ['TwinHealNuke'] = {
             -- Nuke the MA Not the assist target - Levels 85+
-            "Frost Gift X",
-            "Gelid Gift",
-            "Polar Gift",
-            "Wintry Gift",
-            "Frostbitten Gift",
-            "Glacial Gift",
-            "Frigid Gift",
-            "Freezing Gift",
-            "Frozen Gift",
-            "Frost Gift",
+            "Frost Gift X",     -- Level 130
+            "Gelid Gift",       -- Level 125
+            "Polar Gift",       -- Level 120
+            "Wintry Gift",      -- Level 115
+            "Frostbitten Gift", -- Level 110
+            "Glacial Gift",     -- Level 105
+            "Frigid Gift",      -- Level 100
+            "Freezing Gift",    -- Level 95
+            "Frozen Gift",      -- Level 90
+            "Frost Gift",       -- Level 85
         },
         ['PoisonNuke'] = {
             -- Poison Nuke LVL34 +
-            "Tserik's Spear of Venom",
-            "Red Eye's Spear of Venom",
-            "Fleshrot's Spear of Venom",
-            "Narandi's Spear of Venom",
-            "Nexona's Spear of Venom",
-            "Serisaria's Spear of Venom",
-            "Slaunk's Spear of Venom",
-            "Hiqork's Spear of Venom",
-            "Spinechiller's Spear of Venom",
-            "Severilous' Spear of Venom",
-            "Vestax's Spear of Venom",
-            "Ahnkaul's Spear of Venom",
-            "Yoppa's Spear of Venom",
-            "Spear of Torment",
-            "Blast of Venom",
-            "Shock of Venom",
-            "Blast of Poison",
-            "Shock of the Tainted",
+            "Tserik's Spear of Venom",       -- Level 126
+            "Red Eye's Spear of Venom",      -- Level 121
+            "Fleshrot's Spear of Venom",     -- Level 116
+            "Narandi's Spear of Venom",      -- Level 111
+            "Nexona's Spear of Venom",       -- Level 106
+            "Serisaria's Spear of Venom",    -- Level 101
+            "Slaunk's Spear of Venom",       -- Level 96
+            "Hiqork's Spear of Venom",       -- Level 91
+            "Spinechiller's Spear of Venom", -- Level 86
+            "Severilous' Spear of Venom",    -- Level 81
+            "Vestax's Spear of Venom",       -- Level 76
+            "Ahnkaul's Spear of Venom",      -- Level 71
+            "Yoppa's Spear of Venom",        -- Level 66
+            "Spear of Torment",              -- Level 61
+            "Blast of Venom",                -- Level 54
+            "Shock of Venom",                -- Level 47
+            "Blast of Poison",               -- Level 42
+            "Shock of the Tainted",          -- Level 34
         },
         ['FastPoisonNuke'] = {
             -- Fast Poison Nuke LVL73+
-            "Tserik's Bite",
-            "Oka's Bite",
-            "Ander's Bite",
-            "Direfang's Bite",
-            "Mawmun's Bite",
-            "Reefmaw's Bite",
-            "Seedspitter's Bite",
-            "Bite of the Grendlaen",
-            "Bite of the Blightwolf",
-            "Bite of the Ukun",
-            "Bite of the Brownie",
-            "Sting of the Queen",
+            "Tserik's Bite",          -- Level 128
+            "Oka's Bite",             -- Level 123
+            "Ander's Bite",           -- Level 118
+            "Direfang's Bite",        -- Level 113
+            "Mawmun's Bite",          -- Level 108
+            "Reefmaw's Bite",         -- Level 103
+            "Seedspitter's Bite",     -- Level 98
+            "Bite of the Grendlaen",  -- Level 93
+            "Bite of the Blightwolf", -- Level 88
+            "Bite of the Ukun",       -- Level 83
+            "Bite of the Brownie",    -- Level 78
+            "Sting of the Queen",     -- Level 73
         },
         ['IceNuke'] = {
             --- IceNuke - Level 4+
-            "Frost Rift XX",
-            "Ice Barrage",
-            "Heavy Sleet",
-            "Ice Salvo",
-            "Ice Shards",
-            "Ice Squall",
-            "Ice Burst",
-            "Ice Mass",
-            "Ice Floe",
-            "Ice Sheet",
-            "Tundra Crumble",
-            "Glacial Avalanche",
-            "Ice Age",
-            "Velium Strike",
-            "Ice Strike",
-            "Blizzard Blast",
-            "Winter's Roar",
-            "Frost Strike",
-            "Spirit Strike",
-            "Frost Rift",
+            "Frost Rift XX",     -- Level 129
+            "Ice Barrage",       -- Level 124
+            "Heavy Sleet",       -- Level 119
+            "Ice Salvo",         -- Level 114
+            "Ice Shards",        -- Level 109
+            "Ice Squall",        -- Level 104
+            "Ice Burst",         -- Level 99
+            "Ice Mass",          -- Level 94
+            "Ice Floe",          -- Level 89
+            "Ice Sheet",         -- Level 84
+            "Tundra Crumble",    -- Level 79
+            "Glacial Avalanche", -- Level 74
+            "Ice Age",           -- Level 69
+            "Velium Strike",     -- Level 64
+            "Ice Strike",        -- Level 54
+            "Blizzard Blast",    -- Level 44
+            "Winter's Roar",     -- Level 33
+            "Frost Strike",      -- Level 23
+            "Spirit Strike",     -- Level 14
+            "Frost Rift",        -- Level 4
         },
         ['ChaoticDot'] = {
             -- Long Dot(42s) LVL 104+
             -- Two resist types because it throws 2 dots
             -- Stacking: Nectar of Pain - Stacking: Blood of Saryrn
-            "Chaotic Bloodcurse",
-            "Chaotic Poison",
-            "Chaotic Venom",
-            "Chaotic Venin",
-            "Chaotic Toxin",
+            "Chaotic Bloodcurse", -- Level 125
+            "Chaotic Toxin",      -- Level 120
+            "Chaotic Venin",      -- Level 115
+            "Chaotic Poison",     -- Level 109
+            "Chaotic Venom",      -- Level 104
         },
         ['PandemicDot'] = {
             -- Pandemic Dot Long Dot(84s) Level 103+
             -- Two resist types because it throws 2 dots
             -- Stacking: Kralbor's Pandemic  -    Stacking: Breath of Ultor
-            "Hotariton Pandemic",
-            "Tegi Pandemic",
-            "Bledrek's Pandemic",
-            "Elkikatar's Pandemic",
-            "Hemocoraxius' Pandemic",
+            "Hotariton Pandemic",     -- Level 124
+            "Tegi Pandemic",          -- Level 119
+            "Bledrek's Pandemic",     -- Level 114
+            "Elkikatar's Pandemic",   -- Level 108
+            "Hemocoraxius' Pandemic", -- Level 103
         },
         ['MaloDot'] = {
             -- Malo Dot Stacking: Yubai's Affliction - LongDot(96s) Level 99+
-            "Torrentclaw's Malosinera",
-            "Svartmane's Malosinara",
-            "Rirwech's Malosinata",
-            "Livio's Malosenia",
-            "Falhotep's Malosenia",
-            "Txiki's Malosinara",
-            "Krizad's Malosinera",
+            "Torrentclaw's Malosinera", -- Level 129
+            "Krizad's Malosinera",      -- Level 124
+            "Txiki's Malosinara",       -- Level 119
+            "Svartmane's Malosinara",   -- Level 114
+            "Rirwech's Malosinata",     -- Level 109
+            "Livio's Malosenia",        -- Level 104
+            "Falhotep's Malosenia",     -- Level 99
         },
         ['CurseDot1'] = {
             -- Curse Dot 1 Stacking: Curse - Long Dot(30s) - Level 34+
-            "Curse XVII",
-            "Malediction",
-            "Obeah",
-            "Evil Eye",
-            "Jinx",
-            "Garugaru",
-            "Naganaga",
-            "Hoodoo",
-            "Hex",
-            "Mojo",
-            "Pocus",
-            "Juju",
-            "Curse of Sisslak",
-            "Bane",
-            "Anathema",
-            "Odium",
-            "Curse",
+            "Curse XVII",       -- Level 129
+            "Malediction",      -- Level 124
+            "Obeah",            -- Level 119
+            "Evil Eye",         -- Level 114
+            "Jinx",             -- Level 109
+            "Garugaru",         -- Level 104
+            "Naganaga",         -- Level 99
+            "Hoodoo",           -- Level 94
+            "Hex",              -- Level 89
+            "Mojo",             -- Level 84
+            "Pocus",            -- Level 79
+            "Juju",             -- Level 74
+            "Curse of Sisslak", -- Level 69
+            "Bane",             -- Level 64
+            "Anathema",         -- Level 54
+            "Odium",            -- Level 43
+            "Curse",            -- Level 34
         },
         ['CurseDot2'] = {
             ---, Stacking: Enalam's Curse - Long Dot(54s) - 100+
-            "Maniadry's Curse",
-            "Lenrel's Curse",
-            "Marlek's Curse",
-            "Erogo's Curse",
-            "Sraskus' Curse",
-            "Enalam's Curse",
-            "Fandrel's Curse",
+            "Maniadry's Curse", -- Level 130
+            "Fandrel's Curse",  -- Level 125
+            "Lenrel's Curse",   -- Level 120
+            "Marlek's Curse",   -- Level 115
+            "Erogo's Curse",    -- Level 110
+            "Sraskus' Curse",   -- Level 105
+            "Enalam's Curse",   -- Level 100
         },
         ['SaryrnDot'] = {
             -- Stacking: Blood of Saryrn - Long Dot(42s) - Level 8+
-            "Blood of Torrentclaw",
-            "Caustic Blood",
-            "Desperate Vampyre Blood",
-            "Restless Blood",
-            "Reef Crawler Blood",
-            "Phase Spider Blood",
-            "Naeya Blood",
-            "Spinechiller Blood",
-            "Blood of Jaled'Dar",
-            "Blood of Kerafyrm",
-            "Vengeance of Ahnkaul",
-            "Blood of Yoppa",
-            "Blood of Saryrn",
-            "Ancient: Scourge of Nife",
-            "Bane of Nife",
-            "Envenomed Bolt",
-            "Venom of the Snake",
-            "Envenomed Breath",
-            "Tainted Breath",
+            "Blood of Torrentclaw",     -- Level 129
+            "Caustic Blood",            -- Level 124
+            "Desperate Vampyre Blood",  -- Level 120
+            "Restless Blood",           -- Level 115
+            "Reef Crawler Blood",       -- Level 105
+            "Phase Spider Blood",       -- Level 100
+            "Naeya Blood",              -- Level 95
+            "Spinechiller Blood",       -- Level 90
+            "Blood of Jaled'Dar",       -- Level 85
+            "Blood of Kerafyrm",        -- Level 80
+            "Vengeance of Ahnkaul",     -- Level 75
+            "Blood of Yoppa",           -- Level 70
+            "Blood of Saryrn",          -- Level 65
+            "Ancient: Scourge of Nife", -- Level 60
+            "Bane of Nife",             -- Level 56
+            "Envenomed Bolt",           -- Level 49
+            "Venom of the Snake",       -- Level 37
+            "Envenomed Breath",         -- Level 24
+            "Tainted Breath",           -- Level 8
         },
         ['UltorDot'] = {
             ---, Stacking: Breath of Ultor - Long Dot(84s) - Level 4+
-            "Breath of Pustim",
-            "Breath of the Hotariton",
-            "Breath of the Tegi",
-            "Breath of Bledrek",
-            "Breath of Hemocoraxius",
-            "Breath of Natigo",
-            "Breath of Silbar",
-            "Breath of the Shiverback",
-            "Breath of Queen Malarian",
-            "Breath of Big Bynn",
-            "Breath of Ternsmochin",
-            "Breath of Wunshi",
-            "Breath of Ultor",
-            "Pox of Bertoxxulous",
-            "Plague",
-            "Scourge",
-            "Affliction",
-            "Sicken",
+            "Breath of Pustim",         -- Level 126
+            "Breath of the Hotariton",  -- Level 121
+            "Breath of the Tegi",       -- Level 116
+            "Breath of Bledrek",        -- Level 111
+            "Breath of Hemocoraxius",   -- Level 101
+            "Breath of Natigo",         -- Level 96
+            "Breath of Silbar",         -- Level 91
+            "Breath of the Shiverback", -- Level 86
+            "Breath of Queen Malarian", -- Level 81
+            "Breath of Big Bynn",       -- Level 76
+            "Breath of Ternsmochin",    -- Level 71
+            "Breath of Wunshi",         -- Level 67
+            "Breath of Ultor",          -- Level 64
+            "Pox of Bertoxxulous",      -- Level 59
+            "Plague",                   -- Level 49
+            "Scourge",                  -- Level 31
+            "Affliction",               -- Level 19
+            "Sicken",                   -- Level 4
         },
         ['AfflictionDot'] = {
             ---, Stacking: Yubai's Affliction - Long Dot(96s) - Level 9+, used on named only for hybrid
-            "Torrentclaw's Affliction",
-            "Krizad's Affliction",
-            "Brightfeld's Affliction",
-            "Svartmane's Affliction",
-            "Rirwech's Affliction",
-            "Livio's Affliction",
-            "Falhotep's Affliction",
-            "Yubai's Affliction",
+            "Torrentclaw's Affliction", -- Level 127
+            "Krizad's Affliction",      -- Level 122
+            "Brightfeld's Affliction",  -- Level 117
+            "Svartmane's Affliction",   -- Level 112
+            "Rirwech's Affliction",     -- Level 107
+            "Livio's Affliction",       -- Level 102
+            "Falhotep's Affliction",    -- Level 97
+            "Yubai's Affliction",       -- Level 92
         },
-        ['NectarDot'] = { --almost never worth casting in a group, not currently gemmed.
-            "Nectar of Pain XIII",
-            "Nectar of Obscurity",
-            "Nectar of Pain",
-            "Nectar of Agony",
-            "Nectar of Rancor",
-            "Nectar of the Slitheren",
-            "Nectar of Torment",
-            "Nectar of Sholoth",
-            "Nectar of Anguish",
-            "Nectar of Woe",
-            "Nectar of Suffering",
-            "Nectar of Misery",
-            "Nectar of Destitution",
+        ['NectarDot'] = {               --almost never worth casting in a group, not currently gemmed.
+            "Nectar of Pain XIII",      -- Level 129
+            "Nectar of Obscurity",      -- Level 124
+            "Nectar of Destitution",    -- Level 119
+            "Nectar of Misery",         -- Level 114
+            "Nectar of Suffering",      -- Level 109
+            "Nectar of Woe",            -- Level 104
+            "Nectar of Anguish",        -- Level 99
+            "Nectar of Sholoth",        -- Level 94
+            "Nectar of Torment",        -- Level 89
+            "Nectar of the Slitheren",  -- Level 84
+            "Nectar of Rancor",         -- Level 79
+            "Nectar of Agony",          -- Level 74
+            "Nectar of Pain",           -- Level 70
         },
         ['PetSpell'] = {
             -- Pet Spell - 32+
-            "Aramna's Faithful",
-            "Suja's Faithful",
-            "Diabo Sivuela's Faithful",
-            "Grondo's Faithful",
-            "Mirtuk's Faithful",
-            "Olesira's Faithful",
-            "Kriegas' Faithful",
-            "Hilnaah's Faithful",
-            "Wurt's Faithful",
-            "Aina's Faithful",
-            "Vegu's Faithful",
-            "Kyrah's Faithful",
-            "Farrel's Companion",
-            "True Spirit",
-            "Spirit of the Howler",
-            "Frenzied Spirit",
-            "Guardian spirit",
-            "Vigilant Spirit",
-            "Companion Spirit",
+            "Aramna's Faithful",        -- Level 127
+            "Suja's Faithful",          -- Level 122
+            "Diabo Sivuela's Faithful", -- Level 117
+            "Grondo's Faithful",        -- Level 112
+            "Mirtuk's Faithful",        -- Level 107
+            "Olesira's Faithful",       -- Level 102
+            "Kriegas' Faithful",        -- Level 97
+            "Hilnaah's Faithful",       -- Level 92
+            "Wurt's Faithful",          -- Level 87
+            "Aina's Faithful",          -- Level 82
+            "Vegu's Faithful",          -- Level 77
+            "Kyrah's Faithful",         -- Level 72
+            "Farrel's Companion",       -- Level 67
+            "True Spirit",              -- Level 61
+            "Spirit of the Howler",     -- Level 55
+            "Frenzied Spirit",          -- Level 45
+            "Guardian spirit",          -- Level 41
+            "Vigilant Spirit",          -- Level 37
+            "Companion Spirit",         -- Level 32
         },
         ['PetBuffSpell'] = {
             ---Pet Buff Spell - 50+
-            "Spirit Bolstering V",
-            "Spirit Augmentation",
-            "Spirit Reinforcement",
-            "Spirit Bracing",
-            "Spirit Bolstering",
-            "Spirit Quickening",
+            "Spirit Bolstering V",  -- Level 127
+            "Spirit Augmentation",  -- Level 122
+            "Spirit Reinforcement", -- Level 117
+            "Spirit Bracing",       -- Level 112
+            "Spirit Bolstering",    -- Level 97
+            "Spirit Quickening",    -- Level 50
         },
         ['CureDisease'] = {
-            "Cure Disease",
-            "Counteract Disease",
-            "Eradicate Disease",
+            "Eradicate Disease",  -- Level 52
+            "Counteract Disease", -- Level 22
+            "Cure Disease",       -- Level 1
         },
         ['CurePoison'] = {
-            "Counteract Poison",
-            "Abolish Poison",
-            "Eradicate Poison",
+            "Eradicate Poison",  -- Level 56
+            "Counteract Poison", -- Level 26
         },
         ['CureCurse'] = {
-            -- "Eradicate Curse",      -- Level 54 , 30 counters, twice, 400 mana
-            "Remove Greater Curse", -- Level 54 , 9 counters, 5 times, 100 mana
-            "Remove Curse",         -- Level 38
-            "Remove Lesser Curse",  -- Level 24
-            "Remove Minor Curse",   -- Level 9
+            -- "Eradicate Curse",   -- Level 54, counters, twice, 400 mana
+            "Remove Greater Curse",          -- Level 54, counters, 5 times, 100 mana
+            "Remove Curse",                  -- Level 38
+            "Remove Lesser Curse",           -- Level 24
+            "Remove Minor Curse",            -- Level 9
         },
-        ['GroupRegenBuff'] = {      --Does not stack with Dicho Regen
-            "Talisman of Perseverance XV",
-            "Talisman of the Unforgettable",
-            "Talisman of the Tenacious",
-            "Talisman of the Enduring",
-            "Talisman of the Unwavering",
-            "Talisman of the Faithful",
-            "Talisman of the Steadfast",
-            "Talisman of the Indomitable",
-            "Talisman of the Reletntless",
-            "Talisman of the Resolute",
-            "Talisman of the Stalwart",
-            "Talisman of the Stoic One",
-            "Talisman of Perseverance",
-            "Regrowth of Dar Khura", -- Level 56
+        ['GroupRegenBuff'] = {               --Does not stack with Dicho Regen
+            "Talisman of Perseverance XV",   -- Level 126
+            "Talisman of the Unforgettable", -- Level 124
+            "Talisman of the Tenacious",     -- Level 119
+            "Talisman of the Enduring",      -- Level 114
+            "Talisman of the Unwavering",    -- Level 109
+            "Talisman of the Faithful",      -- Level 104
+            "Talisman of the Steadfast",     -- Level 99
+            "Talisman of the Indomitable",   -- Level 94
+            "Talisman of the Relentless",    -- Level 89
+            "Talisman of the Resolute",      -- Level 84
+            "Talisman of the Stalwart",      -- Level 79
+            "Talisman of the Stoic One",     -- Level 74
+            "Talisman of Perseverance",      -- Level 69
+            "Regrowth of Dar Khura",         -- Level 56
         },
         ['SingleRegenBuff'] = {
-            "Regrowth",
-            "Chloroplast",
-            "Regeneration", -- Level 22
+            "Regrowth",     -- Level 52
+            "Chloroplast",  -- Level 39
+            "Regeneration", -- Level 23
         },
         ['ShrinkSpell'] = {
-            "Tiny Terror",
-            "Shrink",
+            "Tiny Terror", -- Level 64
+            "Shrink",      -- Level 15
         },
     },
     ['Helpers']           = {

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -76,221 +76,221 @@ local _ClassConfig = {
     },
     ['AbilitySets']   = {
         ['StandDisc'] = {
-            "Final Stand Discipline VI",
-            "Climactic Stand",
-            "Resolute Stand",
-            "Ultimate Stand Discipline",
-            "Culminating Stand Discipline",
-            "Last Stand Discipline",
-            "Final Stand Discipline",
-            --[] = "Stonewall Discipline",
-            "Defensive Discipline",
+            "Final Stand Discipline VI",    -- Level 128
+            "Climactic Stand",              -- Level 123
+            "Resolute Stand",               -- Level 118
+            "Ultimate Stand Discipline",    -- Level 113
+            "Culminating Stand Discipline", -- Level 108
+            "Last Stand Discipline",        -- Level 98
+            "Final Stand Discipline",       -- Level 72
+            -- "Stonewall Discipline",      -- Level 65
+            "Defensive Discipline",         -- Level 55
         },
         ['Fortitude'] = {
-            "Fortitude Discipline",
+            "Fortitude Discipline", -- Level 59
         },
         ['AbsorbDisc'] = {
-            "Finish the Fight",
-            "Pain Doesn't Hurt",
-            "No Time to Bleed",
+            "Finish the Fight",  -- Level 112
+            "Pain Doesn't Hurt", -- Level 102
+            "No Time to Bleed",  -- Level 96
         },
         ['Flash'] = {
-            "Flash of Anger",
+            "Flash of Anger", -- Level 87
         },
         ['ShieldHit'] = {
-            "Shield Sunder",
-            "Shield Break",
-            "Shield Topple",
-            "Shield Splinter",
-            "Shield Rupture",
-            "Shield Split",
+            "Shield Split",    -- Level 125
+            "Shield Rupture",  -- Level 120
+            "Shield Splinter", -- Level 115
+            "Shield Sunder",   -- Level 110
+            "Shield Break",    -- Level 104
+            "Shield Topple",   -- Level 83
         },
         ['GroupACBuff'] = {
-            "Field Armorer X",
-            "Field Bulwark",
-            "Full Moon's Champion",
-            "Paragon Champion",
-            "Field Champion",
-            "Field Protector",
-            "Field Guardian",
-            "Field Defender",
-            "Field Outfitter",
-            "Field Armorer",
+            "Field Armorer X",      -- Level 130
+            "Field Bulwark",        -- Level 125
+            "Full Moon's Champion", -- Level 120
+            "Paragon Champion",     -- Level 115
+            "Field Champion",       -- Level 110
+            "Field Protector",      -- Level 105
+            "Field Guardian",       -- Level 100
+            "Field Defender",       -- Level 95
+            "Field Outfitter",      -- Level 90
+            "Field Armorer",        -- Level 85
         },
         ['GroupDodgeBuff'] = {
-            "Commanding Voice",
+            "Commanding Voice", -- Level 68
         },
         ['DefenseACBuff'] = {
-            "Bracing Defense X",
-            "Vigorous Defense",
-            "Primal Defense",
-            "Courageous Defense",
-            "Resolute Defense",
-            "Stout Defense",
-            "Steadfast Defense",
-            "Stalwart Defense",
-            "Staunch Defense",
-            "Bracing Defense",
+            "Bracing Defense X",  -- Level 130
+            "Vigorous Defense",   -- Level 125
+            "Primal Defense",     -- Level 120
+            "Courageous Defense", -- Level 115
+            "Resolute Defense",   -- Level 110
+            "Stout Defense",      -- Level 105
+            "Steadfast Defense",  -- Level 100
+            "Stalwart Defense",   -- Level 95
+            "Staunch Defense",    -- Level 90
+            "Bracing Defense",    -- Level 85
         },
         ['DichoShield'] = {
-            "Reciprocal Shield",
-            "Ecliptic Shield",
-            "Composite Shield",
-            "Dissident Shield",
-            "Dichotomic Shield",
+            "Reciprocal Shield", -- Level 121
+            "Ecliptic Shield",   -- Level 116
+            "Composite Shield",  -- Level 111
+            "Dissident Shield",  -- Level 106
+            "Dichotomic Shield", -- Level 101
         },
-        ['AERoar'] = { --does not appear to be worthwhile, very limited level range and low hate value
-            "Roar of Challenge",
-            "Rallying Roar",
+        ['AERoar'] = {           --does not appear to be worthwhile, very limited level range and low hate value
+            "Roar of Challenge", -- Level 93
+            "Rallying Roar",     -- Level 88
         },
         ['SelfBuffAE'] = {
-            "Wade into Battle",
-            "Wade into Conflict",
+            "Wade into Conflict", -- Level 119
+            "Wade into Battle",   -- Level 99
         },
         ['SelfBuffSingle'] = {
-            "Determined Reprisal",
+            "Determined Reprisal", -- Level 97
         },
         ['HealHateAE'] = {
-            "Paradoxical Expanse",
-            "Penumbral Expanse",
-            "Confluent Expanse",
-            "Concordant Expanse",
-            "Harmonious Expanse",
+            "Paradoxical Expanse", -- Level 122
+            "Penumbral Expanse",   -- Level 117
+            "Confluent Expanse",   -- Level 112
+            "Concordant Expanse",  -- Level 107
+            "Harmonious Expanse",  -- Level 102
         },
         ['HealHateSingle'] = {
-            "Paradoxical Precision",
-            "Penumbral Precision",
-            "Confluent Precision",
-            "Concordant Precision",
-            "Harmonious Precision",
+            "Paradoxical Precision", -- Level 123
+            "Penumbral Precision",   -- Level 118
+            "Confluent Precision",   -- Level 113
+            "Concordant Precision",  -- Level 108
+            "Harmonious Precision",  -- Level 103
         },
         ['AEBlades'] = {
-            "Cyclone Blades XIV",
-            "Tempest Blades",
-            "Dragonstrike Blades",
-            "Stormstrike Blades",
-            "Stormwheel Blades",
-            "Cyclonic Blades",
-            "Wheeling Blades",
-            "Maelstrom Blade",
-            "Whorl Blade",
-            "Vortex Blade",
-            "Cyclone Blade",
-            "Whirlwind Blade",
-            "Hurricane Blades",
-            "Spiraling Blades",
+            "Cyclone Blades XIV",  -- Level 127
+            "Spiraling Blades",    -- Level 124
+            "Hurricane Blades",    -- Level 119
+            "Tempest Blades",      -- Level 114
+            "Dragonstrike Blades", -- Level 109
+            "Stormstrike Blades",  -- Level 104
+            "Stormwheel Blades",   -- Level 99
+            "Cyclonic Blades",     -- Level 94
+            "Wheeling Blades",     -- Level 89
+            "Maelstrom Blade",     -- Level 84
+            "Whorl Blade",         -- Level 79
+            "Vortex Blade",        -- Level 74
+            "Cyclone Blade",       -- Level 69
+            "Whirlwind Blade",     -- Level 61
         },
         ['AddHate1'] = {
-            "Bazu Roar X",
-            "Mortimus' Roar",
-            "Namdrows' Roar",
-            "Kragek's Roar",
-            "Kluzen's Roar",
-            "Cyclone Roar",
-            "Krondal's Roar",
-            "Grendlaen Roar",
-            "Bazu Roar",
-            "Ancient: Chaos Cry",
-            "Bazu Bluster",
-            "Bazu Bellow",
-            "Bellow of the Mastruq",
-            "Incite",
-            "Berate",
-            "Bellow",
-            "Provoke",
+            "Bazu Roar X",           -- Level 126
+            "Mortimus' Roar",        -- Level 121
+            "Namdrows' Roar",        -- Level 116
+            "Kragek's Roar",         -- Level 111
+            "Kluzen's Roar",         -- Level 106
+            "Cyclone Roar",          -- Level 101
+            "Krondal's Roar",        -- Level 96
+            "Grendlaen Roar",        -- Level 91
+            "Bazu Roar",             -- Level 86
+            "Bazu Bluster",          -- Level 81
+            "Bazu Bellow",           -- Level 69
+            "Ancient: Chaos Cry",    -- Level 65
+            "Bellow of the Mastruq", -- Level 65
+            "Incite",                -- Level 63
+            "Berate",                -- Level 56
+            "Bellow",                -- Level 52
+            "Provoke",               -- Level 20
         },
         ['AddHate2'] = {
-            "Harassing Shout VII",
-            "Distressing Shout",
-            "Twilight Shout",
-            "Oppressing Shout",
-            "Burning Shout",
-            "Tormenting Shout",
-            "Harassing Shout",
+            "Harassing Shout VII", -- Level 128
+            "Distressing Shout",   -- Level 123
+            "Twilight Shout",      -- Level 118
+            "Oppressing Shout",    -- Level 113
+            "Burning Shout",       -- Level 108
+            "Tormenting Shout",    -- Level 103
+            "Harassing Shout",     -- Level 98
         },
         ['AbsorbTaunt'] = {
-            "Provoke XIX",
-            "Infuriate",
-            "Bristle",
-            "Aggravate",
-            "Slander",
-            "Insult",
-            "Ridicule",
-            "Scorn",
-            "Scoff",
-            "Jeer",
-            "Sneer",
-            "Scowl",
-            "Mock",
+            "Provoke XIX", -- Level 128
+            "Infuriate",   -- Level 123
+            "Bristle",     -- Level 118
+            "Aggravate",   -- Level 113
+            "Slander",     -- Level 108
+            "Insult",      -- Level 103
+            "Ridicule",    -- Level 98
+            "Scorn",       -- Level 95
+            "Scoff",       -- Level 90
+            "Jeer",        -- Level 85
+            "Sneer",       -- Level 80
+            "Scowl",       -- Level 75
+            "Mock",        -- Level 70
         },
         ['StrikeDisc'] = {
-            "Opportunistic Strike IX",
-            "Decisive Strike",
-            "Precision Strike",
-            "Cunning Strike",
-            "Calculated Strike",
-            "Vital Strike",
-            "Strategic Strike",
-            "Opportunistic Strike",
-            "Exploitive Strike",
+            "Opportunistic Strike IX", -- Level 129
+            "Decisive Strike",         -- Level 124
+            "Exploitive Strike",       -- Level 119
+            "Precision Strike",        -- Level 114
+            "Cunning Strike",          -- Level 109
+            "Calculated Strike",       -- Level 104
+            "Vital Strike",            -- Level 93
+            "Strategic Strike",        -- Level 88
+            "Opportunistic Strike",    -- Level 78
         },
         ['EndRegen'] = {
-            "Hiatus V",
-            "Convalesce",
-            "Night's Calming",
-            "Hiatus",
-            "Breather",
-            "Rest",
-            "Reprieve",
-            "Respite",
-            "Fourth Wind",
-            "Third Wind",
-            "Second Wind",
+            "Hiatus V",        -- Level 126
+            "Convalesce",      -- Level 121
+            "Night's Calming", -- Level 116
+            "Hiatus",          -- Level 106
+            "Breather",        -- Level 101
+            "Rest",            -- Level 96
+            "Reprieve",        -- Level 91
+            "Respite",         -- Level 86
+            "Fourth Wind",     -- Level 82
+            "Third Wind",      -- Level 77
+            "Second Wind",     -- Level 72
         },
         ['AuraBuff'] = {
-            "Champion's Aura",
-            "Myrmidon's Aura",
+            "Champion's Aura", -- Level 70
+            "Myrmidon's Aura", -- Level 55
         },
         ['Attention'] = {
-            "Unquestioned Attention",
-            "Unending Attention",
-            "Unyielding Attention",
-            "Unflinching Attention",
-            "Unbroken Attention",
-            "Undivided Attention",
-            "Unrelenting Attention",
-            "Unconditional Attention",
+            "Unquestioned Attention",  -- Level 127
+            "Unconditional Attention", -- Level 122
+            "Unrelenting Attention",   -- Level 117
+            "Unending Attention",      -- Level 112
+            "Unyielding Attention",    -- Level 107
+            "Unflinching Attention",   -- Level 102
+            "Unbroken Attention",      -- Level 97
+            "Undivided Attention",     -- Level 92
         },
         ['AggroPet'] = {
-            "Phantom Aggressor",
+            "Phantom Aggressor", -- Level 100
         },
         ['Onslaught'] = {
-            "Savage Onslaught Discipline",
-            "Brutal Onslaught Discipline",
-            "Brightfeld's Onslaught Discipline",
+            "Brightfeld's Onslaught Discipline", -- Level 117
+            "Brutal Onslaught Discipline",       -- Level 74
+            "Savage Onslaught Discipline",       -- Level 68
         },
         ['RuneShield'] = {
-            "Warrior's Auspice VII",
-            "Warrior's Auspice",
-            "Warrior's Bulwark",
-            "Warrior's Bastion",
-            "Warrior's Rampart",
-            "Warrior's Aegis",
-            "Warrior's Resolve",
+            "Warrior's Auspice VII", -- Level 129
+            "Warrior's Resolve",     -- Level 124
+            "Warrior's Aegis",       -- Level 119
+            "Warrior's Rampart",     -- Level 114
+            "Warrior's Bastion",     -- Level 109
+            "Warrior's Bulwark",     -- Level 104
+            "Warrior's Auspice",     -- Level 99
         },
         ['TongueDisc'] = {
-            "Razor Tongue Discipline",
-            "Biting Tongue Discipline",
-            "Barbed Tongue Discipline",
+            "Razor Tongue Discipline",  -- Level 122
+            "Biting Tongue Discipline", -- Level 107
+            "Barbed Tongue Discipline", -- Level 94
         },
         ['ChargeDisc'] = {
-            "Charge Discipline",
+            "Charge Discipline", -- Level 53
         },
         ['OffensiveDisc'] = {
-            "Offensive Discipline",
+            "Offensive Discipline", -- Level 97
         },
         ['MightyStrike'] = {
-            "Mighty Strike Discipline",
+            "Mighty Strike Discipline", -- Level 54
         },
     },
     ['Helpers']       = {

--- a/class_configs/Live/wiz_class_config.lua
+++ b/class_configs/Live/wiz_class_config.lua
@@ -70,582 +70,582 @@ return {
     },
     ['AbilitySets']   = {
         ['AllianceSpell'] = {
-            "Frostbound Covariance",
-            "Frostbound Conjunction",
-            "Frostbound Coalition",
-            "Frostbound Covenant",
-            "Frostbound Alliance",
+            "Frostbound Covariance",  -- Level 122
+            "Frostbound Conjunction", -- Level 117
+            "Frostbound Coalition",   -- Level 112
+            "Frostbound Covenant",    -- Level 107
+            "Frostbound Alliance",    -- Level 102
         },
         -- ['DichoSpell'] = {
-        --     "Reciprocal Fire",
-        --     "Ecliptic Fire",
-        --     "Composite Fire",
-        --     "Dissident Fire",
-        --     "Dichotomic Fire",
+        --     "Reciprocal Fire", -- Level 121
+        --     "Ecliptic Fire",   -- Level 116
+        --     "Composite Fire",  -- Level 111
+        --     "Dissident Fire",  -- Level 106
+        --     "Dichotomic Fire", -- Level 101
         -- },
         ['IceClaw'] = {
-            "Claw of Tsikut",
-            "Claw of the Void",
-            "Claw of Gozzrem",
-            "Claw of Travenro",
-            "Claw of the Oceanlord",
-            "Claw of the Icewing",
-            "Claw of the Abyss",
-            "Glacial Claw",
-            "Claw of Selig",
-            "Claw of Selay",
-            "Claw of Vox",
-            "Claw of Frost",
-            "Claw of Ankexfen",
+            "Claw of Tsikut",        -- Level 130
+            "Claw of Ankexfen",      -- Level 125
+            "Claw of the Void",      -- Level 120
+            "Claw of Gozzrem",       -- Level 115
+            "Claw of Travenro",      -- Level 110
+            "Claw of the Oceanlord", -- Level 105
+            "Claw of the Icewing",   -- Level 100
+            "Claw of the Abyss",     -- Level 95
+            "Glacial Claw",          -- Level 90
+            "Claw of Selig",         -- Level 80
+            "Claw of Selay",         -- Level 75
+            "Claw of Vox",           -- Level 69
+            "Claw of Frost",         -- Level 61
         },
         ['FireClaw'] = {
-            "Claw of Ashenback",
-            "Claw of Ingot",
-            "Claw of the Duskflame",
-            "Claw of Sontalak",
-            "Claw of Qunard",
-            "Claw of the Flameweaver",
-            "Claw of the Flamewing",
-            "Villification of Havoc", --54s recast but same timer and purpose.
-            "Denunciation of Havoc",
-            "Malediction of Havoc",
+            "Claw of Ashenback",       -- Level 128
+            "Claw of Ingot",           -- Level 123
+            "Claw of the Duskflame",   -- Level 118
+            "Claw of Sontalak",        -- Level 113
+            "Claw of Qunard",          -- Level 108
+            "Claw of the Flameweaver", -- Level 103
+            "Claw of the Flamewing",   -- Level 98
+            "Villification of Havoc",  -- Level 94, 54s recast but same timer and purpose.
+            "Denunciation of Havoc",   -- Level 89
+            "Malediction of Havoc",    -- Level 84
         },
         ['MagicClaw'] = {
-            "Claw of Windshear",
-            "Claw of Itzal",
-            "Claw of Feshlak",
-            "Claw of Ellarr",
-            "Claw of the Indagatori",
-            "Claw of the Ashwing",
-            "Claw of the Battleforged",
+            "Claw of Windshear",        -- Level 126
+            "Claw of the Battleforged", -- Level 121
+            "Claw of Itzal",            -- Level 116
+            "Claw of Feshlak",          -- Level 111
+            "Claw of Ellarr",           -- Level 106
+            "Claw of the Indagatori",   -- Level 101
+            "Claw of the Ashwing",      -- Level 96
         },
         ['CloudburstNuke'] = {
-            "Cloudburst Strike XII",
-            "Cloudburst Lightningstrike",
-            "Cloudburst Joltstrike",
-            "Cloudburst Stormbolt",
-            "Cloudburst Thunderbolt",
-            "Cloudburst Stormstrike",
-            "Cloudburst Thunderbolt",
-            "Cloudburst Tempest",
-            "Cloudburst Storm",
-            "Cloudburst Levin",
-            "Cloudburst Bolts",
-            "Cloudburst Strike",
+            "Cloudburst Strike XII",      -- Level 127
+            "Cloudburst Lightningstrike", -- Level 122
+            "Cloudburst Joltstrike",      -- Level 117
+            "Cloudburst Stormbolt",       -- Level 112
+            "Cloudburst Stormstrike",     -- Level 102
+            "Cloudburst Thunderbolt",     -- Level 97
+            "Cloudburst Thunderbolt",     -- Level 97
+            "Cloudburst Tempest",         -- Level 92
+            "Cloudburst Storm",           -- Level 87
+            "Cloudburst Levin",           -- Level 82
+            "Cloudburst Bolts",           -- Level 77
+            "Cloudburst Strike",          -- Level 72
         },
         ['FuseNuke'] = {
-            "Ethereal Weave VII",
-            "Ethereal Twist",
-            "Ethereal Confluence",
-            "Ethereal Braid",
-            "Ethereal Fuse",
-            "Ethereal Weave",
-            "Ethereal Plait",
+            "Ethereal Weave VII",  -- Level 130
+            "Ethereal Plait",      -- Level 125
+            "Ethereal Twist",      -- Level 120
+            "Ethereal Confluence", -- Level 115
+            "Ethereal Braid",      -- Level 110
+            "Ethereal Fuse",       -- Level 105
+            "Ethereal Weave",      -- Level 100
         },
         ['FireEtherealNuke'] = {
-            "Ether Fire XIII",
-            "Ethereal Immolation",
-            "Ethereal Ignition",
-            "Ethereal Brand",
-            "Ethereal Skyfire",
-            "Ethereal Skyblaze",
-            "Ethereal Incandescence",
-            "Ethereal Blaze",
-            "Ethereal Inferno",
-            "Ethereal Combustion",
-            "Ethereal Incineration",
-            "Ethereal Conflagration",
-            "Ether Flame",
+            "Ethereal Fire XIII",     -- Level 130
+            "Ethereal Immolation",    -- Level 125
+            "Ethereal Ignition",      -- Level 120
+            "Ethereal Brand",         -- Level 115
+            "Ethereal Skyfire",       -- Level 110
+            "Ethereal Skyblaze",      -- Level 105
+            "Ethereal Incandescence", -- Level 100
+            "Ethereal Blaze",         -- Level 95
+            "Ethereal Inferno",       -- Level 90
+            "Ethereal Combustion",    -- Level 85
+            "Ethereal Incineration",  -- Level 80
+            "Ethereal Conflagration", -- Level 75
+            "Ether Flame",            -- Level 70
         },
         ['IceEtherealNuke'] = {
-            "Ethereal Ice XI",
-            "Lunar Ice Comet",
-            "Restless Ice Comet",
-            "Ethereal Icefloe",
-            "Ethereal Rimeblast",
-            "Ethereal Hoarfrost",
-            "Ethereal Frost",
-            "Ethereal Glaciation",
-            "Ethereal Iceblight",
-            "Ethereal Rime",
-            "Ethereal Freeze",
+            "Ethereal Ice XI",     -- Level 129
+            "Ethereal Freeze",     -- Level 124
+            "Lunar Ice Comet",     -- Level 119
+            "Restless Ice Comet",  -- Level 114
+            "Ethereal Icefloe",    -- Level 109
+            "Ethereal Rimeblast",  -- Level 104
+            "Ethereal Hoarfrost",  -- Level 99
+            "Ethereal Frost",      -- Level 94
+            "Ethereal Glaciation", -- Level 89
+            "Ethereal Iceblight",  -- Level 84
+            "Ethereal Rime",       -- Level 79
         },
         ['MagicEtherealNuke'] = {
-            "Ethereal Barrage VIII",
-            "Ethereal Mortar",
-            "Ethereal Blast",
-            "Ethereal Volley",
-            "Ethereal Flash",
-            "Ethereal Salvo",
-            "Ethereal Barrage",
-            "Ethereal Blitz",
+            "Ethereal Barrage VIII", -- Level 127
+            "Ethereal Blitz",        -- Level 122
+            "Ethereal Mortar",       -- Level 117
+            "Ethereal Blast",        -- Level 112
+            "Ethereal Volley",       -- Level 107
+            "Ethereal Flash",        -- Level 102
+            "Ethereal Salvo",        -- Level 97
+            "Ethereal Barrage",      -- Level 92
         },
         ['ChaosNuke'] = {
-            "Chaos Flame XIII",
-            "Chaos Inferno",
-            "Chaos Burn",
-            "Chaos Scintillation",
-            "Chaos Incandescence",
-            "Chaos Blaze",
-            "Chaos Char",
-            "Chaos Combustion",
-            "Chaos Conflagration",
-            "Chaos Immolation",
-            "Chaos Flame",
+            "Chaos Flame XIII",    -- Level 128
+            "Chaos Inferno",       -- Level 113
+            "Chaos Burn",          -- Level 108
+            "Chaos Scintillation", -- Level 103
+            "Chaos Incandescence", -- Level 99
+            "Chaos Blaze",         -- Level 94
+            "Chaos Char",          -- Level 89
+            "Chaos Combustion",    -- Level 84
+            "Chaos Conflagration", -- Level 79
+            "Chaos Immolation",    -- Level 74
+            "Chaos Flame",         -- Level 70
         },
         ['VortexNuke'] = {
             -- NOTE: ${Spell[${VortexNuke}].ResistType} can be used to determine which resist type is getting debuffed
-            "Chromospheric Vortex",
-            "Shadebright Vortex",
-            "Thaumaturgic Vortex",
-            "Stormjolt Vortex",
-            "Shocking Vortex",
+            "Chromospheric Vortex", -- Level 123
+            "Shadebright Vortex",   -- Level 118
+            "Thaumaturgic Vortex",  -- Level 113
+            "Stormjolt Vortex",     -- Level 108
+            "Shocking Vortex",      -- Level 103
             -- Hoarfrost Vortex has a Fire Debuff
-            "Hoarfrost Vortex",
+            "Hoarfrost Vortex",     -- Level 100
             -- Ether Vortex has a Cold Debuff
-            "Ether Vortex",
+            "Ether Vortex",         -- Level 98
             -- Incandescent Vortex has a Magic Debuff
-            "Incandescent Vortex",
+            "Incandescent Vortex",  -- Level 96
             -- Frost Vortex has a Fire Debuff
-            "Frost Vortex",
+            "Frost Vortex",         -- Level 95
             -- Power Vortex has a Cold Debuff
-            "Power Vortex",
+            "Power Vortex",         -- Level 93
             -- Flame Vortex has a Magic Debuff
-            "Flame Vortex",
+            "Flame Vortex",         -- Level 91
             -- Ice Vortex has a Fire Debuff
-            "Ice Vortex",
+            "Ice Vortex",           -- Level 90
             -- Mana Vortex has a Cold Debuff
-            "Mana Vortex",
+            "Mana Vortex",          -- Level 88
             -- Fire Vortex has a Magic Debuff
-            "Fire Vortex",
+            "Fire Vortex",          -- Level 86
         },
         ['WildNuke'] = {
-            "Wildmagic Strike XII",
-            "Wildspell Strike",
-            "Wildflame Strike",
-            "Wildscorch Strike",
-            "Wildflash Strike",
-            "Wildflash Barrage",
-            "Wildether Barrage",
-            "Wildspark Barrage",
-            "Wildmana Barrage",
-            "Wildmagic Blast",
-            "Wildmagic Burst",
-            "Wildmagic Strike",
+            "Wildmagic Strike XII", -- Level 126
+            "Wildspell Strike",     -- Level 121
+            "Wildflame Strike",     -- Level 116
+            "Wildscorch Strike",    -- Level 111
+            "Wildflash Strike",     -- Level 106
+            "Wildflash Barrage",    -- Level 101
+            "Wildether Barrage",    -- Level 96
+            "Wildspark Barrage",    -- Level 91
+            "Wildmana Barrage",     -- Level 86
+            "Wildmagic Blast",      -- Level 81
+            "Wildmagic Burst",      -- Level 76
+            "Wildmagic Strike",     -- Level 71
         },
         ['WildNuke2'] = {
-            "Wildmagic Strike XII",
-            "Wildspell Strike",
-            "Wildflame Strike",
-            "Wildscorch Strike",
-            "Wildflash Strike",
-            "Wildflash Barrage",
-            "Wildether Barrage",
-            "Wildspark Barrage",
-            "Wildmana Barrage",
-            "Wildmagic Blast",
-            "Wildmagic Burst",
-            "Wildmagic Strike",
+            "Wildmagic Strike XII", -- Level 126
+            "Wildspell Strike",     -- Level 121
+            "Wildflame Strike",     -- Level 116
+            "Wildscorch Strike",    -- Level 111
+            "Wildflash Strike",     -- Level 106
+            "Wildflash Barrage",    -- Level 101
+            "Wildether Barrage",    -- Level 96
+            "Wildspark Barrage",    -- Level 91
+            "Wildmana Barrage",     -- Level 86
+            "Wildmagic Blast",      -- Level 81
+            "Wildmagic Burst",      -- Level 76
+            "Wildmagic Strike",     -- Level 71
         },
         ['FireNuke'] = {
-            "Teknaz's Fire",
-            "Kindleheart's Fire",
-            "The Diabo's Fire",
-            "Dagarn's Fire",
-            "Dragoflux's Fire",
-            "Narendi's Fire",
-            "Gosik's Fire",
-            "Daevan's Fire",
-            "Lithara's Fire",
-            "Klixcxyk's Fire",
-            "Inizen's Fire",
-            "Sothgar's Flame",
+            "Teknaz's Fire",                 -- Level 130
+            "Kindleheart's Fire",            -- Level 125
+            "The Diabo's Fire",              -- Level 120
+            "Dagarn's Fire",                 -- Level 115
+            "Dragoflux's Fire",              -- Level 110
+            "Narendi's Fire",                -- Level 105
+            "Gosik's Fire",                  -- Level 100
+            "Daevan's Fire",                 -- Level 95
+            "Lithara's Fire",                -- Level 90
+            "Klixcxyk's Fire",               -- Level 85
+            "Inizen's Fire",                 -- Level 80
+            "Sothgar's Flame",               -- Level 75
             --Not used above this
-            "Spark of Fire",
-            "Draught of Ro",
-            "Draught of Fire",
-            "Conflagration",
-            "Inferno Shock",
-            "Flame Shock",
-            "Fire Bolt",
-            "Shock of Fire",
+            "Spark of Fire",                 -- Level 66
+            "Draught of Ro",                 -- Level 62
+            "Draught of Fire",               -- Level 51
+            "Conflagration",                 -- Level 43
+            "Inferno Shock",                 -- Level 26
+            "Flame Shock",                   -- Level 15
+            "Fire Bolt",                     -- Level 5
+            "Shock of Fire",                 -- Level 4
         },
-        ['BigFireNuke'] = { -- Level 51-70, Long Cast, Heavy Damage
-            "Ancient: Core Fire",
-            "Corona Flare",
-            "Ancient: Strike of Chaos",
-            "White Fire",
-            "Strike of Solusek",
-            "Garrison's Superior Sundering",
-            "Sunstrike",
+        ['BigFireNuke'] = {                  -- Level 51-70, Long Cast, Heavy Damage
+            "Ancient: Core Fire",            -- Level 70
+            "Corona Flare",                  -- Level 70
+            "Ancient: Strike of Chaos",      -- Level 65
+            "White Fire",                    -- Level 65
+            "Strike of Solusek",             -- Level 65
+            "Garrison's Superior Sundering", -- Level 60
+            "Sunstrike",                     -- Level 60
         },
         ['IceNuke'] = {
-            "Glacial Cascade XII",
-            "Glacial Ice Cascade",
-            "Tundra Ice Cascade",
-            "Restless Ice Cascade",
-            "Icefloe Cascade",
-            "Rimeblast Cascade",
-            "Hoarfrost Cascade",
-            "Rime Cascade",
-            "Glacial Cascade",
-            "Icesheet Cascade",
-            "Glacial Collapse",
-            "Icefall Avalanche",
-            "Spark of Ice",
-            "Black Ice",
-            "Draught of E`ci",
-            "Draught of Ice",
-            "Ice Comet",
-            "Ice Shock",
-            "Frost Shock",
-            "Shock of Ice",
-            "Blast of Cold",
+            "Glacial Cascade XII",         -- Level 129
+            "Glacial Ice Cascade",         -- Level 124
+            "Tundra Ice Cascade",          -- Level 119
+            "Restless Ice Cascade",        -- Level 114
+            "Icefloe Cascade",             -- Level 109
+            "Rimeblast Cascade",           -- Level 104
+            "Hoarfrost Cascade",           -- Level 99
+            "Rime Cascade",                -- Level 94
+            "Glacial Cascade",             -- Level 89
+            "Icesheet Cascade",            -- Level 84
+            "Glacial Collapse",            -- Level 79
+            "Icefall Avalanche",           -- Level 74
+            "Spark of Ice",                -- Level 69
+            "Black Ice",                   -- Level 65
+            "Draught of E`ci",             -- Level 64
+            "Draught of Ice",              -- Level 57
+            "Ice Comet",                   -- Level 49
+            "Ice Shock",                   -- Level 34
+            "Frost Shock",                 -- Level 24
+            "Shock of Ice",                -- Level 8
+            "Blast of Cold",               -- Level 1
         },
-        ['BigIceNuke'] = { -- Level 60-70, Timed with great Ratio or High Cast Time/Damage
-            "Gelidin Comet",
-            "Ice Meteor",
-            "Ancient: Destruction of Ice", --13s T1
-            "Ice Spear of Solist",         --13s T2
+        ['BigIceNuke'] = {                 -- Level 60-70, Timed with great Ratio or High Cast Time/Damage
+            "Gelidin Comet",               -- Level 69
+            "Ice Meteor",                  -- Level 64
+            "Ancient: Destruction of Ice", -- Level 60, 13s T1
+            "Ice Spear of Solist",         -- Level 60, 13s T2
         },
         ['MagicNuke'] = {
-            "Lightning Helix XII",
-            "Lightning Cyclone",
-            "Lightning Maelstrom",
-            "Lightning Roar",
-            "Lightning Tempest",
-            "Lightning Storm",
-            "Lightning Squall",
-            "Lightning Swarm",
-            "Lightning Helix",
-            "Ribbon Lightning",
-            "Rolling Lightning",
-            "Ball Lightning",
-            "Spark of Lightning",
-            "Draught of Lightning",
-            "Voltaic Draught",
-            "Rend",
-            "Lightning Shock",
-            "Garrison's Mighty Mana Shock",
-            "Shock of Lightning",
+            "Lightning Helix XII",           -- Level 128
+            "Lightning Cyclone",             -- Level 123
+            "Lightning Maelstrom",           -- Level 118
+            "Lightning Roar",                -- Level 113
+            "Lightning Tempest",             -- Level 108
+            "Lightning Squall",              -- Level 98
+            "Lightning Swarm",               -- Level 93
+            "Lightning Helix",               -- Level 88
+            "Ribbon Lightning",              -- Level 83
+            "Rolling Lightning",             -- Level 78
+            "Ball Lightning",                -- Level 73
+            "Spark of Lightning",            -- Level 68
+            "Draught of Lightning",          -- Level 63
+            "Voltaic Draught",               -- Level 54
+            "Rend",                          -- Level 47
+            "Lightning Shock",               -- Level 37
+            "Lightning Storm",               -- Level 23
+            "Garrison's Mighty Mana Shock",  -- Level 18
+            "Shock of Lightning",            -- Level 10
         },
-        ['BigMagicNuke'] = { -- Level 60-68, High Cast Time/Damage
-            "Thundaka",
-            "Shock of Magic",
-            "Agnarr's Thunder",
-            "Elnerick's Electrical Rending",
+        ['BigMagicNuke'] = {                 -- Level 60-68, High Cast Time/Damage
+            "Thundaka",                      -- Level 68
+            "Shock of Magic",                -- Level 65
+            "Agnarr's Thunder",              -- Level 63
+            "Elnerick's Electrical Rending", -- Level 60
         },
         ['StunSpell'] = {
-            "Telaka XIX",
-            "Teladaka",
-            "Teladaja",
-            "Telajaga",
-            "Telanata",
-            "Telanara",
-            "Telanaga",
-            "Telanama",
-            "Telakama",
-            "Telajara",
-            "Telajasz",
-            "Telakisz",
-            "Telekara",
-            "Telaka",
-            "Telekin",
-            "Markar's Discord",
-            "Markar's Clash",
-            "Tishan's Clash",
+            "Telaka XIX",       -- Level 130
+            "Teladaka",         -- Level 125
+            "Teladaja",         -- Level 120
+            "Telajaga",         -- Level 115
+            "Telanata",         -- Level 110
+            "Telanara",         -- Level 105
+            "Telanaga",         -- Level 100
+            "Telanama",         -- Level 95
+            "Telakama",         -- Level 90
+            "Telajara",         -- Level 85
+            "Telajasz",         -- Level 80
+            "Telakisz",         -- Level 75
+            "Telekara",         -- Level 70
+            "Telaka",           -- Level 65
+            "Telekin",          -- Level 64
+            "Markar's Discord", -- Level 56
+            "Markar's Clash",   -- Level 47
+            "Tishan's Clash",   -- Level 19
         },
         ['SelfHPBuff'] = {
-            "Shielding XXIII",
-            "Shield of Memories",
-            "Shield of Shadow",
-            "Shield of Restless Ice",
-            "Shield of Scales",
-            "Shield of the Pellarus",
-            "Shield of the Dauntless",
-            "Shield of Bronze",
-            "Shield of Dreams",
-            "Shield of the Void",
-            "Bulwark of the Crystalwing",
-            "Shield of the Crystalwing",
-            "Ether Shield",
-            "Shield of Maelin",
-            "Shield of the Arcane",
-            "Shield of the Magi",
-            "Arch Shielding",
-            "Greater Shielding",
-            "Major Shielding",
-            "Shielding",
-            "Lesser Shielding",
-            "Minor Shielding",
+            "Shielding XXIII",            -- Level 126
+            "Shield of Memories",         -- Level 121
+            "Shield of Shadow",           -- Level 116
+            "Shield of Restless Ice",     -- Level 111
+            "Shield of Scales",           -- Level 106
+            "Shield of the Pellarus",     -- Level 101
+            "Shield of the Dauntless",    -- Level 96
+            "Shield of Bronze",           -- Level 91
+            "Shield of Dreams",           -- Level 86
+            "Shield of the Void",         -- Level 81
+            "Bulwark of the Crystalwing", -- Level 76
+            "Shield of the Crystalwing",  -- Level 71
+            "Ether Shield",               -- Level 66
+            "Shield of Maelin",           -- Level 64
+            "Shield of the Arcane",       -- Level 61
+            "Shield of the Magi",         -- Level 54
+            "Arch Shielding",             -- Level 44
+            "Greater Shielding",          -- Level 33
+            "Major Shielding",            -- Level 23
+            "Shielding",                  -- Level 15
+            "Lesser Shielding",           -- Level 6
+            "Minor Shielding",            -- Level 1
         },
         ['SelfSpellShield1'] = {
-            "Shield of Fate VII",
-            "Shield of Inescapability",
-            "Shield of Inevitability",
-            "Shield of Destiny",
-            "Shield of Order",
-            "Shield of Consequence",
-            "Shield of Fate",
+            "Shield of Fate VII",       -- Level 127
+            "Shield of Inescapability", -- Level 122
+            "Shield of Inevitability",  -- Level 117
+            "Shield of Destiny",        -- Level 112
+            "Shield of Order",          -- Level 107
+            "Shield of Consequence",    -- Level 102
+            "Shield of Fate",           -- Level 97
         },
         ['FamiliarBuff'] = {
-            "Greater Familiar",
-            "Familiar",
-            "Lesser Familiar",
-            "Minor Familiar",
+            "Greater Familiar", -- Level 60
+            "Familiar",         -- Level 54
+            "Lesser Familiar",  -- Level 45
+            "Minor Familiar",   -- Level 25
         },
         ['SelfRune1'] = {
-            "Aegis of Feish",
-            "Aegis of Remembrance",
-            "Aegis of the Umbra",
-            "Aegis of the Crystalwing",
-            "Armor of Wirn",
-            "Armor of the Codex",
-            "Armor of the Stonescale",
-            "Armor of the Crystalwing",
-            "Dermis of the Crystalwing",
-            "Squamae of the Crystalwing",
-            "Laminae of the Crystalwing",
-            "Scales of the Crystalwing",
-            "Ether Skin",
-            "Force Shield",
+            "Aegis of Feish",             -- Level 126
+            "Aegis of Remembrance",       -- Level 121
+            "Aegis of the Umbra",         -- Level 116
+            "Aegis of the Crystalwing",   -- Level 113
+            "Armor of Wirn",              -- Level 108
+            "Armor of the Codex",         -- Level 103
+            "Armor of the Stonescale",    -- Level 98
+            "Armor of the Crystalwing",   -- Level 93
+            "Dermis of the Crystalwing",  -- Level 88
+            "Squamae of the Crystalwing", -- Level 83
+            "Laminae of the Crystalwing", -- Level 78
+            "Scales of the Crystalwing",  -- Level 73
+            "Ether Skin",                 -- Level 68
+            "Force Shield",               -- Level 63
         },
         ['Dispel'] = {
-            "Annul Magic",
-            "Nullify Magic",
-            "Cancel Magic",
+            "Annul Magic",   -- Level 53
+            "Nullify Magic", -- Level 34
+            "Cancel Magic",  -- Level 11
         },
         ['TwincastSpell'] = {
-            "Twincast",
+            "Twincast", -- Level 85
         },
         ['GambitSpell'] = {
-            "Contemplative Gambit",
-            "Anodyne Gambit",
-            "Idyllic Gambit",
-            "Musing Gambit",
-            "Quiescent Gambit",
-            "Bucolic Gambit",
+            "Contemplative Gambit", -- Level 125
+            "Anodyne Gambit",       -- Level 120
+            "Idyllic Gambit",       -- Level 115
+            "Musing Gambit",        -- Level 110
+            "Quiescent Gambit",     -- Level 104
+            "Bucolic Gambit",       -- Level 99
         },
         ['PetSpell'] = {
-            "Kindleheart's Pyroblade",
-            "Diabo Xi Fer's Pyroblade",
-            "Ricartine's Pyroblade",
-            "Virnax's Pyroblade",
-            "Yulin's Pyroblade",
-            "Mul's Pyroblade",
-            "Burnmaster's Pyroblade",
-            "Lithara's Pyroblade",
-            "Daveron's Pyroblade",
-            "Euthanos' Flameblade",
-            "Ethantis's Burning Blade",
-            "Solist's Frozen Sword",
-            "Flaming Sword of Xuzl",
+            "Kindleheart's Pyroblade",  -- Level 124
+            "Diabo Xi Fer's Pyroblade", -- Level 119
+            "Ricartine's Pyroblade",    -- Level 114
+            "Virnax's Pyroblade",       -- Level 109
+            "Yulin's Pyroblade",        -- Level 104
+            "Mul's Pyroblade",          -- Level 99
+            "Burnmaster's Pyroblade",   -- Level 94
+            "Lithara's Pyroblade",      -- Level 89
+            "Daveron's Pyroblade",      -- Level 84
+            "Euthanos' Flameblade",     -- Level 79
+            "Ethantis's Burning Blade", -- Level 74
+            "Solist's Frozen Sword",    -- Level 69
+            "Flaming Sword of Xuzl",    -- Level 59
         },
         ['RootSpell'] = {
-            "Greater Fetter",
-            "Fetter",
-            "Paralyzing Earth",
-            "Immobilize",
-            "Instill",
-            "Root",
+            "Greater Fetter",   -- Level 61
+            "Fetter",           -- Level 58
+            "Paralyzing Earth", -- Level 48
+            "Immobilize",       -- Level 39
+            "Instill",          -- Level 17
+            "Root",             -- Level 3
         },
         ['SnareSpell'] = {
-            "Atol's Concussive Shackles",
-            "Atol's Spectral Shackles",
-            "Bonds of Force",
+            "Atol's Concussive Shackles", -- Level 93
+            "Atol's Spectral Shackles",   -- Level 51
+            "Bonds of Force",             -- Level 27
         },
         ['EvacSpell'] = {
-            "Evacuate",
-            "Lesser Evacuate",
+            "Evacuate",        -- Level 57
+            "Lesser Evacuate", -- Level 18
         },
         ['HarvestSpell'] = {
-            "Harvest XIII",
-            "Contemplative Harvest",
-            "Shadow Harvest",
-            "Quiet Harvest",
-            "Musing Harvest",
-            "Quiescent Harvest",
-            "Bucolic Harvest",
-            "Placid Harvest",
-            "Soothing Harvest",
-            "Serene Harvest",
-            "Tranquil Harvest",
-            "Patient Harvest",
-            "Harvest",
+            "Harvest XIII",          -- Level 127
+            "Contemplative Harvest", -- Level 122
+            "Shadow Harvest",        -- Level 117
+            "Quiet Harvest",         -- Level 112
+            "Musing Harvest",        -- Level 107
+            "Quiescent Harvest",     -- Level 102
+            "Bucolic Harvest",       -- Level 97
+            "Placid Harvest",        -- Level 92
+            "Soothing Harvest",      -- Level 87
+            "Serene Harvest",        -- Level 82
+            "Tranquil Harvest",      -- Level 77
+            "Patient Harvest",       -- Level 72
+            "Harvest",               -- Level 32
         },
         ['JoltSpell'] = {
-            "Mindfreeze X",
-            "Spinalfreeze",
-            "Cerebrumfreeze",
-            "Neurofreeze",
-            "Cortexfreeze",
-            "Synapsefreeze",
-            "Skullfreeze",
-            "Thoughtfreeze",
-            "Brainfreeze",
-            "Mindfreeze",
-            "Concussive Flash",
-            "Concussive Burst",
-            "Concussive Blast",
-            "Ancient: Greater Concussion",
-            "Concussion",
+            "Mindfreeze X",                -- Level 127
+            "Spinalfreeze",                -- Level 122
+            "Cerebrumfreeze",              -- Level 117
+            "Neurofreeze",                 -- Level 112
+            "Cortexfreeze",                -- Level 107
+            "Synapsefreeze",               -- Level 102
+            "Skullfreeze",                 -- Level 97
+            "Thoughtfreeze",               -- Level 92
+            "Brainfreeze",                 -- Level 87
+            "Mindfreeze",                  -- Level 82
+            "Concussive Flash",            -- Level 81
+            "Concussive Burst",            -- Level 76
+            "Concussive Blast",            -- Level 71
+            "Ancient: Greater Concussion", -- Level 60
+            "Concussion",                  -- Level 37
         },
         -- Lure Spells
         ['IceLureNuke'] = {
-            "Lure of Frost",
-            "Lure of Ice",
-            "Icebane",
-            "Rimelure",
-            "Voidfrost Lure",
-            "Glacial Lure",
-            "Frigid Lure",
-            "Lure of Isaz",
-            "Lure of the Wastes",
-            "Lure of the Depths",
-            "Lure of Travenro",
-            "Lure of Restless Ice",
-            "Lure of the Cold Moon",
-            "Lure of Winter Memories",
+            "Lure of Winter Memories", -- Level 121
+            "Lure of the Cold Moon",   -- Level 116
+            "Lure of Restless Ice",    -- Level 111
+            "Lure of Travenro",        -- Level 106
+            "Lure of the Depths",      -- Level 101
+            "Lure of the Wastes",      -- Level 96
+            "Frigid Lure",             -- Level 91
+            "Glacial Lure",            -- Level 86
+            "Voidfrost Lure",          -- Level 81
+            "Lure of Isaz",            -- Level 76
+            "Rimelure",                -- Level 71
+            "Icebane",                 -- Level 66
+            "Lure of Ice",             -- Level 60
+            "Lure of Frost",           -- Level 52
         },
         ['FireLureNuke'] = {
-            "Enticement of Flame",
-            "Lure of Flame",
-            "Lure of Ro",
-            "Firebane",
-            "Lavalure",
-            "Pyrolure",
-            "Flarelure",
-            "Flamelure",
-            "Blazelure",
-            "MagmaLure",
-            "PlasmaLure",
-            "Lure of Qunard",
-            "Lure of Sontalak",
-            "Lure of Fyrthek",
-            "Lure of the Arcanaforged",
+            "Lure of the Arcanaforged", -- Level 123
+            "Lure of Fyrthek",          -- Level 118
+            "Lure of Sontalak",         -- Level 113
+            "Lure of Qunard",           -- Level 108
+            "PlasmaLure",               -- Level 103
+            "MagmaLure",                -- Level 98
+            "Blazelure",                -- Level 93
+            "Flamelure",                -- Level 88
+            "Flarelure",                -- Level 83
+            "Pyrolure",                 -- Level 78
+            "Lavalure",                 -- Level 73
+            "Firebane",                 -- Level 68
+            "Lure of Ro",               -- Level 62
+            "Lure of Flame",            -- Level 55
+            "Enticement of Flame",      -- Level 44
         },
         ['MagicLureNuke'] = {
-            "Lure of Lightning",
-            "Lure of Thunder",
-            "Lightningbane",
-            "Permeating Ether",
+            "Permeating Ether",  -- Level 97
+            "Lightningbane",     -- Level 67
+            "Lure of Thunder",   -- Level 61
+            "Lure of Lightning", -- Level 58
         },
         ['StunMagicNuke'] = {
-            "Leap of Lightning XIV",
-            "Leap of Stormjolts",
-            "Leap of Stormbolts",
-            "Leap of Static Sparks",
-            "Leap of Plasma",
-            "Leap of Corposantum",
-            "Leap of Static Jolts",
-            "Leap of Static Bolts",
-            "Leap of Sparks",
-            "Leap of Levinsparks",
-            "Leap of Shocking Bolts",
-            "Spark of Thunder",
-            "Draught of Thunder",
-            "Draught of Jiva",
-            "Force Strike",
-            "Thunder Strike",
-            "Force Snap",
-            "Lightning Bolt",
+            "Leap of Lightning XIV",  -- Level 129
+            "Leap of Levinsparks",    -- Level 117
+            "Leap of Stormjolts",     -- Level 107
+            "Leap of Stormbolts",     -- Level 102
+            "Leap of Static Sparks",  -- Level 97
+            "Leap of Plasma",         -- Level 92
+            "Leap of Corposantum",    -- Level 87
+            "Leap of Static Jolts",   -- Level 82
+            "Leap of Static Bolts",   -- Level 77
+            "Leap of Shocking Bolts", -- Level 73
+            "Leap of Sparks",         -- Level 72
+            "Spark of Thunder",       -- Level 68
+            "Draught of Thunder",     -- Level 63
+            "Draught of Jiva",        -- Level 55
+            "Force Strike",           -- Level 41
+            "Thunder Strike",         -- Level 28
+            "Force Snap",             -- Level 17
+            "Lightning Bolt",         -- Level 16
         },
         -- Rain Spells Listed here are used Primarily for TLP Mode.
         -- Magic Rain - Only have 3 of them so Not Sustainable.
         ['IceRain'] = {
-            "Frost Storm XVII",
-            "Icestrike",
-            "Frost Storm",
-            "Tears of Prexus",
-            "Tears of Marr",
-            "Gelid Rains",
-            "Icicle Deluge",
-            "Icicle Storm",
-            "Icicle Torrent",
-            "Hail Torrent",
-            "Frost Torrent",
-            "Tamagrist Torrent",
-            "Darkwater Torrent",
-            "Frostbite Torrent",
-            "Coldburst Torrent",
-            "Hypothermic Torrent",
-            "Rimeclaw Torrent",
+            "Frost Storm XVII",    -- Level 130
+            "Rimeclaw Torrent",    -- Level 125
+            "Hypothermic Torrent", -- Level 120
+            "Coldburst Torrent",   -- Level 115
+            "Frostbite Torrent",   -- Level 110
+            "Darkwater Torrent",   -- Level 105
+            "Tamagrist Torrent",   -- Level 100
+            "Frost Torrent",       -- Level 95
+            "Hail Torrent",        -- Level 90
+            "Icicle Torrent",      -- Level 85
+            "Icicle Storm",        -- Level 80
+            "Icicle Deluge",       -- Level 75
+            "Gelid Rains",         -- Level 70
+            "Tears of Marr",       -- Level 65
+            "Tears of Prexus",     -- Level 58
+            "Frost Storm",         -- Level 41
+            "Icestrike",           -- Level 6
         },
         ['FireRain'] = {
-            "Tears of Ashbark",
-            "Firestorm",
-            "Lava Storm",
-            "Tears of Solusek",
-            "Tears of Ro",
-            "Tears of the Sun",
-            "Tears of the Betrayed",
-            "Tears of the Forsaken",
-            "Tears of the Pyrilen",
-            "Tears of Flame",
-            "Tears of Daevan",
-            "Tears of Gosik",
-            "Tears of Narendi",
-            "Tears of Dragoflux",
-            "Tears of Wildfire",
-            "Tears of Night Fire",
-            "Tears of the Rescued",
+            "Tears of Ashbark",      -- Level 130
+            "Tears of the Rescued",  -- Level 125
+            "Tears of Night Fire",   -- Level 116
+            "Tears of Wildfire",     -- Level 111
+            "Tears of Dragoflux",    -- Level 106
+            "Tears of Narendi",      -- Level 101
+            "Tears of Gosik",        -- Level 96
+            "Tears of Daevan",       -- Level 91
+            "Tears of Flame",        -- Level 86
+            "Tears of the Pyrilen",  -- Level 81
+            "Tears of the Forsaken", -- Level 76
+            "Tears of the Betrayed", -- Level 71
+            "Tears of the Sun",      -- Level 66
+            "Tears of Ro",           -- Level 61
+            "Tears of Solusek",      -- Level 55
+            "Lava Storm",            -- Level 32
+            "Firestorm",             -- Level 12
         },
         ['FireLureRain'] = {
-            "Volcanic Eruption XIV",
-            "Volcanic Burst",
-            "Tears of Arlyxir",
-            "Meteor Storm",
-            "Volcanic Eruption",
-            "Pyroclastic Eruption",
-            "Magmatic Eruption",
-            "Magmatic Downpour",
-            "Magmatic Outburst",
-            "Magmatic Vent",
-            "Magmatic Burst",
-            "Magmatic Explosion",
-            "Volcanic Downpour",
-            "Volcanic Barrage",
+            "Volcanic Eruption XIV", -- Level 129
+            "Volcanic Burst",        -- Level 124
+            "Volcanic Barrage",      -- Level 119
+            "Volcanic Downpour",     -- Level 114
+            "Magmatic Explosion",    -- Level 109
+            "Magmatic Burst",        -- Level 104
+            "Magmatic Vent",         -- Level 99
+            "Magmatic Outburst",     -- Level 94
+            "Magmatic Downpour",     -- Level 89
+            "Magmatic Eruption",     -- Level 84
+            "Pyroclastic Eruption",  -- Level 79
+            "Volcanic Eruption",     -- Level 74
+            "Meteor Storm",          -- Level 69
+            "Tears of Arlyxir",      -- Level 64
         },
-        ['SnapNuke'] = {  -- T2 Ice ~8.5s recast (shared with Cloudburst)
-            "Cold Snap XII",
-            "Frostblast", -- Level 123
-            "Chillblast",
-            "Coldburst",
-            "Flashfrost",
-            "Flashrime",
-            "Flashfreeze",
-            "Frost Snap",
-            "Freezing Snap",
-            "Gelid Snap",
-            "Rime Snap",
-            "Cold Snap",      -- Level 73
+        ['SnapNuke'] = {             -- T2 Ice ~8.5s recast (shared with Cloudburst)
+            "Cold Snap XII",         -- Level 128
+            "Frostblast",            -- Level 123
+            "Chillblast",            -- Level 118
+            "Coldburst",             -- Level 113
+            "Flashfrost",            -- Level 108
+            "Flashrime",             -- Level 103
+            "Flashfreeze",           -- Level 98
+            "Frost Snap",            -- Level 93
+            "Freezing Snap",         -- Level 88
+            "Gelid Snap",            -- Level 83
+            "Rime Snap",             -- Level 78
+            "Cold Snap",             -- Level 73
         },
-        ['AEBeam'] = {        -- T2 Frontal Fire AE
-            "Coronoa Beam X",
-            "Cremating Beam", -- Level 121
-            "Vaporizing Beam",
-            "Scorching Beam",
-            "Burning Beam",
-            "Combusting Beam",
-            "Incinerating Beam",
-            "Blazing Beam",
-            "Corona Beam",      -- Level 86
-            "Beam of Solteris", -- Level 72
+        ['AEBeam'] = {               -- T2 Frontal Fire AE
+            "Corona Beam X",         -- Level 126
+            "Cremating Beam",        -- Level 121
+            "Vaporizing Beam",       -- Level 116
+            "Scorching Beam",        -- Level 111
+            "Burning Beam",          -- Level 106
+            "Combusting Beam",       -- Level 101
+            "Incinerating Beam",     -- Level 96
+            "Blazing Beam",          -- Level 91
+            "Corona Beam",           -- Level 86
+            "Beam of Solteris",      -- Level 72
         },
-        ['PBFlame'] = {         -- T4 PB Fire AE
-            "Ring of Fire XI",
-            "Gyre of Flame",    -- Level 122
-            "Coil of Flame",
-            "Loop of Flame",
-            "Wheel of Flame",
-            "Corona of Flame",
-            "Circle of Flame",
-            "Ring of Flame",
-            "Ring of Fire",
-            "Talendor's Presence",
-            "Vsorgu's Presence",
-            "Magmaraug's Presence",
-            --"Circle of Fire", -- Level 67 Used in PBAE Mode, wouldn't be used in Modern PBAE
+        ['PBFlame'] = {              -- T4 PB Fire AE
+            "Ring of Fire XI",       -- Level 127
+            "Gyre of Flame",         -- Level 122
+            "Coil of Flame",         -- Level 117
+            "Loop of Flame",         -- Level 112
+            "Wheel of Flame",        -- Level 107
+            "Corona of Flame",       -- Level 102
+            "Circle of Flame",       -- Level 97
+            "Ring of Flame",         -- Level 92
+            "Ring of Fire",          -- Level 87
+            "Talendor's Presence",   -- Level 82
+            "Vsorug's Presence",     -- Level 77
+            "Magmaraug's Presence",  -- Level 72
+            -- "Circle of Fire",    -- Level 67, Used in PBAE Mode, wouldn't be used in Modern PBAE
         },
         ['PBTimer4'] = {
             "Circle of Thunder", -- Level 70, Magic
@@ -658,7 +658,7 @@ return {
             "Jyll's Wave of Heat", -- Level 59
         },
         ['IceJyll'] = {
-            "Jyll's Zephyr of Iced", -- Level 56
+            "Jyll's Zephyr of Ice", -- Level 56
         },
         ['MagicJyll'] = {
             "Jyll's Static Pulse", -- Level 53

--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -45,7 +45,7 @@ return {
     },
     ['AbilitySets']   = {
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70
+            "Third Wind Discipline", -- Level 70 Laz Custom
             -- "Second Wind",        -- Level 65
         },
         ['BerAura'] = {
@@ -81,8 +81,8 @@ return {
             "Cry Havoc", -- Level 65
         },
         ['Scream'] = { -- Stun, Throwing/Archery Dmg taken debuff
-            "Bloodcurdling Scream", -- Level 70
-            "Bewildering Scream",   -- Level 70
+            "Bloodcurdling Scream", -- Level 70 Laz Custom
+            "Bewildering Scream",   -- Level 70 Laz Custom
             "Unsettling Scream",    -- Level 65
         },
         ['StunStrike'] = {

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -207,7 +207,7 @@ local _ClassConfig = {
             "Syvelian's Anti-Magic Aria", -- Level 40
         },
         ['ResistSong'] = {
-            "Verse of Veeshan", -- Level 70
+            "Verse of Veeshan", -- Level 70 Laz Custom
             "Psalm of Veeshan", -- Level 63
         },
         ['MezSong'] = {
@@ -238,10 +238,10 @@ local _ClassConfig = {
             "Thousand Blades", -- Level 69
         },
         ['StormBlade'] = {
-            "Storm Blade Flourish", -- Level 69
+            "Storm Blade Flourish", -- Level 69 Laz Custom
         },
         ['SpellAbsorbSong'] = {
-            "Echoes of the Past", -- Level 70
+            "Echoes of the Past", -- Level 70 Laz Custom
         },
         ['ResistDebuff'] = {
             "Harmony of Sound", -- Level 65

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -50,8 +50,8 @@ return {
     ['AbilitySets']       = {
         ['SwarmPet'] = {
             -- Swarm Pet
-            "Reptilian Venom",  -- Level 68
-            "Amphibious Toxin", -- Level 62
+            "Reptilian Venom",  -- Level 68 Laz Custom
+            "Amphibious Toxin", -- Level 62 Laz Custom
         },
         ['Icelance1'] = {
             -- Lance 1 Timer 7 Ice Nuke Fast Cast
@@ -136,11 +136,11 @@ return {
             "Arag's Celerity",    -- Level 63
             "Sha's Ferocity",     -- Level 59
             "Omakin's Alacrity",  -- Level 55
-            "Bond of The Wild",   -- Level 52
+            "Bond of the Wild",   -- Level 52
             "Yekan's Quickening", -- Level 37
         },
         ['PetSlowProc'] = {
-            "Spirit of Sha", -- Level 70
+            "Spirit of Sha", -- Level 70 Laz Custom
         },
         ['PetGrowl'] = {
             "Growl of the Panther", -- Level 69
@@ -164,7 +164,7 @@ return {
         },
         ['ManaRegenBuff'] = {
             --Mana/Hp/End Regen Buff*
-            "Spiritual Rejuvenation", -- Level 70
+            "Spiritual Rejuvenation", -- Level 70 Laz Custom
             "Spiritual Ascendance",   -- Level 69
             "Spiritual Dominion",     -- Level 64
             "Spiritual Purity",       -- Level 59

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -215,10 +215,10 @@ local _ClassConfig = {
             "Death Pact",          -- Level 51
         },
         ['TwinHealNuke'] = {
-            "Vigilant Condemnation", -- Level 71
+            "Vigilant Condemnation", -- Level 71 Laz Custom
         },
         ['RezSpell'] = {
-            "Spiritual Awakening", -- Level 65
+            "Spiritual Awakening", -- Level 65 Laz Custom
             "Reviviscence",        -- Level 56
             "Resurrection",        -- Level 47
             "Restoration",         -- Level 42

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -135,7 +135,7 @@ local _ClassConfig = {
             "Minor Healing",               -- Level 1
         },
         ['GroupHeal'] = {                  -- Laz specific, some taken from cleric, some custom
-            "Word of Reconstitution",      -- Level 70
+            "Word of Reconstitution",      -- Level 70 Laz Custom
             "Word of Redemption",          -- Level 65
             "Word of Restoration",         -- Level 62
             "Word of Vigor",               -- Level 56
@@ -295,7 +295,7 @@ local _ClassConfig = {
             "Spirit of Wolf",   -- Level 10
         },
         ['PetSpell'] = {
-            "Nature Wanderer's Behest", -- Level 70
+            "Nature Wanderer's Behest", -- Level 70 Laz Custom
             "Nature Walker's Behest",   -- Level 55
         },
         ['Dawnstrike'] = {              -- I think better to just spam solstice strike
@@ -327,7 +327,7 @@ local _ClassConfig = {
             "Pure Blood", -- Level 52
         },
         ['TwinHealNuke'] = {
-            "Sunburst Blessing", -- Level 70, Laz custom, description wrong, target mob
+            "Sunburst Blessing", -- Level 70, Laz Custom, description wrong, target mob
         },
         ['PBAEMagic'] = {
             "Earth Shiver", -- Level 66
@@ -355,7 +355,7 @@ local _ClassConfig = {
             "Lesser Succor", -- Level 18
         },
         ['QuickGroupHeal'] = {
-            "Moon Shadow", -- Level 70
+            "Moon Shadow", -- Level 70 Laz Custom
         },
     },
     ['AASets']            = {

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -94,7 +94,7 @@ local _ClassConfig = {
             "Ward of Bedazzlement", -- Level 65
         },
         ['NdtBuff'] = {
-            "Boon of the Legion",  -- Level 67
+            "Boon of the Legion",  -- Level 67 Laz Custom
             "Night's Dark Terror", -- Level 63
             "Boon of the Garou",   -- Level 40
         },
@@ -188,7 +188,7 @@ local _ClassConfig = {
             "Languid Pace",    -- Level 9
         },
         ['Dispel'] = {
-            "Abashi's Disempowerment", -- Level 70
+            "Abashi's Disempowerment", -- Level 70 Laz Custom
             "Recant Magic",            -- Level 53
             "Pillage Enchantment",     -- Level 42
             "Nullify Magic",           -- Level 28
@@ -319,7 +319,7 @@ local _ClassConfig = {
         --     "Root",             -- Level 6
         -- },
         ['HasteManaCombo'] = {
-            "Unified Alacrity", -- Level 71
+            "Unified Alacrity", -- Level 71 Laz Custom
         },
         ['ColoredNuke'] = {
             "Colored Chaos", -- Level 69

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -123,7 +123,7 @@ _ClassConfig    = {
             "Circle of Fireskin",    -- Level 70
             "Fireskin",              -- Level 66
             "Maelstrom of Ro",       -- Level 63
-            "FlameShield of Ro",     -- Level 61
+            "Flameshield of Ro",     -- Level 61
             "Aegis of Ro",           -- Level 60
             "Cadeau of Flame",       -- Level 56
             "Boon of Immolation",    -- Level 53
@@ -267,7 +267,7 @@ _ClassConfig    = {
             "Call of the Heroes", -- Level 70
         },
         ['Bladegusts'] = {
-            "Burning Bladegusts", -- Level 69
+            "Burning Bladegusts", -- Level 69 Laz Custom
         },
         ['PBAE2'] = {
             "Scintillation", -- Level 51
@@ -276,10 +276,10 @@ _ClassConfig    = {
             "Wind of the Desert", -- Level 60
         },
         ['Myriad'] = {
-            "Shock of Myriad Minions", -- Level 70
+            "Shock of Myriad Minions", -- Level 70 Laz Custom
         },
         ['FranticDS'] = {
-            "Frantic Flames", -- Level 71
+            "Frantic Flames", -- Level 71 Laz Custom
         },
     },
     ['AASets']        = {

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -47,7 +47,7 @@ local _ClassConfig = {
     },
     ['AbilitySets']   = {
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70
+            "Third Wind Discipline", -- Level 70 Laz Custom
             -- "Second Wind",        -- Level 65
         },
         ['MonkAura'] = {
@@ -59,7 +59,7 @@ local _ClassConfig = {
             "Clawstriker's Flurry", -- Level 65
         },
         ['FistsOfWu'] = {
-            "Fists Of Wu", -- Level 65
+            "Fists of Wu", -- Level 65
         },
         ['MeleeMit'] = {
             "Impenetrable Discipline", -- Level 65

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -209,7 +209,7 @@ local _ClassConfig = {
             "Scent of Midnight", -- Level 68
         },
         ['LichSpell'] = {
-            "Ancient: Allure of Extinction", -- Level 70
+            "Ancient: Allure of Extinction", -- Level 70 Laz Custom
             -- "Dark Possession",            -- Level 70, Listed in spell file, does not appear to be in game?
             "Grave Pact",                    -- Level 70
             "Ancient: Seduction of Chaos",   -- Level 65

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -179,7 +179,7 @@ return {
         --     "Resolution",        -- Level 60
         -- },
         ['Brells'] = {
-            "Brell's Vibrant Barricade",   -- Level 70
+            "Brell's Vibrant Barricade",   -- Level 70 Laz Custom
             "Brell's Brawny Bulwark",      -- Level 69
             "Brell's Stalwart Shield",     -- Level 65
             "Brell's Mountainous Barrier", -- Level 60
@@ -210,8 +210,8 @@ return {
         ['ArmorSelfBuff'] = {
             --- Self Buff Armor Line Ac/Hp/Mana regen
             "Armor of the Champion", -- Level 69
-            "Armor of the Crusader", -- Level 64
-            "Armor of the Divine",   -- Level 60
+            "Armor of the Crusader", -- Level 64 Laz Custom
+            "Armor of the Divine",   -- Level 60 Laz Custom
         },
         ['SymbolBuff'] = {
             "Jeron's Mark",      -- Level 68
@@ -286,7 +286,7 @@ return {
             "Remove Minor Curse",   -- Level 19
         },
         ['ForgeDisc'] = {
-            "Hallowforge Discipline", -- Level 70
+            "Hallowforge Discipline", -- Level 70 Laz Custom
             "Holyforge Discipline",   -- Level 55
         },
         ['RezSpell'] = {
@@ -299,14 +299,14 @@ return {
             "Sacred Word",  -- Level 41, does damage
         },
         ['BlockDisc'] = {
-            "Rampart Discipline",    -- Level 70
+            "Rampart Discipline",    -- Level 70 Laz Custom
             "Deflection Discipline", -- Level 59
         },
         ['SancDisc'] = {
             "Sanctification Discipline", -- Level 60
         },
         ['TwinHealNuke'] = {
-            "Justice of Marr", -- Level 71
+            "Justice of Marr", -- Level 71 Laz Custom
         },
         ['GuardDisc'] = {
             "Guard of Righteousness", -- Level 69

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -71,9 +71,9 @@ return {
             "Skin like Wood",         -- Level 7
         },
         ['EyeBuff'] = {               -- Self Archery Buff
-            "Eyes of the Hawk",       -- Level 70
+            "Eyes of the Hawk",       -- Level 70 Laz Custom
             "Eyes of the Owl",        -- Level 65
-            "Eyes of the Eagle",      -- Level 59
+            "Eyes of the Eagle",      -- Level 59 Laz Custom
         },
         ['FireNukeT1'] = {            -- ST Fire DD, Timer 1, 30s Recast
             "Hearth Embers",          -- Level 69
@@ -117,7 +117,7 @@ return {
             "Hail of Arrows",         -- Level 65
         },
         ['FocusedHail'] = {           -- ST multihit archery attack
-            "Focused Hail of Arrows", -- Level 69
+            "Focused Hail of Arrows", -- Level 69 Laz Custom
         },
         ['Dispel'] = {
             "Nature's Balance", -- Level 69
@@ -126,7 +126,7 @@ return {
             "Cancel Magic",     -- Level 30
         },
         ['Heartshot'] = {
-            "Heartslit", -- Level 68
+            "Heartslit", -- Level 68 Laz Custom
             "Heartshot", -- Level 65
         },
         ['RegenBuff'] = {
@@ -182,7 +182,7 @@ return {
             "Shield of Thistles",  -- Level 24
         },
         ['FlameSnap'] = {
-            "Flame Snap",  -- Level 66
+            "Flame Snap",  -- Level 66 Laz Custom
         },
         ['NatureProc'] = { -- ST Hade reduction defensive proc buff
             "Nature Veil", -- Level 66

--- a/class_configs/Project Lazarus/rog_class_config.lua
+++ b/class_configs/Project Lazarus/rog_class_config.lua
@@ -48,7 +48,7 @@ return {
     },
     ['AbilitySets']   = {
         ['ThiefBuff'] = {
-            "Brigand's Gaze", -- Level 70
+            "Brigand's Gaze", -- Level 70 Laz Custom
             "Thief's Eyes",   -- Level 65
         },
         ['Kinesthetics'] = {
@@ -80,7 +80,7 @@ return {
             "Pinpoint Vulnerability", -- Level 69, on Laz
         },
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70
+            "Third Wind Discipline", -- Level 70 Laz Custom
             -- "Second Wind",        -- Level 65
         },
         ['CADisc'] = {

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -148,7 +148,7 @@ local _ClassConfig = {
             "Ichor Guard", -- Level 56, Timer 5
         },
         ['BlockDisc'] = {
-            "Rampart Discipline",    -- Level 70
+            "Rampart Discipline",    -- Level 70 Laz Custom
             "Deflection Discipline", -- Level 59
         },
         ['LeechCurse'] = { 'Leechcurse Discipline', },
@@ -250,7 +250,7 @@ local _ClassConfig = {
             "Lifetap",               -- Level 8
         },
         ['AELifeTap'] = {
-            "Grasp of Lhranc", -- Level 69
+            "Grasp of Lhranc", -- Level 69 Laz Custom
         },
         ['BiteTap'] = {
             "Ancient: Bite of Muram", -- Level 70
@@ -302,7 +302,7 @@ local _ClassConfig = {
             "Disease Cloud",     -- Level 5
         },
         ['HateBuff'] = {         --9 minute reuse makes these somewhat ridiculous to gem on the fly.
-            "Voice of Innoruuk", -- Level 70, 15% hate, 150pt DS (slot 9), 15% decrease DS Mit (VoT AA is still better for tanking at 24%, but they stack. DS smexy)
+            "Voice of Innoruuk", -- Level 70, 15% hate, 150pt DS (slot 9), 15% decrease DS Mit (VoT AA is still better for tanking at 24%, but they stack. DS smexy) Laz Custom
             "Voice of Thule",    -- Level 65, 12% hate
             "Voice of Terris",   -- Level 60, 10% hate
             "Voice of Death",    -- Level 55, 6% hate

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -152,7 +152,7 @@ local _ClassConfig = {
             "Quickness",            -- Level 26
         },
         ['Unification'] = { -- Many buffs combined: 75 Sta, 50 sta cap, 7% evasion, 5% damage
-            "Talisman of Unification", -- Level 70
+            "Talisman of Unification", -- Level 70 Laz Custom
         },
         ['LowLvlStaBuff'] = {
             -- Low Level Stamina Buff --- I guess this may be okay for tanks (but largely a raid thing). Need to scrub which levels. Not currently used.
@@ -279,7 +279,7 @@ local _ClassConfig = {
             "Minor Healing",              -- Level 1
         },
         ['GroupHeal'] = { -- Laz specific, some taken from cleric, some custom
-            "Word of Reconstitution", -- Level 70
+            "Word of Reconstitution", -- Level 70 Laz Custom
             "Word of Redemption",     -- Level 65
             "Word of Restoration",    -- Level 62
             "Word of Vigor",          -- Level 56
@@ -291,7 +291,7 @@ local _ClassConfig = {
             "Ghost of Renewal", -- Level 70
         },
         ['SnareHot'] = {
-            "Transcendent Torpor", -- Level 70
+            "Transcendent Torpor", -- Level 70 Laz Custom
             "Torpor",              -- Level 60
             "Stoicism",            -- Level 44
         },
@@ -319,7 +319,7 @@ local _ClassConfig = {
         -- },
         ['TwinHealNuke'] = {
             -- Nuke the MA Not the assist target - Levels 70
-            "Frostfall Boon", -- Level 70
+            "Frostfall Boon", -- Level 70 Laz Custom
         },
         ['PoisonNuke'] = {
             -- Poison Nuke LVL34 +
@@ -376,12 +376,12 @@ local _ClassConfig = {
         },
         ['PetSpell'] = { --We need to add handling for commune to get the mammoth/etc
             -- Pet Spell - 32+
-            "Commune with the Wild", -- Level 70
+            "Commune with the Wild", -- Level 70 Laz Custom
             "Farrel's Companion",    -- Level 67
             "True Spirit",           -- Level 61
             "Spirit of the Howler",  -- Level 55
             "Frenzied Spirit",       -- Level 45
-            "Guardian spirit",       -- Level 41
+            "Guardian Spirit",       -- Level 41
             "Vigilant Spirit",       -- Level 37
             "Companion Spirit",      -- Level 32
         },

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -102,7 +102,7 @@ local _ClassConfig = {
             "Mock", -- Level 65
         },
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70, also does HP
+            "Third Wind Discipline", -- Level 70, also does HP Laz Custom
             "Second Wind",           -- Level 65
         },
         ['AuraBuff'] = {
@@ -125,7 +125,7 @@ local _ClassConfig = {
             "Throat Jab", -- Level 69
         },
         ['Flaunt'] = {
-            "Flaunt", -- Level 70
+            "Flaunt", -- Level 70 Laz Custom
         },
         ['ShockDisc'] = { -- Timer 7, defensive stun proc
             "Shocking Defense Discipline", -- Level 70

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -139,7 +139,7 @@ return {
             "Elnerick's Electrical Rending", -- Level 60
         },
         ['StunSpell'] = {
-            "Telakemara",       -- Level 70
+            "Telakemara",       -- Level 70 Laz Custom
             "Telekara",         -- Level 70
             "Telaka",           -- Level 65
             "Telekin",          -- Level 61

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2744, }
+return { version = 2745, }

--- a/namedlist/named_eqmight.lua
+++ b/namedlist/named_eqmight.lua
@@ -648,7 +648,6 @@ return {
         "Mystical Arbitor of Earth",
         { name = "Peregrin Rockskull", statusImmunities = { Slow = true, }, },
         "A Fabled Mystical Arbitor of Earth",
-        "The Fabled Skal's Waking Nightmare",
     },
 
     ["poearthb"] = {

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1813,7 +1813,7 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         Targeting.SetTarget(targetId, true)
     end
 
-    local cmd = string.format("/cast \"%s%s\"", Config:GetSetting('UseExactSpellNames') and "=" or "", spellName)
+    local cmd = string.format("/cast \"=%s\"", spellName)
     local castTime = spell.MyCastTime() or 0
     local readyCheck = function() return me.SpellReady(spellName)() end
     -- Expose this if needed for EZServer if they have instant CD spells with 0 gcd
@@ -1926,7 +1926,7 @@ function Casting.UseSong(songName, targetId, bAllowMem, retryCount)
 
     repeat
         Casting.SetLastCastResult(Globals.Constants.CastResults.CAST_RESULT_NONE)
-        Core.DoCmd("/cast \"%s%s\"", Config:GetSetting('UseExactSpellNames') and "=" or "", songName)
+        Core.DoCmd("/cast \"=%s\"", songName)
 
         mq.delay("3s", function() return mq.TLO.Window("CastingWindow").Open() end)
         -- Cast window opening is our cross-platform "song started" signal (EMU has no "you begin singing" event).
@@ -2140,7 +2140,7 @@ function Casting.RunCastLoop(opts)
     local bAllowDead = opts.bAllowDead
     local spellRange = opts.spellRange
     local castTime = opts.castTime or 0
-    local retryCount = opts.retryCount or 2
+    local retryCount = opts.retryCount or Config:GetSetting('CastRetryCountBeta')
 
     -- give a small delay for when we need to rely on an action changing to "not ready" to detect success, this is data from the server. values tested on laz/might numerous times
     local floor = math.max(300, 3 * (mq.TLO.EverQuest.Ping() or 0))

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1270,14 +1270,16 @@ Config.DefaultConfig                                     = {
         ConfigType = "Advanced",
     },
     -- Common/Under the Hood
-    ['UseExactSpellNames']         = {
-        DisplayName = "Use Exact Spell Names",
+    ['SpellRetryCountBeta']        = {
+        DisplayName = "Spell Retry Count",
         Group = "Abilities",
         Header = "Common",
         Category = "Under the Hood",
         Index = 1,
-        Tooltip = "This will cause RGMercs to use '/cast =<Spell>' which , must be supported by your MQ version but will avoid things like 'Bane' casting 'Bane of Nife' instead.",
-        Default = true,
+        Tooltip = "The amount of times to try to recast a spell, AA, or item due to a fizzle, interrupt, or similar.",
+        Default = 2,
+        Min = 0,
+        Max = 5,
         ConfigType = "Advanced",
     },
     ['CastReadyDelayFact']         = {


### PR DESCRIPTION
* Annotation update for Live spell levels (Resolves #571).
* Annotation in EQM/Laz Configs for spells particular to that server.
* Corrected typo in NEC(Live) DMF check (thanks Zat!)
* Exposed the default cast retry counts in beta form. Current default remains 2 during playtesting and may change to 0. See in-game settings (Abilities > Common > Under the Hood).
* Sunset of exact spell names in cast being optional.