### PR TITLE
WAR Adjustments

### DIFF
--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -256,11 +256,8 @@ local _ClassConfig = {
             timer = 1, -- Don't check this more often than once a second to avoid blowing every ability at once (aggro takes time to update)
             doFullRotation = true,
             load_cond = function()
-                if not Core.IsTanking() then return false end
-                local bladeDisc = Config:GetSetting('BladeDiscUse') > 1 and Core.GetResolvedActionMapItem('BladeDisc')
-                local hateAA = Config:GetSetting('AETauntAA') and Casting.CanUseAA("Area Taunt")
-                local epic = Config:GetSetting('DoEpic') and Core.GetResolvedActionMapItem("Epic")
-                return bladeDisc or hateAA or epic
+                return Core.IsTanking() and Config:GetSetting('DoAETaunt') and
+                    (Casting.CanUseAA("Area Taunt") or Core.GetResolvedActionMapItem("BladeDisc"))
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -311,6 +308,17 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
                 return combat_state == "Combat" and Casting.BurnCheck()
+            end,
+        },
+        {
+            name = 'Buffs',
+            state = 1,
+            steps = 1,
+            targetId = function(self)
+                return mq.TLO.Target.ID() == Globals.AutoTargetID and { Globals.AutoTargetID, } or { mq.TLO.Me.ID(), }
+            end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" or (combat_state == "Downtime" and Casting.OkayToBuff())
             end,
         },
         { --Non-threat combat actions
@@ -418,13 +426,6 @@ local _ClassConfig = {
         },
         ['AEHateTools'] = {
             {
-                name = "Epic",
-                type = "Item",
-                cond = function(self, itemName)
-                    return Config:GetSetting('DoAEDamage')
-                end,
-            },
-            {
                 name = "BladeDisc",
                 type = "Disc",
                 load_cond = function(self) return Config:GetSetting('BladeDiscUse') > 1 end,
@@ -435,6 +436,13 @@ local _ClassConfig = {
             {
                 name = "AreaTaunt",
                 type = "AA",
+            },
+            {
+                name = "Rampage",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Config:GetSetting("DoAEDamage")
+                end,
             },
         },
         ['EmergencyDefenses'] = {
@@ -543,7 +551,13 @@ local _ClassConfig = {
                     return Casting.NoDiscActive() and Casting.DiscOnCoolDown('Protective') and Casting.DiscOnCoolDown('StandDisc')
                 end,
             },
-
+            {
+                name = "Epic",
+                type = "Item",
+                cond = function(self, itemName)
+                    return Config:GetSetting('DoEpic')
+                end,
+            },
         },
         ['Burn'] = {
             {
@@ -574,6 +588,15 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Rampage",
+                type = "AA",
+                load_cond = function(self) return not (Core.IsTanking() and Config:GetSetting('DoAETaunt')) end,
+                cond = function(self, aaName, target)
+                    if not Config:GetSetting("DoAEDamage") then return false end
+                    return Combat.AETargetCheck(true)
+                end,
+            },
+            {
                 name = "Rage of Rallos Zek",
                 type = "AA",
             },
@@ -582,6 +605,16 @@ local _ClassConfig = {
                 type = "Disc",
                 cond = function(self, discSpell, target)
                     return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') or Targeting.BigGroupHealsNeeded()
+                end,
+            },
+        },
+        ['Buffs'] = {
+            {
+                name = "Infused by Rage",
+                type = "AA",
+                load_cond = function(self) return Core.IsTanking() end,
+                cond = function(self, aaName)
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
         },
@@ -638,15 +671,6 @@ local _ClassConfig = {
             {
                 name = "Throat",
                 type = "Disc",
-            },
-            {
-                name = "Rampage",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting("DoAEDamage") or Config:GetSetting('UseRampage') == 1 then return false end
-                    return (Config:GetSetting('UseRampage') == 3 or (Config:GetSetting('UseRampage') == 2 and Casting.BurnCheck())) and
-                        Combat.AETargetCheck(true)
-                end,
             },
             {
                 name = "Call of Challenge",
@@ -737,32 +761,16 @@ local _ClassConfig = {
             Min = 1,
             Max = 3,
         },
-        ['UseRampage']      = {
-            DisplayName = "Rampage Use:",
-            Group = "Abilities",
-            Header = "Damage",
-            Category = "AE",
-            Index = 102,
-            Tooltip = "Use Rampage 1-Never 2-Burns 3-Always",
-            Type = "Combo",
-            ComboOptions = { 'Never', 'Burns Only', 'All Combat', },
-            Default = 3,
-            Min = 1,
-            Max = 3,
-            ConfigType = "Advanced",
-        },
-
         --Hate Tools
-        ['AETauntAA']       = {
-            DisplayName = "Use AE Taunt AA",
+        ['DoAETaunt']       = {
+            DisplayName = "Do AE Taunts",
             Group = "Abilities",
             Header = "Tanking",
             Category = "Hate Tools",
-            Index = 101,
-            Tooltip = "Use the Area Taunt AA.",
+            Index = 100,
+            Tooltip = "Use AE hatred Discs and AA (see FAQ for specifics).",
             RequiresLoadoutChange = true,
             Default = true,
-            ConfigType = "Advanced",
         },
         --Defenses
         ['DiscCount']       = {

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -358,6 +358,18 @@ local _ClassConfig = {
                 return combat_state == "Combat" and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
             end,
         },
+        { --Actions that establish or maintain hatred
+            name = 'AEHateTools',
+            state = 1,
+            steps = 1,
+            timer = 1, -- Don't check this more often than once a second to avoid blowing every ability at once (aggro takes time to update)
+            doFullRotation = true,
+            load_cond = function() return Core.IsTanking() and Config:GetSetting('DoAETaunt') end,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
+            end,
+        },
         { --Defensive actions triggered by low HP
             name = 'EmergencyDefenses',
             state = 1,
@@ -399,6 +411,17 @@ local _ClassConfig = {
                 return combat_state == "Combat" and Casting.BurnCheck() and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
             end,
         },
+        {
+            name = 'Buffs',
+            state = 1,
+            steps = 1,
+            targetId = function(self)
+                return mq.TLO.Target.ID() == Globals.AutoTargetID and { Globals.AutoTargetID, } or { mq.TLO.Me.ID(), }
+            end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" or (combat_state == "Downtime" and Casting.OkayToBuff())
+            end,
+        },
         { --DPS and Utility discs
             name = 'Combat',
             state = 1,
@@ -428,73 +451,6 @@ local _ClassConfig = {
                     return not mq.TLO.Me.Aura(1).ID()
                 end,
             },
-            {
-                name = "GroupACBuff",
-                type = "Disc",
-                active_cond = function(self, discSpell)
-                    return Casting.IHaveBuff(discSpell)
-                end,
-                cond = function(self, discSpell)
-                    return Casting.SelfBuffCheck(discSpell)
-                end,
-            },
-            {
-                name = "GroupDodgeBuff",
-                type = "Disc",
-                active_cond = function(self, discSpell)
-                    return Casting.IHaveBuff(discSpell)
-                end,
-                cond = function(self, discSpell)
-                    return Casting.SelfBuffCheck(discSpell)
-                end,
-            },
-            {
-                name = "DefenseACBuff",
-                type = "Disc",
-                active_cond = function(self, discSpell)
-                    return mq.TLO.Me.ActiveDisc.ID() == discSpell.ID()
-                end,
-                cond = function(self, discSpell)
-                    return Core.IsTanking() and Casting.NoDiscActive()
-                end,
-            },
-            {
-                name = "Brace for Impact",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "HealHateAE",
-                type = "Disc",
-                cond = function(self, discSpell, target)
-                    if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.SelfBuffCheck(discSpell)
-                end,
-            },
-            {
-                name = "HealHateSingle",
-                type = "Disc",
-                cond = function(self, discSpell, target)
-                    if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking() and Casting.SelfBuffCheck(discSpell)
-                end,
-            },
-            {
-                name = "Infused by Rage",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Core.IsTanking() and Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Blade Guardian",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
             { --Charm Click, name function stops errors in rotation window when slot is empty
                 name_func = function() return mq.TLO.Me.Inventory("Charm").Name() or "CharmClick(Missing)" end,
                 type = "Item",
@@ -502,6 +458,38 @@ local _ClassConfig = {
                     if not Config:GetSetting('DoCharmClick') or not Casting.ItemHasClicky(itemName) then return false end
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
+            },
+        },
+        ['HateTools(AggroTarget)'] = {
+            {
+                name = "Attention",
+                type = "Disc",
+            },
+            {
+                name = "Blast of Anger",
+                type = "AA",
+            },
+            {
+                name = "Taunt",
+                type = "Ability",
+                cond = function(self, abilityName, target)
+                    return Targeting.GetTargetDistance(target) < 30
+                end,
+            },
+            {
+                name = "AbsorbTaunt",
+                type = "Disc",
+            },
+            {
+                name = "AddHate1",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Casting.DetSpellCheck(discSpell)
+                end,
+            },
+            {
+                name = "AddHate2",
+                type = "Disc",
             },
         },
         ['HateTools(AutoTarget)'] = {
@@ -534,6 +522,23 @@ local _ClassConfig = {
             {
                 name = "AddHate2",
                 type = "Disc",
+            },
+        },
+        ['AEHateTools'] = {
+            {
+                name = "Area Taunt",
+                type = "AA",
+            },
+            {
+                name = "SelfBuffAE",
+                type = "Disc",
+            },
+            {
+                name = "Rampage",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Config:GetSetting("DoAEDamage")
+                end,
             },
         },
         ['EmergencyDefenses'] = {
@@ -682,6 +687,60 @@ local _ClassConfig = {
                 end,
             },
         },
+        ['Buffs'] = {
+            {
+                name = "GroupACBuff",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
+                end,
+            },
+            {
+                name = "GroupDodgeBuff",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
+                end,
+            },
+            {
+                name = "DefenseACBuff",
+                type = "Disc",
+                load_cond = function(self) return Core.IsTanking() end,
+                cond = function(self, discSpell)
+                    return Casting.NoDiscActive()
+                end,
+            },
+            {
+                name = "Brace for Impact",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
+            },
+            {
+                name = "HealHateAE",
+                type = "Disc",
+                load_cond = function(self) return Core.IsTanking() and Config:GetSetting('DoAETaunt') end,
+                cond = function(self, discSpell, target)
+                    return Casting.SelfBuffCheck(discSpell)
+                end,
+            },
+            {
+                name = "HealHateSingle",
+                type = "Disc",
+                load_cond = function(self) return Core.IsTanking() and not Config:GetSetting('DoAETaunt') end,
+                cond = function(self, discSpell, target)
+                    return Casting.SelfBuffCheck(discSpell)
+                end,
+            },
+            {
+                name = "Blade Guardian",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
+            },
+        },
         ['Burn'] = {
             {
                 name = "Spire of the Warlord",
@@ -736,20 +795,9 @@ local _ClassConfig = {
                 type = "AA",
             },
             {
-                name = "SelfBuffAE",
-                type = "Disc",
-                cond = function(self, discSpell)
-                    if not Config:GetSetting('DoAETaunt') or Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking()
-                end,
-            },
-            {
                 name = "SelfBuffSingle",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    if Config:GetSetting('DoAETaunt') and not Config:GetSetting('SafeAETaunt') then return false end
-                    return Core.IsTanking()
-                end,
+                load_cond = function(self) return Core.IsTanking() and not Config:GetSetting('DoAETaunt') end,
             },
             {
                 name = "TongueDisc",
@@ -805,6 +853,7 @@ local _ClassConfig = {
             {
                 name = "Rampage",
                 type = "AA",
+                load_cond = function(self) return not (Core.IsTanking() and Config:GetSetting('DoAETaunt')) end,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting("DoAEDamage") then return false end
                     return Combat.AETargetCheck(true)
@@ -920,7 +969,8 @@ local _ClassConfig = {
             Category = "Hate Tools",
             Index = 101,
             Tooltip = "Use AE hatred Discs and AA.",
-            Default = false,
+            Default = true,
+            RequiresLoadoutChange = true,
             FAQ = "Why am I using AE damage when there are mezzed mobs around?",
             Answer = "It is not currently possible to properly determine Mez status without direct Targeting. If you are mezzing, consider turning this option off.",
         },

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -78,12 +78,12 @@ local _ClassConfig = {
             "Defensive Discipline", -- Level 55
             "Evasive Discipline",   -- Level 52
         },
-        ['Fortitude'] = { -- Timer 3
+        ['Fortitude'] = {           -- Timer 3
             "Fortitude Discipline", -- Level 59
             "Furious Discipline",   -- Level 56
         },
-        ['GroupACBuff'] = { -- Has Commanding Voice (Dodge Buff) baked in
-            "Field Armorer", -- Level 65
+        ['GroupACBuff'] = {         -- Has Commanding Voice (Dodge Buff) baked in
+            "Field Armorer",        -- Level 65
         },
         ['AEBlades'] = {
             "Vortex Blade",    -- Level 69
@@ -125,9 +125,9 @@ local _ClassConfig = {
             "Throat Jab", -- Level 69
         },
         ['Flaunt'] = {
-            "Flaunt", -- Level 70 Laz Custom
+            "Flaunt",                      -- Level 70 Laz Custom
         },
-        ['ShockDisc'] = { -- Timer 7, defensive stun proc
+        ['ShockDisc'] = {                  -- Timer 7, defensive stun proc
             "Shocking Defense Discipline", -- Level 70
         },
     },
@@ -270,6 +270,17 @@ local _ClassConfig = {
                 return combat_state == "Combat" and Casting.BurnCheck()
             end,
         },
+        {
+            name = 'Buffs',
+            state = 1,
+            steps = 1,
+            targetId = function(self)
+                return mq.TLO.Target.ID() == Globals.AutoTargetID and { Globals.AutoTargetID, } or { mq.TLO.Me.ID(), }
+            end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" or (combat_state == "Downtime" and Casting.OkayToBuff())
+            end,
+        },
         { --Non-threat combat actions
             name = 'Combat',
             state = 1,
@@ -291,23 +302,6 @@ local _ClassConfig = {
                 end,
                 cond = function(self, discSpell)
                     return not mq.TLO.Me.Aura(1).ID()
-                end,
-            },
-            {
-                name = "GroupACBuff",
-                type = "Disc",
-                active_cond = function(self, discSpell)
-                    return Casting.IHaveBuff(discSpell)
-                end,
-                cond = function(self, discSpell)
-                    return Casting.SelfBuffCheck(discSpell)
-                end,
-            },
-            {
-                name = "Infused by Rage",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Core.IsTanking() and Casting.SelfBuffAACheck(aaName)
                 end,
             },
         },
@@ -395,6 +389,13 @@ local _ClassConfig = {
             {
                 name = "AreaTaunt",
                 type = "AA",
+            },
+            {
+                name = "Rampage",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Config:GetSetting("DoAEDamage")
+                end,
             },
         },
         ['EmergencyDefenses'] = {
@@ -528,6 +529,15 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Rampage",
+                type = "AA",
+                load_cond = function(self) return not (Core.IsTanking() and Config:GetSetting('DoAETaunt')) end,
+                cond = function(self, aaName, target)
+                    if not Config:GetSetting("DoAEDamage") then return false end
+                    return Combat.AETargetCheck(true)
+                end,
+            },
+            {
                 name = "Rage of Rallos Zek",
                 type = "AA",
             },
@@ -553,6 +563,23 @@ local _ClassConfig = {
                 name = "Intensity of the Resolute",
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+            },
+        },
+        ['Buffs'] = {
+            {
+                name = "GroupACBuff",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Casting.SelfBuffCheck(discSpell)
+                end,
+            },
+            {
+                name = "Infused by Rage",
+                type = "AA",
+                load_cond = function(self) return Core.IsTanking() end,
+                cond = function(self, aaName)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
             },
         },
         ['Combat'] = {
@@ -600,14 +627,6 @@ local _ClassConfig = {
             {
                 name = "Throat",
                 type = "Disc",
-            },
-            {
-                name = "Rampage",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting("DoAEDamage") or Config:GetSetting('UseRampage') == 1 then return false end
-                    return (Config:GetSetting('UseRampage') == 3 or (Config:GetSetting('UseRampage') == 2 and Casting.BurnCheck())) and Combat.AETargetCheck(true)
-                end,
             },
             {
                 name = "Call of Challenge",
@@ -695,21 +714,6 @@ local _ClassConfig = {
         },
 
         -- AE Damage
-        ['UseRampage']      = {
-            DisplayName = "Rampage Use:",
-            Group = "Abilities",
-            Header = "Damage",
-            Category = "AE",
-            Index = 105,
-            Tooltip = "Use Rampage 1-Never 2-Burns 3-Always",
-            Type = "Combo",
-            ComboOptions = { 'Never', 'Burns Only', 'All Combat', },
-            Default = 3,
-            Min = 1,
-            Max = 3,
-            ConfigType = "Advanced",
-        },
-
         --Hate Tools
         ['DoAETaunt']       = {
             DisplayName = "Do AE Taunts",
@@ -718,7 +722,8 @@ local _ClassConfig = {
             Category = "Hate Tools",
             Index = 101,
             Tooltip = "Use AE hatred Discs and AA (see FAQ for specifics).",
-            Default = false,
+            RequiresLoadoutChange = true,
+            Default = true,
         },
 
         --Defenses

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2749, }
+return { version = 2750, }


### PR DESCRIPTION
* All - Move certain buffs out of downtime and into buff rotation that will fire regardless of combat state.
* Live - Properly implement the Hate Tool rotations for Aggro Target and AE.
* Laz, EQM - Adjust Rampage use as an AE Taunt option for tanks with ae taunting enabled, as a burn ability otherwise.