### PR TITLE
Fix Warrior AE Taunt condition to respect extended target counts and aggro conditions.

### DIFF
--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -367,7 +367,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('DoAETaunt') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
+                return combat_state == "Combat" and Combat.AETauntCheck(true) and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
             end,
         },
         { --Defensive actions triggered by low HP


### PR DESCRIPTION
Previously, Warrior AE Taunt was not evaluating extended target counts or threat status before firing. If `DoAETaunt` was enabled and `AETauntCnt` was set greater than 1, AE Taunt would activate whenever it became available, regardless of whether the configured conditions were actually met.

This resulted in AE Taunt firing even when there was only a single mob on the extended target list, as well as situations where all mobs were already aggro'd on the warrior and no additional threat generation was needed.

Adding `Combat.AETauntCheck(true)` ensures that AE Taunt only fires when the extended target count and aggro conditions warrant its use.
