### PR TITLE
Default Retry Count Adjustment

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2757, }
+return { version = 2758, }

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -2140,7 +2140,7 @@ function Casting.RunCastLoop(opts)
     local bAllowDead = opts.bAllowDead
     local spellRange = opts.spellRange
     local castTime = opts.castTime or 0
-    local retryCount = opts.retryCount or Config:GetSetting('CastRetryCountBeta')
+    local retryCount = opts.retryCount or Config:GetSetting('CastRetryCount')
 
     -- give a small delay for when we need to rely on an action changing to "not ready" to detect success, this is data from the server. values tested on laz/might numerous times
     local floor = math.max(300, 3 * (mq.TLO.EverQuest.Ping() or 0))

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1267,14 +1267,14 @@ Config.DefaultConfig                                     = {
         ConfigType = "Advanced",
     },
     -- Common/Under the Hood
-    ['CastRetryCountBeta']         = {
+    ['CastRetryCount']             = {
         DisplayName = "Cast Retry Count",
         Group = "Abilities",
         Header = "Common",
         Category = "Under the Hood",
         Index = 1,
-        Tooltip = "The amount of times to try to recast a spell, AA, or item due to a fizzle, interrupt, or similar.",
-        Default = 2,
+        Tooltip = "The amount of times to try to recast a spell, AA, or item due to a fizzle, interrupt, or similar. Note that queued actions already have a retry built-in.",
+        Default = 0,
         Min = 0,
         Max = 5,
         ConfigType = "Advanced",


### PR DESCRIPTION
Versioned setting out of beta, default is now 0. The previous value was 2, for users who preferred that. Please see in-game tooltips for Cast Retry Count.