### PR TITLE
Cast/Movement refactor

### DIFF
--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -402,6 +402,7 @@ local _ClassConfig = {
             name = 'Downtime',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and not mq.TLO.Me.Invis()
@@ -411,6 +412,7 @@ local _ClassConfig = {
             name = 'Emergency',
             state = 1,
             steps = 1,
+            midSong = true,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
@@ -442,6 +444,7 @@ local _ClassConfig = {
             name = 'Burn',
             state = 1,
             steps = 4,
+            midSong = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.BurnCheck()
@@ -451,6 +454,7 @@ local _ClassConfig = {
             name = 'Combat',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"
@@ -472,42 +476,52 @@ local _ClassConfig = {
             {
                 name = "Quick Time",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Fierce Eye",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Funeral Dirge",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Bladed Song",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Song of Stone",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "ThousandBlades",
                 type = "Disc",
+                midSong = true,
             },
             {
                 name = "OoW_Chest",
                 type = "Item",
+                midSong = true,
             },
             {
                 name = "Dance of Blades",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Cacophony",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "A Tune Stuck In Your Head",
                 type = "AA",
+                midSong = true,
             },
         },
         ['Debuff'] = {
@@ -558,10 +572,23 @@ local _ClassConfig = {
             {
                 name = "Boastful Bellow",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Selo's Kick",
                 type = "AA",
+                midSong = true,
+            },
+            {
+                name = "Selo's Sonata",
+                type = "AA",
+                midSong = true,
+                targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
+                cond = function(self, aaName)
+                    --refresh slightly before expiry for better uptime
+                    return (mq.TLO.Me.Buff(aaName).Duration.TotalSeconds() or 0) < 30
+                end,
             },
         },
         ['CombatSongs'] = {
@@ -734,10 +761,10 @@ local _ClassConfig = {
             {
                 name = "Selo's Sonata",
                 type = "AA",
+                midSong = true,
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
                 load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, aaName)
-                    if not Config:GetSetting('UseRunBuff') then return false end
                     --refresh slightly before expiry for better uptime
                     return (mq.TLO.Me.Buff(aaName).Duration.TotalSeconds() or 0) < 30
                 end,
@@ -769,6 +796,7 @@ local _ClassConfig = {
             {
                 name = "Fading Memories",
                 type = "AA",
+                midSong = true,
                 cond = function(self, aaName)
                     if not Config:GetSetting('UseFading') then return false end
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and self.Helpers.UnwantedAggroCheck(self)
@@ -778,6 +806,7 @@ local _ClassConfig = {
             {
                 name = "Revitalize",
                 type = "Disc",
+                midSong = true,
                 cond = function(self, discSpell, target)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
@@ -785,6 +814,7 @@ local _ClassConfig = {
             {
                 name = "Hymn of the Last Stand",
                 type = "AA",
+                midSong = true,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
@@ -792,6 +822,7 @@ local _ClassConfig = {
             {
                 name = "Shield of Notes",
                 type = "AA",
+                midSong = true,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
@@ -799,6 +830,7 @@ local _ClassConfig = {
             {
                 name = "Protective",
                 type = "Disc",
+                midSong = true,
                 cond = function(self, discSpell, target)
                     return Casting.NoDiscActive()
                 end,
@@ -806,6 +838,7 @@ local _ClassConfig = {
             {
                 name = "Skals",
                 type = "Disc",
+                midSong = true,
                 cond = function(self, discSpell, target)
                     return Casting.NoDiscActive()
                 end,

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -845,6 +845,7 @@ local _ClassConfig = {
             name = 'Downtime',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and not mq.TLO.Me.Invis()
@@ -854,6 +855,7 @@ local _ClassConfig = {
             name = 'Emergency',
             state = 1,
             steps = 1,
+            midSong = true,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
@@ -885,6 +887,7 @@ local _ClassConfig = {
             name = 'Burn',
             state = 1,
             steps = 4,
+            midSong = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.BurnCheck()
@@ -894,6 +897,7 @@ local _ClassConfig = {
             name = 'Combat',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"
@@ -915,34 +919,42 @@ local _ClassConfig = {
             {
                 name = "Quick Time",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Funeral Dirge",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Spire of the Minstrels",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Bladed Song",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "ThousandBlades",
                 type = "Disc",
+                midSong = true,
             },
             {
                 name = "Song of Stone",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Flurry of Notes",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Dance of Blades",
                 type = "AA",
+                midSong = true,
             },
             { --Chest Click, name function stops errors in rotation window when slot is empty
                 name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
@@ -955,14 +967,17 @@ local _ClassConfig = {
             {
                 name = "Cacophony",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Frenzied Kicks",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
@@ -993,18 +1008,6 @@ local _ClassConfig = {
             },
         },
         ['Combat'] = {
-            -- Kludge that addresses bards not attempting to start attacking until after a song completes
-            -- Uncomment if you'd like to occasionally start attacking earlier than normal
-            --[[{
-                name = "Force Attack",
-                type = "AA",
-                cond = function(self, itemName)
-                    local mytar = mq.TLO.Target
-                    if not mq.TLO.Me.Combat() and mytar() and mytar.Distance() < 50 then
-                        Core.DoCmd("/keypress AUTOPRIM")
-                    end
-                end,
-            },]]
             {
                 name = "Epic",
                 type = "Item",
@@ -1016,6 +1019,7 @@ local _ClassConfig = {
             {
                 name = "Fierce Eye",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('UseFierceEye') > 1 end,
                 cond = function(self, aaName)
                     return (Config:GetSetting('UseFierceEye') == 3 or (Config:GetSetting('UseFierceEye') == 2 and Casting.BurnCheck()))
@@ -1024,6 +1028,7 @@ local _ClassConfig = {
             {
                 name = "ReflexStrike",
                 type = "Disc",
+                midSong = true,
                 tooltip = Tooltips.ReflexStrike,
                 cond = function(self, discSpell)
                     local pct = Config:GetSetting('GroupManaPct')
@@ -1033,6 +1038,7 @@ local _ClassConfig = {
             {
                 name = "Boastful Bellow",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('UseBellow') > 1 end,
                 cond = function(self, aaName, target)
                     return ((Config:GetSetting('UseBellow') == 3 and mq.TLO.Me.PctEndurance() > Config:GetSetting('SelfEndPct')) or (Config:GetSetting('UseBellow') == 2 and Casting.BurnCheck())) and
@@ -1042,6 +1048,7 @@ local _ClassConfig = {
             {
                 name = "Vainglorious Shout",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('UseShout') > 1 end,
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoAEDamage') then return false end
@@ -1052,6 +1059,7 @@ local _ClassConfig = {
             {
                 name = "Rallying Solo", --Rallying Call theoretically possible but problematic, needs own rotation akin to Focused Paragon, etc
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Casting.CanUseAA('Rallying Solo') end,
                 cond = function(self, aaName)
                     return (mq.TLO.Me.PctEndurance() < 30 or mq.TLO.Me.PctMana() < 30)
@@ -1060,7 +1068,19 @@ local _ClassConfig = {
             {
                 name = "Intimidation",
                 type = "Ability",
+                midSong = true,
                 load_cond = function(self) return Casting.AARank("Intimidation") > 1 end,
+            },
+            {
+                name = "Selo's Sonata",
+                type = "AA",
+                midSong = true,
+                targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
+                cond = function(self, aaName)
+                    --refresh slightly before expiry for better uptime
+                    return (mq.TLO.Me.Buff(mq.TLO.AltAbility(aaName).Spell.Trigger(1)).Duration.TotalSeconds() or 0) < 30
+                end,
             },
         },
         ['CombatSongs'] = {
@@ -1359,10 +1379,10 @@ local _ClassConfig = {
             {
                 name = "Selo's Sonata",
                 type = "AA",
+                midSong = true,
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
                 load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, aaName)
-                    if not Config:GetSetting('UseRunBuff') then return false end
                     --refresh slightly before expiry for better uptime
                     return (mq.TLO.Me.Buff(mq.TLO.AltAbility(aaName).Spell.Trigger(1)).Duration.TotalSeconds() or 0) < 30
                 end,
@@ -1406,6 +1426,7 @@ local _ClassConfig = {
             {
                 name = "Armor of Experience",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() < 35
@@ -1414,6 +1435,7 @@ local _ClassConfig = {
             {
                 name = "Fading Memories",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and self.Helpers.UnwantedAggroCheck(self)
@@ -1423,6 +1445,7 @@ local _ClassConfig = {
             {
                 name = "Hymn of the Last Stand",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Casting.CanUseAA('Hymn of the Last Stand') end,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
@@ -1431,6 +1454,7 @@ local _ClassConfig = {
             {
                 name = "Shield of Notes",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Casting.CanUseAA('Shield of Notes') end,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -358,6 +358,7 @@ local _ClassConfig = {
             name = 'Downtime',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and not mq.TLO.Me.Invis()
@@ -367,6 +368,7 @@ local _ClassConfig = {
             name = 'Emergency',
             state = 1,
             steps = 1,
+            midSong = true,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
@@ -398,6 +400,7 @@ local _ClassConfig = {
             name = 'Burn',
             state = 1,
             steps = 4,
+            midSong = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.BurnCheck()
@@ -407,6 +410,7 @@ local _ClassConfig = {
             name = 'Combat',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat"
@@ -428,14 +432,17 @@ local _ClassConfig = {
             {
                 name = "Quick Time",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Fierce Eye",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Funeral Dirge",
                 type = "AA",
+                midSong = true,
             },
             { -- Spire, the SpireChoice setting will determine which ability is displayed/used.
                 name_func = function(self)
@@ -443,39 +450,48 @@ local _ClassConfig = {
                     return Casting.CanUseAA(spireAbil) and spireAbil or "Spire Not Purchased/Selected"
                 end,
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Bladed Song",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Song of Stone",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "ThousandBlades",
                 type = "Disc",
+                midSong = true,
             },
             {
                 name = "OoW_Chest",
                 type = "Item",
+                midSong = true,
             },
             {
                 name = "Dance of Blades",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Cacophony",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Intensity of the Resolute",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
             {
                 name = "A Tune Stuck In Your Head",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "SpellAbsorbSong",
@@ -533,15 +549,29 @@ local _ClassConfig = {
             {
                 name = "Boastful Bellow",
                 type = "AA",
+                midSong = true,
             },
             {
                 name = "Vainglorious Shout",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('UseShout') end,
             },
             {
                 name = "Kick",
                 type = "Ability",
+                midSong = true,
+            },
+            {
+                name = "Selo's Sonata",
+                type = "AA",
+                midSong = true,
+                targetId = function(self) return { mq.TLO.Me.ID(), } end,
+                load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
+                cond = function(self, aaName)
+                    --refresh slightly before expiry for better uptime
+                    return (mq.TLO.Me.Buff(aaName).Duration.TotalSeconds() or 0) < 30
+                end,
             },
         },
         ['CombatSongs'] = {
@@ -708,10 +738,10 @@ local _ClassConfig = {
             {
                 name = "Selo's Sonata",
                 type = "AA",
+                midSong = true,
                 targetId = function(self) return { mq.TLO.Me.ID(), } end,
                 load_cond = function(self) return Config:GetSetting('UseRunBuff') and Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, aaName)
-                    if not Config:GetSetting('UseRunBuff') then return false end
                     --refresh slightly before expiry for better uptime
                     return (mq.TLO.Me.Buff(aaName).Duration.TotalSeconds() or 0) < 30
                 end,
@@ -743,6 +773,7 @@ local _ClassConfig = {
             {
                 name = "Armor of Experience",
                 type = "AA",
+                midSong = true,
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() < 35
@@ -751,6 +782,7 @@ local _ClassConfig = {
             {
                 name = "Fading Memories",
                 type = "AA",
+                midSong = true,
                 cond = function(self, aaName)
                     if not Config:GetSetting('UseFading') then return false end
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and self.Helpers.UnwantedAggroCheck(self)
@@ -760,6 +792,7 @@ local _ClassConfig = {
             {
                 name = "Hymn of the Last Stand",
                 type = "AA",
+                midSong = true,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,
@@ -767,6 +800,7 @@ local _ClassConfig = {
             {
                 name = "Shield of Notes",
                 type = "AA",
+                midSong = true,
                 cond = function(self, aaName)
                     return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
                 end,

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2758, }
+return { version = 2759, }

--- a/init.lua
+++ b/init.lua
@@ -397,6 +397,7 @@ local function Main()
             Globals.AutoTargetID = 0
             Globals.AutoTargetIsNamed = false
             Globals.AggroTargetID = 0
+            Globals.CombatNavTargetId = 0
             Globals.SetForcedTargetId(0)
         end
         mq.delay(100)
@@ -454,6 +455,7 @@ local function Main()
             Targeting.ForceBurnTargetID = 0
             Globals.LastPulledID        = 0
             Globals.AutoTargetID        = 0
+            Globals.CombatNavTargetId   = 0
             Globals.IgnoredTargetIDs    = Set.new({})
             Globals.LastBurnCheck       = false
             Modules:ExecModule("Pull", "SetLastPullOrCombatEndedTimer")

--- a/modules/charm.lua
+++ b/modules/charm.lua
@@ -640,6 +640,8 @@ function Module:GiveTime()
 
 	if not Core.IsCharming() then return end
 
+	if mq.TLO.Navigation.Active() or mq.TLO.MoveTo.Moving() then return end
+
 	-- dead... whoops
 	if mq.TLO.Me.Hovering() then return end
 

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -66,6 +66,7 @@ Module.TempSettings.CureChecksStale          = false
 Module.TempSettings.ImmuneTargets            = {}
 Module.TempSettings.RotationClickies         = Set.new({})
 Module.TempSettings.RotationAAs              = Set.new({})
+Module.TempSettings.MidSongFireable          = {}
 
 Module.FAQ                                   = {
     {
@@ -813,6 +814,77 @@ function Module:IsCharming()
         return false
     end
     return self.ClassConfig.ModeChecks.IsCharming()
+end
+
+--- Runs the main-loop engage step mid-song, gated to the combat target so it never re-targets off a mez/charm/cure victim.
+---@param targetId number The song's target (UseSong's targetId).
+function Module:DoMidSongEngage(targetId)
+    if (Globals.AutoTargetID or 0) <= 0 or targetId ~= Globals.AutoTargetID then return end
+
+    if not Globals.BackOffFlag then
+        Combat.FindBestAutoTarget(Combat.OkToEngagePreValidateId)
+    end
+
+    if Combat.OkToEngage(Globals.AutoTargetID) then
+        Combat.EngageTarget(Globals.AutoTargetID)
+    end
+end
+
+--- Whether a midSong-flagged entry is a fireable instant; errors once per zone when it isn't.
+---@param entry table
+---@return boolean
+function Module:MidSongAllowed(entry)
+    local cached = self.TempSettings.MidSongFireable[entry]
+    if cached ~= nil then return cached end
+
+    local entryType = (entry.type or ""):lower()
+    local castTime = 0
+    local instantType = true
+
+    if entryType == "disc" then
+        local discSpell = self.ResolvedActionMap[entry.name]
+        castTime = discSpell and discSpell.MyCastTime() or 0
+    elseif entryType == "aa" then
+        local aaName = self.ResolvedActionMap[entry.name] or entry.name
+        castTime = aaName and (mq.TLO.Me.AltAbility(aaName).Spell.MyCastTime() or 0) or 0
+    elseif entryType == "item" or entryType == "clickyitem" then
+        local itemName = entryType == "clickyitem" and (entry.name and Config:GetSetting(entry.name)) or self.ResolvedActionMap[entry.name] or entry.name
+        local item = itemName and mq.TLO.FindItem("=" .. itemName)
+        castTime = (item and item()) and ((item.Clicky() and item.Clicky.CastTime()) or item.CastTime() or 0) or 0
+    elseif entryType ~= "ability" then
+        instantType = false -- song/spell would start a song; customfunc excluded as a conservative default
+    end
+
+    local fireable = instantType and (castTime or 0) == 0
+    self.TempSettings.MidSongFireable[entry] = fireable
+    if not fireable then
+        Logger.log_error("\arMidSong: '%s' (type %s) isn't instant - it can't fire mid-song; remove its midSong flag.", entry.name or "?", entry.type or "nil")
+    end
+    return fireable
+end
+
+--- Fires the midSong-flagged instant rotation entries through ExecEntry in fire-and-return mode, so a singing bard's instants go off without clipping the song.
+---@param targetId number The song's target (the combat autotarget).
+function Module:DoMidSongActions(targetId)
+    local combat_state = Combat.GetCachedCombatState()
+    local enabledRotations = Config:GetSetting('EnabledRotations') or {}
+    local enabledEntries = Config:GetSetting('EnabledRotationEntries') or {}
+
+    for _, r in ipairs(self.TempSettings.RotationStates) do
+        if r.midSong and enabledRotations[r.name] ~= false then
+            if Core.SafeCallFunc("MidSong rotation cond " .. r.name, r.cond, self, combat_state) then
+                for _, entry in ipairs(self:GetRotationTable(r.name)) do
+                    if entry.midSong and enabledEntries[entry.name] ~= false and self:MidSongAllowed(entry) then
+                        Core.SafeCallFunc("MidSong entry " .. entry.name, function()
+                            if Rotation.TestConditionForEntry(self, self.ResolvedActionMap, entry, targetId) then
+                                Rotation.ExecEntry(self, entry, targetId, self.ResolvedActionMap, false)
+                            end
+                        end)
+                    end
+                end
+            end
+        end
+    end
 end
 
 ---@return boolean
@@ -1752,6 +1824,7 @@ function Module:OnZone()
     end
     Module.TempSettings.ImmuneTargets = {}   -- clear list of slow/snare/stun immune mobs
     Module.TempSettings.QueuedAbilities = {} -- clear queued actions
+    Module.TempSettings.MidSongFireable = {} -- re-check (and re-warn) mid-song eligibility each zone
 end
 
 function Module:DoGetState()

--- a/modules/lootnscoot.lua
+++ b/modules/lootnscoot.lua
@@ -213,6 +213,8 @@ function Module:GiveTime()
 
 	if not Core.OkayToNotHeal() or mq.TLO.Me.Invis() or Casting.IAmFeigning() then return end
 
+	if Combat.CombatNavActive() then return end
+
 	if not self:CheckChaseTargetInRange() then
 		Logger.log_super_verbose("\ay::LOOT:: \arAborted!\ax Chase Target too far away.")
 		return

--- a/modules/mez.lua
+++ b/modules/mez.lua
@@ -764,6 +764,8 @@ function Module:GiveTime()
 
     if not Core.IsMezzing() then return end
 
+    if mq.TLO.Navigation.Active() or mq.TLO.MoveTo.Moving() then return end
+
     -- dead... whoops
     if mq.TLO.Me.Hovering() then return end
 

--- a/modules/named.lua
+++ b/modules/named.lua
@@ -236,14 +236,16 @@ function Module:CheckZoneNamed()
 
     for _, spawn in ipairs(namedSpawns) do
         local name = spawn.CleanName()
-        table.insert(tmpTbl, {
-            Name      = name,
-            Spawn     = spawn,
-            Distance  = spawn and spawn.Distance() or 9999,
-            Loc       = spawn and spawn.LocYXZ() or "0,0,0",
-            Immunities = self:ImmunitySummary(self.NamedList[name]),
-        })
-        upNameds[name] = true
+        if name then
+            table.insert(tmpTbl, {
+                Name      = name,
+                Spawn     = spawn,
+                Distance  = spawn and spawn.Distance() or 9999,
+                Loc       = spawn and spawn.LocYXZ() or "0,0,0",
+                Immunities = self:ImmunitySummary(self.NamedList[name]),
+            })
+            upNameds[name] = true
+        end
     end
 
     for name, entry in pairs(self.NamedList) do

--- a/modules/smartloot.lua
+++ b/modules/smartloot.lua
@@ -3,6 +3,7 @@ local mq        = require('mq')
 local Set       = require("mq.Set")
 local Base      = require("modules.base")
 local Casting   = require("utils.casting")
+local Combat    = require("utils.combat")
 local Config    = require('utils.config')
 local Core      = require("utils.core")
 local Events    = require("utils.events")
@@ -297,6 +298,8 @@ function Module:GiveTime()
 	if Globals.PauseMain then return end
 
 	if not Core.OkayToNotHeal() or mq.TLO.Me.Invis() or Casting.IAmFeigning() then return end
+
+	if Combat.CombatNavActive() then return end
 
 	-- Check for corpses using SmartLoot
 	if self.TempSettings.Looting or (self:GetSLTLO() and (self:GetSLTLO().HasNewCorpses() and self:GetSLTLO().SafeToLoot())) then

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1591,6 +1591,20 @@ function Casting.SongReady(songSpell, skipGemTimer)
     return Casting.CastCheck(songSpell)
 end
 
+--- A bard may fire an instant action while a song's cast window is open.
+---@param castTimeMs number?
+---@return boolean
+function Casting.CanActMidSong(castTimeMs)
+    return Core.MyClassIs("BRD") and (castTimeMs or -1) == 0
+end
+
+---@param castTimeMs number?
+---@return boolean
+function Casting.MoveBlocksCast(castTimeMs)
+    if Core.MyClassIs("brd") then return false end
+    return mq.TLO.Me.Moving() and (castTimeMs or -1) > 0
+end
+
 --- Checks CombatAbilityReady for the disc's ranked name, then runs CastCheck allowing movement and, for bards with an instant-cast disc (0 cast time), allowing an open casting window.
 --- @param discSpell MQSpell The name of the discipline spell to check.
 --- @return boolean Returns true if the discipline is ready, false otherwise.
@@ -1603,9 +1617,7 @@ function Casting.DiscReady(discSpell)
 
     if not ready then return false end
 
-    local allowCastWindow = Core.MyClassIs("BRD") and (discSpell.MyCastTime() or -1) == 0
-
-    return Casting.CastCheck(discSpell, true, allowCastWindow)
+    return Casting.CastCheck(discSpell, true)
 end
 
 --- Verifies AltAbilityReady is true for the named AA and then runs CastCheck against the AA's associated spell to confirm mana/endurance/movement/control conditions are met.
@@ -1657,7 +1669,7 @@ function Casting.ItemReady(itemName)
 
     local clicky = mq.TLO.FindItem("=" .. itemName).Clicky
     local levelCheck = me.Level() >= (clicky.RequiredLevel() or 0)
-    local movingCheck = Core.MyClassIs("brd") or not (me.Moving() and (clicky.CastTime() or -1) > 0)
+    local movingCheck = not Casting.MoveBlocksCast(clicky.CastTime())
     local controlCheck = not (me.Stunned() or me.Feared() or me.Charmed() or me.Mezzed())
 
     Logger.log_verbose("ItemReady for %s: LevelCheck(%s) MovingCheck(%s) ControlCheck(%s)", itemName, Strings.BoolToColorString(levelCheck),
@@ -1671,14 +1683,13 @@ end
 --- (adjusted for med regen ticks), and control state.
 ---@param spell MQSpell The spell whose cost and cast time to evaluate.
 ---@param bAllowMove boolean? Skip the movement check if true.
----@param bAllowCast boolean? Skip the casting-window check if true.
 ---@return boolean True if all pre-cast conditions are met.
-function Casting.CastCheck(spell, bAllowMove, bAllowCast)
+function Casting.CastCheck(spell, bAllowMove)
     if not spell or not spell() then return false end
 
     local me = mq.TLO.Me
-    local castingCheck = bAllowCast or (not (me.Casting() or mq.TLO.Window("CastingWindow").Open()))
-    local movingCheck = bAllowMove or Core.MyClassIs("brd") or not (me.Moving() and (spell.MyCastTime() or -1) > 0)
+    local castingCheck = Casting.CanActMidSong(spell.MyCastTime()) or (not (me.Casting() or mq.TLO.Window("CastingWindow").Open()))
+    local movingCheck = bAllowMove or not Casting.MoveBlocksCast(spell.MyCastTime())
 
     local currentMana = me.CurrentMana()
     local currentEnd = me.CurrentEndurance()
@@ -1726,7 +1737,7 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         return false
     end
 
-    if me.Moving() then
+    if Casting.MoveBlocksCast(spell.MyCastTime()) then
         Logger.log_debug("\ayUseSpell(): \arCan't cast %s - I am moving", spellName)
         return false
     end
@@ -1964,6 +1975,11 @@ function Casting.UseSong(songName, targetId, bAllowMem, retryCount)
 
             if scanTimer % 500 == 0 then
                 Casting.RescanCombatTargets()
+                Modules:ExecModule("Class", "DoMidSongEngage", targetId)
+            end
+
+            if scanTimer % 100 == 0 then
+                Modules:ExecModule("Class", "DoMidSongActions", targetId)
             end
 
             mq.delay(20)
@@ -2037,8 +2053,7 @@ function Casting.UseDisc(discSpell, targetId)
     local discName = discSpell.RankName.Name()
     local castTime = discSpell.MyCastTime() or 0
 
-    local allowCastWindow = Core.MyClassIs("BRD") and castTime == 0
-    if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not allowCastWindow then
+    if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not Casting.CanActMidSong(castTime) then
         Logger.log_debug("\ayUseDisc(): \arCan't use %s - Casting Window Open", discName)
         return false
     end
@@ -2142,6 +2157,12 @@ function Casting.RunCastLoop(opts)
     local castTime = opts.castTime or 0
     local retryCount = opts.retryCount or Config:GetSetting('CastRetryCount')
 
+    -- bard firing a 0-cast action mid-song: fire-and-return so we don't wait on or clip the in-progress song.
+    if castTime == 0 and (mq.TLO.Window("CastingWindow").Open() or mq.TLO.Me.Casting()) then
+        Core.DoCmd(cmd)
+        return
+    end
+
     -- give a small delay for when we need to rely on an action changing to "not ready" to detect success, this is data from the server. values tested on laz/might numerous times
     local floor = math.max(300, 3 * (mq.TLO.EverQuest.Ping() or 0))
     local delay = castTime < floor and floor or castTime
@@ -2206,8 +2227,7 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
         return false
     end
 
-    local allowCastWindow = Core.MyClassIs("BRD") and (aaSpell.MyCastTime() or -1) == 0
-    if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not allowCastWindow then
+    if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not Casting.CanActMidSong(aaSpell.MyCastTime()) then
         Logger.log_debug("\ayUseAA(): \arCan't cast %s - Casting Window Open", aaName)
         return false
     end
@@ -2317,8 +2337,7 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount)
     local itemSpell = item.Spell
     local targetType = itemSpell and itemSpell.TargetType()
 
-    local allowCastWindow = Core.MyClassIs("BRD") and castTime == 0
-    if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not allowCastWindow then
+    if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not Casting.CanActMidSong(castTime) then
         Logger.log_debug("\ayUseItem(): \arCan't use %s - Casting Window Open", itemName)
         return false
     end

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -124,7 +124,7 @@ function Combat.EngageTarget(autoTargetId)
                     Logger.log_verbose("EngageTarget(): Target is too far! %d>%d attempting to nav to it.", target.Distance3D(),
                         target.MaxRangeTo())
 
-                    Movement:NavInCombat(autoTargetId, Targeting.GetTargetMaxRangeTo(target), false)
+                    Movement:NavInCombat(autoTargetId, Targeting.GetTargetMaxRangeTo(target), false, false, true)
                 else
                     Logger.log_verbose("EngageTarget(): Target is in range moving to combat")
                     if mq.TLO.Navigation.Active() then
@@ -703,6 +703,11 @@ function Combat.FindBestAutoTarget(validateFn)
             end
         end
     end
+end
+
+---@return boolean
+function Combat.CombatNavActive()
+    return mq.TLO.Navigation.Active() and Globals.CombatNavTargetId > 0 and Globals.CombatNavTargetId == Globals.AutoTargetID
 end
 
 --- Validates if it is acceptable to engage with a target based on its ID.

--- a/utils/event_handlers.lua
+++ b/utils/event_handlers.lua
@@ -62,7 +62,7 @@ mq.event("CantSee", "You cannot see your target.", function()
                             end
 
                             Logger.log_debug("CantSee: Can't See target (%s [%d]). Naving to %d away.", target.CleanName() or "", target.ID(), desiredDistance)
-                            Movement:NavInCombat(target.ID(), desiredDistance, false, true)
+                            Movement:NavInCombat(target.ID(), desiredDistance, false, true, true)
                         end
                     end
                 end
@@ -177,7 +177,7 @@ local function tooFarHandler()
                         else
                             local navDist = maxRange * 0.7
                             Logger.log_debug("TooFar: Too Far from Target (%s [%d]). Naving to %d away.", target.CleanName() or "", target.ID() or 0, navDist)
-                            Movement:NavInCombat(target.ID(), navDist, false, true)
+                            Movement:NavInCombat(target.ID(), navDist, false, true, true)
                         end
                     else
                         Logger.log_debug("TooFar event detected, but we are not ok to engage or autoengage is disabled.")

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -20,6 +20,7 @@ Globals.AutoTargetIsNamed                  = false
 Globals.AutoTargetElementalImmunities      = {}
 Globals.AutoTargetStatusImmunities         = {}
 Globals.ForceCombatID                 = 0
+Globals.CombatNavTargetId             = 0
 Globals.LastPulledID                  = 0
 Globals.CurrentState                  = "None"
 Globals.IgnoredTargetIDs              = Set.new({})

--- a/utils/movement.lua
+++ b/utils/movement.lua
@@ -167,13 +167,13 @@ function Movement:GetSecondsSinceLastNav()
     return Globals.GetTimeSeconds() - self.LastDoNav
 end
 
---- Navigates to targetId during combat, then optionally sticks. Blocks
---- until nav or moveto completes, processing events along the way.
+--- Navigates to the combat target then sticks; bNoWait issues the nav and returns immediately instead of waiting for arrival.
 ---@param targetId number Spawn ID of the combat target.
 ---@param distance number Desired distance to maintain from the target.
 ---@param bDontStick boolean If true, skips the final DoStick call.
 ---@param bCalledFromInsideEvent boolean? If true, skips mq.doevents during nav.
-function Movement:NavInCombat(targetId, distance, bDontStick, bCalledFromInsideEvent)
+---@param bNoWait boolean? If true, issues the nav and returns immediately (skips the wait loop and trailing stick).
+function Movement:NavInCombat(targetId, distance, bDontStick, bCalledFromInsideEvent, bNoWait)
     if bCalledFromInsideEvent == nil then bCalledFromInsideEvent = false end
 
     if not Config:GetSetting('DoAutoEngage') then return end
@@ -184,8 +184,9 @@ function Movement:NavInCombat(targetId, distance, bDontStick, bCalledFromInsideE
     end
 
     if mq.TLO.Navigation.PathExists("id " .. tostring(targetId) .. " distance " .. tostring(distance))() then
+        Globals.CombatNavTargetId = targetId
         Movement:DoNav(false, "id %d distance=%d log=off lineofsight=on", targetId, distance or 15)
-        while mq.TLO.Navigation.Active() and mq.TLO.Navigation.Velocity() > 0 do
+        while not bNoWait and mq.TLO.Navigation.Active() and mq.TLO.Navigation.Velocity() > 0 do
             mq.delay(100)
             if not bCalledFromInsideEvent then
                 mq.doevents()
@@ -195,7 +196,7 @@ function Movement:NavInCombat(targetId, distance, bDontStick, bCalledFromInsideE
     else
         Movement:MoveToSpawnId(targetId, distance)
 
-        while mq.TLO.MoveTo.Moving() and not mq.TLO.MoveUtils.Stuck() do
+        while not bNoWait and mq.TLO.MoveTo.Moving() and not mq.TLO.MoveUtils.Stuck() do
             mq.delay(100)
             if not bCalledFromInsideEvent then
                 mq.doevents()
@@ -204,7 +205,7 @@ function Movement:NavInCombat(targetId, distance, bDontStick, bCalledFromInsideE
         end
     end
 
-    if not bDontStick then
+    if not bDontStick and not bNoWait then
         self:DoStick(targetId)
     end
 end


### PR DESCRIPTION
* Bards will now use most instant actions while singing.
* Instant actions will now always process during combat movement (engage, combatnav, stick, etc), and some may process in downtime.
* * The buff wait move timer still governs Downtime/Group Buff rotations for now.

Custom Config users are directed to the midSong = true flag in bard rotations and entries found in the default configs.