### PR TITLE
Pet Positioning Beta

### DIFF
--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -13,6 +13,10 @@ return {
     ['Modes']             = {
         'DPS',
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['ModeChecks']        = {
         IsHealing = function() return Config:GetSetting('DoHeals') end,
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or Targeting.GetXTHaterCount() == 0) end,

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -20,6 +20,10 @@ local _ClassConfig = {
     ['Modes']             = {
         'Heal',
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Cures']             = {
         GetCureSpells = function(self)
             --(re)initialize the table for loadout changes

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -20,6 +20,10 @@ local _ClassConfig = {
     ['Modes']         = {
         'Default',
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']        = {
         ['Default'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.05, g = 0.45, b = 0.50, a = 0.8, }, },

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -19,6 +19,10 @@ _ClassConfig    = {
         'DPS',
         'PBAE',
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']        = {
         ['DPS'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.60, g = 0.20, b = 0.02, a = 0.8, }, },

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -12,6 +12,10 @@ local _ClassConfig = {
     ['Modes']           = {
         'DPS',
     },
+    ['PetPosition']     = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['ModeChecks']      = {
         CanCharm   = function() return true end,
         IsCharming = function() return (Config:GetSetting('CharmOn') and mq.TLO.Pet.ID() == 0) end,

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -87,6 +87,10 @@ local _ClassConfig = {
         'Tank',
         'DPS',
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']        = {
         ['Tank'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.5, g = 0.05, b = 0.05, a = .8, }, },

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -20,6 +20,10 @@ local _ClassConfig = {
         'Heal',
         'Hybrid',
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Cures']             = {
         GetCureSpells = function(self)
             --(re)initialize the table for loadout changes

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -16,6 +16,13 @@ return {
     ['ModeChecks']        = {
         IsHealing = function() return true end,
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function()
+            local cdAA = mq.TLO.Me.AltAbility("Companion's Discipline")
+            return (cdAA and cdAA.Rank() or 0) >= 4 and "Companion's Discipline"
+        end,
+    },
     ['Themes']            = {
         ['DPS'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.50, g = 0.28, b = 0.03, a = 0.8, }, },

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -40,6 +40,13 @@ local _ClassConfig    = {
         'Default',
         'ModernEra', --Different DPS rotation, meant for ~90+ (and may not come fully online until 105ish)
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function()
+            local cdAA = mq.TLO.Me.AltAbility("Companion's Discipline")
+            return (cdAA and cdAA.Rank() or 0) >= 5 and "Companion's Discipline"
+        end,
+    },
     ['Themes']        = {
         ['Default'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.05, g = 0.45, b = 0.50, a = 0.8, }, },

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -18,6 +18,13 @@ _ClassConfig    = {
         'DPS',
         'PetTank',
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function()
+            local cdAA = mq.TLO.Me.AltAbility("Companion's Discipline")
+            return (cdAA and cdAA.Rank() or 0) >= 4 and "Companion's Discipline"
+        end,
+    },
     ['OnModeChange']      = function(self, mode)
         if mode == "PetTank" then
             Core.DoCmd("/pet taunt on")

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -28,6 +28,13 @@ local _ClassConfig = {
         CanCharm   = function() return true end,
         IsCharming = function() return (Config:GetSetting('CharmOn') and mq.TLO.Pet.ID() == 0) end,
     },
+    ['PetPosition']     = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function()
+            local cdAA = mq.TLO.Me.AltAbility("Companion's Discipline")
+            return (cdAA and cdAA.Rank() or 0) >= 7 and "Companion's Discipline"
+        end,
+    },
     ['Themes']          = {
         ['DPS'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.5, g = 0.05, b = 1.0, a = .8, }, },

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -86,6 +86,13 @@ local _ClassConfig = {
         'Tank',
         'DPS',
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function()
+            local cdAA = mq.TLO.Me.AltAbility("Companion's Discipline")
+            return (cdAA and cdAA.Rank() or 0) >= 4 and "Companion's Discipline"
+        end,
+    },
     ['Themes']        = {
         ['Tank'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.5, g = 0.05, b = 0.05, a = .8, }, },

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -19,6 +19,13 @@ local _ClassConfig = {
         'Heal',
         'Hybrid',
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function()
+            local cdAA = mq.TLO.Me.AltAbility("Companion's Discipline")
+            return (cdAA and cdAA.Rank() or 0) >= 4 and "Companion's Discipline"
+        end,
+    },
     ['Cures']             = {
         -- this code is slightly ineffecient (we could just check for CureSpell once), but adding corruption or more options would have us change it back to this
         -- -- since it is only run at startup, i'm fine with it. - Algar 8/29/25

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -16,6 +16,10 @@ return {
     ['ModeChecks']        = {
         IsHealing = function() return Config:GetSetting('DoHeals') end,
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']            = {
         ['DPS'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.50, g = 0.28, b = 0.03, a = 0.8, }, },

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -20,6 +20,10 @@ local _ClassConfig = {
     ['Modes']         = {
         'Default',
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']        = {
         ['Default'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.05, g = 0.45, b = 0.50, a = 0.8, }, },

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -16,6 +16,10 @@ _ClassConfig    = {
         'DPS',
         'PBAE',
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']        = {
         ['DPS'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.60, g = 0.20, b = 0.02, a = 0.8, }, },

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -16,6 +16,10 @@ local _ClassConfig = {
         CanCharm   = function() return true end,
         IsCharming = function() return (Config:GetSetting('CharmOn') and mq.TLO.Pet.ID() == 0) end,
     },
+    ['PetPosition']     = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']          = {
         ['DPS'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.5, g = 0.05, b = 1.0, a = .8, }, },

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -87,6 +87,10 @@ local _ClassConfig = {
         'Tank',
         'DPS',
     },
+    ['PetPosition']   = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Themes']        = {
         ['Tank'] = {
             { element = ImGuiCol.TitleBgActive,    color = { r = 0.5, g = 0.05, b = 0.05, a = .8, }, },
@@ -171,14 +175,14 @@ local _ClassConfig = {
             "Augment Death",         -- Level 60
             "Strengthen Death",      -- Level 29
         },
-        ['Horror'] = {           -- HP Tap Proc
-            "Shroud of Discord", -- Level 67, -- Buff Slot 1 <
-            "Shroud of Chaos",   -- Level 63
-            "Shroud of Death",   -- Level 55
+        ['Horror'] = {               -- HP Tap Proc
+            "Shroud of Discord",     -- Level 67, -- Buff Slot 1 <
+            "Shroud of Chaos",       -- Level 63
+            "Shroud of Death",       -- Level 55
         },
-        ['Mental'] = {           -- Mana Tap Proc
-            "Mental Horror",     -- Level 65, --Buff Slot 1 >
-            "Mental Corruption", -- Level 52
+        ['Mental'] = {               -- Mana Tap Proc
+            "Mental Horror",         -- Level 65, --Buff Slot 1 >
+            "Mental Corruption",     -- Level 52
         },
         ['Skin'] = {
             "Decrepit Skin", -- Level 70

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -19,6 +19,10 @@ local _ClassConfig = {
         'Heal',
         'Hybrid',
     },
+    ['PetPosition']       = {
+        SummonAA   = function() return Casting.CanUseAA("Summon Companion") and "Summon Companion" end,
+        RelocateAA = function() return Casting.CanUseAA("Companion's Relocation") and "Companion's Relocation" end,
+    },
     ['Cures']             = {
         GetCureSpells = function(self)
             --(re)initialize the table for loadout changes

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2765, }
+return { version = 2766, }

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -1616,6 +1616,52 @@ function Module:QueueAbility(type, name, targetId)
     })
 end
 
+function Module:PositionPet()
+    local petPos = self.ClassConfig.PetPosition
+    if not petPos then return end
+
+    if mq.TLO.Me.Moving() or mq.TLO.Me.Casting() then return end
+
+    local targetId = Globals.AutoTargetID
+    if targetId == 0 then return end
+
+    if (Globals.GetTimeSeconds() - (self.TempSettings.LastPetPosCheck or 0)) < 1 then return end
+    self.TempSettings.LastPetPosCheck = Globals.GetTimeSeconds()
+
+    local pet = mq.TLO.Me.Pet
+    if (pet.ID() or 0) == 0 or not pet.Combat() or (pet.Target.ID() or 0) ~= targetId then return end
+
+    local target = mq.TLO.Spawn(targetId)
+    if not target() then return end
+
+    local myHeading = mq.TLO.Me.Heading.DegreesCCW() or 0
+    local headingDelta = math.abs(myHeading - (self.TempSettings.LastPetPosHeading or myHeading))
+    self.TempSettings.LastPetPosHeading = myHeading
+    if headingDelta > 180 then headingDelta = 360 - headingDelta end
+    if headingDelta > 5 then return end
+
+    local frontArc = 180
+    local targetFacing = target.Heading.DegreesCCW() or 0
+    local inFrontArc = function(y, x)
+        local diff = (((target.HeadingToLoc(y, x).DegreesCCW() or 0) - targetFacing + 540) % 360) - 180
+        return math.abs(diff) < frontArc / 2
+    end
+
+    if not inFrontArc(pet.Y(), pet.X()) then return end
+
+    local ability
+    if inFrontArc(mq.TLO.Me.Y(), mq.TLO.Me.X()) then
+        ability = petPos.RelocateAA()
+    else
+        ability = petPos.SummonAA()
+    end
+
+    if not ability or not Casting.AAReady(ability) then return end
+
+    Logger.log_debug("PositionPet: pet in %s's front arc, using %s.", target.CleanName() or "target", ability)
+    Casting.UseAA(ability)
+end
+
 function Module:GiveTime()
     local combat_state = Combat.GetCachedCombatState()
 
@@ -1735,6 +1781,10 @@ function Module:GiveTime()
                 end
             end
         end
+    end
+
+    if combat_state == "Combat" and Config:GetSetting('DoPetPositioningBeta') then
+        self:PositionPet()
     end
 
     -- stop singing after pause so we can take over again (if we are active, we will stop our own songs). If paused, allow user to manage their own songs.

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -343,6 +343,10 @@ Binds.Handlers    = {
                 Globals.BackOffFlag = false
             end
 
+            if Globals.BackOffFlag and Config:GetSetting('DoPetCommands') and mq.TLO.Me.Pet.ID() > 0 then
+                Core.DoCmd("/squelch /pet back off")
+            end
+
             Logger.log_info("\ayBackoff \awset to: %s", Strings.BoolToColorString(Globals.BackOffFlag))
         end,
     },

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -853,6 +853,8 @@ end
 ---@param targetId number The ID of the target to attack.
 ---@param sendSwarm boolean Whether to send a swarm attack or not.
 function Combat.PetAttack(targetId, sendSwarm)
+    if Globals.BackOffFlag then return end
+
     local pet = mq.TLO.Me.Pet
 
     local target = mq.TLO.Spawn(targetId)

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1159,6 +1159,15 @@ Config.DefaultConfig                                     = {
         Answer =
         "If you enable Manual Mode, it will disable all automated movement options for your character, but will still allow it to use abilities as normal. This is ideal for those who want to control their character's positioning manually, but still want to benefit from the spell and item usage of RGMercs. Please note that enabling this will also disable some features that rely on movement automation, such as handling 'cannot see target' messages or auto-facing the target in combat.",
     },
+    ['DoPetPositioningBeta']       = {
+        DisplayName = "Reposition Pet",
+        Group = "Combat",
+        Header = "Positioning",
+        Category = "General Positioning",
+        Index = 10,
+        Tooltip = "Use summon and move AA to reposition your pet to avoid ripostes.",
+        Default = false, --flip to true after beta period
+    },
 
     -- Positioning/Tank
     ['MovebackWhenTank']           = {


### PR DESCRIPTION
Added the "Position Pets" setting in positioning options.
* If enabled, classes with the proper AA (Summon Companion and either Companion's Relocation or the correct rank of Companion's Discipline for Live) will use these abilities in combat to attempt to maneuver pets out of the frontal (180deg) arc of the current autotarget.
* During the Beta period , this setting defaults to false.
* Feedback is requested for those willing. Initial testing is very positive.
* There is a debug log entry when an ability is attempted for those who wish to monitor (filter to "PositionPet").