### PR TITLE
Pet command adjustment (Thanks Debuff!)

### DIFF
--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2773, }
+return { version = 2774, }

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -881,7 +881,12 @@ function Combat.PetAttack(targetId, sendSwarm)
     if pet.ID() == 0 then return end
 
     if Config:GetSetting('DoPetCommands') and (not pet.Combat() or pet.Target.ID() ~= targetId) and (targetId == Globals.ForceTargetID or targetId == Globals.AutoTargetID or Targeting.TargetIsType("npc", target)) then
-        Core.DoCmd("/multiline ; /squelch /pet back off ; /timed 1 /squelch /pet attack")
+        -- only back off to redirect a pet already fighting the wrong target; an idle pet (e.g. during a pull) just attacks
+        if pet.Combat() then
+            Core.DoCmd("/multiline ; /squelch /pet back off ; /timed 1 /squelch /pet attack")
+        else
+            Core.DoCmd("/squelch /pet attack")
+        end
         if sendSwarm then
             Core.DoCmd("/squelch /pet swarm")
         end


### PR DESCRIPTION
* We will not longer use the backoff command when the pet isn't in combat.