### PR TITLE
Healing Adjustments

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -961,7 +961,7 @@ local _ClassConfig = {
             load_cond = function(self) return Core.OnEMU() end,
             cond = function(self, combat_state)
                 if not Config:GetSetting('DoPet') or mq.TLO.Me.Pet.ID() ~= 0 then return false end
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToPetBuff() and Casting.AmIBuffable()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToPetBuff() and Casting.AmIBuffable()
             end,
         },
         {
@@ -1674,6 +1674,20 @@ local _ClassConfig = {
             Tooltip = "Use your short duration damage shield (Barkspur line) on the MA during combat.",
             RequiresLoadoutChange = true,
             Default = false,
+        },
+        ['HealPriority'] = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -329,7 +329,7 @@ return {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Config:GetSetting('DowntimeFP') and Casting.OkayToBuff()
                 local combat = combat_state == "Combat"
-                return (downtime or combat) and not Casting.IHaveBuff(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
+                return (downtime or combat) and not Casting.IHaveBuff(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -348,7 +348,7 @@ return {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck()
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -356,7 +356,7 @@ return {
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             load_cond = function() return Core.GetResolvedActionMapItem("PetGrowl") end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not mq.TLO.Me.Song("Growl")()
+                return combat_state == "Combat" and not mq.TLO.Me.Song("Growl")() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -365,7 +365,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat"
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -374,7 +374,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Targeting.AggroCheckOkay()
+                return combat_state == "Combat" and Targeting.AggroCheckOkay() and Core.CombatActionsCheck()
             end,
         },
     },
@@ -1096,6 +1096,20 @@ return {
             Default = 50,
             Min = 1,
             Max = 100,
+            ConfigType = "Advanced",
+        },
+        ['HealPriority']   = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -613,7 +613,7 @@ local _ClassConfig = {
             name = 'Downtime',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff() and Casting.AmIBuffable()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff() and Casting.AmIBuffable()
             end,
         },
         { --Spells that should be checked on group members
@@ -622,7 +622,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff()
             end,
         },
         {
@@ -631,7 +631,7 @@ local _ClassConfig = {
             steps = 3,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1362,6 +1362,20 @@ local _ClassConfig = {
             Default = true,
             FAQ = "Why am I using Yaulp? Clerics are not supposed to melee!",
             Answer = "The Yaulp spells we use also contain a mana regen component. You can disable this behavior on the Utility tab in the Class Options.",
+        },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -504,7 +504,7 @@ local _ClassConfig = {
             load_cond = function(self) return Core.OnEMU() end,
             cond = function(self, combat_state)
                 if not Config:GetSetting('DoPet') or mq.TLO.Me.Pet.ID() ~= 0 then return false end
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToPetBuff() and Casting.AmIBuffable()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToPetBuff() and Casting.AmIBuffable()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
@@ -512,7 +512,7 @@ local _ClassConfig = {
             timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
             end,
         },
         {
@@ -1461,6 +1461,20 @@ local _ClassConfig = {
             Tooltip = "Use your Artifact of Nature Spirit to summon the donor mammoth pet.",
             RequiresLoadoutChange = true, -- this is a load condition
             Default = true,
+        },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -731,7 +731,7 @@ return {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 if not Config:GetSetting('DoAEDamage') or (Core.IsTanking() and mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')) then return false end
-                return combat_state == "Combat" and Combat.AETargetCheck(true)
+                return combat_state == "Combat" and Combat.AETargetCheck(true) and Core.CombatActionsCheck()
             end,
         },
         { --DPS Spells, includes recourse/gift maintenance
@@ -976,9 +976,6 @@ return {
                 type = "Spell",
                 allowDead = true,
                 load_cond = function(self) return Config:GetSetting('AEStunUse') == 3 and Core.GetResolvedActionMapItem('PBAEStun') end,
-                cond = function(self, spell, target)
-                    return mq.TLO.Me.PctEndurance() >= Config:GetSetting("ManaToNuke") -- save mana for emergency healing
-                end,
             },
             {
                 name = "BladeDisc",
@@ -1226,13 +1223,13 @@ return {
         ['AEStunUse']         = {
             DisplayName = "AEStun Spell Use:",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Stun",
-            Index = 103,
-            Tooltip = "When to use your AE Stun Spell Line (DPS mode will not attempt to regain hate).",
+            Index = 102,
+            Tooltip = "When to use your AE Stun Spell Line.",
             RequiresLoadoutChange = true,
             Type = "Combo",
-            ComboOptions = { 'Disabled', 'Only To Regain Hate', 'Whenever Possible', },
+            ComboOptions = { 'Disabled', 'To Regain Hate If In Tank Mode', 'Whenever Possible', },
             Default = 2,
             Min = 1,
             Max = 3,
@@ -1243,10 +1240,10 @@ return {
             Header = "Damage",
             Category = "AE",
             Index = 102,
-            Tooltip = "When to use your AE Blade Disc Line (DPS mode will not attempt to regain hate).",
+            Tooltip = "When to use your AE Blade Disc Line.",
             RequiresLoadoutChange = true,
             Type = "Combo",
-            ComboOptions = { 'Disabled', 'Only To Regain Hate', 'Whenever Possible', },
+            ComboOptions = { 'Disabled', 'To Regain Hate If In Tank Mode', 'Whenever Possible', },
             Default = 2,
             Min = 1,
             Max = 3,
@@ -1601,6 +1598,20 @@ return {
             FAQ = "Why am I using and Undead proc, I'm not fighting any undead?",
             Answer = "If you have elected to use the Standard DD proc (default) and it is not yet available, we will use the Undead proc still.\n" ..
                 "Your desired proc can be adjusted with the Proc Buff Choice setting in Self Buff category.",
+        },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -231,6 +231,9 @@ return {
         ['Skals'] = {
             "Skal's Stance Discipline", -- Level 61 EQM Custom
         },
+        ['Quickshot'] = {               -- 2-hit kick attack
+            "QuickShot Discipline",     -- Level 61
+        },
         -- ['JoltProcBuff'] = {
         --     "Jolting Blades", -- Level 54
         -- },
@@ -316,7 +319,7 @@ return {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck()
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -326,7 +329,7 @@ return {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (Config:GetSetting('DoHeals') and Casting.OkayToNuke() or Targeting.AggroCheckOkay())
+                return combat_state == "Combat" and Core.CombatActionsCheck() and (Config:GetSetting('DoHeals') and Casting.OkayToNuke() or Targeting.AggroCheckOkay())
             end,
         },
         {
@@ -335,7 +338,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Targeting.AggroCheckOkay()
+                return combat_state == "Combat" and Targeting.AggroCheckOkay() and Core.CombatActionsCheck()
             end,
         },
     },
@@ -372,13 +375,13 @@ return {
                         Movement:NavAroundCircle(mq.TLO.Target, Config:GetSetting('BowNavDistance'))
                     end
                 elseif tooClose then
-                    if chaseDistance < 30 then
+                    if chaseDistance < 10 then
                         Logger.log_warning(
                             "Custom Ranger combatNav: \arWarning! \awChase distance is %d. \ayThis may interfere with ranged combat, depending on chase target movement!",
                             chaseDistance)
                     end
                     Core.DoCmd('/squelch face fast')
-                    Movement:DoStickCmd("10 moveback")
+                    Movement:DoStickCmd("%d moveback", Config:GetSetting('BowNavDistance'))
                 elseif tooFar or forceMove then
                     Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, Config:GetSetting('BowNavDistance'))
                     Core.DoCmd('/squelch /face fast')
@@ -452,14 +455,14 @@ return {
                 name = "Trueshot",
                 type = "Disc",
                 cond = function(self, aaName, target)
-                    return not Config:GetSetting('DoMelee')
+                    return not Config:GetSetting('DoMelee') and Casting.NoDiscActive()
                 end,
             },
             {
                 name = "WrathDisc",
                 type = "Disc",
                 cond = function(self, aaName, target)
-                    return Config:GetSetting('DoMelee')
+                    return Config:GetSetting('DoMelee') and Casting.NoDiscActive()
                 end,
             },
             {
@@ -524,7 +527,7 @@ return {
                 name = "WeaponShield",
                 type = "Discipline",
                 cond = function(self, discName, target)
-                    return Targeting.IHaveAggro(100) and not mq.TLO.Me.Song("Outrider's Evasion")
+                    return Targeting.IHaveAggro(100) and not mq.TLO.Me.Song("Outrider's Evasion") and Casting.NoDiscActive()
                 end,
             },
             {
@@ -574,6 +577,13 @@ return {
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAEDamage') then return false end
                     return Combat.AETargetCheck(true)
+                end,
+            },
+            {
+                name = "Quickshot",
+                type = "Disc",
+                cond = function(self, aaName, target)
+                    return not Config:GetSetting('DoMelee') and Casting.NoDiscActive()
                 end,
             },
         },
@@ -763,8 +773,8 @@ return {
             Index = 101,
             Tooltip = "The distance from your target you should nav to for ranged attacks when necessary.\n" ..
                 "If Nav Circle is enabled, the distance to circle at.",
-            Default = 45,
-            Min = 30,
+            Default = 30,
+            Min = 10,
             Max = 200,
             FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
             Answer = "Some terrain blocks line of sight while MQ reports that the ranger has line of sight.\n" ..
@@ -944,6 +954,20 @@ return {
             Default = 3,
             Min = 1,
             Max = 99,
+        },
+        ['HealPriority']    = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -175,6 +175,7 @@ local _ClassConfig = {
             "Talisman of Celerity", -- Level 64
             "Swift Like the Wind",  -- Level 63
             "Celerity",             -- Level 56
+            "Alacrity",             -- Level 42
             "Quickness",            -- Level 26
         },
         ['LowLvlStaBuff'] = {
@@ -621,7 +622,7 @@ local _ClassConfig = {
             },
         },
     },
-    ['Charm']         = {
+    ['Charm']             = {
         ['Assist'] = {
             {
                 name = "Malosinete",
@@ -647,7 +648,7 @@ local _ClassConfig = {
             name = 'Downtime',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff() and
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff() and
                     Casting.AmIBuffable()
             end,
         },
@@ -655,7 +656,7 @@ local _ClassConfig = {
             name = 'PetSummon',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() == 0 and Casting.OkayToPetBuff() and
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() == 0 and Casting.OkayToPetBuff() and
                     Casting.AmIBuffable()
             end,
         },
@@ -664,7 +665,7 @@ local _ClassConfig = {
             timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
             end,
         },
         { --Spells that should be checked on group members
@@ -673,7 +674,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff()
             end,
         },
         {
@@ -683,7 +684,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSTMalo') or Config:GetSetting('DoAEMalo') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -693,7 +694,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSTSlow') or Config:GetSetting('DoAESlow') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -703,7 +704,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoCripple') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -713,7 +714,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoPutrid') and Core.GetResolvedActionMapItem("PutridDecay") end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -722,7 +723,7 @@ local _ClassConfig = {
             steps = 3,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -731,7 +732,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -742,7 +743,7 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
                 local combat = combat_state == "Combat"
-                return (downtime or combat) and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return (downtime or combat) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -751,7 +752,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -946,7 +947,7 @@ local _ClassConfig = {
                 type = "Spell",
                 waitReadyTime = function() return Config:GetSetting('DiseaseSlowWaitTime') end,
                 cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell) and not Casting.SlowImmuneTarget(target)
+                    return Casting.DetSpellCheck(spell) and (spell and spell.RankName.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and not Casting.SlowImmuneTarget(target)
                 end,
             },
         },
@@ -1845,6 +1846,20 @@ local _ClassConfig = {
             Tooltip = "Use your Artifact of Nature Spirit to summon the donor mammoth pet.",
             RequiresLoadoutChange = true, -- this is a load condition
             Default = true,
+        },
+        ['HealPriority']        = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -752,7 +752,7 @@ return {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Config:GetSetting('DowntimeFP') and Casting.OkayToBuff()
                 local combat = combat_state == "Combat"
-                return (downtime or combat) and not Casting.IHaveBuff(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
+                return (downtime or combat) and not Casting.IHaveBuff(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -771,7 +771,7 @@ return {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck()
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -780,7 +780,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat"
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -789,7 +789,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat"
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
@@ -1797,6 +1797,20 @@ return {
             Tooltip = "Click your Epic Weapon.",
             Default = false,
             RequiresLoadoutChange = true,
+        },
+        ['HealPriority']   = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -1136,7 +1136,7 @@ local _ClassConfig = {
             name = 'Downtime',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff() and Casting.AmIBuffable()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff() and Casting.AmIBuffable()
             end,
         },
         { --Spells that should be checked on group members
@@ -1145,7 +1145,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff()
             end,
         },
         {
@@ -1154,7 +1154,7 @@ local _ClassConfig = {
             steps = 3,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1167,7 +1167,7 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
                 local combat = combat_state == "Combat"
-                return (downtime or combat) and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return (downtime or combat) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1178,7 +1178,7 @@ local _ClassConfig = {
             load_cond = function(self) return self:GetResolvedActionMapItem('ReverseDS') or self:GetResolvedActionMapItem('WardBuff') end,
             targetId = function(self) return { Core.GetMainAssistId(), } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1187,7 +1187,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1845,6 +1845,20 @@ local _ClassConfig = {
             Default = 1,
             Min = 1,
             Max = 3,
+            ConfigType = "Advanced",
+        },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -955,7 +955,7 @@ local _ClassConfig = {
             load_cond = function(self) return Core.OnEMU() end,
             cond = function(self, combat_state)
                 if not Config:GetSetting('DoPet') or mq.TLO.Me.Pet.ID() ~= 0 then return false end
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToPetBuff() and Casting.AmIBuffable()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToPetBuff() and Casting.AmIBuffable()
             end,
         },
         {
@@ -1782,6 +1782,20 @@ local _ClassConfig = {
             Default = true,
             FAQ = "Why am I spamming my Group Regen buff?",
             Answer = "Certain Shaman and Druid group regen buffs report cross-stacking. You should deselect the option on one of the PCs if they are grouped together.",
+        },
+        ['HealPriority'] = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -2259,6 +2259,20 @@ local _ClassConfig = {
             Max = 3,
             RequiresLoadoutChange = true,
         },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
+        },
     },
     ['ClassFAQ']          = {
         {

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -892,7 +892,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and
-                    Casting.BurnCheck()
+                    Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -911,7 +911,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Core.IsModeActive("Healer")
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -920,7 +920,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Core.IsModeActive("Healer")
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1666,7 +1666,7 @@ local _ClassConfig = {
                             chaseDistance)
                     end
                     Core.DoCmd('/squelch face fast')
-                    Movement:DoStickCmd("10 moveback")
+                    Movement:DoStickCmd("%d moveback", Config:GetSetting('BowNavDistance'))
                 elseif tooFar or forceMove then
                     Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, Config:GetSetting('BowNavDistance'))
                     Core.DoCmd('/squelch /face fast')
@@ -1847,6 +1847,20 @@ local _ClassConfig = {
             Category = "Self",
             Tooltip = "Use Aggro Reduction Buffs.",
             Default = true,
+        },
+        ['HealPriority']       = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -171,6 +171,7 @@ local _ClassConfig = {
             "Talisman of Celerity", -- Level 64
             "Swift Like the Wind",  -- Level 63
             "Celerity",             -- Level 56
+            "Alacrity",             -- Level 42
             "Quickness",            -- Level 26
         },
         ['TempHPBuff'] = {
@@ -1028,7 +1029,7 @@ local _ClassConfig = {
             name = 'Downtime',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff() and
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff() and
                     Casting.AmIBuffable()
             end,
         },
@@ -1036,7 +1037,7 @@ local _ClassConfig = {
             name = 'PetSummon',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() == 0 and Casting.OkayToPetBuff() and
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() == 0 and Casting.OkayToPetBuff() and
                     Casting.AmIBuffable()
             end,
         },
@@ -1046,7 +1047,7 @@ local _ClassConfig = {
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and
-                    (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff() and Casting.AmIBuffable()
+                    Core.CombatActionsCheck() and Casting.OkayToBuff() and Casting.AmIBuffable()
             end,
         },
         { --Spells that should be checked on group members
@@ -1055,7 +1056,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
@@ -1063,7 +1064,7 @@ local _ClassConfig = {
             timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
             end,
         },
         {
@@ -1073,7 +1074,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSTMalo') or Config:GetSetting('DoAEMalo') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1083,7 +1084,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSTSlow') or Config:GetSetting('DoAESlow') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1093,7 +1094,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Casting.BurnCheck() and
-                    (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                    Core.CombatActionsCheck()
             end,
         },
         {
@@ -1105,7 +1106,7 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
                 local combat = combat_state == "Combat"
-                return (downtime or combat) and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return (downtime or combat) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1115,7 +1116,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1125,7 +1126,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or (Config:GetSetting('DoHealDPS') and Core.CombatActionsCheck()))
+                return combat_state == "Combat" and ((not Core.IsModeActive('Heal') or Config:GetSetting('DoHealDPS')) and Core.CombatActionsCheck())
             end,
         },
     },
@@ -1253,7 +1254,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoSTSlow') and not Casting.CanUseAA("Turgur's Swarm") end,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoSTSlow') or Casting.CanUseAA("Turgur's Swarm") then return false end
-                    return Casting.DetSpellCheck(spell) and not Casting.SlowImmuneTarget(target)
+                    return Casting.DetSpellCheck(spell) and (spell and spell.RankName.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and not Casting.SlowImmuneTarget(target)
                 end,
             },
             {
@@ -2085,7 +2086,7 @@ local _ClassConfig = {
         ['DoSTMalo']            = {
             DisplayName = "Do ST Malo",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Resist",
             Index = 101,
             Tooltip = "Do ST Malo Spells/AAs",
@@ -2095,7 +2096,7 @@ local _ClassConfig = {
         ['DoAEMalo']            = {
             DisplayName = "Do AE Malo",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Resist",
             Index = 102,
             Tooltip = "Do AE Malo Spells/AAs",
@@ -2105,7 +2106,7 @@ local _ClassConfig = {
         ['DoSTSlow']            = {
             DisplayName = "Do ST Slow",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Slow",
             Index = 101,
             Tooltip = "Do ST Slow Spells/AAs",
@@ -2115,7 +2116,7 @@ local _ClassConfig = {
         ['DoAESlow']            = {
             DisplayName = "Do AE Slow",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Slow",
             Index = 102,
             Tooltip = "Do AE Slow Spells/AAs",
@@ -2125,7 +2126,7 @@ local _ClassConfig = {
         ['AESlowCount']         = {
             DisplayName = "AE Slow Count",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Slow",
             Index = 103,
             Tooltip = "Number of XT Haters before we use AE Slow.",
@@ -2137,7 +2138,7 @@ local _ClassConfig = {
         ['AEMaloCount']         = {
             DisplayName = "AE Malo Count",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Resist",
             Index = 103,
             Tooltip = "Number of XT Haters before we use AE Malo.",
@@ -2149,7 +2150,7 @@ local _ClassConfig = {
         ['DoDiseaseSlow']       = {
             DisplayName = "Disease Slow",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Slow",
             Index = 104,
             Tooltip = "Use Disease Slow instead of normal ST Slow",
@@ -2207,6 +2208,20 @@ local _ClassConfig = {
             Index = 110,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
             Default = false,
+            ConfigType = "Advanced",
+        },
+        ['HealPriority']        = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -295,7 +295,7 @@ return {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Config:GetSetting('DowntimeFP') and Casting.OkayToBuff()
                 local combat = combat_state == "Combat"
-                return (downtime or combat) and not Casting.IHaveBuff(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell)
+                return (downtime or combat) and not Casting.IHaveBuff(mq.TLO.Me.AltAbility('Paragon of Spirit').Spell) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -314,7 +314,7 @@ return {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck()
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -325,7 +325,7 @@ return {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
                 local burning = combat_state == "Combat" and Casting.BurnCheck() and not Casting.IAmFeigning()
-                return downtime or burning
+                return (downtime or burning) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -333,7 +333,7 @@ return {
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             load_cond = function() return Core.GetResolvedActionMapItem("PetGrowl") end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not mq.TLO.Me.Song("Growl")()
+                return combat_state == "Combat" and not mq.TLO.Me.Song("Growl")() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -342,7 +342,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat"
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -351,7 +351,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Targeting.AggroCheckOkay()
+                return combat_state == "Combat" and Targeting.AggroCheckOkay() and Core.CombatActionsCheck()
             end,
         },
     },
@@ -1015,6 +1015,20 @@ return {
             Index = 102,
             Tooltip = "Click your Blood Drinker's Coating in an emergency.",
             Default = false,
+        },
+        ['HealPriority']   = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -524,7 +524,7 @@ local _ClassConfig = {
             name = 'Downtime',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff() and Casting.AmIBuffable()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff() and Casting.AmIBuffable()
             end,
         },
         { --Spells that should be checked on group members
@@ -533,7 +533,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff()
             end,
         },
         {
@@ -542,7 +542,7 @@ local _ClassConfig = {
             steps = 3,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -1262,6 +1262,20 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
             RequiresLoadoutChange = true,
+        },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -471,7 +471,7 @@ local _ClassConfig = {
             load_cond = function(self) return Core.OnEMU() end,
             cond = function(self, combat_state)
                 if not Config:GetSetting('DoPet') or mq.TLO.Me.Pet.ID() ~= 0 then return false end
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToPetBuff() and Casting.AmIBuffable()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToPetBuff() and Casting.AmIBuffable()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
@@ -479,7 +479,7 @@ local _ClassConfig = {
             timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
             end,
         },
         {
@@ -1439,6 +1439,20 @@ local _ClassConfig = {
             Tooltip = "Keep (Lesser) Succor memorized.",
             Default = false,
             RequiresLoadoutChange = true,
+        },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -344,8 +344,8 @@ return {
                 { name = "SereneStun",      cond = function(self) return Config:GetSetting('DoSereneStun') end, },
                 { name = "StunTimer4",      cond = function(self) return Core.IsTanking() end, },
                 { name = "StunTimer5",      cond = function(self) return Core.IsTanking() end, },
-                { name = "PBAEStun",        cond = function(self) return Config:GetSetting('DoPBAEStun') end, },
-                { name = "AEStun",          cond = function(self) return Config:GetSetting('DoAEStun') end, },
+                { name = "PBAEStun",        cond = function(self) return Config:GetSetting('PBAEStunUse') > 1 end, },
+                { name = "AEStun",          cond = function(self) return Config:GetSetting('AEStunUse') > 1 end, },
                 { name = "CureCurse",       cond = function(self) return Config:GetSetting('KeepCurseMemmed') end, },
                 { name = "PurityCure",      cond = function(self) return Config:GetSetting('KeepPurityMemmed') end, },
                 { name = "UndeadNuke",      cond = function(self) return Config:GetSetting('DoUndeadNuke') end, },
@@ -587,9 +587,10 @@ return {
             steps = 1,
             doFullRotation = true,
             load_cond = function()
-                local hateSpell = Config:GetSetting('DoAEStun') and (Core.GetResolvedActionMapItem('AEStun') or Core.GetResolvedActionMapItem('PBAEStun'))
+                local aeStun = Config:GetSetting('AEStunUse') > 1 and Core.GetResolvedActionMapItem('AEStun')
+                local pbaeStun = Config:GetSetting('PBAEStunUse') > 1 and Core.GetResolvedActionMapItem('PBAEStun')
                 local hateAA = Config:GetSetting('AETauntAA') and Casting.CanUseAA("Beacon of the Righteous")
-                return Core.IsTanking() and (hateSpell or hateAA)
+                return Core.IsTanking() and (aeStun or pbaeStun or hateAA)
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -657,14 +658,14 @@ return {
             state = 1,
             steps = 1,
             load_cond = function()
-                local aeSpell = Config:GetSetting('DoAEStun') and Core.GetResolvedActionMapItem('AEStun')
-                local pbaeSpell = Config:GetSetting('DoPBAEStun') and Core.GetResolvedActionMapItem('PBAEStun')
-                return (Core.IsTanking() or Config:GetSetting('AEStunUse') > 1) and (aeSpell or pbaeSpell)
+                local aeSpell = Config:GetSetting('AEStunUse') == 3 and Core.GetResolvedActionMapItem('AEStun')
+                local pbaeSpell = Config:GetSetting('PBAEStunUse') == 3 and Core.GetResolvedActionMapItem('PBAEStun')
+                return Core.IsTanking() or aeSpell or pbaeSpell
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 if not Config:GetSetting('DoAEDamage') or (Core.IsTanking() and mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')) then return false end
-                return combat_state == "Combat" and Combat.AETargetCheck(true)
+                return combat_state == "Combat" and Combat.AETargetCheck(true) and Core.CombatActionsCheck()
             end,
         },
         { --DPS Spells, includes recourse/gift maintenance
@@ -887,6 +888,7 @@ return {
                 name = "PBAEStun",
                 type = "Spell",
                 allowDead = true,
+                load_cond = function(self) return Config:GetSetting('PBAEStunUse') > 1 end,
                 cond = function(self, spell, target)
                     return Config:GetSetting('DoAEDamage')
                 end,
@@ -894,8 +896,9 @@ return {
             {
                 name = "AEStun",
                 type = "Spell",
+                load_cond = function(self) return Config:GetSetting('AEStunUse') > 1 end,
                 cond = function(self, spell, target)
-                    return Config:GetSetting('DoAEDamage') or spell.Name() ~= "The Sacred Word" -- Sacred Word does damage
+                    return Config:GetSetting('DoAEDamage') or spell.Name() ~= "Sacred Word" -- Sacred Word does damage
                 end,
             },
         },
@@ -903,18 +906,13 @@ return {
             {
                 name = "AEStun",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Core.IsTanking() or Config:GetSetting('AEStunUse') == 3 or Core.GetMainAssistPctHPs() < Config:GetSetting('EmergencyStart')
-                end,
-
+                load_cond = function(self) return Config:GetSetting('AEStunUse') == 3 and Core.GetResolvedActionMapItem('AEStun') end,
             },
             {
                 name = "PBAEStun",
                 type = "Spell",
                 allowDead = true,
-                cond = function(self, spell, target)
-                    return Core.IsTanking() or Config:GetSetting('AEStunUse') == 3 or Core.GetMainAssistPctHPs() < Config:GetSetting('EmergencyStart')
-                end,
+                load_cond = function(self) return Config:GetSetting('PBAEStunUse') == 3 and Core.GetResolvedActionMapItem('PBAEStun') end,
             },
             {
                 name = "Forsaken Fayguard Bladecatcher",
@@ -1166,37 +1164,31 @@ return {
         },
 
         --AE(All Modes)
-        ['DoAEStun']          = {
-            DisplayName = "Do AE Stun",
+        ['AEStunUse']         = {
+            DisplayName = "AE Stun Use:",
             Group = "Abilities",
-            Header = "Debuff",
+            Header = "Debuffs",
             Category = "Stun",
             Index = 101,
-            Tooltip = "Use your Targeted AE Stun (Stun Command or Sacred Word) as needed to maintain AE aggro (tank mode) or help with control (dps mode).",
-            Default = true,
-            RequiresLoadoutChange = true,
-        },
-        ['DoPBAEStun']        = {
-            DisplayName = "Do PBAE Stun",
-            Group = "Abilities",
-            Header = "Debuff",
-            Category = "Stun",
-            Index = 102,
-            Tooltip = "Use your PBAE Stun (The Silent Command) as needed to maintain AE aggro (tank mode) or help with control (dps mode).",
-            Default = true,
-            RequiresLoadoutChange = true,
-        },
-        ['AEStunUse']         = {
-            DisplayName = "AEStun Use(DPS Mode):",
-            Group = "Abilities",
-            Header = "Debuff",
-            Category = "Stun",
-            Index = 103,
-            Tooltip = "When to use your AE Stun Lines in DPS Mode.",
+            Tooltip = "When to use your Targeted AE Stun (Stun Command / Sacred Word).",
             RequiresLoadoutChange = true,
             Type = "Combo",
-            ComboOptions = { 'Never', 'At low MA health', 'Whenever Possible', },
-            Default = 1,
+            ComboOptions = { 'Disabled', 'To Regain Hate If In Tank Mode', 'Whenever Possible', },
+            Default = 2,
+            Min = 1,
+            Max = 3,
+        },
+        ['PBAEStunUse']       = {
+            DisplayName = "PBAE Stun Use:",
+            Group = "Abilities",
+            Header = "Debuffs",
+            Category = "Stun",
+            Index = 102,
+            Tooltip = "When to use your PBAE Stun (The Silent Command).",
+            RequiresLoadoutChange = true,
+            Type = "Combo",
+            ComboOptions = { 'Disabled', 'To Regain Hate If In Tank Mode', 'Whenever Possible', },
+            Default = 2,
             Min = 1,
             Max = 3,
         },
@@ -1449,7 +1441,7 @@ return {
             Group = "Abilities",
             Header = "Debuffs",
             Category = "Stun",
-            Index = 101,
+            Index = 103,
             Tooltip = "Use the Quellious/Serene stun line (long duration stun with DD component).",
             RequiresLoadoutChange = true,
             Default = false,
@@ -1573,6 +1565,20 @@ return {
             FAQ = "Why am I using and Undead proc, I'm not fighting any undead?",
             Answer = "If you have elected to use the Standard DD proc (default) and it is not yet available, we will use the Undead proc still.\n" ..
                 "Your desired proc can be adjusted with the Proc Buff Choice setting in Self Buff category.",
+        },
+        ['HealPriority']      = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -306,7 +306,7 @@ return {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck()
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -316,7 +316,7 @@ return {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (Config:GetSetting('DoHeals') and Casting.OkayToNuke() or Targeting.AggroCheckOkay())
+                return combat_state == "Combat" and Core.CombatActionsCheck() and (Config:GetSetting('DoHeals') and Casting.OkayToNuke() or Targeting.AggroCheckOkay())
             end,
         },
         {
@@ -325,7 +325,7 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Targeting.AggroCheckOkay()
+                return combat_state == "Combat" and Targeting.AggroCheckOkay() and Core.CombatActionsCheck()
             end,
         },
     },
@@ -351,13 +351,13 @@ return {
                         Movement:NavAroundCircle(mq.TLO.Target, Config:GetSetting('BowNavDistance'))
                     end
                 elseif tooClose then
-                    if chaseDistance < 30 then
+                    if chaseDistance < 10 then
                         Logger.log_warn(
                             "Custom Ranger combatNav: \arWarning! \awChase distance is %d. \ayThis may interfere with ranged combat, depending on chase target movement!",
                             chaseDistance)
                     end
                     Core.DoCmd('/squelch face fast')
-                    Movement:DoStickCmd("10 moveback")
+                    Movement:DoStickCmd("%d moveback", Config:GetSetting('BowNavDistance'))
                 elseif tooFar or forceMove then
                     Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, Config:GetSetting('BowNavDistance'))
                     Core.DoCmd('/squelch /face fast')
@@ -759,8 +759,8 @@ return {
             Index = 101,
             Tooltip = "The distance from your target you should nav to for ranged attacks when necessary.\n" ..
                 "If Nav Circle is enabled, the distance to circle at.",
-            Default = 45,
-            Min = 30,
+            Default = 30,
+            Min = 10,
             Max = 200,
             FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
             Answer = "Some terrain blocks line of sight while MQ reports that the ranger has line of sight.\n" ..
@@ -961,6 +961,20 @@ return {
             Default = 3,
             Min = 1,
             Max = 99,
+        },
+        ['HealPriority']    = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', },
+            Default = 2,
+            Min = 1,
+            Max = 2,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            ConfigType = "Advanced",
         },
     },
     ['ClassFAQ']          = {

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -157,6 +157,7 @@ local _ClassConfig = {
             "Talisman of Celerity",    -- Level 64
             "Swift Like the Wind",     -- Level 63
             "Celerity",                -- Level 56
+            "Alacrity",                -- Level 42
             "Quickness",               -- Level 26
         },
         ['Unification'] = {            -- Many buffs combined: 75 Sta, 50 sta cap, 7% evasion, 5% damage
@@ -576,7 +577,7 @@ local _ClassConfig = {
             name = 'Downtime',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff() and
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff() and
                     Casting.AmIBuffable()
             end,
         },
@@ -584,7 +585,7 @@ local _ClassConfig = {
             name = 'PetSummon',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() == 0 and Casting.OkayToPetBuff() and
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() == 0 and Casting.OkayToPetBuff() and
                     Casting.AmIBuffable()
             end,
         },
@@ -593,7 +594,7 @@ local _ClassConfig = {
             timer = 10,
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
             end,
         },
         { --Spells that should be checked on group members
@@ -602,7 +603,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
-                return combat_state == "Downtime" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck()) and Casting.OkayToBuff()
+                return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToBuff()
             end,
         },
         {
@@ -612,7 +613,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSTMalo') or Config:GetSetting('DoAEMalo') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -622,7 +623,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSTSlow') or Config:GetSetting('DoAESlow') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -632,7 +633,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoPutrid') and Core.GetResolvedActionMapItem("PutridDecay") end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.OkayToDebuff() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -641,7 +642,7 @@ local _ClassConfig = {
             steps = 3,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -653,7 +654,7 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
                 local combat = combat_state == "Combat"
-                return (downtime or combat) and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return (downtime or combat) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -662,7 +663,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
         {
@@ -672,7 +673,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not mq.TLO.Me.Buff("Focus of Arcanum")() and (not Core.IsModeActive('Heal') or Core.CombatActionsCheck())
+                return combat_state == "Combat" and not mq.TLO.Me.Buff("Focus of Arcanum")() and Core.CombatActionsCheck()
             end,
         },
 
@@ -812,7 +813,7 @@ local _ClassConfig = {
                 type = "Spell",
                 waitReadyTime = function() return Config:GetSetting('DiseaseSlowWaitTime') end,
                 cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell) and not Casting.SlowImmuneTarget(target)
+                    return Casting.DetSpellCheck(spell) and (spell and spell.RankName.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and not Casting.SlowImmuneTarget(target)
                 end,
             },
         },
@@ -1725,6 +1726,20 @@ local _ClassConfig = {
             Index = 108,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
             Default = false,
+            ConfigType = "Advanced",
+        },
+        ['HealPriority']        = {
+            DisplayName = "Healing Priority",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "Healing Thresholds",
+            Index = 101,
+            Type = "Combo",
+            ComboOptions = { 'Ignore', 'Big Heal Point', 'Main Heal Point', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
             ConfigType = "Advanced",
         },
     },

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2787, }
+return { version = 2788, }

--- a/modules/charm.lua
+++ b/modules/charm.lua
@@ -914,7 +914,7 @@ function Module:CharmAssistNeeded()
     self.TempSettings.LastCharmAssistTime = Globals.GetTimeMS()
 
     local assistOn = Config:GetSetting('DoCharmAssist')
-    local healClear = Core.OkayToNotHeal(Config:GetSetting('PriorityHealing'))
+    local healClear = Core.OkayToNotHeal(Config:GetSetting('HealPriority', true))
     local mezClear = Core.OkayToNotMez(Config:GetSetting('PriorityMez'))
     local hpOk = (mq.TLO.Me.PctHPs() or 100) > (Config:GetSetting('HPCritical', true) or Config:GetSetting('EmergencyStart', true) or 0)
     -- only scan for a loose charm once the cheaper gates pass

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -611,7 +611,7 @@ function Module:Render()
     local pressed = false
 
     if self.ClassConfig and self.ModuleLoaded then
-        Ui.RenderText("Active Mode:")
+        Ui.RenderText("Current Mode:")
         ImGui.SameLine()
         ImGui.SetNextItemWidth(150)
         Ui.Tooltip(self.ClassConfig.DefaultConfig.Mode.Tooltip)
@@ -1265,6 +1265,19 @@ function Module:RunHealRotation()
     else
         self:HealById(Combat.FindWorstHurtXT(Config:GetSetting('MaxHealPoint')))
     end
+end
+
+--- True if anyone we heal (group/pets + heal list or XT) is below the gate threshold this frame.
+---@param priority integer HealPriority setting: 2 Big Heal Point, 3 Main Heal Point
+---@return boolean
+function Module:NeedToHeal(priority)
+    local point = Config:GetSetting(priority == 3 and 'MainHealPoint' or 'BigHealPoint')
+    if (mq.TLO.Group.Injured(point)() or 0) > 0 then return true end
+    if Config:GetSetting('DoPetHeals') and Combat.AnyHurtGroupPet(Config:GetSetting('PetHealPoint')) then return true end
+    if Config:GetSetting('UseHealList') then
+        return Combat.FindWorstHurtHealList(point) > 0
+    end
+    return Combat.FindWorstHurtXT(point) > 0
 end
 
 function Module:ClearCureFromList(id)

--- a/modules/lootnscoot.lua
+++ b/modules/lootnscoot.lua
@@ -61,12 +61,23 @@ Module.DefaultConfig   = {
 		Tooltip = "Enables looting during RGMercs-defined combat.",
 		Default = false,
 	},
+	['LootSettleTime']                         = {
+		DisplayName = "Loot Settle Time",
+		Group = "General",
+		Header = "Loot(Emu)",
+		Category = "LNS",
+		Index = 3,
+		Tooltip = "Seconds to wait after combat ends before looting, so we don't begin to loot while adds are popping.",
+		Default = 2,
+		Min = 0,
+		Max = 10,
+	},
 	['LootRespectMedState']                    = {
 		DisplayName = "Respect Med State",
 		Group = "General",
 		Header = "Loot(Emu)",
 		Category = "LNS",
-		Index = 3,
+		Index = 4,
 		Tooltip = "Hold looting if you are currently meditating.",
 		Default = false,
 	},
@@ -75,7 +86,7 @@ Module.DefaultConfig   = {
 		Group = "General",
 		Header = "Loot(Emu)",
 		Category = "LNS",
-		Index = 4,
+		Index = 5,
 		Tooltip = "The length of time in seconds that RGMercs will allow LNS to process loot actions in a single check.",
 		Default = 5,
 		Min = 1,
@@ -86,7 +97,7 @@ Module.DefaultConfig   = {
 		Group = "General",
 		Header = "Loot(Emu)",
 		Category = "LNS",
-		Index = 5,
+		Index = 6,
 		Tooltip = "If chase is on, we won't loot (and will abort looting) any corpses when the chase target is farther than this value away from us.",
 		Default = 300,
 		Min = 1,
@@ -206,6 +217,9 @@ function Module:GiveTime()
 	local combat_state = Combat.GetCachedCombatState()
 
 	if not Config:GetSetting('DoLoot') then return end
+
+	if combat_state == "Combat" then self.TempSettings.LastCombatTime = Globals.GetTimeSeconds() end
+
 	if Globals.PauseMain then return end
 	if mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' then
 		if not suppressWarning then
@@ -237,9 +251,14 @@ function Module:GiveTime()
 	if myCorpseCount > 0 then deadCount = deadCount + 1 end
 	Logger.log_verbose("\ay[LOOT]: \agFound %d corpses within range.", deadCount)
 	if self.Actor == nil then self:LootMessageHandler() end
+
+	local settled = Config:GetSetting('CombatLooting') or (Globals.GetTimeSeconds() - (self.TempSettings.LastCombatTime or 0)) >= Config:GetSetting('LootSettleTime')
+
 	-- send actors message to loot
 	if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then
-		if not self.TempSettings.Looting then
+		if not settled then
+			Logger.log_super_verbose("\ay::LOOT:: \arHolding!\ax Waiting for combat to settle before looting.")
+		elseif not self.TempSettings.Looting then
 			self.Actor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', },
 				{ who = Globals.CurLoadedChar, server = serverLNSFormat, directions = 'doloot', })
 			self.TempSettings.Looting = true

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -2855,4 +2855,9 @@ function Casting.LevelCheckPass(targetLevel, spellLevel)
     return maxSpellLevel >= spellLevel
 end
 
+function Casting.SlowSpellCheck(spell, target)
+    if not spell or not spell() then return false end
+    return (spell.RankName.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and not Casting.SlowImmuneTarget(target)
+end
+
 return Casting

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -1095,34 +1095,33 @@ function Combat.FindWorstHurtGroupMember(minHPs)
     for i = 1, groupSize do
         local healTarget = mq.TLO.Group.Member(i)
 
-        if healTarget and healTarget() and (healTarget.Distance3D() or 999) <= 300 and not (healTarget.Dead() or healTarget.OtherZone() or healTarget.Offline()) then
-            -- Heal the aggro holder if they are in our group and below the mainheal point, no other checks needed
-            if Targeting.TargetIsType("NPC", mq.TLO.Target) and mq.TLO.Me.TargetOfTarget.ID() == healTarget.ID() and Targeting.BigHealsNeeded(healTarget) then
-                Logger.log_verbose("\agSomeone with aggro is hurt, prioritizing id %d", healTarget.ID())
-                return healTarget.ID()
-            end
+        if healTarget and healTarget() then
+            if (healTarget.Distance3D() or 999) <= 300 and not (healTarget.Dead() or healTarget.OtherZone() or healTarget.Offline()) then
+                -- Heal the aggro holder if they are in our group and below the mainheal point, no other checks needed
+                if Targeting.TargetIsType("NPC", mq.TLO.Target) and mq.TLO.Me.TargetOfTarget.ID() == healTarget.ID() and Targeting.BigHealsNeeded(healTarget) then
+                    Logger.log_verbose("\agSomeone with aggro is hurt, prioritizing id %d", healTarget.ID())
+                    return healTarget.ID()
+                end
 
-            -- Prioritize any tanks in the group that are under mainhealpoint, otherwise, treat them as normal group members
-            if Targeting.TargetIsATank(healTarget) and (healTarget.PctHPs() or 101) < tankPct then
-                tankPct = (healTarget.PctHPs() or tankPct)
-                tankId = (healTarget.PctHPs() and healTarget.ID() or tankId)
-            else
-                if (healTarget.PctHPs() or 101) < worstPct then
+                -- Prioritize any tanks in the group that are under mainhealpoint, otherwise, treat them as normal group members
+                if Targeting.TargetIsATank(healTarget) and (healTarget.PctHPs() or 101) < tankPct then
+                    tankPct = (healTarget.PctHPs() or tankPct)
+                    tankId = (healTarget.PctHPs() and healTarget.ID() or tankId)
+                elseif (healTarget.PctHPs() or 101) < worstPct then
                     Logger.log_verbose("\aySo far %s is the worst off.", healTarget.DisplayName())
                     -- this looks weird but it guards against a possible yield between the if above and this line where the healtarget might have died.
                     worstPct = (healTarget.PctHPs() or worstPct)
                     worstId = (healTarget.PctHPs() and healTarget.ID() or worstId)
                 end
+            end
 
-                if Config:GetSetting('DoPetHeals') and (healTarget.Pet.ID() or 0) > 0 then
-                    local petHP = healTarget.Pet.PctHPs() or 101
-                    if petHP < worstPct and petHP < Config:GetSetting('PetHealPoint') then
-                        Logger.log_verbose("\aySo far %s's pet %s is the worst off.", healTarget.DisplayName(),
-                            healTarget.Pet.DisplayName())
-                        -- this looks weird but it guards against a possible yield between the if above and this line where the healtarget might have died.
-                        worstPct = (healTarget.Pet.PctHPs() or worstPct)
-                        worstId = (healTarget.Pet.PctHPs() and healTarget.Pet.ID() or worstId)
-                    end
+            -- Pet heals gate on the pet's own range; a live pet implies the owner is in-zone even if out of heal range
+            if Config:GetSetting('DoPetHeals') and (healTarget.Pet.ID() or 0) > 0 then
+                local petHP = healTarget.Pet.PctHPs() or 101
+                if petHP > 0 and petHP < worstPct and petHP < Config:GetSetting('PetHealPoint') and (healTarget.Pet.Distance3D() or 999) <= 300 then
+                    Logger.log_verbose("\aySo far %s's pet %s is the worst off.", healTarget.DisplayName(), healTarget.Pet.DisplayName())
+                    worstPct = (healTarget.Pet.PctHPs() or worstPct)
+                    worstId = (healTarget.Pet.PctHPs() and healTarget.Pet.ID() or worstId)
                 end
             end
         end
@@ -1140,6 +1139,23 @@ function Combat.FindWorstHurtGroupMember(minHPs)
 
     Logger.log_verbose("\agNo one is hurt!")
     return 0
+end
+
+--- True if any group member's pet is in heal range and below the given HP%.
+---@param minHPs number Pet HP% threshold.
+---@return boolean
+function Combat.AnyHurtGroupPet(minHPs)
+    for i = 1, mq.TLO.Group.Members() do
+        local member = mq.TLO.Group.Member(i)
+        if member and member() and (member.Pet.ID() or 0) > 0 then
+            local pet = member.Pet
+            local petHP = pet.PctHPs() or 101
+            if petHP > 0 and petHP < minHPs and (pet.Distance3D() or 999) <= 300 then
+                return true
+            end
+        end
+    end
+    return false
 end
 
 --- Finds the entity with the worst hurt mana exceeding a minimum threshold.
@@ -1213,25 +1229,33 @@ end
 function Combat.FindWorstHurtHealList(minHPs)
     local worstId = 0
     local worstPct = minHPs
-    local hpPct = 101
+    local myX, myY, myZ = mq.TLO.Me.X(), mq.TLO.Me.Y(), mq.TLO.Me.Z()
 
     Logger.log_verbose("\ayChecking for worst Hurt from Heal List.")
     for _, name in ipairs(Config:GetSetting('HealList') or {}) do
-        local healTarget = mq.TLO.Spawn(string.format("PC =%s", name))
-        if healTarget and healTarget() and (healTarget.Distance3D() or 0) < 300 and not healTarget.Dead() then
-            local heartbeat = Comms.GetPeerHeartbeatByName(name)
+        local hpPct, id = nil, nil
+        local data = Comms.GetPeerHeartbeat(Comms.GetPeerName(name, Globals.CurServer)).Data
 
-            if heartbeat and heartbeat.Data and heartbeat.Data.HPs then
-                hpPct = tonumber(heartbeat.Data.HPs) or 101
-            else
+        if data and data.HPs and data.ZoneId == Globals.CurZoneId and data.InstanceId == Globals.CurInstanceId then
+            -- RGMercs peer in our zone/instance: evaluate from the heartbeat (no spawn lookup, squared distance, no sqrt)
+            local dx, dy, dz = (data.X or 0) - myX, (data.Y or 0) - myY, (data.Z or 0) - myZ
+            if data.HPs > 0 and (dx * dx + dy * dy + dz * dz) < 90000 then
+                hpPct = data.HPs
+                id = data.ID
+            end
+        else
+            -- Non-RGMercs heal target (e.g. another player's tank): fall back to a spawn lookup
+            local healTarget = mq.TLO.Spawn(string.format("PC =%s", name))
+            if healTarget and healTarget() and (healTarget.Distance3D() or 0) < 300 and not healTarget.Dead() then
                 hpPct = healTarget.PctHPs() or 101
+                id = healTarget.ID()
             end
+        end
 
-            if hpPct < worstPct then
-                Logger.log_verbose("\aySo far %s is the worst off.", healTarget.DisplayName() or "Error")
-                worstId = healTarget.ID()
-                worstPct = hpPct
-            end
+        if hpPct and id and hpPct < worstPct then
+            Logger.log_verbose("\aySo far heal-list id %d is the worst off.", id)
+            worstId = id
+            worstPct = hpPct
         end
     end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1695,16 +1695,6 @@ Config.DefaultConfig                                     = {
         Max = 100,
         ConfigType = "Advanced",
     },
-    ['PriorityHealing']            = {
-        DisplayName = "Prioritize Healing",
-        Group = "Abilities",
-        Header = "Recovery",
-        Category = "Healing Thresholds",
-        Index = 8,
-        Default = true,
-        Tooltip = "Yield offensive rotations at the Main Heal Point instead of the Big Heal Point.",
-        ConfigType = "Advanced",
-    },
     --Recovery/Curing
     ['DoCureSpells']               = {
         DisplayName = "Do Cure Spells",

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -416,7 +416,7 @@ function Core.ShieldEquipped()
 end
 
 --- Safe to skip healing this frame.
----@param priority boolean? when set, yields at MainHealPoint instead of BigHealPoint
+---@param priority integer? HealPriority setting: 1 Ignore, 2 Big Heal Point, 3 Main Heal Point (nil/absent treats as Ignore)
 ---@return boolean True if it is safe to perform non-heal actions.
 function Core.OkayToNotHeal(priority)
     if not Core.IsHealing() then return true end
@@ -425,7 +425,9 @@ function Core.OkayToNotHeal(priority)
         Logger.log_verbose("OkayToNotHeal: We have a queued cure to process! Skipping.")
         return false
     end
-    return (mq.TLO.Group.Injured(Config:GetSetting(priority and 'MainHealPoint' or 'BigHealPoint'))() or 0) == 0
+
+    if (priority or 1) == 1 then return true end
+    return not Modules:ExecModule("Class", "NeedToHeal", priority)
 end
 
 --- Safe to skip mezzing this frame.
@@ -454,7 +456,7 @@ end
 function Core.CombatActionsCheck()
     if not Core.OkayToNotCharm() then return false end
     if Core.CharmAssistNeeded() then return false end
-    if not Core.OkayToNotHeal(Config:GetSetting('PriorityHealing')) then return false end
+    if not Core.OkayToNotHeal(Config:GetSetting('HealPriority', true)) then return false end
     if not Core.OkayToNotMez(Config:GetSetting('PriorityMez')) then return false end
     return true
 end

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -389,7 +389,7 @@ end
 --- Renders a combo box for selecting the active class config directory.
 function Ui.RenderConfigSelector()
     if Globals.ClassConfigDirs ~= nil then
-        Ui.RenderText("Config Type:")
+        Ui.RenderText("Active Config:")
         ImGui.SameLine()
         ImGui.SetNextItemWidth(200)
         local newConfigDir, changed = ImGui.Combo("##config_type", Ui.GetClassConfigIDFromName(Config:GetSetting('ClassConfigDir')), Globals.ClassConfigDirs,


### PR DESCRIPTION
* New Setting: Heal Priority. When to yield offensive rotations for healing. Options are never, at the big heal point (old default behavior), and at the main heal point. Defaults - Main: CLR, DRU, SHM. Big: BST, PAL, RNG.

* Improved healing gates to scan for members of the heal list and pets, depending on operative settings (Use Heal List, Heal Pets as PCs).
* Rewrote heal checks to prioritize peer data if available.