### PR TITLE
Ranger Ranged Nav Rewrite

### DIFF
--- a/class_configs/Alpha (Live)/dru_class_config.lua
+++ b/class_configs/Alpha (Live)/dru_class_config.lua
@@ -1686,7 +1686,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -1109,7 +1109,7 @@ return {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -1374,7 +1374,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -1473,7 +1473,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -1610,7 +1610,7 @@ return {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -6,7 +6,6 @@ local Core      = require("utils.core")
 local Globals   = require('utils.globals')
 local Logger    = require("utils.logger")
 local Movement  = require("utils.movement")
-local Strings   = require("utils.strings")
 local Targeting = require("utils.targeting")
 
 return {
@@ -282,10 +281,9 @@ return {
             end,
         },
         {
-            name = 'Circle Nav',
+            name = 'Ranged Positioning',
             state = 1,
             steps = 1,
-            load_cond = function(self) return Config:GetSetting('NavCircle') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and not Config:GetSetting('DoMelee')
@@ -354,37 +352,68 @@ return {
 
             return false
         end,
-        combatNav = function(forceMove)
-            if not Config:GetSetting('DoMelee') then
-                if not mq.TLO.Me.AutoFire() then
-                    Core.DoCmd('/squelch face fast')
-                    Core.DoCmd('/autofire on')
+        rangedNav = function(reason)
+            if Config:GetSetting('DoMelee') then return end
+            if (Globals.AutoTargetID or 0) == 0 then return end
+
+            local bowRange = Config:GetSetting('BowRange')
+
+            if reason then
+                Logger.log_verbose("rangedNav: reason=%s dist=%d bowRange=%d stick=%s LoS=%s", reason,
+                    Targeting.GetTargetDistance(), bowRange, Config:GetSetting('UseRangedStick'), mq.TLO.Target.LineOfSight())
+            end
+
+            if not mq.TLO.Me.Moving() then
+                Core.DoCmd('/squelch /face fast')
+            end
+
+            if not mq.TLO.Me.AutoFire() then
+                Core.DoCmd('/autofire on')
+            end
+
+            -- No line of sight: sweep laterally around the target for a spot with a real (game) clear shot.
+            if reason == "cantsee" then
+                if not Movement:NavAroundCircle(mq.TLO.Target, bowRange) then
+                    -- Nav can't path (off the mesh): stick toward the target to walk back onto it.
+                    Logger.log_warn("Ranged nav: no navigable line-of-sight spot (off mesh?), falling back to a stick.")
+                    Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                    if not Config:GetSetting('UseRangedStick') then
+                        -- Loose holds nothing: run the stick only until we regain line of sight, then drop it.
+                        mq.delay(100, function() return mq.TLO.Stick.Active() end)
+                        mq.delay(3000, function() return mq.TLO.Target.ID() == 0 or mq.TLO.Target.LineOfSight() end)
+                        Movement:DoStickCmd("off")
+                        Movement:ClearLastStickTimer()
+                    end
                 end
+                return
+            end
 
-                local targetDistance = Targeting.GetTargetDistance()
-                local chaseDistance = Config:GetSetting('ChaseDistance')
-                local useChaseDistance = chaseDistance > 75 and chaseDistance < 200
-                local tooClose = targetDistance < 30
-                --- the distance of 200 could be further refined by checking actual distances based off range + ammo distance if desired.
-                local tooFar = useChaseDistance and targetDistance > chaseDistance or targetDistance > 75
-
-                Logger.log_verbose("Custom Ranger combatNav engaged. TargetDistance: %d, LOS:%s, ChaseDistance: %d, forceMove: %s, tooClose: %s, tooFar: %s", targetDistance,
-                    mq.TLO.Target.LineOfSight(), chaseDistance, Strings.BoolToColorString(forceMove), Strings.BoolToColorString(tooClose), Strings.BoolToColorString(tooFar))
-                if Config:GetSetting('NavCircle') then
-                    if tooClose or tooFar or forceMove then
-                        Movement:NavAroundCircle(mq.TLO.Target, Config:GetSetting('BowNavDistance'))
+            if Config:GetSetting('UseRangedStick') then -- Use Ranged Stick: hold bow range with a stick.
+                if reason == "toofar" or Targeting.GetTargetDistance() > bowRange + 10 then
+                    if not mq.TLO.Navigation.Active() then
+                        Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, bowRange)
+                        Core.DoCmd('/squelch /face fast')
                     end
-                elseif tooClose then
-                    if chaseDistance < 10 then
-                        Logger.log_warning(
-                            "Custom Ranger combatNav: \arWarning! \awChase distance is %d. \ayThis may interfere with ranged combat, depending on chase target movement!",
-                            chaseDistance)
-                    end
-                    Core.DoCmd('/squelch face fast')
-                    Movement:DoStickCmd("%d moveback", Config:GetSetting('BowNavDistance'))
-                elseif tooFar or forceMove then
-                    Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, Config:GetSetting('BowNavDistance'))
+                elseif (mq.TLO.Stick.StickTarget() or 0) ~= Globals.AutoTargetID or (mq.TLO.Stick.Status() or "off"):lower() == "off" then
                     Core.DoCmd('/squelch /face fast')
+                    local stickHow = Config:GetSetting('StickHow') or ""
+                    if #stickHow > 0 then
+                        Movement:DoStickCmd("%s", stickHow)
+                    else
+                        Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                    end
+                end
+            else -- Loose: react to the game's own range messages, one-shot, no held position.
+                if reason == "toofar" then
+                    Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, bowRange)
+                    Core.DoCmd('/squelch /face fast')
+                elseif reason == "tooclose" then
+                    Core.DoCmd('/squelch /face fast')
+                    Movement:DoStickCmd("%d moveback uw", bowRange)
+                    mq.delay(100, function() return mq.TLO.Stick.Active() end)
+                    mq.delay(500, function() return not mq.TLO.Me.Moving() end)
+                    Movement:DoStickCmd("off")
+                    Movement:ClearLastStickTimer()
                 end
             end
         end,
@@ -392,16 +421,16 @@ return {
 
     },
     ['Rotations']         = {
-        ['Circle Nav'] = {
+        ['Ranged Positioning'] = {
             {
-                name = "Ranged Mode",
+                name = "Ranged Nav",
                 type = "CustomFunc",
                 custom_func = function(self)
-                    Core.SafeCallFunc("Ranger Custom Nav", self.Helpers.combatNav, false)
+                    Core.SafeCallFunc("Ranger Ranged Nav", self.Helpers.rangedNav)
                 end,
             },
         },
-        ['Burn']       = {
+        ['Burn']               = {
             {
                 name = "Auspice of the Hunter",
                 type = "AA",
@@ -489,7 +518,7 @@ return {
                 type = "AA",
             },
         },
-        ['Snare']      = {
+        ['Snare']              = {
             {
                 name = "Entrap",
                 type = "AA",
@@ -507,7 +536,7 @@ return {
                 end,
             },
         },
-        ['Emergency']  = {
+        ['Emergency']          = {
             {
                 name = "Cover Tracks",
                 type = "AA",
@@ -538,7 +567,7 @@ return {
                 end,
             },
         },
-        ['Combat']     = {
+        ['Combat']             = {
             {
                 name = "Epic",
                 type = "Item",
@@ -587,7 +616,7 @@ return {
                 end,
             },
         },
-        ['Weaves']     = {
+        ['Weaves']             = {
             {
                 name = "KickDisc",
                 type = "Disc",
@@ -600,7 +629,7 @@ return {
                 type = "Ability",
             },
         },
-        ['GroupBuff']  = {
+        ['GroupBuff']          = {
             {
                 name = "PredatorBuff",
                 type = "Spell",
@@ -678,7 +707,7 @@ return {
                 end,
             },
         },
-        ['Downtime']   = {
+        ['Downtime']           = {
             {
                 name = "SelfBuff",
                 type = "Spell",
@@ -765,30 +794,47 @@ return {
         },
 
         --Archery
-        ['BowNavDistance']  = {
-            DisplayName = "Bow Nav Distance",
+        ['BowRange']        = {
+            DisplayName = "Bow Range",
             Group = "Combat",
             Header = "Positioning",
             Category = "Archery",
             Index = 101,
-            Tooltip = "The distance from your target you should nav to for ranged attacks when necessary.\n" ..
-                "If Nav Circle is enabled, the distance to circle at.",
-            Default = 30,
+            Tooltip = "The preferred distance to reposition to if we are too close/far or have no LoS (also the default range for ranged stick).",
+            Default = 15,
             Min = 10,
-            Max = 200,
+            Max = 300,
             FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
-            Answer = "Some terrain blocks line of sight while MQ reports that the ranger has line of sight.\n" ..
-                "Reducing Bow Nav Distance to a value near the minimum or maximum may solve for some of these (not RG-Mercs) issues, as a workaround.",
+            Answer = "Some terrain blocks LoS while MQ reports that the ranger has LoS.\n" ..
+                "While we will attempt to solve this issue, manual intervention or setting adjustment may be required (Bow Range, Ranged Stick, etc).",
         },
-        ['NavCircle']       = {
-            DisplayName = "Nav Circle",
+        ['UseRangedStick']  = {
+            DisplayName = "Use Ranged Stick",
             Group = "Combat",
             Header = "Positioning",
             Category = "Archery",
             Index = 102,
-            Tooltip = "Use Nav to Circle your target while autofiring.",
+            Tooltip = "Disabled - autofire from present position, moving only if needed (too close/far, no LoS).\n" ..
+                "Enabled - use stick while autofiring. Uses Stick How setting if set, otherwise uses '<bowrangesetting> moveback uw'",
             Default = false,
-            RequiresLoadoutChange = true, -- this is a load condition
+            Warning = function()
+                if not Config:GetSetting('UseRangedStick') then return false, "" end
+                local bowRange = Config:GetSetting('BowRange')
+                if Config:GetSetting('ChaseOn') then
+                    if Config:GetSetting('ChaseDistance') < bowRange then
+                        return true, "Warning: Chase Distance is below Bow Range - chase may fight the ranged stick hold."
+                    end
+                elseif Config:GetSetting('ReturnToCamp') then
+                    if Config:GetSetting('CampHard') then
+                        return true, "Warning: Camp Hard pulls you to camp center - the ranged stick may not hold its bow range."
+                    elseif Config:GetSetting('AutoCampRadius') < bowRange then
+                        return true, "Warning: Camp Radius is below Bow Range - camp return may fight the ranged stick hold."
+                    end
+                end
+                return false, ""
+            end,
+            FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
+            Answer = "Turn off Use Ranged Stick (the default), so the ranger only repositions when a shot is actually refused instead of holding position.",
         },
 
         --Buffs

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -1012,7 +1012,7 @@ return {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -1858,7 +1858,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -1809,7 +1809,7 @@ return {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -1858,7 +1858,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1794,7 +1794,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -2270,7 +2270,7 @@ local _ClassConfig = {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -896,10 +896,9 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Circle Nav',
+            name = 'Ranged Positioning',
             state = 1,
             steps = 1,
-            load_cond = function(self) return Config:GetSetting('NavCircle') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and not Config:GetSetting('DoMelee') and not Core.IsModeActive("Healer")
@@ -1255,12 +1254,12 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Circle Nav'] = {
+        ['Ranged Positioning'] = {
             {
-                name = "Ranged Mode",
+                name = "Ranged Nav",
                 type = "CustomFunc",
                 custom_func = function(self)
-                    Core.SafeCallFunc("Ranger Custom Nav", self.Helpers.combatNav, false)
+                    Core.SafeCallFunc("Ranger Ranged Nav", self.Helpers.rangedNav)
                 end,
             },
         },
@@ -1634,42 +1633,68 @@ local _ClassConfig = {
         },
     },
     ['Helpers']           = {
-        combatNav = function(forceMove)
-            if not Config:GetSetting('DoMelee') then
-                if not mq.TLO.Me.AutoFire() then
-                    Core.DoCmd('/squelch face fast')
-                    Core.DoCmd('/autofire on')
-                end
+        rangedNav = function(reason)
+            if Config:GetSetting('DoMelee') then return end
+            if (Globals.AutoTargetID or 0) == 0 then return end
 
-                local targetDistance = Targeting.GetTargetDistance()
-                local chaseDistance = Config:GetSetting('ChaseDistance')
-                local useChaseDistance = chaseDistance > 75 and chaseDistance < 200
-                local tooClose = targetDistance < 30
-                --- the distance of 200 could be further refined by checking actual distances based off range + ammo distance if desired.
-                local tooFar = useChaseDistance and targetDistance > chaseDistance or targetDistance > 75
+            local bowRange = Config:GetSetting('BowRange')
 
-                Logger.log_verbose("Custom Ranger combatNav engaged. TargetDistance: %d, LOS:%s, ChaseDistance: %d, forceMove: %s, tooClose: %s, tooFar: %s", targetDistance,
-                    mq.TLO.Target.LineOfSight(), chaseDistance, Strings.BoolToColorString(forceMove), Strings.BoolToColorString(tooClose), Strings.BoolToColorString(tooFar))
+            if reason then
+                Logger.log_verbose("rangedNav: reason=%s dist=%d bowRange=%d stick=%s LoS=%s", reason,
+                    Targeting.GetTargetDistance(), bowRange, Config:GetSetting('UseRangedStick'), mq.TLO.Target.LineOfSight())
+            end
 
-                if forceMove and mq.TLO.Target.LineOfSight() then
-                    Logger.log_warn(
-                        "Custom Ranger combatNav: \arWarning! \aw Mercs has detected a \"Can't See\" condition, but MQ is reporting line of sight. \ayManual intervention may be required.")
-                end
-                if Config:GetSetting('NavCircle') then
-                    if tooClose or tooFar or forceMove then
-                        Movement:NavAroundCircle(mq.TLO.Target, Config:GetSetting('BowNavDistance'))
+            if not mq.TLO.Me.Moving() then
+                Core.DoCmd('/squelch /face fast')
+            end
+
+            if not mq.TLO.Me.AutoFire() then
+                Core.DoCmd('/autofire on')
+            end
+
+            -- No line of sight: sweep laterally around the target for a spot with a real (game) clear shot.
+            if reason == "cantsee" then
+                if not Movement:NavAroundCircle(mq.TLO.Target, bowRange) then
+                    -- Nav can't path (off the mesh): stick toward the target to walk back onto it.
+                    Logger.log_warn("Ranged nav: no navigable line-of-sight spot (off mesh?), falling back to a stick.")
+                    Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                    if not Config:GetSetting('UseRangedStick') then
+                        -- Loose holds nothing: run the stick only until we regain line of sight, then drop it.
+                        mq.delay(100, function() return mq.TLO.Stick.Active() end)
+                        mq.delay(3000, function() return mq.TLO.Target.ID() == 0 or mq.TLO.Target.LineOfSight() end)
+                        Movement:DoStickCmd("off")
+                        Movement:ClearLastStickTimer()
                     end
-                elseif tooClose then
-                    if chaseDistance < 30 then
-                        Logger.log_warn(
-                            "Custom Ranger combatNav: \arWarning! \awChase distance is %d. \ayThis may interfere with ranged combat, depending on chase target movement!",
-                            chaseDistance)
+                end
+                return
+            end
+
+            if Config:GetSetting('UseRangedStick') then -- Use Ranged Stick: hold bow range with a stick.
+                if reason == "toofar" or Targeting.GetTargetDistance() > bowRange + 10 then
+                    if not mq.TLO.Navigation.Active() then
+                        Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, bowRange)
+                        Core.DoCmd('/squelch /face fast')
                     end
-                    Core.DoCmd('/squelch face fast')
-                    Movement:DoStickCmd("%d moveback", Config:GetSetting('BowNavDistance'))
-                elseif tooFar or forceMove then
-                    Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, Config:GetSetting('BowNavDistance'))
+                elseif (mq.TLO.Stick.StickTarget() or 0) ~= Globals.AutoTargetID or (mq.TLO.Stick.Status() or "off"):lower() == "off" then
                     Core.DoCmd('/squelch /face fast')
+                    local stickHow = Config:GetSetting('StickHow') or ""
+                    if #stickHow > 0 then
+                        Movement:DoStickCmd("%s", stickHow)
+                    else
+                        Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                    end
+                end
+            else -- Loose: react to the game's own range messages, one-shot, no held position.
+                if reason == "toofar" then
+                    Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, bowRange)
+                    Core.DoCmd('/squelch /face fast')
+                elseif reason == "tooclose" then
+                    Core.DoCmd('/squelch /face fast')
+                    Movement:DoStickCmd("%d moveback uw", bowRange)
+                    mq.delay(100, function() return mq.TLO.Stick.Active() end)
+                    mq.delay(500, function() return not mq.TLO.Me.Moving() end)
+                    Movement:DoStickCmd("off")
+                    Movement:ClearLastStickTimer()
                 end
             end
         end,
@@ -1724,30 +1749,47 @@ local _ClassConfig = {
                 "4. Hybrid - This mode is a combination of the other 3 and will attempt to be a jack of all trades.",
         },
         --Archery
-        ['BowNavDistance']     = {
-            DisplayName = "Bow Nav Distance",
+        ['BowRange']           = {
+            DisplayName = "Bow Range",
             Group = "Combat",
             Header = "Positioning",
             Category = "Archery",
             Index = 101,
-            Tooltip = "The distance from your target you should nav to for ranged attacks when necessary.\n" ..
-                "If Nav Circle is enabled, the distance to circle at.",
-            Default = 45,
-            Min = 30,
-            Max = 200,
+            Tooltip = "The preferred distance to reposition to if we are too close/far or have no LoS (also the default range for ranged stick).",
+            Default = 40,
+            Min = 31,
+            Max = 300,
             FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
-            Answer = "Some terrain blocks line of sight while MQ reports that the ranger has line of sight.\n" ..
-                "Reducing Bow Nav Distance to a value near the minimum or maximum may solve for some of these (not RG-Mercs) issues, as a workaround.",
+            Answer = "Some terrain blocks LoS while MQ reports that the ranger has LoS.\n" ..
+                "While we will attempt to solve this issue, manual intervention or setting adjustment may be required (Bow Range, Ranged Stick, etc).",
         },
-        ['NavCircle']          = {
-            DisplayName = "Nav Circle",
+        ['UseRangedStick']     = {
+            DisplayName = "Use Ranged Stick",
             Group = "Combat",
             Header = "Positioning",
             Category = "Archery",
             Index = 102,
-            Tooltip = "Use Nav to Circle your target while autofiring.",
+            Tooltip = "Disabled - autofire from present position, moving only if needed (too close/far, no LoS).\n" ..
+                "Enabled - use stick while autofiring. Uses Stick How setting if set, otherwise uses '<bowrangesetting> moveback uw'",
             Default = false,
-            RequiresLoadoutChange = true, -- this is a load condition
+            Warning = function()
+                if not Config:GetSetting('UseRangedStick') then return false, "" end
+                local bowRange = Config:GetSetting('BowRange')
+                if Config:GetSetting('ChaseOn') then
+                    if Config:GetSetting('ChaseDistance') < bowRange then
+                        return true, "Warning: Chase Distance is below Bow Range - chase may fight the ranged stick hold."
+                    end
+                elseif Config:GetSetting('ReturnToCamp') then
+                    if Config:GetSetting('CampHard') then
+                        return true, "Warning: Camp Hard pulls you to camp center - the ranged stick may not hold its bow range."
+                    elseif Config:GetSetting('AutoCampRadius') < bowRange then
+                        return true, "Warning: Camp Radius is below Bow Range - camp return may fight the ranged stick hold."
+                    end
+                end
+                return false, ""
+            end,
+            FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
+            Answer = "Turn off Use Ranged Stick (the default), so the ranger only repositions when a shot is actually refused instead of holding position.",
         },
         ['DoSnare']            = {
             DisplayName = "Cast Snares",

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -1901,7 +1901,7 @@ local _ClassConfig = {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -2221,7 +2221,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -1027,7 +1027,7 @@ return {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -1274,7 +1274,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -1451,7 +1451,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -1577,7 +1577,7 @@ return {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -1019,7 +1019,7 @@ return {
             Default = 2,
             Min = 1,
             Max = 2,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never) or at the Big Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -6,7 +6,6 @@ local Core      = require("utils.core")
 local Globals   = require("utils.globals")
 local Logger    = require("utils.logger")
 local Movement  = require("utils.movement")
-local Strings   = require("utils.strings")
 local Targeting = require("utils.targeting")
 
 return {
@@ -269,10 +268,9 @@ return {
             end,
         },
         {
-            name = 'Circle Nav',
+            name = 'Ranged Positioning',
             state = 1,
             steps = 1,
-            load_cond = function(self) return Config:GetSetting('NavCircle') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and not Config:GetSetting('DoMelee')
@@ -330,37 +328,68 @@ return {
         },
     },
     ['Helpers']           = {
-        combatNav = function(forceMove)
-            if not Config:GetSetting('DoMelee') then
-                if not mq.TLO.Me.AutoFire() then
-                    Core.DoCmd('/squelch face fast')
-                    Core.DoCmd('/autofire on')
+        rangedNav = function(reason)
+            if Config:GetSetting('DoMelee') then return end
+            if (Globals.AutoTargetID or 0) == 0 then return end
+
+            local bowRange = Config:GetSetting('BowRange')
+
+            if reason then
+                Logger.log_verbose("rangedNav: reason=%s dist=%d bowRange=%d stick=%s LoS=%s", reason,
+                    Targeting.GetTargetDistance(), bowRange, Config:GetSetting('UseRangedStick'), mq.TLO.Target.LineOfSight())
+            end
+
+            if not mq.TLO.Me.Moving() then
+                Core.DoCmd('/squelch /face fast')
+            end
+
+            if not mq.TLO.Me.AutoFire() then
+                Core.DoCmd('/autofire on')
+            end
+
+            -- No line of sight: sweep laterally around the target for a spot with a real (game) clear shot.
+            if reason == "cantsee" then
+                if not Movement:NavAroundCircle(mq.TLO.Target, bowRange) then
+                    -- Nav can't path (off the mesh): stick toward the target to walk back onto it.
+                    Logger.log_warn("Ranged nav: no navigable line-of-sight spot (off mesh?), falling back to a stick.")
+                    Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                    if not Config:GetSetting('UseRangedStick') then
+                        -- Loose holds nothing: run the stick only until we regain line of sight, then drop it.
+                        mq.delay(100, function() return mq.TLO.Stick.Active() end)
+                        mq.delay(3000, function() return mq.TLO.Target.ID() == 0 or mq.TLO.Target.LineOfSight() end)
+                        Movement:DoStickCmd("off")
+                        Movement:ClearLastStickTimer()
+                    end
                 end
+                return
+            end
 
-                local targetDistance = Targeting.GetTargetDistance()
-                local chaseDistance = Config:GetSetting('ChaseDistance')
-                local useChaseDistance = chaseDistance > 75 and chaseDistance < 200
-                local tooClose = targetDistance < 30
-                --- the distance of 200 could be further refined by checking actual distances based off range + ammo distance if desired.
-                local tooFar = useChaseDistance and targetDistance > chaseDistance or targetDistance > 75
-
-                Logger.log_verbose("Custom Ranger combatNav engaged. TargetDistance: %d, LOS:%s, ChaseDistance: %d, forceMove: %s, tooClose: %s, tooFar: %s", targetDistance,
-                    mq.TLO.Target.LineOfSight(), chaseDistance, Strings.BoolToColorString(forceMove), Strings.BoolToColorString(tooClose), Strings.BoolToColorString(tooFar))
-                if Config:GetSetting('NavCircle') then
-                    if tooClose or tooFar or forceMove then
-                        Movement:NavAroundCircle(mq.TLO.Target, Config:GetSetting('BowNavDistance'))
+            if Config:GetSetting('UseRangedStick') then -- Use Ranged Stick: hold bow range with a stick.
+                if reason == "toofar" or Targeting.GetTargetDistance() > bowRange + 10 then
+                    if not mq.TLO.Navigation.Active() then
+                        Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, bowRange)
+                        Core.DoCmd('/squelch /face fast')
                     end
-                elseif tooClose then
-                    if chaseDistance < 10 then
-                        Logger.log_warn(
-                            "Custom Ranger combatNav: \arWarning! \awChase distance is %d. \ayThis may interfere with ranged combat, depending on chase target movement!",
-                            chaseDistance)
-                    end
-                    Core.DoCmd('/squelch face fast')
-                    Movement:DoStickCmd("%d moveback", Config:GetSetting('BowNavDistance'))
-                elseif tooFar or forceMove then
-                    Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, Config:GetSetting('BowNavDistance'))
+                elseif (mq.TLO.Stick.StickTarget() or 0) ~= Globals.AutoTargetID or (mq.TLO.Stick.Status() or "off"):lower() == "off" then
                     Core.DoCmd('/squelch /face fast')
+                    local stickHow = Config:GetSetting('StickHow') or ""
+                    if #stickHow > 0 then
+                        Movement:DoStickCmd("%s", stickHow)
+                    else
+                        Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                    end
+                end
+            else -- Loose: react to the game's own range messages, one-shot, no held position.
+                if reason == "toofar" then
+                    Movement:DoNav(true, "id %d distance=%d lineofsight=on", Globals.AutoTargetID, bowRange)
+                    Core.DoCmd('/squelch /face fast')
+                elseif reason == "tooclose" then
+                    Core.DoCmd('/squelch /face fast')
+                    Movement:DoStickCmd("%d moveback uw", bowRange)
+                    mq.delay(100, function() return mq.TLO.Stick.Active() end)
+                    mq.delay(500, function() return not mq.TLO.Me.Moving() end)
+                    Movement:DoStickCmd("off")
+                    Movement:ClearLastStickTimer()
                 end
             end
         end,
@@ -368,16 +397,16 @@ return {
 
     },
     ['Rotations']         = {
-        ['Circle Nav'] = {
+        ['Ranged Positioning'] = {
             {
-                name = "Ranged Mode",
+                name = "Ranged Nav",
                 type = "CustomFunc",
                 custom_func = function(self)
-                    Core.SafeCallFunc("Ranger Custom Nav", self.Helpers.combatNav, false)
+                    Core.SafeCallFunc("Ranger Ranged Nav", self.Helpers.rangedNav)
                 end,
             },
         },
-        ['Burn']       = {
+        ['Burn']               = {
             {
                 name = "Auspice of the Hunter",
                 type = "AA",
@@ -460,7 +489,7 @@ return {
                 type = "AA",
             },
         },
-        ['Snare']      = {
+        ['Snare']              = {
             {
                 name = "Entrap",
                 type = "AA",
@@ -478,7 +507,7 @@ return {
                 end,
             },
         },
-        ['Emergency']  = {
+        ['Emergency']          = {
             {
                 name = "Armor of Experience",
                 type = "AA",
@@ -514,7 +543,7 @@ return {
                 end,
             },
         },
-        ['Combat']     = {
+        ['Combat']             = {
             {
                 name = "Epic",
                 type = "Item",
@@ -572,7 +601,7 @@ return {
                 type = "Spell",
             },
         },
-        ['Weaves']     = {
+        ['Weaves']             = {
             {
                 name = "Kick",
                 type = "Ability",
@@ -585,7 +614,7 @@ return {
                 end,
             },
         },
-        ['GroupBuff']  = {
+        ['GroupBuff']          = {
             {
                 name = "PredatorBuff",
                 type = "Spell",
@@ -663,7 +692,7 @@ return {
                 end,
             },
         },
-        ['Downtime']   = {
+        ['Downtime']           = {
             {
                 name = "SelfBuff",
                 type = "Spell",
@@ -751,30 +780,47 @@ return {
         },
 
         --Archery
-        ['BowNavDistance']  = {
-            DisplayName = "Bow Nav Distance",
+        ['BowRange']        = {
+            DisplayName = "Bow Range",
             Group = "Combat",
             Header = "Positioning",
             Category = "Archery",
             Index = 101,
-            Tooltip = "The distance from your target you should nav to for ranged attacks when necessary.\n" ..
-                "If Nav Circle is enabled, the distance to circle at.",
-            Default = 30,
+            Tooltip = "The preferred distance to reposition to if we are too close/far or have no LoS (also the default range for ranged stick).",
+            Default = 15,
             Min = 10,
-            Max = 200,
+            Max = 300,
             FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
-            Answer = "Some terrain blocks line of sight while MQ reports that the ranger has line of sight.\n" ..
-                "Reducing Bow Nav Distance to a value near the minimum or maximum may solve for some of these (not RG-Mercs) issues, as a workaround.",
+            Answer = "Some terrain blocks LoS while MQ reports that the ranger has LoS.\n" ..
+                "While we will attempt to solve this issue, manual intervention or setting adjustment may be required (Bow Range, Ranged Stick, etc).",
         },
-        ['NavCircle']       = {
-            DisplayName = "Nav Circle",
+        ['UseRangedStick']  = {
+            DisplayName = "Use Ranged Stick",
             Group = "Combat",
             Header = "Positioning",
             Category = "Archery",
             Index = 102,
-            Tooltip = "Use Nav to Circle your target while autofiring.",
+            Tooltip = "Disabled - autofire from present position, moving only if needed (too close/far, no LoS).\n" ..
+                "Enabled - use stick while autofiring. Uses Stick How setting if set, otherwise uses '<bowrangesetting> moveback uw'",
             Default = false,
-            RequiresLoadoutChange = true, -- this is a load condition
+            Warning = function()
+                if not Config:GetSetting('UseRangedStick') then return false, "" end
+                local bowRange = Config:GetSetting('BowRange')
+                if Config:GetSetting('ChaseOn') then
+                    if Config:GetSetting('ChaseDistance') < bowRange then
+                        return true, "Warning: Chase Distance is below Bow Range - chase may fight the ranged stick hold."
+                    end
+                elseif Config:GetSetting('ReturnToCamp') then
+                    if Config:GetSetting('CampHard') then
+                        return true, "Warning: Camp Hard pulls you to camp center - the ranged stick may not hold its bow range."
+                    elseif Config:GetSetting('AutoCampRadius') < bowRange then
+                        return true, "Warning: Camp Radius is below Bow Range - camp return may fight the ranged stick hold."
+                    end
+                end
+                return false, ""
+            end,
+            FAQ = "Why is my ranger rubber-banding, charging back and forth or changing heading constantly?",
+            Answer = "Turn off Use Ranged Stick (the default), so the ranger only repositions when a shot is actually refused instead of holding position.",
         },
 
         --Buffs

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -1739,7 +1739,7 @@ local _ClassConfig = {
             Default = 3,
             Min = 1,
             Max = 3,
-            Tooltip = "When to yield offensive rotations for healing: Ignore (never), at the Big Heal Point, or at the Main Heal Point.",
+            Tooltip = "When to yield offensive rotations for healing:\n1 - Ignore (never)\n2 - Big Heal Point\n3 - Main Heal Point",
             ConfigType = "Advanced",
         },
     },

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2788, }
+return { version = 2789, }

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1042,13 +1042,14 @@ Config.DefaultConfig                                     = {
         Header = "Positioning",
         Category = "General Positioning",
         Index = 2,
-        Tooltip = "Custom arguments for /stick command. Leave blank for default (varies on class).",
+        Tooltip = "Custom arguments for /stick command, used in melee or ranged combat. Leave blank for default (varies on class).",
         Default = "",
         ConfigType = "Advanced",
         FAQ = "What are the default stick settings?",
         Answer = "   If the Stick How entry is left blank, we will use default stick settings as follows:\n" ..
             "If MA: < 10 moveback* uw >\n" ..
-            "Others: < 10** behindonce moveback uw >\n\n" ..
+            "Others: < 10** behindonce moveback uw >\n" ..
+            "Ranged (Use Ranged Stick): < <bowrangesetting> moveback uw >\n\n" ..
             "* - Optional moveback flag (if 'Moveback As Tank' is enabled).\n" ..
             "** - On larger targets this value becomes 20.",
     },

--- a/utils/event_handlers.lua
+++ b/utils/event_handlers.lua
@@ -44,7 +44,11 @@ mq.event("CantSee", "You cannot see your target.", function()
             local haterCount = Targeting.GetXTHaterCount()
             if Config:GetSetting('DoAutoEngage') and not mq.TLO.Me.Moving() or haterCount > 0 then
                 local helpers = Core.GetHelpers()
-                if helpers and helpers.combatNav then
+                if helpers and helpers.rangedNav then
+                    Logger.log_debug("CantSee: \ayWe are in COMBAT and Cannot see our target - using ranged positioning!")
+                    Core.SafeCallFunc("Ranger Ranged Nav", helpers.rangedNav, "cantsee")
+                elseif helpers and helpers.combatNav then
+                    -- DEPRECATED 6/26 (sunset ~8/26): legacy boolean combatNav; configs should define rangedNav(reason).
                     Logger.log_debug("CantSee: \ayWe are in COMBAT and Cannot see our target - using custom combatNav!")
                     Core.SafeCallFunc("Ranger Custom Nav", helpers.combatNav, true)
                 else
@@ -124,7 +128,10 @@ mq.event("TooClose", "Your target is too close to use a ranged weapon!", functio
             if Config:GetSetting('DoAutoEngage') and not mq.TLO.Me.Moving() and haterCount > 0 then
                 Logger.log_debug("TooCloseHandler: Pull State not detected, using Combat Nav.")
                 local helpers = Core.GetHelpers()
-                if helpers and helpers.combatNav then
+                if helpers and helpers.rangedNav then
+                    Core.SafeCallFunc("Ranger Ranged Nav", helpers.rangedNav, "tooclose")
+                elseif helpers and helpers.combatNav then
+                    -- DEPRECATED 6/26 (sunset ~8/26): legacy boolean combatNav; configs should define rangedNav(reason).
                     Core.SafeCallFunc("Ranger Custom Nav", helpers.combatNav, false)
                 else
                     Logger.log_debug("TooClose event detected, but we don't have class-specific combat nav for ranged combat!")
@@ -176,7 +183,10 @@ local function tooFarHandler()
             local helpers = Core.GetHelpers()
             local haterCount = Targeting.GetXTHaterCount()
             if Config:GetSetting('DoAutoEngage') and not mq.TLO.Me.Moving() and haterCount > 0 then
-                if helpers and helpers.combatNav then
+                if helpers and helpers.rangedNav then
+                    Core.SafeCallFunc("Ranger Ranged Nav", helpers.rangedNav, "toofar")
+                elseif helpers and helpers.combatNav then
+                    -- DEPRECATED 6/26 (sunset ~8/26): legacy boolean combatNav; configs should define rangedNav(reason).
                     Core.SafeCallFunc("Custom Nav", helpers.combatNav)
                 elseif Config:GetSetting('DoMelee') then
                     Logger.log_debug("TooFar: \ayWe are in COMBAT and too far from our target!")

--- a/utils/movement.lua
+++ b/utils/movement.lua
@@ -224,8 +224,7 @@ function Movement:NavAroundCircle(target, radius)
     local spawn_y = target.Y()
     local spawn_z = target.Z()
 
-    local tgt_x = 0
-    local tgt_y = 0
+    local tgt_x, tgt_y
     -- We need to get the spawn's heading to _us_ based on our heading to the spawn
     -- to nav a circle around it. This is done by inverting the coordinates. E.g.,
     -- If our heading to the mob is 90 degrees CCW, their heading to us is 270 degrees CCW.
@@ -236,14 +235,17 @@ function Movement:NavAroundCircle(target, radius)
     -- Loop until we find an x,y loc ${radius} away from the mob,
     -- that we can navigate to, and is in LoS
 
-    for steps = 1, 36 do
+    -- Skip our current angle (start at +10 deg): repositioning to where we already stand can't fix a
+    -- blocked shot, and re-picking it would loop when the LoS TLO and the game's LoS disagree.
+    for steps = 1, 35 do
         -- EQ's x coordinates have an opposite number line. Positive x values are to the left of 0,
         -- negative values are to the right of 0, so we need to - our radius.
         -- EQ's unit circle starts 0 degrees at the top of the unit circle instead of the right, so
         -- the below still finds coordinates rotated counter-clockwise 90 degrees.
 
-        tgt_x = spawn_x + (-1 * radius * math.cos(tmp_degrees))
-        tgt_y = spawn_y + (radius * math.sin(tmp_degrees))
+        local rad = math.rad(tmp_degrees + steps * 10)
+        tgt_x = spawn_x + (-1 * radius * math.cos(rad))
+        tgt_y = spawn_y + (radius * math.sin(rad))
 
         Logger.log_debug("\aw%d\ax tmp_degrees \aw%d\ax tgt_x \aw%0.2f\ax tgt_y \aw%02.f\ax", steps, tmp_degrees,
             tgt_x, tgt_y)
@@ -254,9 +256,9 @@ function Movement:NavAroundCircle(target, radius)
                 -- Make sure it's a valid loc...
                 if mq.TLO.EverQuest.ValidLoc(string.format("%0.2f %0.2f %0.2f", tgt_x, tgt_y, spawn_z))() then
                     Logger.log_debug(" \ag--> Found Valid Circling Loc: %0.2f %0.2f %0.2f", tgt_x, tgt_y, spawn_z)
-                    Movement:DoNav(false, "locyxz %0.2f %0.2f %0.2f facing=backward", tgt_y, tgt_x, spawn_z)
+                    Movement:DoNav(false, "locyxz %0.2f %0.2f %0.2f", tgt_y, tgt_x, spawn_z)
                     mq.delay("2s", function() return mq.TLO.Navigation.Active() end)
-                    mq.delay("10s", function() return not mq.TLO.Navigation.Active() end)
+                    mq.delay("5s", function() return not mq.TLO.Navigation.Active() end)
                     Core.DoCmd("/squelch /face fast")
                     return true
                 else


### PR DESCRIPTION
* New settings:
* * Bow Range: The preferred distance to reposition to if we are too close/far or have no LoS (also the default range for ranged stick). Defaults - Live: 40, Laz/EQM: 15.
* * Use Ranged Stick:
* * * Disabled - autofire from present position, moving only if needed (too close/far, no LoS).
* * * Enabled - use stick while autofiring. Uses Stick How setting if set, otherwise uses '<bowrangesetting> moveback uw'
* Circle nav is used as needed when we receive a "can't see" message.
* As always, turning off melee will enable ranged combat for rangers.

Minor Update
* Corrected Heal Priority tooltip.