### PR TITLE
Made camp settings less "Hard"

### DIFF
--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -1070,6 +1070,7 @@ return {
             Index = 101,
             Tooltip = "Use your Run/Move Speed buff spells or AA.",
             Default = false,
+            RequiresLoadoutChange = true,
         },
         ['DoAvatar']       = {
             DisplayName = "Do Avatar",

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -824,12 +824,8 @@ return {
                     if Config:GetSetting('ChaseDistance') < bowRange then
                         return true, "Warning: Chase Distance is below Bow Range - chase may fight the ranged stick hold."
                     end
-                elseif Config:GetSetting('ReturnToCamp') then
-                    if Config:GetSetting('CampHard') then
-                        return true, "Warning: Camp Hard pulls you to camp center - the ranged stick may not hold its bow range."
-                    elseif Config:GetSetting('AutoCampRadius') < bowRange then
-                        return true, "Warning: Camp Radius is below Bow Range - camp return may fight the ranged stick hold."
-                    end
+                elseif Config:GetSetting('ReturnToCamp') and Config:GetSetting('CampLeashCombat') and Config:GetSetting('AutoCampRadius') < bowRange then
+                    return true, "Warning: Camp Radius is below Bow Range - Leash to Camp (Combat) may fight the ranged stick hold."
                 end
                 return false, ""
             end,

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -1624,6 +1624,7 @@ local _ClassConfig = {
             Index = 101,
             Tooltip = "Do Run Speed Spells/AAs",
             Default = true,
+            RequiresLoadoutChange = true,
             FAQ = "Why are my buffers in a run speed buff war?",
             Answer = "Many run speed spells freely stack and overwrite each other, you will need to disable Run Speed Buffs on some of the buffers.",
         },

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -1779,12 +1779,8 @@ local _ClassConfig = {
                     if Config:GetSetting('ChaseDistance') < bowRange then
                         return true, "Warning: Chase Distance is below Bow Range - chase may fight the ranged stick hold."
                     end
-                elseif Config:GetSetting('ReturnToCamp') then
-                    if Config:GetSetting('CampHard') then
-                        return true, "Warning: Camp Hard pulls you to camp center - the ranged stick may not hold its bow range."
-                    elseif Config:GetSetting('AutoCampRadius') < bowRange then
-                        return true, "Warning: Camp Radius is below Bow Range - camp return may fight the ranged stick hold."
-                    end
+                elseif Config:GetSetting('ReturnToCamp') and Config:GetSetting('CampLeashCombat') and Config:GetSetting('AutoCampRadius') < bowRange then
+                    return true, "Warning: Camp Radius is below Bow Range - Leash to Camp (Combat) may fight the ranged stick hold."
                 end
                 return false, ""
             end,

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -2002,6 +2002,7 @@ local _ClassConfig = {
             Index = 101,
             Tooltip = "Do Run Speed Spells/AAs",
             Default = true,
+            RequiresLoadoutChange = true,
             FAQ = "Why are my buffers in a run speed buff war?",
             Answer = "Many run speed spells freely stack and overwrite each other, you will need to disable Run Speed Buffs on some of the buffers.",
         },

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -972,6 +972,7 @@ return {
             Category = "Group",
             Index = 101,
             Tooltip = "Use your Run/Move Speed buff spells or AA.",
+            RequiresLoadoutChange = true,
             Default = false,
         },
         ['DoAvatar']       = {

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -810,12 +810,8 @@ return {
                     if Config:GetSetting('ChaseDistance') < bowRange then
                         return true, "Warning: Chase Distance is below Bow Range - chase may fight the ranged stick hold."
                     end
-                elseif Config:GetSetting('ReturnToCamp') then
-                    if Config:GetSetting('CampHard') then
-                        return true, "Warning: Camp Hard pulls you to camp center - the ranged stick may not hold its bow range."
-                    elseif Config:GetSetting('AutoCampRadius') < bowRange then
-                        return true, "Warning: Camp Radius is below Bow Range - camp return may fight the ranged stick hold."
-                    end
+                elseif Config:GetSetting('ReturnToCamp') and Config:GetSetting('CampLeashCombat') and Config:GetSetting('AutoCampRadius') < bowRange then
+                    return true, "Warning: Camp Radius is below Bow Range - Leash to Camp (Combat) may fight the ranged stick hold."
                 end
                 return false, ""
             end,

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -1522,6 +1522,7 @@ local _ClassConfig = {
             Index = 101,
             Tooltip = "Do Run Speed Spells/AAs",
             Default = true,
+            RequiresLoadoutChange = true,
             FAQ = "Why are my buffers in a run speed buff war?",
             Answer = "Many run speed spells freely stack and overwrite each other, you will need to disable Run Speed Buffs on some of the buffers.",
         },

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2796, }
+return { version = 2797, }

--- a/init.lua
+++ b/init.lua
@@ -444,6 +444,7 @@ local function Main()
         end
 
         Globals.CurrentState = "Combat"
+        Globals.LastCombatTime = Globals.GetTimeMS()
         if Config:GetSetting('FaceTarget') and not Targeting.FacingTarget() and mq.TLO.Target.ID() ~= mq.TLO.Me.ID() and not mq.TLO.Me.Moving() then
             Core.DoCmd("/squelch /face fast")
         end

--- a/modules/lootnscoot.lua
+++ b/modules/lootnscoot.lua
@@ -61,23 +61,12 @@ Module.DefaultConfig   = {
 		Tooltip = "Enables looting during RGMercs-defined combat.",
 		Default = false,
 	},
-	['LootSettleTime']                         = {
-		DisplayName = "Loot Settle Time",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 3,
-		Tooltip = "Seconds to wait after combat ends before looting, so we don't begin to loot while adds are popping.",
-		Default = 2,
-		Min = 0,
-		Max = 10,
-	},
 	['LootRespectMedState']                    = {
 		DisplayName = "Respect Med State",
 		Group = "General",
 		Header = "Loot(Emu)",
 		Category = "LNS",
-		Index = 4,
+		Index = 3,
 		Tooltip = "Hold looting if you are currently meditating.",
 		Default = false,
 	},
@@ -86,7 +75,7 @@ Module.DefaultConfig   = {
 		Group = "General",
 		Header = "Loot(Emu)",
 		Category = "LNS",
-		Index = 5,
+		Index = 4,
 		Tooltip = "The length of time in seconds that RGMercs will allow LNS to process loot actions in a single check.",
 		Default = 5,
 		Min = 1,
@@ -97,7 +86,7 @@ Module.DefaultConfig   = {
 		Group = "General",
 		Header = "Loot(Emu)",
 		Category = "LNS",
-		Index = 6,
+		Index = 5,
 		Tooltip = "If chase is on, we won't loot (and will abort looting) any corpses when the chase target is farther than this value away from us.",
 		Default = 300,
 		Min = 1,
@@ -218,8 +207,6 @@ function Module:GiveTime()
 
 	if not Config:GetSetting('DoLoot') then return end
 
-	if combat_state == "Combat" then self.TempSettings.LastCombatTime = Globals.GetTimeSeconds() end
-
 	if Globals.PauseMain then return end
 	if mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' then
 		if not suppressWarning then
@@ -252,7 +239,7 @@ function Module:GiveTime()
 	Logger.log_verbose("\ay[LOOT]: \agFound %d corpses within range.", deadCount)
 	if self.Actor == nil then self:LootMessageHandler() end
 
-	local settled = Config:GetSetting('CombatLooting') or (Globals.GetTimeSeconds() - (self.TempSettings.LastCombatTime or 0)) >= Config:GetSetting('LootSettleTime')
+	local settled = Config:GetSetting('CombatLooting') or Combat.CombatSettled(1000)
 
 	-- send actors message to loot
 	if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then

--- a/modules/move.lua
+++ b/modules/move.lua
@@ -235,39 +235,72 @@ Module.DefaultConfig   = {
 
 
     -- Camp
-    ['AutoCampRadius']   = {
+    ['AutoCampRadius']    = {
         DisplayName = "Camp Radius",
         Group = "Movement",
         Header = "Following",
         Category = "Camp",
         Index = 1,
-        Tooltip = "The distance to allow from camp before you return to it. During combat, we relax this distance slightly.",
+        Tooltip = "The distance to allow from camp before returning to it.",
         Default = 100,
         Min = 10,
         Max = 300,
         Warning = function()
-            if Config:GetSetting('AssistRange') > Config:GetSetting('AutoCampRadius') then
-                return true, "Warning: AssistRange exceeds AutoCampRadius - this might cause your characters to run out of camp to assist."
+            if Config:GetSetting('CampExceedRadius') <= Config:GetSetting('AutoCampRadius') then
+                return true, "Warning: Camp Exceed Distance is at or below Camp Radius - camp will turn off as soon as you exceed the radius."
             end
             return false, ""
         end,
         OnChange = function(self) Movement.UpdateMapRadii() end,
     },
-    ['CampHard']         = {
-        DisplayName = "Camp Hard",
+    ['CampLeashDowntime'] = {
+        DisplayName = "Leash to Camp (Downtime)",
         Group = "Movement",
         Header = "Following",
         Category = "Camp",
         Index = 2,
-        Tooltip = "Return to the exact camp location whenever possible, even if we are within the Camp Radius.",
+        Tooltip = "Return to the exact camp location outside of combat, even if we are within the Camp Radius.",
         Default = false,
     },
-    ['MaintainCampfire'] = {
-        DisplayName = "Maintain Campfire",
+    ['CampLeashCombat']   = {
+        DisplayName = "Leash to Camp (Combat)",
         Group = "Movement",
         Header = "Following",
         Category = "Camp",
         Index = 3,
+        Tooltip = "Return to the exact camp location during combat if we leave the Camp Radius.",
+        Default = false,
+        Warning = function()
+            if Config:GetSetting('AssistRange') > Config:GetSetting('AutoCampRadius') then
+                return true, "Warning: AssistRange exceeds Camp Radius - the combat leash will pull characters back from engagements past the radius."
+            end
+            return false, ""
+        end,
+    },
+    ['CampExceedRadius']  = {
+        DisplayName = "Camp Exceed Distance",
+        Group = "Movement",
+        Header = "Following",
+        Category = "Camp",
+        Index = 4,
+        Tooltip = "Turn camp off if not pulling and your current distance from the camp is greater than this value.",
+        Default = 400,
+        Min = 100,
+        Max = 2000,
+        Warning = function()
+            if Config:GetSetting('CampExceedRadius') <= Config:GetSetting('AutoCampRadius') then
+                return true, "Warning: Camp Exceed Distance is at or below Camp Radius - camp will turn off as soon as you exceed the radius."
+            end
+            return false, ""
+        end,
+        ConfigType = "Advanced",
+    },
+    ['MaintainCampfire']  = {
+        DisplayName = "Maintain Campfire",
+        Group = "Movement",
+        Header = "Following",
+        Category = "Camp",
+        Index = 5,
         Tooltip = "Official Servers: Maintain the selected Fellowship Campfire.",
         Type = "Combo",
         ComboOptions = Module.Constants.CampfireTypes,
@@ -275,12 +308,12 @@ Module.DefaultConfig   = {
         Min = 1,
         Max = #Module.Constants.CampfireTypes,
     },
-    ['DoFellow']         = {
+    ['DoFellow']          = {
         DisplayName = "Enable Fellowship Insignia",
         Group = "Movement",
         Header = "Following",
         Category = "Camp",
-        Index = 4,
+        Index = 6,
         Tooltip = "Official Servers: Use your fellowship insignia to automatically return to the zone you were camped in after death.",
         Default = false,
         ConfigType = "Advanced",
@@ -717,7 +750,7 @@ function Module:GiveTime()
         self:DoAutoCampCheck()
     end
 
-    if (Core.IsTanking() and Config:GetSetting('MovebackWhenBehind')) and Targeting.IHaveAggro(100) then
+    if Config:GetSetting('ReturnToCamp') and Config:GetSetting('CampLeashCombat') and not Combat.ShouldDoCamp() then
         self:DoCombatCampCheck()
     end
 

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1778,12 +1778,13 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         return false
     end
 
-    -- If we're combat casting we need to both have the same swimming status
-    if targetId == 0 or (targetSpawn() and targetSpawn.FeetWet() ~= me.FeetWet()) then
+    if targetId == 0 then
         Logger.log_debug("\ayUseSpell(): \arCasting Failed: I tried to cast a spell %s I don't have a target (%d) for it.",
             spellName, targetId)
         return false
     end
+    -- TEMP 6/26: FeetWet swim-state check disabled - a flyer flying above a pool (e.g. Hartini in Stillmoon) reports FeetWet but its feet aren't actually wet, blocking all casts. Not a verified EQ mechanic.
+    -- if targetSpawn() and targetSpawn.FeetWet() ~= me.FeetWet() then return false end
 
     if not bAllowDead and targetSpawn() and targetSpawn.Dead() then
         Logger.log_verbose("\ayUseSpell(): \arCasting Failed: I tried to cast a spell %s but my target (%d) is dead.",
@@ -2241,10 +2242,11 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
 
     local targetSpawn = mq.TLO.Spawn(targetId)
 
-    if targetSpawn() and targetSpawn.FeetWet() ~= me.FeetWet() then
-        Logger.log_debug("\ayUseAA(): \arCan't cast %s on %d - swim state mismatch", aaName, targetId)
-        return false
-    end
+    -- TEMP 6/26: FeetWet swim-state check disabled - a flyer flying above a pool (e.g. Hartini in Stillmoon) reports FeetWet but its feet aren't actually wet, blocking all casts. Not a verified EQ mechanic.
+    -- if targetSpawn() and targetSpawn.FeetWet() ~= me.FeetWet() then
+    --     Logger.log_debug("\ayUseAA(): \arCan't cast %s on %d - swim state mismatch", aaName, targetId)
+    --     return false
+    -- end
 
     if not bAllowDead and targetSpawn() and targetSpawn.Dead() then
         Logger.log_debug("\ayUseAA(): \arAbility Failed!: I tried to use %s but my target (%d) is dead.",

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -28,6 +28,13 @@ function Combat.GetCachedCombatState()
     return Globals.CurrentState
 end
 
+--- Returns true once at least thresholdMs has elapsed since the last combat frame.
+---@param thresholdMs number Milliseconds to wait after combat before considering it settled.
+---@return boolean
+function Combat.CombatSettled(thresholdMs)
+    return (Globals.GetTimeMS() - Globals.LastCombatTime) >= thresholdMs
+end
+
 --- Designates the main assist from the assist list, raid, group, or self as a fallback.
 function Combat.SetMainAssist()
     local inRaid = mq.TLO.Raid.Members() > 0
@@ -932,7 +939,7 @@ function Combat.ShouldDoCamp()
         (not Core.IsTanking() and Targeting.GetAutoTargetPctHPs() > Config:GetSetting('AutoAssistAt'))
 end
 
---- Navigates back to camp if ReturnToCamp is enabled and we are outside the camp radius.
+--- Navigates back to camp out of combat if Camp is on and we are outside the camp radius.
 ---@param tempConfig           table    Camp configuration containing AutoCampX/Y/Z, CampZoneId, etc.
 ---@param bCalledFromInsideEvent? boolean True if called from within an event handler (skips doevents calls).
 function Combat.AutoCampCheck(tempConfig, bCalledFromInsideEvent)
@@ -942,10 +949,8 @@ function Combat.AutoCampCheck(tempConfig, bCalledFromInsideEvent)
 
     if mq.TLO.Me.Casting() and not Core.MyClassIs("brd") then return end
 
-    -- chasing a toon dont use camnp.
     if Config:GetSetting('ChaseOn') then return end
 
-    -- camped in a different zone.
     if tempConfig.CampZoneId ~= mq.TLO.Zone.ID() then return end
 
     -- let pulling module handle camp decisions while it is enabled.
@@ -962,13 +967,13 @@ function Combat.AutoCampCheck(tempConfig, bCalledFromInsideEvent)
 
     local distanceToCamp = Math.GetDistance(me.Y(), me.X(), tempConfig.AutoCampY, tempConfig.AutoCampX)
 
-    if distanceToCamp >= 400 and not Config:GetSetting('DoPull') then
-        Comms.PrintGroupMessage("I'm over 400 units from camp, not returning!")
+    if distanceToCamp >= Config:GetSetting('CampExceedRadius') and not Config:GetSetting('DoPull') then
+        Comms.PrintGroupMessage("I'm over %d units from camp, not returning!", Config:GetSetting('CampExceedRadius'))
         Core.DoCmd("/rgl campoff")
         return
     end
 
-    if not Config:GetSetting('CampHard') then
+    if not Config:GetSetting('CampLeashDowntime') or not Combat.CombatSettled(1000) then
         if distanceToCamp < Config:GetSetting('AutoCampRadius') then return end
     end
 
@@ -1001,44 +1006,48 @@ function Combat.AutoCampCheck(tempConfig, bCalledFromInsideEvent)
     end
 end
 
---- Navigates back to camp during combat if ReturnToCamp is enabled and we are outside the camp radius.
+--- Navigates back to camp during combat if CampLeashCombat is enabled and we are outside the camp radius.
 ---@param tempConfig table Camp configuration containing AutoCampX/Y/Z and CampZoneId.
 function Combat.CombatCampCheck(tempConfig)
     if not Config:GetSetting('ReturnToCamp') then return end
+    if not Config:GetSetting('CampLeashCombat') then return end
 
     if mq.TLO.Me.Casting() and not Core.MyClassIs("brd") then return end
 
-    -- chasing a toon dont use camnp.
     if Config:GetSetting('ChaseOn') then return end
 
-    -- camped in a different zone.
     if tempConfig.CampZoneId ~= mq.TLO.Zone.ID() then return end
 
-    local me = mq.TLO.Me
+    -- let pulling module handle camp decisions while it is enabled.
+    if Config:GetSetting('DoPull') then
+        local pullState = Modules:ExecModule("Pull", "GetPullState")
 
-    local distanceToCampSq = Math.GetDistanceSquared(me.Y(), me.X(), tempConfig.AutoCampY, tempConfig.AutoCampX)
-
-    if not Config:GetSetting('CampHard') then
-        if distanceToCampSq < Config:GetSetting('AutoCampRadius') ^ 2 then return end
+        -- if we are idle or in groupwatch waiting its possible we wandered out of camp to loot and need to come back.
+        if pullState > 2 then
+            return
+        end
     end
 
-    if distanceToCampSq > 25 then
-        local navTo = string.format("locyxz %d %d %d", tempConfig.AutoCampY, tempConfig.AutoCampX, tempConfig.AutoCampZ)
-        if mq.TLO.Navigation.PathExists(navTo)() then
-            Movement:DoNav(false, "%s", navTo)
-            mq.delay("2s", function() return mq.TLO.Navigation.Active() and mq.TLO.Navigation.Velocity() > 0 end)
-            while mq.TLO.Navigation.Active() and mq.TLO.Navigation.Velocity() > 0 do
-                mq.delay(10)
-                mq.doevents()
-                Events.DoEvents()
-            end
-        else
-            Movement:MoveToLoc(tempConfig.AutoCampY, tempConfig.AutoCampX)
-            while mq.TLO.MoveTo.Moving() and not mq.TLO.MoveTo.Stopped() do
-                mq.delay(10)
-                mq.doevents()
-                Events.DoEvents()
-            end
+    local me = mq.TLO.Me
+    local distanceToCampSq = Math.GetDistanceSquared(me.Y(), me.X(), tempConfig.AutoCampY, tempConfig.AutoCampX)
+
+    if distanceToCampSq < Config:GetSetting('AutoCampRadius') ^ 2 then return end
+
+    local navTo = string.format("locyxz %d %d %d", tempConfig.AutoCampY, tempConfig.AutoCampX, tempConfig.AutoCampZ)
+    if mq.TLO.Navigation.PathExists(navTo)() then
+        Movement:DoNav(false, "%s", navTo)
+        mq.delay("2s", function() return mq.TLO.Navigation.Active() and mq.TLO.Navigation.Velocity() > 0 end)
+        while mq.TLO.Navigation.Active() and mq.TLO.Navigation.Velocity() > 0 do
+            mq.delay(10)
+            mq.doevents()
+            Events.DoEvents()
+        end
+    else
+        Movement:MoveToLoc(tempConfig.AutoCampY, tempConfig.AutoCampX)
+        while mq.TLO.MoveTo.Moving() and not mq.TLO.MoveTo.Stopped() do
+            mq.delay(10)
+            mq.doevents()
+            Events.DoEvents()
         end
     end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -822,12 +822,6 @@ Config.DefaultConfig                                     = {
         Default = 100,
         Min = 0,
         Max = 300,
-        Warning = function()
-            if Config:GetSetting('AssistRange') > Config:GetSetting('AutoCampRadius') then
-                return true, "Warning: AssistRange exceeds AutoCampRadius - this might cause your characters to run out of camp to assist."
-            end
-            return false, ""
-        end,
     },
     ['DoMelee']                    = {
         DisplayName = "Enable Melee Combat",

--- a/utils/event_handlers.lua
+++ b/utils/event_handlers.lua
@@ -528,7 +528,7 @@ end)
 -- [ SUMMONED HANDLERS ] --
 
 mq.event('Summoned', "You have been summoned!", function(_)
-    if Config:GetSetting('DoAutoEngage') and not Config:GetSetting('DoMelee') and not Core.IAmMA() and Config:GetSetting('ReturnToCamp') then
+    if Config:GetSetting('DoAutoEngage') and not Config:GetSetting('DoMelee') and not Core.IsTanking() and Config:GetSetting('ReturnToCamp') then
         Comms.PrintGroupMessage("%s was just summoned -- returning to camp!", Globals.CurLoadedChar)
         Modules:ExecModule("Movement", "DoAutoCampCheck", true)
     end

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -24,6 +24,7 @@ Globals.ForceCombatID                 = 0
 Globals.CombatNavTargetId             = 0
 Globals.LastPulledID                  = 0
 Globals.CurrentState                  = "None"
+Globals.LastCombatTime                = 0
 Globals.IgnoredTargetIDs              = Set.new({})
 Globals.CharmedPetIDs                 = Set.new({})
 Globals.LooseCharms                   = {}


### PR DESCRIPTION
* Removed "Camp Hard" setting.
* Added three new settings:
* Camp Leash (Downtime) - return to the exact camp location after each fight (Default: false).
* Camp Leash (Combat) - return to the exact camp location in combat if you leave the camp radius (Default: false).
* Camp Exceed Distance - turn camp off if your distance from the camp somehow exceeds this value (if not pulling) (Default: 400, which was the previous hardcoded value).

* Added a global settle time for returning to camp, hooked the loot checks up to that global time.

* Fixed lack of loadoutscan on run buff options for some classes.