### PR TITLE
Loadout Scan Changes

### DIFF
--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -600,7 +600,7 @@ local _ClassConfig = {
             },
         },
     },
-    ['Charm']         = {
+    ['Charm']             = {
         ['Assist'] = {
             { name = "LowLevelStun", type = "Spell", cond = function(self, spell, target) return Targeting.TargetNotStunned() end, },
             { name = "StunTimer6",   type = "Spell", cond = function(self, spell, target) return Targeting.TargetNotStunned() end, },
@@ -1067,6 +1067,7 @@ local _ClassConfig = {
             Default = 1,
             Min = 1,
             Max = 4,
+            RequiresLoadoutChange = true,
         },
         ['DoACBuff']          = {
             DisplayName = "Use AC Buff",

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -609,7 +609,7 @@ local _ClassConfig = {
             name = 'InstantRunBuff',
             state = 1,
             steps = 1,
-            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableGroupIDs() end,
+            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableIDs() end,
             load_cond = function(self) return Config:GetSetting('DoMoveBuffs') and Casting.CanUseAA("Communion of the Cheetah") end,
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and not mq.TLO.Me.Invis()
@@ -1018,7 +1018,8 @@ local _ClassConfig = {
                     local aaBuff = Casting.GetAASpell(aaName).Name() or ""
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others
-                    return (combatState == "Combat" and (mq.TLO.Me.Buff(aaBuff).Duration.TotalSeconds() or 0) < 15) or (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
+                    return (combatState == "Combat" and (mq.TLO.Me.Buff(aaBuff).Duration.TotalSeconds() or 0) < 15) or
+                        (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
                 end,
             },
         },

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -1540,6 +1540,7 @@ return {
             Default = 1,
             Min = 1,
             Max = 4,
+            RequiresLoadoutChange = true,
         },
         ['DoACBuff']          = {
             DisplayName = "Use AC Buff",

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -773,7 +773,7 @@ local _ClassConfig = {
             name = 'InstantRunBuff',
             state = 1,
             steps = 1,
-            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableGroupIDs() end,
+            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableIDs() end,
             load_cond = function(self) return Config:GetSetting('DoRunSpeed') and Casting.CanUseAA("Communion of the Cheetah") end,
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and not mq.TLO.Me.Invis()

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -565,7 +565,7 @@ local _ClassConfig = {
             name = 'InstantRunBuff',
             state = 1,
             steps = 1,
-            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableGroupIDs() end,
+            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableIDs() end,
             load_cond = function(self) return Config:GetSetting('DoMoveBuffs') and Casting.CanUseAA("Communion of the Cheetah") end,
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and not mq.TLO.Me.Invis()
@@ -973,7 +973,8 @@ local _ClassConfig = {
                     local aaBuff = Casting.GetAASpell(aaName).Name() or ""
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others
-                    return (combatState == "Combat" and (mq.TLO.Me.Buff(aaBuff).Duration.TotalSeconds() or 0) < 15) or (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
+                    return (combatState == "Combat" and (mq.TLO.Me.Buff(aaBuff).Duration.TotalSeconds() or 0) < 15) or
+                        (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
                 end,
             },
         },

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2797, }
+return { version = 2798, }

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -54,6 +54,8 @@ Module.TempSettings.ShowFailedSpells         = false
 Module.TempSettings.ResolvingActions         = true
 Module.TempSettings.CombatModeSet            = false
 Module.TempSettings.NewCombatMode            = false
+Module.TempSettings.ForceRepackGems          = false
+Module.TempSettings.LastFastPathTime         = 0
 Module.TempSettings.CombatModeChangeTime     = 0
 Module.TempSettings.MissingSpells            = {}
 Module.TempSettings.MissingSpellsHighestOnly = true
@@ -149,14 +151,13 @@ Module.CommandHandlers                       = {
                     return true
                 end
 
-                if not self:IsModeActive(newMode) then
-                    Config:SetSetting('Mode', newModeIdx)
-                    self:SetCombatMode(newMode)
+                if self:IsModeActive(newMode) then
+                    Logger.log_info("\awMode \am%s\aw is already active.", newMode)
                     return true
                 end
 
-                Logger.log_info("\awMode successfully set to: \am%s", newMode)
-
+                Config:SetSetting('Mode', newModeIdx)
+                Logger.log_info("\awMode change to \am%s\aw requested.", newMode)
                 return true
             end,
     },
@@ -167,6 +168,17 @@ Module.CommandHandlers                       = {
             self:RescanLoadout()
 
             Logger.log_info("\awManual loadout scan initiated.")
+
+            return true
+        end,
+    },
+    reordergems = {
+        usage = "/rgl reordergems",
+        about = "Repack your spell bar into priority order, ignoring current placement.",
+        handler = function(self)
+            self:ReorderGems()
+
+            Logger.log_info("\awGem reorder initiated.")
 
             return true
         end,
@@ -465,6 +477,11 @@ function Module:RescanLoadout()
     self.TempSettings.NewCombatMode = true
 end
 
+function Module:ReorderGems()
+    self.TempSettings.ForceRepackGems = true
+    self.TempSettings.NewCombatMode = true
+end
+
 function Module:SetCombatMode(mode)
     if not Tables.TableContains(self.ClassConfig.Modes, mode) then
         Logger.log_error("\ayInvalid Mode: \am%s", mode)
@@ -478,14 +495,14 @@ function Module:SetCombatMode(mode)
         self.TempSettings.ResolvingActions = false
 
         if self.ClassConfig.SpellList then
-            self.SpellLoadOut, self.LoadOutName = Rotation.SetSpellLoadOutByPriority(self, self.ClassConfig.SpellList)
+            local forceRepack = self.TempSettings.ForceRepackGems or not self.TempSettings.CombatModeSet
+            self.SpellLoadOut, self.LoadOutName = Rotation.SetSpellLoadOutByPriority(self, self.ClassConfig.SpellList, forceRepack)
+            self.TempSettings.ForceRepackGems = false
         else
             self.SpellLoadOut = Rotation.SetSpellLoadOutByGem(self, self.ClassConfig.Spells)
             self.LoadOutName = "Default"
         end
     end
-
-    Rotation.LoadSpellLoadOut(self.SpellLoadOut)
 
     if self.ClassConfig.OnModeChange then
         self.ClassConfig.OnModeChange(self, mode)
@@ -494,6 +511,81 @@ function Module:SetCombatMode(mode)
     self.TempSettings.MissingSpells = Rotation.FindAllMissingSpells(self.ClassConfig.AbilitySets, self.TempSettings.MissingSpellsHighestOnly)
 
     Modules:ExecAll("OnCombatModeChanged")
+end
+
+function Module:ComputedLoadoutMatchesCurrent()
+    if not self.ClassConfig or not self.ClassConfig.SpellList then return false end
+
+    local now = Globals.GetTimeMS()
+    if (now - self.TempSettings.LastFastPathTime) < 1000 then return false end
+    self.TempSettings.LastFastPathTime = now
+
+    local savedMap = self.ResolvedActionMap
+    self.ResolvedActionMap = Rotation.ResolveActions(self.ClassConfig.ItemSets, self.ClassConfig.AbilitySets, self.ClassConfig.AASets)
+
+    local forceRepack = self.TempSettings.ForceRepackGems
+    local candidate = Rotation.SetSpellLoadOutByPriority(self, self.ClassConfig.SpellList, forceRepack)
+
+    local me = mq.TLO.Me
+    for gem = 1, me.NumGems() do
+        local entry = candidate[gem]
+        local computedRank = entry and entry.spell and entry.spell.RankName() or nil
+        if computedRank ~= me.Gem(gem)() then
+            self.ResolvedActionMap = savedMap
+            return false
+        end
+    end
+    return true
+end
+
+function Module:ReconcileLoadout()
+    if not self.ClassConfig or not self.SpellLoadOut then return end
+    if self.TempSettings.ResolvingActions then return end
+    if Globals.CurrentState ~= "Downtime" then return end
+    if not Combat.CombatSettled(1000) then return end
+
+    local me = mq.TLO.Me
+    if me.Feigning() then return end
+
+    local numGems = me.NumGems()
+    for gem = 1, numGems do
+        local loadoutData = self.SpellLoadOut[gem]
+        if loadoutData then
+            local desiredRank = loadoutData.spell and loadoutData.spell.RankName() or nil
+            if desiredRank and me.Gem(gem)() ~= desiredRank then
+                Logger.log_debug("\ayReconcile:\ax gem \am%d\ax mismatch (have=\at%s\ax, want=\ag%s\ax)",
+                    gem, tostring(me.Gem(gem)()), desiredRank)
+                local _, permanent = Casting.MemorizeSpell(gem, desiredRank, false, 15000)
+                if permanent then
+                    Logger.log_warning("\ayReconcile:\ar %s no longer in book; skipping gem %d.", desiredRank, gem)
+                end
+            end
+        end
+    end
+end
+
+function Module:PromptRestoreSwapSlot()
+    if not self.ClassConfig or not self.SpellLoadOut then return end
+    if Targeting.GetXTHaterCount() > 0 then return end
+
+    local me = mq.TLO.Me
+    if me.Feigning() then return end
+
+    local swapGem = Casting.UseGem
+    for gem = 1, me.NumGems() do
+        if gem ~= swapGem then
+            local entry = self.SpellLoadOut[gem]
+            local rank = entry and entry.spell and entry.spell.RankName() or nil
+            if rank and me.Gem(gem)() ~= rank then return end
+        end
+    end
+
+    local desired = self.SpellLoadOut[swapGem]
+    local desiredRank = desired and desired.spell and desired.spell.RankName() or nil
+    if not desiredRank then return end
+    if me.Gem(swapGem)() == desiredRank then return end
+
+    Casting.MemorizeSpell(swapGem, desiredRank, false, 15000)
 end
 
 function Module:OnCombatModeChanged()
@@ -651,9 +743,17 @@ function Module:Render()
 
         if ImGui.CollapsingHeader(string.format("Spell Loadout (%s)", self.LoadOutName)) then
             ImGui.Indent()
-            if ImGui.SmallButton("Reload Spells") then
-                self:RescanLoadout()
-                Logger.log_info("\awManual loadout scan initiated.")
+            if self.ClassConfig.SpellList then
+                if ImGui.SmallButton("Reorder Gems") then
+                    self:ReorderGems()
+                    Logger.log_info("\awGem reorder initiated.")
+                end
+                Ui.Tooltip("Repack your spell bar into priority order.")
+            else
+                if ImGui.SmallButton("Reload Spells") then
+                    self:RescanLoadout()
+                    Logger.log_info("\awManual loadout scan initiated.")
+                end
             end
 
             if Tables.GetTableSize(self.SpellLoadOut) > 0 then
@@ -1722,25 +1822,31 @@ function Module:GiveTime()
         return
     end
 
-    -- Main Module logic goes here.
-    if (self.TempSettings.NewCombatMode and combat_state == "Downtime") or not self.TempSettings.CombatModeSet then
-        Logger.log_debug("New Combat Mode Requested: %s", self.ClassConfig.Modes[Config:GetSetting('Mode')])
+    if self.TempSettings.NewCombatMode or not self.TempSettings.CombatModeSet then
+        local canApply = (not self.TempSettings.CombatModeSet)
+            or (combat_state == "Downtime" and Combat.CombatSettled(1000))
+            or self:ComputedLoadoutMatchesCurrent()
 
-        self:SetCombatMode(self.ClassConfig.Modes[Config:GetSetting('Mode')])
-        self:GetRotations()
-        if self:IsCuring() then
-            if self.ClassConfig.Cures and self.ClassConfig.Cures.GetCureSpells then
-                Core.SafeCallFunc("GetCureSpells", self.ClassConfig.Cures.GetCureSpells, self)
+        if canApply then
+            Logger.log_debug("New Combat Mode Requested: %s", self.ClassConfig.Modes[Config:GetSetting('Mode')])
+
+            self:SetCombatMode(self.ClassConfig.Modes[Config:GetSetting('Mode')])
+            self:GetRotations()
+            if self:IsCuring() then
+                if self.ClassConfig.Cures and self.ClassConfig.Cures.GetCureSpells then
+                    Core.SafeCallFunc("GetCureSpells", self.ClassConfig.Cures.GetCureSpells, self)
+                end
             end
-        end
-        self:SetRotationActions()
-        self.TempSettings.NewCombatMode = false
-        self.TempSettings.CombatModeSet = true
-        self.TempSettings.CombatModeChangeTime = Globals.GetTimeSeconds()
+            self:SetRotationActions()
+            self.TempSettings.NewCombatMode = false
+            self.TempSettings.CombatModeSet = true
+            self.TempSettings.CombatModeChangeTime = Globals.GetTimeSeconds()
 
-        -- update our peers about our new state.
-        Config:BroadcastConfigs()
+            Config:BroadcastConfigs()
+        end
     end
+
+    self:ReconcileLoadout()
 
     if self.CombatState ~= combat_state and combat_state == "Downtime" then
         self:ResetRotation()

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1320,12 +1320,13 @@ end
 --- @param spell string The name of the spell to memorize.
 --- @param waitSpellReady boolean Whether to wait until the spell is ready to be memorized.
 --- @param maxWait number The maximum time to wait for the spell to be ready, in milliseconds.
---- @return boolean|nil
+--- @return boolean loaded True when the gem ended up showing the requested spell.
+--- @return boolean permanent True when the spell is no longer in the book (e.g. persona change) and a retry is pointless.
 function Casting.MemorizeSpell(gem, spell, waitSpellReady, maxWait)
     local me = mq.TLO.Me
     if me.CombatState():lower() == "combat" and Targeting.IHaveAggro(100) then
         Logger.log_warning("\atMemorizeSpell\aw():\ar %s was not memorized in slot %d due to aggro! The loadout may need manual rescan after combat.", spell, gem)
-        return false
+        return false, false
     end
     local aggressiveMem      = Config:GetSetting('AggressivelyMemorizeSpells')
     local aggressiveMemTimer = Config:GetSetting('AggressivelyMemorizeTimer') * 1000
@@ -1337,6 +1338,8 @@ function Casting.MemorizeSpell(gem, spell, waitSpellReady, maxWait)
 
     Casting.Memorizing = true
 
+    local interrupted = false
+    local permanent = false
     local startMem = Globals.GetTimeMS()
     while (me.Gem(gem)() ~= mq.TLO.Spell(spell).Name() or (waitSpellReady and not me.SpellReady(gem)())) and ((Globals.GetTimeMS() - startMem) < maxWait) do
         Logger.log_debug("\atMemorizeSpell\aw():\ay Waiting for '%s' to load in slot %d'...", spell, gem)
@@ -1345,10 +1348,12 @@ function Casting.MemorizeSpell(gem, spell, waitSpellReady, maxWait)
                 "\atMemorizeSpell\aw():\ay I was interrupted while waiting for spell '%s' to load in slot %d'! Aborting. CombatState(%s) Casting(%s) Moving(%s) Stick(%s) Nav(%s) MoveTo(%s))",
                 spell, gem, me.CombatState(), me.Casting() or "None", Strings.BoolToColorString(me.Moving()), Strings.BoolToColorString(mq.TLO.Stick.Active()),
                 Strings.BoolToColorString(mq.TLO.Navigation.Active()), Strings.BoolToColorString(mq.TLO.MoveTo.Moving()))
+            interrupted = true
             break
         end
         if not me.Book(spell)() then
             Logger.log_debug("\atMemorizeSpell\aw():\ar I was trying to memorize %s as my persona was changed, aborting.", spell)
+            permanent = true
             break
         end
 
@@ -1369,6 +1374,12 @@ function Casting.MemorizeSpell(gem, spell, waitSpellReady, maxWait)
         spell, gem, (Globals.GetTimeMS() - startMem) / 1000, maxWait / 1000)
 
     Casting.Memorizing = false
+
+    local loaded = me.Gem(gem)() == mq.TLO.Spell(spell).Name()
+    if not loaded and not interrupted and not permanent then
+        Logger.log_error("\atMemorizeSpell\aw():\ar Timed out memming '%s' in slot %d with no interrupt detected - the spell bar may be incomplete.", spell, gem)
+    end
+    return loaded, permanent
 end
 
 --- Returns true if the player owns the AA (not nil), meets the minimum level requirement (or is on the Might server), and has at least rank 1 purchased. All three gates must pass.

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -848,7 +848,7 @@ Config.DefaultConfig                                     = {
         Group = "Abilities",
         Header = "Common",
         Category = "Common Rules",
-        Index = 7,
+        Index = 6,
         Tooltip = "Don't use spells with a fire resist type (as long as they aren't flagged in the config to ignore this check).\n" ..
             "This is a top-level setting that can be freely toggled without changing spell loadout. Refer to the Named List FAQs for more details.",
         Default = false,
@@ -863,7 +863,7 @@ Config.DefaultConfig                                     = {
         Group = "Abilities",
         Header = "Common",
         Category = "Common Rules",
-        Index = 8,
+        Index = 7,
         Tooltip = "Don't use spells with a cold resist type (as long as they aren't flagged in the config to ignore this check).\n" ..
             "This is a top-level setting that can be freely toggled without changing spell loadout. Refer to the Named List FAQs for more details.",
         Default = false,
@@ -874,7 +874,7 @@ Config.DefaultConfig                                     = {
         Group = "Abilities",
         Header = "Common",
         Category = "Common Rules",
-        Index = 9,
+        Index = 8,
         Tooltip = "Don't use spells with a magic resist type (as long as they aren't flagged in the config to ignore this check).\n" ..
             "This is a top-level setting that can be freely toggled without changing spell loadout. Refer to the Named List FAQs for more details.",
         Default = false,
@@ -885,7 +885,7 @@ Config.DefaultConfig                                     = {
         Group = "Abilities",
         Header = "Common",
         Category = "Common Rules",
-        Index = 10,
+        Index = 9,
         Tooltip = "Don't use spells with a poison resist type (as long as they aren't flagged in the config to ignore this check).\n" ..
             "This is a top-level setting that can be freely toggled without changing spell loadout. Refer to the Named List FAQs for more details.",
         Default = false,
@@ -896,7 +896,7 @@ Config.DefaultConfig                                     = {
         Group = "Abilities",
         Header = "Common",
         Category = "Common Rules",
-        Index = 11,
+        Index = 10,
         Tooltip = "Don't use spells with a disease resist type (as long as they aren't flagged in the config to ignore this check).\n" ..
             "This is a top-level setting that can be freely toggled without changing spell loadout. Refer to the Named List FAQs for more details.",
         Default = false,
@@ -907,7 +907,7 @@ Config.DefaultConfig                                     = {
         Group = "Abilities",
         Header = "Common",
         Category = "Common Rules",
-        Index = 12,
+        Index = 11,
         Tooltip = "Use immunity data shipped with RGMercs (if available) to automatically determine whether to skip a spell.\n" ..
             "Refer to the Named List FAQs for more details.",
         Default = true,
@@ -1243,29 +1243,12 @@ Config.DefaultConfig                                     = {
         Max = 999,
         ConfigType = "Advanced",
     },
-    ['LastGemRemem']               = {
-        DisplayName = "Remem After Buff:",
-        Group = "Abilities",
-        Header = "Common",
-        Category = "Common Rules",
-        Index = 5,
-        Tooltip = "Choose what do with the last gem slot after we use it to buff:\n" ..
-            "Do Nothing: Use the slot as needed for buffs, but don't rememorize anything.\n" ..
-            "Remem Previous Spell: Rememorize the spell that was in the slot before buffing, if there was one.\n" ..
-            "Remem Loadout Spell: Rememorize the spell from the current loadout, if there is one.",
-        Default = 3,
-        Min = 1,
-        Max = #Globals.Constants.LastGemRemem,
-        Type = "Combo",
-        ComboOptions = Globals.Constants.LastGemRemem,
-        ConfigType = "Advanced",
-    },
     ['IgnoreLevelCheck']           = {
         DisplayName = "Ignore Spell Level Checks",
         Group = "Abilities",
         Header = "Common",
         Category = "Common Rules",
-        Index = 6,
+        Index = 5,
         Tooltip = "Ignore checks for minimum level on spells. Used on servers that allow heals, buffs and other spells to land on PCs regardless of level.",
         Default = Globals.ServerEnv:lower() ~= "live", -- more emu servers ignore level checks than not, and all the ones we support currently do. lesser of two evils.
         ConfigType = "Advanced",

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -268,7 +268,6 @@ for i, v in ipairs(Globals.Constants.ConColors) do Globals.Constants.ConColorsNa
 
 Globals.Constants.SpireChoices      = { "First", "Second", "Third", "Disabled", }
 
-Globals.Constants.LastGemRemem      = { "Do Nothing", "Mem Previous Spell", "Mem Loadout Spell", }
 Globals.Constants.DebuffChoice      = { "Never", "Based on Con Color", "Always", }
 
 Globals.Constants.ScanNamedPriority = { "Named", "No Preference", "Non-Named", }

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -8,7 +8,6 @@ local Globals    = require("utils.globals")
 local Logger     = require("utils.logger")
 local Modules    = require("utils.modules")
 local Strings    = require("utils.strings")
-local Targeting  = require("utils.targeting")
 
 local Rotation   = { _version = '1.0', _name = "Rotation", _author = 'Derple', }
 Rotation.__index = Rotation
@@ -303,7 +302,6 @@ end
 
 --- Iterates rotationTable from start_step, testing conditions and executing
 --- entries against targetTable until steps successful casts or end of table.
---- Restores the UseGem spell after combat if LastGemRemem is configured.
 ---@param caller any Class module instance passed to condition/exec functions.
 ---@param rotationTable table Array of rotation entries from the class config.
 ---@param targetTable table Array of spawn IDs to target for each entry.
@@ -317,11 +315,9 @@ end
 ---@return number nextStep The index to resume from on the next call.
 ---@return boolean anySuccess True if at least one entry executed successfully.
 function Rotation.Run(caller, rotationTable, targetTable, resolvedActionMap, steps, start_step, bAllowMem, bDoFullRotation, fnRotationCond, enabledRotationEntries)
-    local oldSpellInSlot = mq.TLO.Me.Gem(Casting.UseGem)
-    local loadoutSpell   = (Modules.ModuleList.Class.SpellLoadOut[Casting.UseGem] and Modules.ModuleList.Class.SpellLoadOut[Casting.UseGem].spell)
-    local stepsThisTime  = 0
-    local lastStepIdx    = 0
-    local anySuccess     = false
+    local stepsThisTime = 0
+    local lastStepIdx   = 0
+    local anySuccess    = false
 
     -- This is useful when class config wants to re-check every rotation condition every run
     -- For example, if gem1 meets all condition criteria, it WILL cast repeatedly on every cast
@@ -429,17 +425,8 @@ function Rotation.Run(caller, rotationTable, targetTable, resolvedActionMap, ste
         end
     end
 
-    if Targeting.GetXTHaterCount() == 0 then -- no magic numbers, just 4 u bb
-        if Globals.Constants.LastGemRemem[Config:GetSetting('LastGemRemem')] == "Mem Previous Spell" and oldSpellInSlot() and mq.TLO.Me.Gem(Casting.UseGem)() ~= oldSpellInSlot.Name() then
-            Logger.log_debug("\ayRestoring %s in slot %d", oldSpellInSlot, Casting.UseGem)
-            Casting.MemorizeSpell(Casting.UseGem, oldSpellInSlot.Name(), false, 15000)
-        elseif Globals.Constants.LastGemRemem[Config:GetSetting('LastGemRemem')] == "Mem Loadout Spell" and loadoutSpell and mq.TLO.Me.Gem(Casting.UseGem)() ~= loadoutSpell.RankName() then
-            Logger.log_debug("\ayRestoring %s in slot %d", loadoutSpell.RankName(), Casting.UseGem)
-            Casting.MemorizeSpell(Casting.UseGem, loadoutSpell.RankName(), false, 15000)
-        end
-    end
+    Modules:ExecModule("Class", "PromptRestoreSwapSlot")
 
-    -- Move to the next step
     lastStepIdx = lastStepIdx + 1
 
     if lastStepIdx > #rotationTable then
@@ -487,62 +474,111 @@ function Rotation.ResolveActions(itemSets, abilitySets, aaSets)
     return resolvedActionMap
 end
 
---- Evaluates each list in spellList in order, selects the first whose
---- condition passes, and assigns spells to gems by priority within that list.
+--- Builds a gem assignment from the first list in spellList whose cond passes, keeping long-refresh spells out of the swap slot and reusing already-memmed placements unless forceRepack is true.
 ---@param caller any Class module instance passed to list/spell conditions.
 ---@param spellList table Array of {name, cond, spells} list descriptors.
+---@param forceRepack boolean? Ignore current gem placement and pack in priority order; default is stable.
 ---@return table spellLoadOut Map of gem number → {selectedSpellData, spell}.
 ---@return string listName Name of the selected list, or an error string.
-function Rotation.SetSpellLoadOutByPriority(caller, spellList)
+function Rotation.SetSpellLoadOutByPriority(caller, spellList, forceRepack)
     local spellLoadOut = {}
-    local spellsToLoad = {}
     local listName = "Error: No Valid List Found!"
 
-    Casting.UseGem = mq.TLO.Me.NumGems()
+    local numGems = mq.TLO.Me.NumGems()
+    local swapGem = numGems
+    Casting.UseGem = swapGem
+
+    local desired = {}
+    local picked = {}
 
     for _, l in ipairs(spellList or {}) do
         if l ~= nil and (not l.cond or Core.SafeCallFunc(string.format("List Condition Check %s", l.name), l.cond, caller)) then
             Logger.log_debug("\ayList \am%s\ay will be loaded.", l.name)
             listName = l.name
-            for i = 1, mq.TLO.Me.NumGems() do
-                for _, s in ipairs(l.spells) do
-                    if s.name_func then
-                        s.name = Core.SafeCallFunc("Spell Name Func", s.name_func, caller) or
-                            "Error in name_func!"
-                    end
-                    local spellName = s.name
-                    Logger.log_debug("\aw  ==> Testing \at%s\aw for Gem \am%d", spellName, i)
-                    local bestSpell = Core.GetResolvedActionMapItem(spellName)
-                    if bestSpell then
-                        local bookSpell = mq.TLO.Me.Book(bestSpell.RankName())()
-                        local pass = Core.SafeCallFunc(
-                            string.format("Spell Condition Check: %s", bestSpell() or "None"), s.cond, caller, bestSpell)
-                        local loadedSpell = spellsToLoad[bestSpell.RankName()] or false
-
-                        if pass and bestSpell and bookSpell and not loadedSpell then
-                            Logger.log_debug("    ==> \ayGem \am%d\ay will load \at%s\ax ==> \ag%s", i, s
-                                .name, bestSpell.RankName())
-                            spellLoadOut[i] = { selectedSpellData = s, spell = bestSpell, }
-                            spellsToLoad[bestSpell.RankName()] = true
-                            i = i + 1
-                            break
-                        else
-                            Logger.log_debug(
-                                "    ==> \ayGem \am%d will \arNOT\ay load \at%s (pass=%s, bestSpell=%s, bookSpell=%d, loadedSpell=%s)",
-                                i, s.name,
-                                Strings.BoolToColorString(pass), bestSpell and bestSpell.RankName() or "", bookSpell or -1,
-                                Strings.BoolToColorString(loadedSpell))
-                        end
+            for _, s in ipairs(l.spells) do
+                if #desired >= numGems then break end
+                if s.name_func then
+                    s.name = Core.SafeCallFunc("Spell Name Func", s.name_func, caller) or
+                        "Error in name_func!"
+                end
+                local spellName = s.name
+                Logger.log_debug("\aw  ==> Testing \at%s", spellName)
+                local bestSpell = Core.GetResolvedActionMapItem(spellName)
+                if bestSpell then
+                    local rankName = bestSpell.RankName()
+                    local bookSpell = mq.TLO.Me.Book(rankName)()
+                    local pass = Core.SafeCallFunc(
+                        string.format("Spell Condition Check: %s", bestSpell() or "None"), s.cond, caller, bestSpell)
+                    if pass and bookSpell and not picked[rankName] then
+                        local recastMs = bestSpell.RecastTime() or 0
+                        local isLong = recastMs >= 30000
+                        table.insert(desired, { selectedSpellData = s, spell = bestSpell, rankName = rankName, isLong = isLong, })
+                        picked[rankName] = true
+                        Logger.log_debug("    ==> \aydesired[%d]\ay = \at%s\ax (recast \am%.1fs\ax, \ag%s\ax)", #desired, rankName, recastMs / 1000,
+                            isLong and "long" or "short")
                     else
                         Logger.log_debug(
-                            "    ==> \ayGem \am%d\ay will \arNOT\ay load \at%s\ax ==> \arNo Resolved Spell!", i,
-                            s.name)
+                            "    ==> \arSkip\ay \at%s\ay (pass=%s, bookSpell=%d, alreadyPicked=%s)",
+                            spellName, Strings.BoolToColorString(pass), bookSpell or -1,
+                            Strings.BoolToColorString(picked[rankName] or false))
                     end
+                else
+                    Logger.log_debug("    ==> \arNo Resolved Spell for \at%s", spellName)
                 end
             end
-            break --we only want the first valid spellset
+            break
         else
             Logger.log_debug("\ayList \am%s\ay will \arNOT\ay be loaded ==> \arCondition Check Failed!", l.name)
+        end
+    end
+
+    local swapOccupantIdx = nil
+    if #desired >= numGems then
+        for i = #desired, 1, -1 do
+            if not desired[i].isLong then
+                swapOccupantIdx = i
+                break
+            end
+        end
+        if not swapOccupantIdx then
+            swapOccupantIdx = #desired
+        end
+    end
+
+    if swapOccupantIdx then
+        local occ = desired[swapOccupantIdx]
+        spellLoadOut[swapGem] = { selectedSpellData = occ.selectedSpellData, spell = occ.spell, }
+        Logger.log_debug("\aySwap slot \am%d\ay = \at%s\ax (lowest-priority %s)", swapGem, occ.rankName,
+            occ.isLong and "long-refresh fallback" or "short-refresh")
+        table.remove(desired, swapOccupantIdx)
+    end
+
+    local nonSwapOpen = {}
+    for g = 1, numGems - 1 do nonSwapOpen[g] = true end
+
+    if not forceRepack then
+        for i = #desired, 1, -1 do
+            local d = desired[i]
+            for g = 1, numGems - 1 do
+                if nonSwapOpen[g] and mq.TLO.Me.Gem(g)() == d.rankName then
+                    spellLoadOut[g] = { selectedSpellData = d.selectedSpellData, spell = d.spell, }
+                    nonSwapOpen[g] = false
+                    table.remove(desired, i)
+                    Logger.log_debug("\ay  Stable: \at%s\ay kept in gem \am%d", d.rankName, g)
+                    break
+                end
+            end
+        end
+    end
+
+    for _, d in ipairs(desired) do
+        for g = 1, numGems - 1 do
+            if nonSwapOpen[g] then
+                spellLoadOut[g] = { selectedSpellData = d.selectedSpellData, spell = d.spell, }
+                nonSwapOpen[g] = false
+                Logger.log_debug("\ay  Fill: gem \am%d\ay = \at%s", g, d.rankName)
+                break
+            end
         end
     end
 
@@ -622,21 +658,6 @@ function Rotation.SetSpellLoadOutByGem(caller, spellGemList)
     end
 
     return spellLoadOut
-end
-
---- Memorizes each spell in spellLoadOut into its assigned gem slot if the
---- slot doesn't already hold the correct spell.
----@param spellLoadOut table Map of gem number → {selectedSpellData, spell}.
-function Rotation.LoadSpellLoadOut(spellLoadOut)
-    local selectedRank = ""
-
-    for gem, loadoutData in pairs(spellLoadOut) do
-        selectedRank = loadoutData.spell.RankName()
-        Logger.log_debug("Loading \ay%s\ax into gem \ag%d\ax", selectedRank, gem)
-        if mq.TLO.Me.Gem(gem)() ~= selectedRank then
-            Casting.MemorizeSpell(gem, selectedRank, false, 15000)
-        end
-    end
 end
 
 --- Appends entries for spells in spellList that are not in the spellbook


### PR DESCRIPTION
* Loadouts not involving gem swaps will be instantly applied during combat; any gem swap loadout change will not occur until the next downtime.
* Spell Loadout is now "smart" and refresh-time ( >30s) aware.  We will avoid excessive gem swaps on settings change whenever possible.
* * Reordering of gems occurs on script start, or when directed by a button in the loadout UI or the /rgl reordergems command.
* Spell Loadouts self-heal during downtime in the event of an interruption.
* Removed the Last Gem Remem option.