### PR TITLE
Buff Check, Clicky Module Updates

### DIFF
--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -411,14 +411,46 @@ local _ClassConfig    = {
             { name = "CharmSpell", type = "Spell", },
         },
         ['PreCharm']  = {
-            { name = "TashRod",   type = "Item",  load_cond = function(self) return self.Helpers.PreferTashItem(self) end,     cond = function(self, itemName, target) return not target.Tashed() end, },
-            { name = "TashSpell", type = "Spell", load_cond = function(self) return not self.Helpers.PreferTashItem(self) end, cond = function(self, spell, target) return not target.Tashed() end, },
+            {
+                name = "TashRod",
+                type = "Item",
+                load_cond = function(self) return self.Helpers.PreferTashItem(self) end,
+                cond = function(self, itemName, target)
+                    return not
+                        target.Tashed()
+                end,
+            },
+            {
+                name = "TashSpell",
+                type = "Spell",
+                load_cond = function(self) return not self.Helpers.PreferTashItem(self) end,
+                cond = function(self, spell, target)
+                    return not target
+                        .Tashed()
+                end,
+            },
         },
         ['Assist']    = {
             { name = "SpinStunSpell", type = "Spell", cond = function(self, spell, target) return Targeting.TargetNotStunned() end, },
             { name = "PBAEStunSpell", type = "Spell", cond = function(self, spell, target) return Targeting.TargetNotStunned() and Targeting.InSpellRange(spell, target) end, },
-            { name = "TashRod",       type = "Item",  load_cond = function(self) return self.Helpers.PreferTashItem(self) end,     cond = function(self, itemName, target) return Casting.DetItemCheck(itemName, target) end, },
-            { name = "TashSpell",     type = "Spell", load_cond = function(self) return not self.Helpers.PreferTashItem(self) end, cond = function(self, spell, target) return Casting.DetSpellCheck(spell, target) end, },
+            {
+                name = "TashRod",
+                type = "Item",
+                load_cond = function(self) return self.Helpers.PreferTashItem(self) end,
+                cond = function(
+                    self, itemName, target)
+                    return Casting.DetItemCheck(itemName, target)
+                end,
+            },
+            {
+                name = "TashSpell",
+                type = "Spell",
+                load_cond = function(self) return not self.Helpers.PreferTashItem(self) end,
+                cond = function(
+                    self, spell, target)
+                    return Casting.DetSpellCheck(spell, target)
+                end,
+            },
         },
     },
     ['RotationOrder'] = {
@@ -816,7 +848,8 @@ local _ClassConfig    = {
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     if not Targeting.TargetIsATank(target) then return false end
-                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.CastReady(spell) and
+                        Casting.GroupBuffCheck(spell, target, false, true) -- skip trigger checks, we are not worried about spells with a seperate illusion trigger
                 end,
             },
             {
@@ -826,7 +859,8 @@ local _ClassConfig    = {
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     if Config:GetSetting('DoTankIllusionBuff') and Targeting.TargetIsATank(target) and Core.GetResolvedActionMapItem('TankIllusionBuff') then return false end
-                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
+                    return Casting.CastReady(spell) and
+                        Casting.GroupBuffCheck(spell, target, false, true) -- skip trigger checks, we are not worried about spells with a seperate illusion trigger
                 end,
             },
             {

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -10,8 +10,6 @@ local Logger       = require("utils.logger")
 local Targeting    = require("utils.targeting")
 local Ui           = require("utils.ui")
 
-local Colors       = Globals.Constants.Colors
-
 --todo: add a LOT of tooltips or scrap them entirely. Hopefully the former.
 local Tooltips     = {
     Mantle              = "Spell Line: Melee Absorb Proc",
@@ -586,10 +584,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('ProcChoice') == 1 end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    local tt = Core.NewTooltip()
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return selfBuffCheck
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -599,10 +594,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('ProcChoice') == 2 end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    local tt = Core.NewTooltip()
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return selfBuffCheck
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -611,12 +603,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.CloakHP,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    local tt = Core.NewTooltip()
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return selfBuffCheck
+                    return Casting.SelfBuffCheck(spell)
                 end,
-
             },
             {
                 name = "SelfDS",
@@ -624,10 +612,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.SelfDS,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    local tt = Core.NewTooltip()
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return selfBuffCheck
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -637,10 +622,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting("DoCallBuff") end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    local tt = Core.NewTooltip()
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return selfBuffCheck
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             --You'll notice my use of TotalSeconds, this is to keep as close to 100% uptime as possible on these buffs, rebuffing early to decrease the chance of them falling off in combat
@@ -652,16 +634,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Skin,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    if not spell() then
-                        Core.SetRotationEntryTooltip({ { text = "Spell data not found.", color = Colors.LightRed, }, })
-                        return false
-                    end
-                    local tt = Core.NewTooltip()
-                    local stacksCheck = spell.RankName.Stacks()
-                    local durationCheck = (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 60
-                    tt:Add("Stacks", stacksCheck)
-                    tt:Add("Duration < 60", durationCheck)
-                    return stacksCheck and durationCheck
+                    return spell.RankName.Stacks() and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 60
                 end,
             },
             {
@@ -671,10 +644,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Casting.CanUseAA("Voice of Thule") and Config:GetSetting('DoHateBuff') end,
                 active_cond = function(self, aaName) return Casting.IHaveBuff(mq.TLO.Me.AltAbility(aaName).Spell.ID()) end,
                 cond = function(self, aaName)
-                    local tt = Core.NewTooltip()
-                    local aaCheck, reason = Casting.SelfBuffAACheck(aaName)
-                    tt:Add("Self Buff Check", aaCheck, reason)
-                    return aaCheck
+                    return Casting.SelfBuffAACheck(aaName)
                 end,
             },
             {
@@ -684,26 +654,16 @@ local _ClassConfig = {
                 load_cond = function(self) return not Casting.CanUseAA("Voice of Thule") and Config:GetSetting('DoHateBuff') end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    local tt = Core.NewTooltip()
-                    local castReady = tt:Add("Cast Ready", Casting.CastReady(spell))
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return castReady and selfBuffCheck
+                    if not Casting.CastReady(spell) then return false end
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
                 name = "Emergency Visage Cancel",
                 desc = "Removes VoD at Critical HP",
                 type = "CustomFunc",
-                load_cond = function(self) return Casting.CanUseAA("Visage of Death") end,
-                cond = function(self)
-                    local hpCritical = Config:GetSetting('HPCritical')
-                    local hasVoD = mq.TLO.Me.Buff("Visage of Death")() ~= nil
-                    local tt = Core.NewTooltip()
-                    tt:Add("HP Critical", hpCritical)
-                    tt:Add("Has VoD", hasVoD)
-                    return hpCritical and hasVoD
-                end,
+                load_cond = function(self) Casting.CanUseAA("Visage of Death") end,
+                cond = function(self) return Config:GetSetting('HPCritical') and mq.TLO.Me.Buff("Visage of Death")() end,
                 custom_func = function(self)
                     Core.DoCmd("/removebuff \"Visage of Death\"")
                 end,
@@ -733,10 +693,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PetHaste,
                 active_cond = function(self, spell) return mq.TLO.Me.PetBuff(spell.RankName())() ~= nil end,
                 cond = function(self, spell)
-                    local petBuffCheck, reason = Casting.PetBuffCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Pet Buff Check", petBuffCheck, reason)
-                    return petBuffCheck
+                    return Casting.PetBuffCheck(spell)
                 end,
             },
             {
@@ -744,20 +701,14 @@ local _ClassConfig = {
                 type = "AA",
                 active_cond = function(self, aaName) return mq.TLO.Me.PetBuff(aaName)() ~= nil end,
                 cond = function(self, aaName)
-                    local petBuffAACheck, reason = Casting.PetBuffAACheck(aaName)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Pet Buff AA Check", petBuffAACheck, reason)
-                    return petBuffAACheck
+                    return Casting.PetBuffAACheck(aaName)
                 end,
             },
             {
                 name = "Minionskin",
                 type = "Spell",
                 cond = function(self, spell)
-                    local petBuffCheck, reason = Casting.PetBuffCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Pet Buff Check", petBuffCheck, reason)
-                    return petBuffCheck
+                    return Casting.PetBuffCheck(spell)
                 end,
             },
 
@@ -781,11 +732,7 @@ local _ClassConfig = {
                     end
                 end,
                 cond = function(self, discSpell)
-                    local noDiscActive = Casting.NoDiscActive()
-                    local discActive = not noDiscActive
-                    local tt = Core.NewTooltip()
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    return noDiscActive
+                    return Casting.NoDiscActive()
                 end,
             },
             {
@@ -793,11 +740,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.LeechCurse,
                 cond = function(self)
-                    local noDiscActive = Casting.NoDiscActive()
-                    local discActive = not noDiscActive
-                    local tt = Core.NewTooltip()
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    return noDiscActive
+                    return Casting.NoDiscActive()
                 end,
             },
             {
@@ -805,11 +748,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.UnholyAura,
                 cond = function(self, discSpell, target)
-                    local noDiscActive = Casting.NoDiscActive()
-                    local discActive = not noDiscActive
-                    local tt = Core.NewTooltip()
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    return noDiscActive
+                    return Casting.NoDiscActive()
                 end,
             },
             {
@@ -817,14 +756,7 @@ local _ClassConfig = {
                 desc = "Removes VoD at Critical HP",
                 type = "CustomFunc",
                 load_cond = function(self) Casting.CanUseAA("Visage of Death") end,
-                cond = function(self)
-                    local hpCritical = Config:GetSetting('HPCritical')
-                    local hasVoD = mq.TLO.Me.Buff("Visage of Death")() ~= nil
-                    local tt = Core.NewTooltip()
-                    tt:Add("HP Critical", hpCritical)
-                    tt:Add("Has VoD", hasVoD)
-                    return hpCritical and hasVoD
-                end,
+                cond = function(self) return Config:GetSetting('HPCritical') and mq.TLO.Me.Buff("Visage of Death")() end,
                 custom_func = function(self)
                     Core.DoCmd("/removebuff \"Visage of Death\"")
                 end,
@@ -836,10 +768,7 @@ local _ClassConfig = {
                 type = "Ability",
                 tooltip = Tooltips.Taunt,
                 cond = function(self, abilityName, target)
-                    local lostAggro = Targeting.LostAutoTargetAggro()
-                    local tt = Core.NewTooltip()
-                    tt:Add("Lost Auto Target Aggro", lostAggro)
-                    return lostAggro
+                    return Targeting.LostAutoTargetAggro()
                 end,
             },
             {
@@ -853,11 +782,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return Config:GetSetting('DoTerror') end,
                 cond = function(self, spell, target)
-                    local secondaryAggro = mq.TLO.Target.SecondaryPctAggro() or 0
-                    local aggroCheck = secondaryAggro > 60
-                    local tt = Core.NewTooltip()
-                    tt:Add("Secondary Aggro% > 60", aggroCheck, "(" .. secondaryAggro .. "%)")
-                    return aggroCheck
+                    return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
@@ -866,11 +791,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return Config:GetSetting('DoTerror') end,
                 cond = function(self, spell, target)
-                    local secondaryAggro = mq.TLO.Target.SecondaryPctAggro() or 0
-                    local aggroCheck = secondaryAggro > 60
-                    local tt = Core.NewTooltip()
-                    tt:Add("Secondary Aggro% > 60", aggroCheck, "(" .. secondaryAggro .. "%)")
-                    return aggroCheck
+                    return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
             {
@@ -879,11 +800,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return Config:GetSetting('DoTerror') end,
                 cond = function(self, spell, target)
-                    local secondaryAggro = mq.TLO.Target.SecondaryPctAggro() or 0
-                    local aggroCheck = secondaryAggro > 80
-                    local tt = Core.NewTooltip()
-                    tt:Add("Secondary Aggro% > 80", aggroCheck, "(" .. secondaryAggro .. "%)")
-                    return aggroCheck
+                    return (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
                 end,
             },
         },
@@ -908,10 +825,7 @@ local _ClassConfig = {
                 type = "Disc",
                 load_cond = function(self) return Config:GetSetting('BladeDiscUse') > 1 end,
                 cond = function(self, discSpell)
-                    local doAEDamage = Config:GetSetting('DoAEDamage')
-                    local tt = Core.NewTooltip()
-                    tt:Add("Do AE Damage", doAEDamage)
-                    return doAEDamage
+                    return Config:GetSetting('DoAEDamage')
                 end,
             },
             {
@@ -919,12 +833,7 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.AETaunt,
                 cond = function(self, spell, target)
-                    local pctHPs = mq.TLO.Me.PctHPs() or 0
-                    local emergencyStart = Config:GetSetting('EmergencyStart')
-                    local hpCheck = pctHPs > emergencyStart
-                    local tt = Core.NewTooltip()
-                    tt:Add("HP% > Emergency Start", hpCheck, "(" .. pctHPs .. "% > " .. emergencyStart .. "%)")
-                    return hpCheck
+                    return mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyStart')
                 end,
             },
         },
@@ -968,10 +877,7 @@ local _ClassConfig = {
                 name = "Visage of Death",
                 type = "AA",
                 cond = function(self, aaName)
-                    local doVisage = Config:GetSetting('DoVisage')
-                    local tt = Core.NewTooltip()
-                    tt:Add("Do Visage", doVisage)
-                    return doVisage
+                    return Config:GetSetting('DoVisage')
                 end,
             },
             { -- for DPS mode
@@ -980,10 +886,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.UnholyAura,
                 load_cond = function(self) return not Core.IsTanking() end,
                 cond = function(self)
-                    local discActive = not Casting.NoDiscActive()
-                    local tt = Core.NewTooltip()
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    return not discActive
+                    return Casting.NoDiscActive()
                 end,
             },
             { -- for DPS mode
@@ -991,10 +894,7 @@ local _ClassConfig = {
                 type = "Disc",
                 load_cond = function(self) return not Core.IsTanking() end,
                 cond = function(self)
-                    local discActive = not Casting.NoDiscActive()
-                    local tt = Core.NewTooltip()
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    return not discActive
+                    return Casting.NoDiscActive()
                 end,
             },
             {
@@ -1007,10 +907,7 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
-                    local doLeechTouch = Config:GetSetting('DoLeechTouch') ~= 1
-                    local tt = Core.NewTooltip()
-                    tt:Add("Do Leech Touch", doLeechTouch)
-                    return doLeechTouch
+                    return Config:GetSetting('DoLeechTouch') ~= 1
                 end,
             },
             {
@@ -1018,15 +915,8 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.Skin,
                 cond = function(self, spell, target)
-                    local isTanking = Core.IsTanking()
-                    local isNamed = Globals.AutoTargetIsNamed
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Is Tanking", isTanking)
-                    tt:Add("Is Named", isNamed)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    if not isTanking or not isNamed then return false end
-                    return selfBuffCheck
+                    if not Core.IsTanking() or not Globals.AutoTargetIsNamed then return false end
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
         },
@@ -1037,14 +927,7 @@ local _ClassConfig = {
                 type = "AA",
                 load_cond = function(self) return Casting.CanUseAA("Encroaching Darkness") end,
                 cond = function(self, aaName, target)
-                    local detAACheck, reason = Casting.DetAACheck(aaName)
-                    local lowHP = Targeting.MobHasLowHP(target)
-                    local snareImmune = Casting.SnareImmuneTarget(target)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Det AA Check", detAACheck, reason)
-                    tt:Add("Low HP", lowHP)
-                    tt:Add("Snare Immune", snareImmune, nil, true)
-                    return detAACheck and lowHP and not snareImmune
+                    return Casting.DetAACheck(aaName) and Targeting.MobHasLowHP(target) and not Casting.SnareImmuneTarget(target)
                 end,
             },
             {
@@ -1053,14 +936,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.SnareDot,
                 load_cond = function(self) return not Casting.CanUseAA("Encroaching Darkness") end,
                 cond = function(self, spell, target)
-                    local detSpellCheck, reason = Casting.DetSpellCheck(spell)
-                    local lowHP = Targeting.MobHasLowHP(target)
-                    local snareImmune = Casting.SnareImmuneTarget(target)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Det Spell Check", detSpellCheck, reason)
-                    tt:Add("Low HP", lowHP)
-                    tt:Add("Snare Immune", snareImmune, nil, true)
-                    return detSpellCheck and lowHP and not snareImmune
+                    return Casting.DetSpellCheck(spell) and Targeting.MobHasLowHP(target) and not Casting.SnareImmuneTarget(target)
                 end,
             },
         },
@@ -1070,10 +946,7 @@ local _ClassConfig = {
                 type = "Disc",
                 load_cond = function(self) return Core.IsTanking() end,
                 cond = function(self, discSpell, target)
-                    local discActive = not Casting.NoDiscActive()
-                    local tt = Core.NewTooltip()
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    return not discActive
+                    return Casting.NoDiscActive()
                 end,
             },
             {
@@ -1082,12 +955,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Mantle,
                 load_cond = function(self) return Core.IsTanking() end,
                 cond = function(self, discSpell, target)
-                    local discActive = not Casting.NoDiscActive()
-                    local protectiveOnCD = Casting.DiscOnCoolDown('Protective')
-                    local tt = Core.NewTooltip()
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    tt:Add("Protective On CD", protectiveOnCD)
-                    return not discActive and protectiveOnCD
+                    return Casting.NoDiscActive() and Casting.DiscOnCoolDown('Protective')
                 end,
             },
             {
@@ -1095,17 +963,8 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName, target)
-                    local holdForNoDisc = Config:GetSetting('HoldEpicForNoDisc')
-                    local discActive = not Casting.NoDiscActive()
-                    local leechCheck = self.Helpers.LeechCheck(self)
-                    local isNamed = Globals.AutoTargetIsNamed
-                    local tt = Core.NewTooltip()
-                    tt:Add("Hold For No Disc", holdForNoDisc)
-                    tt:Add("Another Disc Active", discActive, nil, true)
-                    tt:Add("Leech Check", leechCheck)
-                    tt:Add("Is Named", isNamed)
-                    if holdForNoDisc and discActive then return false end
-                    return leechCheck or isNamed
+                    if Config:GetSetting('HoldEpicForNoDisc') and not Casting.NoDiscActive() then return false end
+                    return self.Helpers.LeechCheck(self) or Globals.AutoTargetIsNamed
                 end,
             },
         },
@@ -1116,14 +975,8 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
-                    local doLeechTouch = Config:GetSetting('DoLeechTouch') ~= 2
-                    local pctHPs = mq.TLO.Me.PctHPs() or 0
-                    local hpCritical = Config:GetSetting('HPCritical')
-                    local hpCheck = pctHPs <= hpCritical
-                    local tt = Core.NewTooltip()
-                    tt:Add("Do Leech Touch", doLeechTouch)
-                    tt:Add("HP% <= Critical", hpCheck, "(" .. pctHPs .. "% <= " .. hpCritical .. "%)")
-                    return doLeechTouch and hpCheck
+                    if Config:GetSetting('DoLeechTouch') == 2 then return false end
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
                 end,
             },
             {
@@ -1131,17 +984,8 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.LifeTap,
                 cond = function(self, spell)
-                    local pctHPs = mq.TLO.Me.PctHPs() or 0
-                    local haveMana = Casting.HaveManaToNuke()
-                    local startLifeTap = Config:GetSetting('StartLifeTap')
-                    local emergencyStart = Config:GetSetting('EmergencyStart')
-                    local manaAndHP = haveMana and pctHPs <= startLifeTap
-                    local emergency = pctHPs <= emergencyStart
-                    local tt = Core.NewTooltip()
-                    tt:Add("Have Mana", haveMana)
-                    tt:Add("HP% <= Start", pctHPs <= startLifeTap, "(" .. pctHPs .. "% <= " .. startLifeTap .. "%)")
-                    tt:Add("Emergency", emergency, "(" .. pctHPs .. "% <= " .. emergencyStart .. "%)")
-                    return manaAndHP or emergency
+                    local myHP = mq.TLO.Me.PctHPs()
+                    return Casting.HaveManaToNuke() and myHP <= Config:GetSetting('StartLifeTap') or myHP <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {
@@ -1149,17 +993,8 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.LifeTap,
                 cond = function(self, spell)
-                    local pctHPs = mq.TLO.Me.PctHPs() or 0
-                    local haveMana = Casting.HaveManaToNuke()
-                    local startLifeTap = Config:GetSetting('StartLifeTap')
-                    local emergencyStart = Config:GetSetting('EmergencyStart')
-                    local manaAndHP = haveMana and pctHPs <= startLifeTap
-                    local emergency = pctHPs <= emergencyStart
-                    local tt = Core.NewTooltip()
-                    tt:Add("Have Mana", haveMana)
-                    tt:Add("HP% <= Start", pctHPs <= startLifeTap, "(" .. pctHPs .. "% <= " .. startLifeTap .. "%)")
-                    tt:Add("Emergency", emergency, "(" .. pctHPs .. "% <= " .. emergencyStart .. "%)")
-                    return manaAndHP or emergency
+                    local myHP = mq.TLO.Me.PctHPs()
+                    return Casting.HaveManaToNuke() and myHP <= Config:GetSetting('StartLifeTap') or myHP <= Config:GetSetting('EmergencyStart')
                 end,
             },
             {
@@ -1167,17 +1002,8 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.LifeTap,
                 cond = function(self, spell)
-                    local pctHPs = mq.TLO.Me.PctHPs() or 0
-                    local haveMana = Casting.HaveManaToNuke()
-                    local startLifeTap = Config:GetSetting('StartLifeTap')
-                    local emergencyStart = Config:GetSetting('EmergencyStart')
-                    local manaAndHP = haveMana and pctHPs <= startLifeTap
-                    local emergency = pctHPs <= emergencyStart
-                    local tt = Core.NewTooltip()
-                    tt:Add("Have Mana", haveMana)
-                    tt:Add("HP% <= Start", pctHPs <= startLifeTap, "(" .. pctHPs .. "% <= " .. startLifeTap .. "%)")
-                    tt:Add("Emergency", emergency, "(" .. pctHPs .. "% <= " .. emergencyStart .. "%)")
-                    return manaAndHP or emergency
+                    local myHP = mq.TLO.Me.PctHPs()
+                    return Casting.HaveManaToNuke() and myHP <= Config:GetSetting('StartLifeTap') or myHP <= Config:GetSetting('EmergencyStart')
                 end,
             },
         },
@@ -1188,10 +1014,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ForPower,
                 load_cond = function(self) return Core.IsTanking() end,
                 cond = function(self, spell, target)
-                    local detSpellCheck, reason = Casting.DetSpellCheck(spell, target)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Det Spell Check", detSpellCheck, reason)
-                    return detSpellCheck
+                    return Casting.DetSpellCheck(spell, target)
                 end,
             },
             {
@@ -1199,10 +1022,7 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.SpearNuke,
                 cond = function(self, spell, target)
-                    local haveMana = Casting.HaveManaToNuke()
-                    local tt = Core.NewTooltip()
-                    tt:Add("Have Mana To Nuke", haveMana)
-                    return haveMana
+                    return Casting.HaveManaToNuke()
                 end,
             },
             {
@@ -1210,14 +1030,7 @@ local _ClassConfig = {
                 type = "Disc",
                 load_cond = function(self) return Config:GetSetting('BladeDiscUse') == 3 and Core.GetResolvedActionMapItem('BladeDisc') end,
                 cond = function(self, discSpell)
-                    local doAEDamage = Config:GetSetting('DoAEDamage')
-                    local pctEndurance = mq.TLO.Me.PctEndurance() or 0
-                    local manaToNuke = Config:GetSetting("ManaToNuke")
-                    local enduranceCheck = pctEndurance >= manaToNuke
-                    local tt = Core.NewTooltip()
-                    tt:Add("Do AE Damage", doAEDamage)
-                    tt:Add("Endurance% >= ManaToNuke", enduranceCheck, "(" .. pctEndurance .. "% >= " .. manaToNuke .. "%)")
-                    return doAEDamage and enduranceCheck
+                    return Config:GetSetting('DoAEDamage') and mq.TLO.Me.PctEndurance() >= Config:GetSetting("ManaToNuke") -- save endurance for emergency discs
                 end,
             },
             {
@@ -1226,17 +1039,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.BondTap,
                 load_cond = function(self) return Config:GetSetting('DoBondTap') end,
                 cond = function(self, spell, target)
-                    local dotNamedOnly = Config:GetSetting('DotNamedOnly')
-                    local isNamed = Globals.AutoTargetIsNamed
-                    local haveManaToDot = Casting.HaveManaToDot()
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Named Only", dotNamedOnly)
-                    tt:Add("Is Named", isNamed)
-                    tt:Add("Have Mana To Dot", haveManaToDot)
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    if dotNamedOnly and not isNamed then return false end
-                    return haveManaToDot and selfBuffCheck
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
+                    return Casting.HaveManaToDot() and Casting.SelfBuffCheck(spell) -- use for recourse --Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1245,17 +1049,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.PoisonDot,
                 load_cond = function(self) return Config:GetSetting('DoPoisonDot') end,
                 cond = function(self, spell, target)
-                    local dotNamedOnly = Config:GetSetting('DotNamedOnly')
-                    local isNamed = Globals.AutoTargetIsNamed
-                    local haveManaToDot = Casting.HaveManaToDot()
-                    local dotSpellCheck, reason = Casting.DotSpellCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Named Only", dotNamedOnly)
-                    tt:Add("Is Named", isNamed)
-                    tt:Add("Have Mana To Dot", haveManaToDot)
-                    tt:Add("Dot Spell Check", dotSpellCheck, reason)
-                    if dotNamedOnly and not isNamed then return false end
-                    return haveManaToDot and dotSpellCheck
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
+                    return Casting.HaveManaToDot() and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1264,17 +1059,8 @@ local _ClassConfig = {
                 tooltip = Tooltips.DireDot,
                 load_cond = function(self) return Config:GetSetting('DoDireDot') end,
                 cond = function(self, spell, target)
-                    local dotNamedOnly = Config:GetSetting('DotNamedOnly')
-                    local isNamed = Globals.AutoTargetIsNamed
-                    local haveManaToDot = Casting.HaveManaToDot()
-                    local dotSpellCheck, reason = Casting.DotSpellCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Named Only", dotNamedOnly)
-                    tt:Add("Is Named", isNamed)
-                    tt:Add("Have Mana To Dot", haveManaToDot)
-                    tt:Add("Dot Spell Check", dotSpellCheck, reason)
-                    if dotNamedOnly and not isNamed then return false end
-                    return haveManaToDot and dotSpellCheck
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
+                    return Casting.HaveManaToDot() and Casting.DotSpellCheck(spell)
                 end,
             },
             {
@@ -1291,12 +1077,7 @@ local _ClassConfig = {
                 name = "Companion's Blessing",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    local petPctHPs = mq.TLO.Me.Pet.PctHPs() or 999
-                    local bigHealPoint = Config:GetSetting('BigHealPoint')
-                    local hpCheck = petPctHPs <= bigHealPoint
-                    local tt = Core.NewTooltip()
-                    tt:Add("Pet HP% <= Big Heal", hpCheck, "(" .. petPctHPs .. "% <= " .. bigHealPoint .. "%)")
-                    return hpCheck
+                    return (mq.TLO.Me.Pet.PctHPs() or 999) <= Config:GetSetting('BigHealPoint')
                 end,
             },
             {
@@ -1305,10 +1086,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAC,
                 load_cond = function(self) return Config:GetSetting('DoACTap') end,
                 cond = function(self, spell, target)
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return selfBuffCheck
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1317,10 +1095,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.PowerTapAtk,
                 load_cond = function(self) return Config:GetSetting('DoAtkTap') end,
                 cond = function(self, spell, target)
-                    local selfBuffCheck, reason = Casting.SelfBuffCheck(spell)
-                    local tt = Core.NewTooltip()
-                    tt:Add("Self Buff Check", selfBuffCheck, reason)
-                    return selfBuffCheck
+                    return Casting.SelfBuffCheck(spell)
                 end,
             },
             {
@@ -1328,12 +1103,7 @@ local _ClassConfig = {
                 type = "Ability",
                 tooltip = Tooltips.Bash,
                 cond = function(self)
-                    local shieldEquipped = Core.ShieldEquipped()
-                    local canTwoHandBash = Casting.CanUseAA("2 Hand Bash")
-                    local tt = Core.NewTooltip()
-                    tt:Add("Shield Equipped", shieldEquipped)
-                    tt:Add("2H Bash AA", canTwoHandBash)
-                    return shieldEquipped or canTwoHandBash
+                    return (Core.ShieldEquipped() or Casting.CanUseAA("2 Hand Bash"))
                 end,
             },
             {
@@ -1348,18 +1118,8 @@ local _ClassConfig = {
                 name = "Equip Shield",
                 type = "CustomFunc",
                 cond = function(self, target)
-                    local shieldActive = mq.TLO.Me.Bandolier("Shield").Active()
-                    local pctHPs = mq.TLO.Me.PctHPs() or 0
-                    local equipShield = Config:GetSetting('EquipShield')
-                    local hpCheck = pctHPs <= equipShield
-                    local isNamed = Globals.AutoTargetIsNamed
-                    local namedShieldLock = Config:GetSetting('NamedShieldLock')
-                    local tt = Core.NewTooltip()
-                    tt:Add("Shield Already Active", shieldActive, nil, true)
-                    tt:Add("HP% <= Equip Shield", hpCheck, "(" .. pctHPs .. "% <= " .. equipShield .. "%)")
-                    tt:Add("Named Shield Lock", isNamed and namedShieldLock)
-                    if shieldActive then return false end
-                    return hpCheck or (isNamed and namedShieldLock)
+                    if mq.TLO.Me.Bandolier("Shield").Active() then return false end
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EquipShield')) or (Globals.AutoTargetIsNamed and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("Shield") end,
             },
@@ -1367,21 +1127,9 @@ local _ClassConfig = {
                 name = "Equip 2Hand",
                 type = "CustomFunc",
                 cond = function()
-                    local twoHandActive = mq.TLO.Me.Bandolier("2Hand").Active()
-                    local pctHPs = mq.TLO.Me.PctHPs() or 0
-                    local equip2Hand = Config:GetSetting('Equip2Hand')
-                    local hpCheck = pctHPs >= equip2Hand
-                    local activeDisc = mq.TLO.Me.ActiveDisc() or ""
-                    local noDeflection = activeDisc ~= "Deflection Discipline"
-                    local isNamed = Globals.AutoTargetIsNamed
-                    local namedShieldLock = Config:GetSetting('NamedShieldLock')
-                    local tt = Core.NewTooltip()
-                    tt:Add("2Hand Already Active", twoHandActive, nil, true)
-                    tt:Add("HP% >= Equip 2Hand", hpCheck, "(" .. pctHPs .. "% >= " .. equip2Hand .. "%)")
-                    tt:Add("No Deflection Disc", noDeflection)
-                    tt:Add("Named Shield Lock", isNamed and namedShieldLock, nil, true)
-                    if twoHandActive then return false end
-                    return hpCheck and noDeflection and not (isNamed and namedShieldLock)
+                    if mq.TLO.Me.Bandolier("2Hand").Active() then return false end
+                    return mq.TLO.Me.PctHPs() >= Config:GetSetting('Equip2Hand') and mq.TLO.Me.ActiveDisc() ~= "Deflection Discipline" and
+                        not (Globals.AutoTargetIsNamed and Config:GetSetting('NamedShieldLock'))
                 end,
                 custom_func = function(self) return ItemManager.BandolierSwap("2Hand") end,
             },

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2804, }
+return { version = 2805, }

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -450,29 +450,6 @@ function Module:GetResolvedActionMapItem(item)
     return self.ResolvedActionMap[item]
 end
 
-function Module:SetRotationEntryTooltip(tooltipLines)
-    if not self.TempSettings.CurrentRotationStateId or not self.TempSettings.CurrentRotationEntryId then return end
-
-    Logger.log_verbose("SetRotationEntryTooltip(): Setting Rotation(%d) Entry(%d) Tooltip: %s", self.TempSettings.CurrentRotationStateId, self.TempSettings.CurrentRotationEntryId,
-        Tables.TableToString(tooltipLines))
-
-    -- get the rotation and entry
-    local rotation = self.TempSettings.CurrentRotationStateType == 1 and self.TempSettings.RotationStates[self.TempSettings.CurrentRotationStateId] or
-        self.TempSettings.HealRotationStates[self.TempSettings.CurrentRotationStateId]
-    if not rotation then return end
-
-    Logger.log_verbose("SetRotationEntryTooltip(): Found Rotation for Tooltip: %s", rotation.name)
-
-    local rotationEntries = self.TempSettings.CurrentRotationStateType == 1 and self:GetRotationTable(rotation.name) or self:GetHealRotationTable(rotation.name)
-
-    local entry = rotationEntries and rotationEntries[self.TempSettings.CurrentRotationEntryId]
-    if not entry then return end
-
-    Logger.log_verbose("SetRotationEntryTooltip(): Found Entry for Tooltip: %s", entry.name)
-
-    entry.cond_tooltip = tooltipLines
-end
-
 function Module:RescanLoadout()
     self.TempSettings.NewCombatMode = true
 end

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -217,15 +217,15 @@ Module.DefaultServerClickies                  = {
 Module.DefaultServerClickies['Project Might'] = Module.DefaultServerClickies['EQ Might']
 
 Module.DefaultConfig                          = {
-    ['MaxClickiesPerFrame']                    = {
-        DisplayName = "Max Clickies Per Frame",
+    ['MaxClickiesPerCycle']                    = {
+        DisplayName = "Max Clickies Per Cycle",
         Group = "Items",
         Header = "Clickies",
         Category = "User Clickies",
         Index = 1,
         Tooltip =
-        "The max number of clickies that can successfully be used per frame/processing cycle before we move on, 0 for no limit.\nThis setting may help prevent delays in other processing if a high number of clickies are used.",
-        Default = 0,
+        "The max number of clickies that can successfully be used per processing cycle before we move on, 0 for no limit.\nClickies attached to rotations are exempt from this limit.\nThis setting may help prevent delays in other processing if a high number of clickies are used.",
+        Default = 1,
         Min = 0,
         Max = 99,
         ConfigType = "Advanced",
@@ -248,8 +248,8 @@ Module.DefaultConfig                          = {
     },
 }
 
-Module.CombatTargetTypes                      = { 'Self', 'Pet', 'Main Assist', 'Auto Target', 'Mercs Peer', 'Rotation Target', }
-Module.NonCombatTargetTypes                   = { 'Self', 'Pet', 'Main Assist', 'Mercs Peer', 'Rotation Target', }
+Module.CombatTargetTypes                      = { 'Self', 'Pet', 'Main Assist', 'Auto Target', 'Mercs Peer', 'All Buffable', }
+Module.NonCombatTargetTypes                   = { 'Self', 'Pet', 'Main Assist', 'Mercs Peer', 'All Buffable', }
 Module.RotationTargetTypes                    = { 'Rotation Target', }
 Module.MercPeerTargetTypes                    = { 'Mercs Peer', }
 Module.CombatStates                           = { 'Downtime', 'Combat', 'Any', 'During Rotation', 'During Heal Rotation', }
@@ -519,6 +519,21 @@ Module.LogicBlocks                            = {
             { name = "Disease",    type = "boolean", default = true, },
             { name = "Curse",      type = "boolean", default = true, },
             { name = "Corruption", type = "boolean", default = true, },
+        },
+    },
+
+    {
+        name = "Free Aura Check",
+        cond = function(self, target, peerData, auraName)
+            if not auraName or auraName == "" then return false end
+            return not Casting.AuraActiveByName(auraName) and Casting.HasFreeAuraSlot()
+        end,
+        tooltip = "Only use when this aura isn't up and you have a free aura slot.",
+        render_header_text = function(self, cond)
+            return string.format("Aura '%s' is missing and a free aura slot is available", cond.args[1] or "None")
+        end,
+        args = {
+            { name = "Aura", type = "string", default = "", },
         },
     },
 
@@ -1183,6 +1198,10 @@ function Module:LoadSettings()
                 clicky.no_target_change = false
                 settingsChanged = true
             end
+            if clicky.skipTriggerCheck == nil then
+                clicky.skipTriggerCheck = false
+                settingsChanged = true
+            end
             settingsChanged = self:ValidateClickyRotationSettings(clicky) or settingsChanged
         end
 
@@ -1370,7 +1389,7 @@ function Module:RenderConditionTargetCombo(cond, condIdx, combatState)
         end
         ImGui.EndTable()
         Ui.Tooltip(
-            "Target Types\nSelf - This PC\nPet - This PC's pet\nMain Assist - The current RGMercs Main Assist\nAuto Target - The current RGMercs Combat Auto Target\nMercs Peer - A character running RGMercs on the same network\nRotation Target - The target passed in by the active rotation")
+            "Target Types\nSelf - This PC\nPet - This PC's pet\nMain Assist - The current RGMercs Main Assist\nAuto Target - The current RGMercs Combat Auto Target\nMercs Peer - A character running RGMercs on the same network\nAll Buffable - Checks all buffable targets in your Actor Buff Scope and uses the first one that needs the buff\nRotation Target - The target passed in by the active rotation")
     end
 
     if cond.target == "Mercs Peer" then
@@ -1417,6 +1436,14 @@ function Module:RenderClickyTargetCombo(clicky, clickyIdx)
                 defaultTarget = "Self"
             end
 
+            -- DEPRECATION FALLBACK BEGIN (added 6/26, remove this entire block after 9/26)
+            -- 'Rotation Target' used to be selectable for any combat state; reset stale stored values so the dropdown doesn't desync.
+            if not targetTypeIDs[clicky.target or ""] then
+                clicky.target = defaultTarget
+                Config:SetSetting('Clickies', Config:GetSetting('Clickies'))
+            end
+            -- DEPRECATION FALLBACK END
+
             local selectedNum, changed = ImGui.Combo("##clicky_cond_target_" .. "_" .. clickyIdx, tonumber(targetTypeIDs[clicky.target or defaultTarget]) or 1,
                 targetTypes, #targetTypes)
             if changed then
@@ -1426,7 +1453,7 @@ function Module:RenderClickyTargetCombo(clicky, clickyIdx)
         end
         ImGui.EndTable()
         Ui.Tooltip(
-            "Target Types\nSelf - This PC\nPet - This PC's pet\nMain Assist - The current RGMercs Main Assist\nAuto Target - The current RGMercs Combat Auto Target\nMercs Peer - A character running RGMercs on the same network\nRotation Target - The target passed in by the active rotation")
+            "Target Types\nSelf - This PC\nPet - This PC's pet\nMain Assist - The current RGMercs Main Assist\nAuto Target - The current RGMercs Combat Auto Target\nMercs Peer - A character running RGMercs on the same network\nAll Buffable - Checks all buffable targets in your Actor Buff Scope and uses the first one that needs the buff\nRotation Target - The target passed in by the active rotation")
     end
 
     if clicky.target == "Mercs Peer" then
@@ -1446,29 +1473,48 @@ function Module:RenderClickyTargetCombo(clicky, clickyIdx)
     end
 end
 
-function Module:RenderClickyNoTargetChangeToggle(clicky, clickyIdx)
+function Module:RenderClickyToggles(clicky, clickyIdx)
     local isRotationTarget = clicky.target == "Rotation Target"
-    if ImGui.BeginTable("##clicky_target_no_change_table_" .. clickyIdx, 2, bit32.bor(ImGuiTableFlags.None)) then
-        ImGui.TableSetupColumn("Key", ImGuiTableColumnFlags.WidthFixed, 140)
-        ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch, 0)
+    if ImGui.BeginTable("##clicky_toggles_table_" .. clickyIdx, 4, bit32.bor(ImGuiTableFlags.None)) then
+        ImGui.TableSetupColumn("Key1", ImGuiTableColumnFlags.WidthFixed, 140)
+        ImGui.TableSetupColumn("Value1", ImGuiTableColumnFlags.WidthFixed, 40)
+        ImGui.TableSetupColumn("Key2", ImGuiTableColumnFlags.WidthFixed, 140)
+        ImGui.TableSetupColumn("Value2", ImGuiTableColumnFlags.WidthStretch, 0)
+
         ImGui.TableNextColumn()
+        ImGui.AlignTextToFramePadding()
         Ui.RenderText("Don't Change Target")
         ImGui.TableNextColumn()
+        ImGui.BeginGroup()
         ImGui.BeginDisabled(isRotationTarget)
-        local new_no_target_change, clicked = Ui.RenderOptionToggle("##clicky_no_target_change_" .. clickyIdx, "",
+        local newNoTargetChange, ntcClicked = Ui.RenderOptionToggle("##clicky_no_target_change_" .. clickyIdx, "",
             clicky.no_target_change)
         ImGui.EndDisabled()
-
+        ImGui.EndGroup()
         if isRotationTarget and clicky.no_target_change then
             clicky.no_target_change = false
             Config:SetSetting('Clickies', Config:GetSetting('Clickies'))
         end
-
-        if not isRotationTarget and clicked then
-            clicky.no_target_change = new_no_target_change
+        if not isRotationTarget and ntcClicked then
+            clicky.no_target_change = newNoTargetChange
             Config:SetSetting('Clickies', Config:GetSetting('Clickies'))
         end
         Ui.Tooltip("If enabled, we will not change targets to use this clicky.")
+
+        ImGui.TableNextColumn()
+        ImGui.AlignTextToFramePadding()
+        Ui.RenderText("Skip Trigger Checks")
+        ImGui.TableNextColumn()
+        ImGui.BeginGroup()
+        local newSkipTriggerCheck, skipClicked = Ui.RenderOptionToggle("##clicky_skip_trigger_check_" .. clickyIdx, "",
+            clicky.skipTriggerCheck or false)
+        ImGui.EndGroup()
+        if skipClicked then
+            clicky.skipTriggerCheck = newSkipTriggerCheck
+            Config:SetSetting('Clickies', Config:GetSetting('Clickies'))
+        end
+        Ui.Tooltip("Only check the clicky buff for stacking, ignoring any secondary spell effects triggered by the clicky spell.")
+
         ImGui.EndTable()
     end
 end
@@ -1478,7 +1524,7 @@ function Module:RenderClickyCombatStateCombo(clicky, clickyIdx)
         ImGui.TableSetupColumn("Key", ImGuiTableColumnFlags.WidthFixed, 140)
         ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch, 0)
         ImGui.TableNextColumn()
-        Ui.RenderText("Combat State")
+        Ui.RenderText("Usage")
         ImGui.TableNextColumn()
         local selectedNum, changed = ImGui.Combo("##clicky_cond_combat_state_" .. "_" .. clickyIdx, tonumber(self.CombatStateIDs[clicky.combat_state or "Any"]) or 1,
             self.CombatStates,
@@ -1711,10 +1757,7 @@ function Module:RenderClickiesWithConditions(type, clickies)
     end
     Ui.Tooltip("Add server-specific default clickies to the end of the list.")
 
-    ImGui.SameLine()
-    Ui.RenderText(Icons.MD_INFO_OUTLINE .. " Special Note on Clickies " .. Icons.MD_INFO_OUTLINE)
-    Ui.Tooltip(
-        "All clickies have inherent presence and stacking checks built in; that is to say, we will only use a clicky if we detect that the effect is absent (and would stack) on its intended target.\n\nAdding conditions to check for the clicky's effect is generally not required or performant, be it buff, debuff or otherwise.")
+    Ui.RenderText("For best performance, assign clickies to rotations whenever feasible.")
 
     ImGui.Separator()
     if #clickies > 0 then
@@ -1765,7 +1808,7 @@ function Module:RenderClickiesWithConditions(type, clickies)
 
                     self:RenderClickyCombatStateCombo(clicky, clickyIdx)
                     self:RenderClickyTargetCombo(clicky, clickyIdx)
-                    self:RenderClickyNoTargetChangeToggle(clicky, clickyIdx)
+                    self:RenderClickyToggles(clicky, clickyIdx)
 
                     ImGui.SeparatorText("Usage Info")
                     self:RenderClickyData(clicky, clickyIdx)
@@ -1971,9 +2014,9 @@ function Module:GiveTime()
     -- Main Module logic goes here.
     self:ValidateClickies()
 
-    local maxClickiesPerFrame = Config:GetSetting('MaxClickiesPerFrame') or 0
-    local clickiesUsedThisFrame = 0
-    local startingClickyIdx = maxClickiesPerFrame > 0 and self.ClickyRotationIndex or 1
+    local maxClickiesPerCycle = Config:GetSetting('MaxClickiesPerCycle') or 0
+    local clickiesUsedThisCycle = 0
+    local startingClickyIdx = maxClickiesPerCycle > 0 and self.ClickyRotationIndex or 1
     local clickies = Config:GetSetting('Clickies') or {}
     local numClickies = #clickies
     local moving = mq.TLO.Me.Moving() or mq.TLO.Navigation.Active() or mq.TLO.MoveTo.Moving()
@@ -2032,13 +2075,13 @@ function Module:GiveTime()
 
                             if clicky.target == "Self" then
                                 target = mq.TLO.Me
-                                buffCheckPassed = Casting.SelfBuffItemCheck(clicky.itemName)
+                                buffCheckPassed = Casting.SelfBuffItemCheck(clicky.itemName, nil, clicky.skipTriggerCheck)
                             elseif clicky.target == "Pet" then
                                 target = mq.TLO.Me.Pet
-                                buffCheckPassed = target and Casting.PetBuffItemCheck(clicky.itemName)
+                                buffCheckPassed = target and Casting.PetBuffItemCheck(clicky.itemName, nil, clicky.skipTriggerCheck)
                             elseif clicky.target == "Main Assist" then
                                 target = Core.GetMainAssistSpawn()
-                                buffCheckPassed = target and Casting.GroupBuffItemCheck(clicky.itemName, target)
+                                buffCheckPassed = target and Casting.GroupBuffItemCheck(clicky.itemName, target, nil, clicky.skipTriggerCheck)
                             elseif clicky.target == "Auto Target" then
                                 target = Targeting.GetAutoTarget()
                                 buffCheckPassed = target and Casting.DetItemCheck(clicky.itemName, target)
@@ -2051,10 +2094,21 @@ function Module:GiveTime()
                                     Strings.BoolToColorString(peerFound))
                                 if peerFound then
                                     target = mq.TLO.Spawn(targetPeer.Data.ID)
-                                    buffCheckPassed = target and Casting.ActorBuffCheck(item.Clicky.Spell.RankName.ID(), target)
+                                    buffCheckPassed = target and Casting.ActorBuffCheck(item.Clicky.Spell.RankName.ID(), target, nil, clicky.skipTriggerCheck)
                                 else
                                     buffCheckPassed = false
                                 end
+                            elseif clicky.target == "All Buffable" then
+                                local buffableIds = Casting.GetBuffableIDs()
+                                for _, peerId in ipairs(buffableIds) do
+                                    local candidate = mq.TLO.Spawn(peerId)
+                                    if candidate() and Casting.GroupBuffItemCheck(clicky.itemName, candidate, nil, clicky.skipTriggerCheck) then
+                                        target = candidate
+                                        buffCheckPassed = true
+                                        break
+                                    end
+                                end
+                                if not target then buffCheckPassed = false end
                             end
 
                             if not clicky.no_target_change then
@@ -2084,10 +2138,10 @@ function Module:GiveTime()
                             if buffCheckPassed and distanceCheckPassed and readyCheckPassed and elementCheckPassed then
                                 Logger.log_verbose("\ayClicky: \awItem \am%s\aw Clicky Spell: \at%s\ag!", item.Name(), item.Clicky.Spell.RankName.Name())
                                 Casting.UseItem(item.Name(), targetId)
-                                clickiesUsedThisFrame = clickiesUsedThisFrame + 1
-                                if maxClickiesPerFrame > 0 and clickiesUsedThisFrame >= maxClickiesPerFrame then
-                                    Logger.log_debug("\ayClicky: \a-tMax Clickies Per Frame of \am%d\a-t reached, stopping for this frame and picking up with %d next frame.",
-                                        maxClickiesPerFrame, self.ClickyRotationIndex)
+                                clickiesUsedThisCycle = clickiesUsedThisCycle + 1
+                                if maxClickiesPerCycle > 0 and clickiesUsedThisCycle >= maxClickiesPerCycle then
+                                    Logger.log_debug("\ayClicky: \a-tMax Clickies Per Cycle of \am%d\a-t reached, stopping for this cycle and picking up with %d next cycle.",
+                                        maxClickiesPerCycle, self.ClickyRotationIndex)
                                     break
                                 end
                                 self.TempSettings.ClickyState[clicky.itemName].lastUsed = Globals.GetTimeSeconds()
@@ -2145,13 +2199,13 @@ function Module:GetClickiesForRotations(clickyCombatState, rotationName)
                     local buffCheckPassed = true
 
                     if targetSpawn.ID() == mq.TLO.Me.ID() then
-                        buffCheckPassed = Casting.SelfBuffItemCheck(clicky.itemName)
+                        buffCheckPassed = Casting.SelfBuffItemCheck(clicky.itemName, nil, clicky.skipTriggerCheck)
                     elseif targetSpawn.ID() == mq.TLO.Me.Pet.ID() then
                         ---@diagnostic disable-next-line: cast-local-type
-                        buffCheckPassed = mq.TLO.Me.Pet.ID() > 0 and Casting.PetBuffItemCheck(clicky.itemName)
+                        buffCheckPassed = mq.TLO.Me.Pet.ID() > 0 and Casting.PetBuffItemCheck(clicky.itemName, nil, clicky.skipTriggerCheck)
                     elseif targetSpawn.Type() == "PC" then
                         ---@diagnostic disable-next-line: cast-local-type
-                        buffCheckPassed = Casting.GroupBuffItemCheck(clicky.itemName, targetSpawn)
+                        buffCheckPassed = Casting.GroupBuffItemCheck(clicky.itemName, targetSpawn, nil, clicky.skipTriggerCheck)
                     else ---@diagnostic disable-next-line: cast-local-type
                         buffCheckPassed = Casting.DetItemCheck(clicky.itemName, targetSpawn)
                     end

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -75,203 +75,212 @@ function Casting.TargetHasBuff(effect, target, bAllowTargetChange)
     return mq.TLO.Target.Buff(spell)() ~= nil
 end
 
+-- Buff Check Family: Local, LocalPet, Peer, Actor, ActorPet.
+-- By default, if the buff's triggers are still up we won't recast it, even after the parent spell has expired. This stops Unity-style spells (short duration parent buff we don't care about) from recasting every 6 seconds.
+-- Set skipTriggerCheck to ignore triggers and recast whenever the parent spell itself is missing -- needed for spells like ENC illusion buffs with an illusion trigger we don't care about. Can also be used if we know we don't need triggers.
+
 --- Complex buff check that will check for presence and stacking of the buff (and any triggers) on the PC or the PC's pet.
 --- @param spellId integer The ID of the spell to check.
 --- @param skipBlockCheck boolean|nil whether to check the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
---- @return boolean, string True if the PC checking should cast the buff, false otherwise.
+--- @return boolean True if the PC checking should cast the buff, false otherwise.
 function Casting.LocalBuffCheck(spellId, skipBlockCheck, skipTriggerCheck)
-    if not spellId then return false, "No Spell Id" end
+    if not spellId then return false end
 
     local buffSpell = mq.TLO.Spell(spellId)
-    if not buffSpell or not buffSpell() then return false, "Invalid Spell" end
+    if not buffSpell or not buffSpell() then return false end
     local spellName = buffSpell.Name()
+    if not spellName then return false end
 
-    if not skipBlockCheck then
-        if mq.TLO.Me.BlockedBuff(spellName)() == spellName then
-            Logger.log_verbose("LocalBuffCheck: %s(ID:%d) is on the blocked spell list, aborting check.", spellName, spellId)
-            return false, "Blocked Spell"
-        end
+    local spellBlocked = not skipBlockCheck and mq.TLO.Me.BlockedBuff(spellName)() == spellName
+    if spellBlocked then
+        Logger.log_verbose("LocalBuffCheck: %s(ID:%d) is blocked, counting as present.", spellName, spellId)
     end
 
-    if mq.TLO.Me.FindBuff("id " .. spellId)() then
-        Logger.log_verbose("LocalBuffCheck: %s(ID:%d) found, ending check.", spellName, spellId)
-        return false, "Buff Already Present"
-    end
+    local spellPresent = spellBlocked or mq.TLO.Me.FindBuff("id " .. spellId)() ~= nil
 
-    if not buffSpell.Stacks() then
+    if not spellPresent and not buffSpell.Stacks() then
         Logger.log_verbose("LocalBuffCheck: %s(ID:%d) does not stack, ending check.", spellName, spellId)
-        return false, "Does Not Stack"
+        return false
     end
 
-    -- Check triggers
-    if not skipTriggerCheck then
-        Logger.log_verbose("LocalBuffCheck: %s(ID:%d) not found, let's check for triggers.", spellName, spellId)
-        local numEffects = buffSpell.NumEffects()
-        local triggerCount = 0
-        local triggerFound = 0
-        for i = 1, numEffects do
-            local triggerSpell = buffSpell.Trigger(i)
-            --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
-            if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
-                Logger.log_verbose("LocalBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
-                break
-            end
-
-            local triggerName = triggerSpell.Name()
-            local triggerId = triggerSpell.ID()
-            triggerCount = triggerCount + 1
-
-            if mq.TLO.Me.FindBuff("id " .. triggerId)() then
-                Logger.log_verbose("LocalBuffCheck: Trigger %s(ID:%d) found, moving on.", triggerName, triggerId)
-                triggerFound = triggerFound + 1
-            elseif triggerSpell.Stacks() then
-                Logger.log_verbose("LocalBuffCheck: Trigger %s(ID:%d) seems to stack, let's do it!", triggerName, triggerId)
-                return true, ""
-            else
-                Logger.log_verbose("LocalBuffCheck: Trigger %s(ID:%d) does not stack, moving on.", triggerName, triggerId)
-                triggerFound = triggerFound + 1
-            end
+    if skipTriggerCheck then
+        if spellPresent then
+            Logger.log_verbose("LocalBuffCheck: %s(ID:%d) present, trigger check skipped.", spellName, spellId)
+            return false
         end
+        Logger.log_verbose("LocalBuffCheck: %s(ID:%d) missing and stacks, trigger check skipped, let's do it!", spellName, spellId)
+        return true
+    end
 
-        if triggerCount > 0 and triggerFound >= triggerCount then
-            Logger.log_verbose("LocalBuffCheck: Total triggers for %s(ID:%d): %d. Triggers found: %d. Ending Check.", spellName, spellId, triggerCount, triggerFound)
-            return false, "Triggers Present & Don't Stack"
+    Logger.log_verbose("LocalBuffCheck: %s(ID:%d) checking for triggers.", spellName, spellId)
+    local numEffects = buffSpell.NumEffects()
+    local hasTriggers = false
+    for i = 1, numEffects do
+        local triggerSpell = buffSpell.Trigger(i)
+        --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
+        if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
+            Logger.log_verbose("LocalBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
+            break
+        end
+        hasTriggers = true
+
+        local triggerName = triggerSpell.Name()
+        local triggerId = triggerSpell.ID()
+
+        if not skipBlockCheck and mq.TLO.Me.BlockedBuff(triggerName)() == triggerName then
+            Logger.log_verbose("LocalBuffCheck: Trigger %s(ID:%d) is blocked, counting as present.", triggerName, triggerId)
+        elseif mq.TLO.Me.FindBuff("id " .. triggerId)() then
+            Logger.log_verbose("LocalBuffCheck: Trigger %s(ID:%d) found, moving on.", triggerName, triggerId)
+        elseif triggerSpell.Stacks() then
+            Logger.log_verbose("LocalBuffCheck: Trigger %s(ID:%d) missing and stacks, let's do it!", triggerName, triggerId)
+            return true
+        else
+            Logger.log_verbose("LocalBuffCheck: Trigger %s(ID:%d) does not stack, moving on.", triggerName, triggerId)
         end
     end
 
-    Logger.log_verbose("LocalBuffCheck: %s(ID:%d) seems to stack, let's do it!", spellName, spellId)
-    return true, ""
+    if not hasTriggers and not spellPresent then
+        Logger.log_verbose("LocalBuffCheck: %s(ID:%d) missing and stacks with no triggers, let's do it!", spellName, spellId)
+        return true
+    end
+
+    Logger.log_verbose("LocalBuffCheck: %s(ID:%d) handled, no need to cast.", spellName, spellId)
+    return false
 end
 
 --- Delegates to LocalBuffCheck after resolving the spell rank via
 --- GetUseableSpellId. Checks blocked list, buff/song window presence,
 --- and stacking including trigger spells.
 ---@param spell MQSpell The spell to check.
----@return boolean, string True if the spell should be cast on self.
+---@return boolean True if the spell should be cast on self.
 function Casting.SelfBuffCheck(spell)
-    if not (spell and spell()) then return false, "Invalid Spell" end
+    if not (spell and spell()) then return false end
     return Casting.LocalBuffCheck(Casting.GetUseableSpellId(spell))
 end
 
 --- Gates on CanUseAA, then delegates to LocalBuffCheck using the AA's
 --- spell ID to confirm not blocked, not present, and stacks.
 ---@param aaName string The AA name to check.
----@return boolean, string True if the AA buff should be cast on self.
+---@return boolean True if the AA buff should be cast on self.
 function Casting.SelfBuffAACheck(aaName)
-    if not Casting.CanUseAA(aaName) then return false, "Cannot Use AA" end
+    if not Casting.CanUseAA(aaName) then return false end
     return Casting.LocalBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell.ID())
 end
 
 --- Gets the clicky spell via GetClickySpell, then delegates to
 --- LocalBuffCheck to confirm not blocked, not present, and stacks.
 ---@param itemName string The item name whose clicky to check.
----@return boolean, string True if the item's clicky buff should be applied to self.
-function Casting.SelfBuffItemCheck(itemName)
+---@param skipBlockCheck boolean|nil whether to skip the blocked-spell check
+---@param skipTriggerCheck boolean|nil whether to skip the trigger check
+---@return boolean True if the item's clicky buff should be applied to self.
+function Casting.SelfBuffItemCheck(itemName, skipBlockCheck, skipTriggerCheck)
     local clickySpell = Casting.GetClickySpell(itemName)
-    if not (clickySpell and clickySpell()) then return false, "Invalid Clicky Spell" end
-    return Casting.LocalBuffCheck(clickySpell.ID())
+    if not (clickySpell and clickySpell()) then return false end
+    return Casting.LocalBuffCheck(clickySpell.ID(), skipBlockCheck, skipTriggerCheck)
 end
 
 --- Complex buff check that will check for presence and stacking of the buff (and any triggers) on the PC or the PC's pet.
 --- @param spellId integer The ID of the spell to check.
 --- @param skipBlockCheck boolean|nil whether to check the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
---- @return boolean, string True if the PC checking should cast the buff, false otherwise.
+--- @return boolean True if the PC checking should cast the buff, false otherwise.
 function Casting.LocalPetBuffCheck(spellId, skipBlockCheck, skipTriggerCheck)
-    if not spellId then return false, "No Spell Id" end
-    if mq.TLO.Me.Pet.ID() == 0 then return false, "No Pet" end
+    if not spellId then return false end
+    if mq.TLO.Me.Pet.ID() == 0 then return false end
 
     local buffSpell = mq.TLO.Spell(spellId)
-    if not buffSpell or not buffSpell() then return false, "Invalid Spell" end
+    if not buffSpell or not buffSpell() then return false end
     local spellName = buffSpell.Name()
+    if not spellName then return false end
 
-    if not skipBlockCheck then
-        if mq.TLO.Me.BlockedPetBuff(spellName)() == spellName then
-            Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) is on the blocked spell list, aborting check.", spellName, spellId)
-            return false, "Blocked Spell"
-        end
+    local spellBlocked = not skipBlockCheck and mq.TLO.Me.BlockedPetBuff(spellName)() == spellName
+    if spellBlocked then
+        Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) is blocked, counting as present.", spellName, spellId)
     end
 
     -- I would like to use FindBuff with an ID here but it mysteriously does not see certain buffs.
-    if mq.TLO.Me.Pet.Buff(spellName)() then
-        Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) found, ending check.", spellName, spellId)
-        return false, "Buff Already Present"
-    end
+    local spellPresent = spellBlocked or mq.TLO.Me.Pet.Buff(spellName)() ~= nil
 
-    -- Check stacking
-    if not buffSpell.StacksPet() then
+    if not spellPresent and not buffSpell.StacksPet() then
         Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) does not stack, ending check.", spellName, spellId)
-        return false, "Does Not Stack"
+        return false
     end
 
-    -- Check triggers
-    if not skipTriggerCheck then
-        Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) not found, let's check for triggers.", spellName, spellId)
-        local numEffects = buffSpell.NumEffects()
-        local triggerCount = 0
-        local triggerFound = 0
-        for i = 1, numEffects do
-            local triggerSpell = buffSpell.Trigger(i)
-            --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
-            if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
-                Logger.log_verbose("LocalPetBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
-                break
-            end
-
-            local triggerName = triggerSpell.Name()
-            local triggerId = triggerSpell.ID()
-            triggerCount = triggerCount + 1
-
-            if mq.TLO.Me.Pet.Buff(triggerName)() then
-                Logger.log_verbose("LocalPetBuffCheck: Trigger %s(ID:%d) found, moving on.", triggerName, triggerId)
-                triggerFound = triggerFound + 1
-            elseif triggerSpell.StacksPet() then
-                Logger.log_verbose("LocalPetBuffCheck: Trigger %s(ID:%d) seems to stack, let's do it!", triggerName, triggerId)
-                return true, ""
-            else
-                Logger.log_verbose("LocalPetBuffCheck: Trigger %s(ID:%d) does not stack, moving on.", triggerName, triggerId)
-                triggerFound = triggerFound + 1
-            end
+    if skipTriggerCheck then
+        if spellPresent then
+            Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) present, trigger check skipped.", spellName, spellId)
+            return false
         end
+        Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) missing and stacks, trigger check skipped, let's do it!", spellName, spellId)
+        return true
+    end
 
-        if triggerCount > 0 and triggerFound >= triggerCount then
-            Logger.log_verbose("LocalPetBuffCheck: Total triggers for %s(ID:%d): %d. Triggers found: %d. Ending Check.", spellName, spellId, triggerCount, triggerFound)
-            return false, "Triggers Present & Don't Stack"
+    Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) checking for triggers.", spellName, spellId)
+    local numEffects = buffSpell.NumEffects()
+    local hasTriggers = false
+    for i = 1, numEffects do
+        local triggerSpell = buffSpell.Trigger(i)
+        --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
+        if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
+            Logger.log_verbose("LocalPetBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
+            break
+        end
+        hasTriggers = true
+
+        local triggerName = triggerSpell.Name()
+        local triggerId = triggerSpell.ID()
+
+        if not skipBlockCheck and mq.TLO.Me.BlockedPetBuff(triggerName)() == triggerName then
+            Logger.log_verbose("LocalPetBuffCheck: Trigger %s(ID:%d) is blocked, counting as present.", triggerName, triggerId)
+        elseif mq.TLO.Me.Pet.Buff(triggerName)() then
+            Logger.log_verbose("LocalPetBuffCheck: Trigger %s(ID:%d) found, moving on.", triggerName, triggerId)
+        elseif triggerSpell.StacksPet() then
+            Logger.log_verbose("LocalPetBuffCheck: Trigger %s(ID:%d) missing and stacks, let's do it!", triggerName, triggerId)
+            return true
+        else
+            Logger.log_verbose("LocalPetBuffCheck: Trigger %s(ID:%d) does not stack, moving on.", triggerName, triggerId)
         end
     end
 
-    Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) seems to stack, let's do it!", spellName, spellId)
-    return true, ""
+    if not hasTriggers and not spellPresent then
+        Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) missing and stacks with no triggers, let's do it!", spellName, spellId)
+        return true
+    end
+
+    Logger.log_verbose("LocalPetBuffCheck: %s(ID:%d) handled, no need to cast.", spellName, spellId)
+    return false
 end
 
 --- Delegates to LocalPetBuffCheck after resolving the spell rank via
 --- GetUseableSpellId. Checks pet blocked list, pet buff window, and
 --- stacking including trigger spells.
 ---@param spell MQSpell The spell to check.
----@return boolean, string True if the spell should be cast on the player's pet.
+---@return boolean True if the spell should be cast on the player's pet.
 function Casting.PetBuffCheck(spell)
-    if not (spell and spell()) then return false, "Invalid Spell" end
+    if not (spell and spell()) then return false end
     return Casting.LocalPetBuffCheck(Casting.GetUseableSpellId(spell))
 end
 
 --- Gates on CanUseAA, then delegates to LocalPetBuffCheck using the
 --- AA's spell ID to confirm not blocked on pet, not present, stacks.
 ---@param aaName string The AA name to check.
----@return boolean, string True if the AA buff should be cast on the pet.
+---@return boolean True if the AA buff should be cast on the pet.
 function Casting.PetBuffAACheck(aaName)
-    if not Casting.CanUseAA(aaName) then return false, "Cannot Use AA" end
+    if not Casting.CanUseAA(aaName) then return false end
     return Casting.LocalPetBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell.ID())
 end
 
 --- Gets the clicky spell via GetClickySpell, then delegates to
 --- LocalPetBuffCheck to confirm not blocked on pet, not present, stacks.
 ---@param itemName string The item name whose clicky to check.
----@return boolean, string True if the item's clicky buff should be applied to the pet.
-function Casting.PetBuffItemCheck(itemName)
+---@param skipBlockCheck boolean|nil whether to skip the blocked-spell check
+---@param skipTriggerCheck boolean|nil whether to skip the trigger check
+---@return boolean True if the item's clicky buff should be applied to the pet.
+function Casting.PetBuffItemCheck(itemName, skipBlockCheck, skipTriggerCheck)
     local clickySpell = Casting.GetClickySpell(itemName)
-    if not (clickySpell and clickySpell()) then return false, "Invalid Clicky Spell" end
-    return Casting.LocalPetBuffCheck(clickySpell.ID())
+    if not (clickySpell and clickySpell()) then return false end
+    return Casting.LocalPetBuffCheck(clickySpell.ID(), skipBlockCheck, skipTriggerCheck)
 end
 
 --- Helper that will perform complex checks for presence and stacking of buffs (and any triggers) using the best (determined) method available.
@@ -279,10 +288,10 @@ end
 --- @param target MQTarget|MQSpawn|MQCharacter? The target to check for the buff.
 --- @param skipBlockCheck boolean|nil whether to check the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
---- @return boolean, string True if the PC checking should cast the buff, false otherwise.
+--- @return boolean True if the PC checking should cast the buff, false otherwise.
 function Casting.ResolveBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
-    if not spellId or type(spellId) ~= "number" then return false, "Invalid Spell ID" end
-    if not (target and target()) then return false, "Invalid Target" end
+    if not spellId or type(spellId) ~= "number" then return false end
+    if not (target and target()) then return false end
 
     local spell = mq.TLO.Spell(spellId)
 
@@ -299,7 +308,7 @@ function Casting.ResolveBuffCheck(spellId, target, skipBlockCheck, skipTriggerCh
         if Targeting.GetTargetDistance(target) > spellRange then
             Logger.log_verbose("ResolveBuffCheck: Aborting check because %s(Range:%d) is out of range(%d) for %s.", targetName, Targeting.GetTargetDistance(target), spellRange,
                 spell.RankName.Name())
-            return false, "Out of Range"
+            return false
         end
 
         local isPet = Targeting.TargetIsType("Pet", target)
@@ -333,7 +342,7 @@ function Casting.ResolveBuffCheck(spellId, target, skipBlockCheck, skipTriggerCh
             local now = Globals.GetTimeSeconds()
             if now - (Globals.LastCachedBuffUpdate[target.ID()] or 0) < Config:GetSetting('BuffTargetingInterval') then
                 Logger.log_verbose("ResolveBuffCheck: Throttled target-change for %s(ID:%d).", target.CleanName(), target.ID())
-                return false, "Throttled Target Change"
+                return false
             end
             Globals.LastCachedBuffUpdate[target.ID()] = now
         end
@@ -346,7 +355,7 @@ end
 --- Used for manual stacking overrides where only presence matters.
 ---@param spellId number The spell ID to check for on the target.
 ---@param target MQSpawn? The target to check; defaults to current target.
----@return boolean, string True if the spell is not already present on the target.
+---@return boolean True if the spell is not already present on the target.
 function Casting.AddedBuffCheck(spellId, target)
     return Casting.ResolveBuffCheck(spellId, target, true, true)
 end
@@ -358,9 +367,9 @@ end
 ---@param target MQSpawn? The target to check.
 ---@param skipBlockCheck boolean? Skip the blocked-buff list check.
 ---@param skipTriggerCheck boolean? Skip trigger stacking checks.
----@return boolean, string True if the spell should be cast on the target.
+---@return boolean True if the spell should be cast on the target.
 function Casting.GroupBuffCheck(spell, target, skipBlockCheck, skipTriggerCheck)
-    if not (spell and spell()) then return false, "Invalid Spell" end
+    if not (spell and spell()) then return false end
     return Casting.ResolveBuffCheck(Casting.GetUseableSpellId(spell), target, skipBlockCheck, skipTriggerCheck)
 end
 
@@ -371,11 +380,11 @@ end
 ---@param target MQSpawn? The target to check.
 ---@param skipBlockCheck boolean? Skip the blocked-buff list check.
 ---@param skipTriggerCheck boolean? Skip trigger stacking checks.
----@return boolean, string True if the AA buff should be cast on the target.
+---@return boolean True if the AA buff should be cast on the target.
 function Casting.GroupBuffAACheck(aaName, target, skipBlockCheck, skipTriggerCheck)
-    if not Casting.CanUseAA(aaName) then return false, "Cannot Use AA" end
+    if not Casting.CanUseAA(aaName) then return false end
     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
-    if not aaSpell or not aaSpell() then return false, "Invalid AA Spell" end
+    if not aaSpell or not aaSpell() then return false end
     return Casting.ResolveBuffCheck(aaSpell.ID(), target, skipBlockCheck, skipTriggerCheck)
 end
 
@@ -386,10 +395,10 @@ end
 ---@param target MQSpawn? The target to check.
 ---@param skipBlockCheck boolean? Skip the blocked-buff list check.
 ---@param skipTriggerCheck boolean? Skip trigger stacking checks.
----@return boolean, string True if the item's clicky buff should be cast on the target.
+---@return boolean True if the item's clicky buff should be cast on the target.
 function Casting.GroupBuffItemCheck(itemName, target, skipBlockCheck, skipTriggerCheck)
     local clickySpell = Casting.GetClickySpell(itemName)
-    if not (clickySpell and clickySpell()) then return false, "Invalid Clicky Spell" end
+    if not (clickySpell and clickySpell()) then return false end
     return Casting.ResolveBuffCheck(clickySpell.ID(), target, skipBlockCheck, skipTriggerCheck)
 end
 
@@ -399,16 +408,16 @@ end
 --- @param bAllowTargetChange boolean|nil Allows the function to set the target to check buffs if true.
 --- @param bAllowDuplicates boolean|nil Checks whether the function should only return false if the effect was cast by this PC.
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
---- @return boolean, string True if the PC checking should cast the buff, false otherwise.
+--- @return boolean True if the PC checking should cast the buff, false otherwise.
 function Casting.TargetBuffCheck(spellId, target, bAllowTargetChange, bAllowDuplicates, skipTriggerCheck)
-    if not spellId then return false, "Invalid Spell ID" end
+    if not spellId then return false end
     if not target then target = mq.TLO.Target end
-    if not (target and target()) then return false, "Invalid Target" end
+    if not (target and target()) then return false end
 
     if target.ID() ~= mq.TLO.Target.ID() then
         if not bAllowTargetChange then
             Logger.log_verbose("TargetBuffCheck: Passed target(ID:%d) isn't our current target(ID:%d), cannot check spell stacking, aborting.", target.ID(), mq.TLO.Target.ID())
-            return false, "Target Mismatch"
+            return false
         else
             Logger.log_verbose("TargetBuffCheck: Passed target(ID:%d) isn't our current target(ID:%d), setting target to populate buffs.", target.ID(), mq.TLO.Target.ID())
             Targeting.SetTarget(target.ID(), false)
@@ -420,13 +429,13 @@ function Casting.TargetBuffCheck(spellId, target, bAllowTargetChange, bAllowDupl
     local buffSpell = mq.TLO.Spell(spellId)
     local spellName = buffSpell.Name() or buffSpell()
 
-    if not spellName then return false, "Invalid Spell Name" end
+    if not spellName then return false end
 
     local buffSearch = bAllowDuplicates and string.format("id %d and caster =%s", spellId, mq.TLO.Me.DisplayName()) or string.format("id %d", spellId)
 
     if mq.TLO.Target.FindBuff(buffSearch)() then
         Logger.log_verbose("TargetBuffCheck: %s(ID:%d) found on %s(ID:%d), ending check.", spellName, spellId, targetName, targetId)
-        return false, "Buff Already Present"
+        return false
     end
 
     if not skipTriggerCheck then
@@ -453,7 +462,7 @@ function Casting.TargetBuffCheck(spellId, target, bAllowTargetChange, bAllowDupl
                 triggerFound = triggerFound + 1
             elseif triggerSpell.StacksTarget() then
                 Logger.log_verbose("TargetBuffCheck: %s(ID:%d) seems to stack on %s(ID:%d), let's do it!", triggerName, triggerId, targetName, targetId)
-                return true, ""
+                return true
             else
                 Logger.log_verbose("TargetBuffCheck: %s(ID:%d) does not stack on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
                 triggerFound = triggerFound + 1
@@ -462,17 +471,17 @@ function Casting.TargetBuffCheck(spellId, target, bAllowTargetChange, bAllowDupl
 
         if triggerCount > 0 and triggerFound >= triggerCount then
             Logger.log_verbose("TargetBuffCheck: Total triggers for %s(ID:%d): %d. Triggers found: %d. Ending Check.", spellName, spellId, triggerCount, triggerFound)
-            return false, "Triggers Present & Don't Stack"
+            return false
         end
     end
 
     if buffSpell.StacksTarget() then
         Logger.log_verbose("TargetBuffCheck: %s(ID:%d) seems to stack on %s(ID:%d), let's do it!", spellName, spellId, targetName, targetId)
-        return true, ""
+        return true
     end
 
     Logger.log_verbose("TargetBuffCheck: %s(ID:%d) does not seem to stack, ending check.", spellName, spellId)
-    return false, "Does Not Stack"
+    return false
 end
 
 --- Complex buff check that will check for presence and stacking of the buff (and any triggers) on a DanNet peer.
@@ -480,99 +489,106 @@ end
 --- @param target MQTarget|MQSpawn|MQCharacter? The target to check for the buff.
 --- @param skipBlockCheck boolean|nil whether to check the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
---- @return boolean, string True if the PC checking should cast the buff, false otherwise.
+--- @return boolean True if the PC checking should cast the buff, false otherwise.
 function Casting.PeerBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
-    if not spellId then return false, "Invalid Spell ID" end
-    if not (target and target()) then return false, "Invalid Target" end
+    if not spellId then return false end
+    if not (target and target()) then return false end
 
     local targetName = target.CleanName()
     local targetId = target.ID()
     local buffSpell = mq.TLO.Spell(spellId)
     local spellName = buffSpell.Name() or buffSpell()
 
-    if not spellName then return false, "Invalid Spell Name" end
+    if not spellName then return false end
 
     if not mq.TLO.DanNet(mq.TLO.Spawn(targetId).CleanName())() then
         Logger.log_verbose(
             "PeerBuffCheck: Tried to check a peer's buff, but that peer isn't found! Did this peer zone or crash?" ..
             "If this behavior continues, please report this. Spell:%s(ID:%d), Target:%s(ID:%d)",
             spellName, spellId, targetName, targetId)
-        return false, "DanNet Peer Not Found"
+        return false
     end
 
-    if not skipBlockCheck then
-        local blockedResult = DanNet.query(targetName, string.format("Me.BlockedBuff[%s]", spellName), 1000)
-        if not blockedResult then
-            Logger.log_error(
-                "PeerBuffCheck: Tried to check buff blocking, but something seems to have gone wrong! Your character may not be responding. If this persists, please report it. Spell:%s(ID:%d), Target:%s(ID:%d)",
-                spellName, spellId, targetName, targetId)
-        elseif blockedResult:lower() == spellName:lower() then
-            Logger.log_verbose("PeerBuffCheck: %s(ID:%d) appears to be blocked on %s(ID:%d). Aborting Check.", spellName, spellId, targetName, targetId)
-            return false, "Blocked Spell"
-        else
-            Logger.log_verbose("PeerBuffCheck: %s(ID:%d) does not appear to be blocked on %s(ID:%d).", spellName, spellId, targetName, targetId)
-        end
-    end
-
+    -- check presence first because blocking is rare
     local spellResult = DanNet.query(targetName, string.format("Me.FindBuff[id %d]", spellId), 1000)
-
-    if spellResult:lower() == spellName:lower() then
-        Logger.log_verbose("PeerBuffCheck: %s(ID:%d) found on %s(ID:%d), ending check.", spellName, spellId, targetName, targetId)
-        return false, "Buff Already Present"
-    elseif spellResult:lower() ~= "null" then
+    local spellPresent = spellResult:lower() == spellName:lower()
+    if not spellPresent and spellResult:lower() ~= "null" then
         Logger.log_error(
             "PeerBuffCheck: Tried to check buff presence, but something seems to have gone wrong! Your character may not be responding. If this persists, please report it. Spell:%s(ID:%d), Target:%s(ID:%d) Result:%s",
             spellName, spellId, targetName, targetId, spellResult)
-        return false, "Error Checking Buff Presence"
+        return false
     end
 
-    local spellStackResult = DanNet.query(targetName, string.format("Spell[%d].Stacks", spellId), 1000)
-    if spellStackResult:lower() ~= "true" then
-        Logger.log_verbose("PeerBuffCheck: %s(ID:%d) does not stack on %s(ID:%d), ending check.", spellName, spellId, targetName, targetId)
-        return false, "Does Not Stack"
+    if not spellPresent and not skipBlockCheck then
+        local blockedResult = DanNet.query(targetName, string.format("Me.BlockedBuff[%s]", spellName), 1000)
+        if blockedResult:lower() == spellName:lower() then
+            Logger.log_verbose("PeerBuffCheck: %s(ID:%d) is blocked on %s(ID:%d), counting as present.", spellName, spellId, targetName, targetId)
+            spellPresent = true
+        end
     end
 
-    if not skipTriggerCheck then
-        Logger.log_verbose("PeerBuffCheck: %s(ID:%d) stacks on %s(ID:%d), but let's check for triggers.", spellName, spellId, targetName, targetId)
-        local numEffects = buffSpell.NumEffects()
-        local triggerCount = 0
-        local triggerFound = 0
-        for i = 1, numEffects do
-            local triggerSpell = buffSpell.Trigger(i)
-            if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
-                Logger.log_verbose("PeerBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
-                break
-            end
+    if not spellPresent then
+        local spellStackResult = DanNet.query(targetName, string.format("Spell[%d].Stacks", spellId), 1000)
+        if spellStackResult:lower() ~= "true" then
+            Logger.log_verbose("PeerBuffCheck: %s(ID:%d) does not stack on %s(ID:%d), ending check.", spellName, spellId, targetName, targetId)
+            return false
+        end
+    end
 
-            local triggerName = triggerSpell.Name()
-            local triggerId = triggerSpell.ID()
-            local triggerResult = DanNet.query(targetName, string.format("Me.FindBuff[id %d]", triggerId), 1000)
+    if skipTriggerCheck then
+        if spellPresent then
+            Logger.log_verbose("PeerBuffCheck: %s(ID:%d) present on %s(ID:%d), trigger check skipped.", spellName, spellId, targetName, targetId)
+            return false
+        end
+        Logger.log_verbose("PeerBuffCheck: %s(ID:%d) missing on %s(ID:%d) and stacks, trigger check skipped, let's do it!", spellName, spellId, targetName, targetId)
+        return true
+    end
 
-            triggerCount = triggerCount + 1
+    Logger.log_verbose("PeerBuffCheck: %s(ID:%d) checking for triggers on %s(ID:%d).", spellName, spellId, targetName, targetId)
+    local numEffects = buffSpell.NumEffects()
+    local hasTriggers = false
+    for i = 1, numEffects do
+        local triggerSpell = buffSpell.Trigger(i)
+        if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
+            Logger.log_verbose("PeerBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
+            break
+        end
+        hasTriggers = true
 
-            if triggerResult:lower() == triggerName:lower() then
-                Logger.log_verbose("PeerBuffCheck: %s(ID:%d) found on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
-                triggerFound = triggerFound + 1
-            elseif triggerResult:lower() == "null" then
-                local triggerStackResult = DanNet.query(targetName, string.format("Spell[%d].Stacks", triggerId), 1000)
-                if triggerStackResult:lower() == "true" then
-                    Logger.log_verbose("PeerBuffCheck: %s(ID:%d) seems to stack on %s(ID:%d), let's do it!", triggerName, triggerId, targetName, targetId)
-                    return true, ""
-                else
-                    Logger.log_verbose("PeerBuffCheck: %s(ID:%d) does not stack on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
-                    triggerFound = triggerFound + 1
+        local triggerName = triggerSpell.Name()
+        local triggerId = triggerSpell.ID()
+        local triggerResult = DanNet.query(targetName, string.format("Me.FindBuff[id %d]", triggerId), 1000)
+
+        if triggerResult:lower() == triggerName:lower() then
+            Logger.log_verbose("PeerBuffCheck: Trigger %s(ID:%d) found on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
+        elseif triggerResult:lower() == "null" then
+            local triggerBlocked = false
+            if not skipBlockCheck then
+                local triggerBlockedResult = DanNet.query(targetName, string.format("Me.BlockedBuff[%s]", triggerName), 1000)
+                if triggerBlockedResult:lower() == triggerName:lower() then
+                    triggerBlocked = true
                 end
             end
-        end
-
-        if triggerCount > 0 and triggerFound >= triggerCount then
-            Logger.log_verbose("PeerBuffCheck: Total triggers for %s(ID:%d): %d. Present or non-stacking triggers: %d. Ending Check.", spellName, spellId, triggerCount, triggerFound)
-            return false, "Triggers Present & Don't Stack"
+            if triggerBlocked then
+                Logger.log_verbose("PeerBuffCheck: Trigger %s(ID:%d) is blocked on %s(ID:%d), counting as present.", triggerName, triggerId, targetName, targetId)
+            else
+                local triggerStackResult = DanNet.query(targetName, string.format("Spell[%d].Stacks", triggerId), 1000)
+                if triggerStackResult:lower() == "true" then
+                    Logger.log_verbose("PeerBuffCheck: Trigger %s(ID:%d) missing and stacks on %s(ID:%d), let's do it!", triggerName, triggerId, targetName, targetId)
+                    return true
+                end
+                Logger.log_verbose("PeerBuffCheck: Trigger %s(ID:%d) does not stack on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
+            end
         end
     end
 
-    Logger.log_verbose("PeerBuffCheck: %s(ID:%d) seems to stack on %s(ID:%d), let's do it!", spellName, spellId, targetName, targetId)
-    return true, ""
+    if not hasTriggers and not spellPresent then
+        Logger.log_verbose("PeerBuffCheck: %s(ID:%d) missing on %s(ID:%d) and stacks with no triggers, let's do it!", spellName, spellId, targetName, targetId)
+        return true
+    end
+
+    Logger.log_verbose("PeerBuffCheck: %s(ID:%d) handled on %s(ID:%d), no need to cast.", spellName, spellId, targetName, targetId)
+    return false
 end
 
 --- Complex buff check that will check for presence and stacking of the buff (and any triggers) on an actor peer.
@@ -580,26 +596,25 @@ end
 --- @param target MQTarget|MQSpawn|MQCharacter? The target to check for the buff.
 --- @param skipBlockCheck boolean|nil whether to skip checking the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
---- @return boolean, string True if the PC checking should cast the buff, false otherwise.
+--- @return boolean True if the PC checking should cast the buff, false otherwise.
 function Casting.ActorBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
-    if not spellId then return false, "Invalid Spell ID" end
-    if not (target and target()) then return false, "Invalid Target" end
+    if not spellId then return false end
+    if not (target and target()) then return false end
 
     local targetName = target.DisplayName()
     local targetId = target.ID()
     local buffSpell = mq.TLO.Spell(spellId)
     local spellName = buffSpell.Name() or buffSpell()
 
-    if not spellName then return false, "Invalid Spell Name" end
+    if not spellName then return false end
 
     local heartbeat = Comms.GetPeerHeartbeatByName(targetName)
 
     if not heartbeat or not heartbeat.Data then
         Logger.log_error(
-            "ActorBuffCheck: Tried to check a peer's buff, but that peer isn't found! " ..
-            "If this behavior continues, please report this. Spell:%s(ID:%d), Target:%s(ID:%d)",
-            spellName, spellId, targetName, targetId)
-        return false, "Peer or Heartbeat Data Not Found"
+            "ActorBuffCheck: Tried to check a peer's buff, but that peer isn't found! If this behavior continues, please report this. Spell:%s(ID:%d), Target:%s(ID:%d)", spellName,
+            spellId, targetName, targetId)
+        return false
     end
 
     local blockedList = heartbeat.Data.Blocked
@@ -614,118 +629,93 @@ function Casting.ActorBuffCheck(spellId, target, skipBlockCheck, skipTriggerChec
         return Casting.PeerBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
     end
 
-    if not skipBlockCheck then
-        if Tables.TableContains(blockedList, spellId) then
-            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) appears to be blocked on %s(ID:%d). Aborting Check.", spellName, spellId, targetName, targetId)
-            return false, "Blocked Spell"
-        else
-            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) does not appear to be blocked on %s(ID:%d).", spellName, spellId, targetName, targetId)
-        end
-    else
-        Logger.log_verbose("ActorBuffCheck: %s(ID:%d) block check skipped on %s(ID:%d).", spellName, spellId, targetName, targetId)
+    local spellBlocked = not skipBlockCheck and Tables.TableContains(blockedList, spellId)
+    if spellBlocked then
+        Logger.log_verbose("ActorBuffCheck: %s(ID:%d) is blocked on %s(ID:%d), counting as present.", spellName, spellId, targetName, targetId)
     end
 
-    -- if they don't have open buff slots, even if local stacking is true, it may not be able to land on them... they should check it.
-    -- if this PC doesn't have open buff slots, some stackswith checks will incorrectly return false, so they need to check it then as well.
-    local myOpenBuffs = mq.TLO.Me.MaxBuffSlots() - Globals.CurrentBuffCount
-    if openBuffs <= 0 or myOpenBuffs <= 0 then
-        Logger.log_verbose(
-            "ActorBuffCheck: Either %s or myself has full buffs, falling back on DanNet checks for %s(ID: %d). MyOpenSlots: %d, TargetOpenSlots: %d", targetName, spellName, spellId,
-            myOpenBuffs, openBuffs)
-        return Casting.PeerBuffCheck(spellId, target, true, skipTriggerCheck) -- we already did the block check (if needed) here, skip it, saves a query
+    local spellWindow = buffSpell.DurationWindow()
+    local activeList = spellWindow == 1 and songList or buffList
+    local spellPresent = spellBlocked or Tables.TableContains(activeList, spellId)
+
+    -- if the spell isn't already up and the target's buff window is full, have the PC check via DanNet to see if this could overwrite an existing spell instead of assuming it won't land
+    if not spellPresent and spellWindow == 0 and openBuffs <= 0 then
+        Logger.log_verbose("ActorBuffCheck: %s has a full buff window, falling back on DanNet checks for %s(ID:%d).", targetName, spellName, spellId)
+        return Casting.PeerBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
     end
 
-    for _, buffId in ipairs(buffList) do
-        if buffId == spellId then
-            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) found on %s(ID:%d), ending check.", spellName, spellId, targetName, targetId)
-            return false, "Buff Already Present"
-        end
-        ---@diagnostic disable-next-line: redundant-parameter
-        if not buffSpell.StacksWith(buffId)() then
-            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) does not stack with %s(ID:%d) on %s(ID:%d), ending check.", spellName, spellId, mq.TLO.Spell(buffId).Name(), buffId,
-                targetName, targetId)
-            return false, "Does Not Stack"
-        end
-    end
-
-    for _, songId in ipairs(songList) do
-        if songId == spellId then
-            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) found on %s(ID:%d), ending check.", spellName, spellId, targetName, targetId)
-            return false, "Buff Already Present as Song"
-        end
-        ---@diagnostic disable-next-line: redundant-parameter
-        if not buffSpell.StacksWith(songId)() then
-            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) does not stack with %s(ID:%d) on %s(ID:%d), ending check.", spellName, spellId, mq.TLO.Spell(songId).Name(), songId,
-                targetName, targetId)
-            return false, "Does Not Stack with Song"
-        end
-    end
-
-    if not skipTriggerCheck then
-        Logger.log_verbose("ActorBuffCheck: %s(ID:%d) seems to stack on %s(ID:%d), let's check for triggers.", spellName, spellId, targetName, targetId)
-        local numEffects = buffSpell.NumEffects()
-        local triggerCount = 0
-        local triggerFound = 0
-
-        for i = 1, numEffects do
-            local triggerSpell = buffSpell.Trigger(i)
-            --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
-            if triggerSpell and triggerSpell() and triggerSpell.ID() > 0 then
-                local triggerName = triggerSpell.Name()
-                local triggerId = triggerSpell.ID()
-                triggerCount = triggerCount + 1
-                local triggerHandled = false
-                for _, buffId in ipairs(buffList) do
-                    if buffId == triggerId then
-                        Logger.log_verbose("ActorBuffCheck: %s(ID:%d) found on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
-                        triggerFound = triggerFound + 1
-                        triggerHandled = true
-                        break
-                    end
-                    ---@diagnostic disable-next-line: redundant-parameter
-                    if not triggerSpell.StacksWith(buffId)() then
-                        Logger.log_verbose("ActorBuffCheck: %s(ID:%d) does not stack with %s(ID:%d) on %s(ID:%d), moving on.", triggerName, triggerId, mq.TLO.Spell(buffId).Name(),
-                            buffId, targetName, targetId)
-                        triggerFound = triggerFound + 1
-                        triggerHandled = true
-                        break
-                    end
-                end
-                if not triggerHandled then
-                    for _, songId in ipairs(songList) do
-                        if songId == triggerId then
-                            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) found on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
-                            triggerFound = triggerFound + 1
-                            triggerHandled = true
-                            break
-                        end
-                        ---@diagnostic disable-next-line: redundant-parameter
-                        if not triggerSpell.StacksWith(songId)() then
-                            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) does not stack with %s(ID:%d) on %s(ID:%d), moving on.", triggerName, triggerId,
-                                mq.TLO.Spell(songId).Name(), songId, targetName, targetId)
-                            triggerFound = triggerFound + 1
-                            triggerHandled = true
-                            break
-                        end
-                    end
-                end
-                if not triggerHandled then
-                    Logger.log_verbose("ActorBuffCheck: %s(ID:%d) seems to stack on %s(ID:%d), let's do it!", triggerName, triggerId, targetName, targetId)
-                    return true, ""
-                end
-            else
-                Logger.log_verbose("ActorBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
-                break
+    if not spellPresent then
+        for _, buffId in ipairs(activeList) do
+            ---@diagnostic disable-next-line: redundant-parameter
+            if not buffSpell.StacksWith(buffId)() then
+                Logger.log_verbose("ActorBuffCheck: %s(ID:%d) does not stack with %s(ID:%d) on %s(ID:%d), ending check.", spellName, spellId,
+                    mq.TLO.Spell(buffId).Name() or "Error", buffId, targetName, targetId)
+                return false
             end
         end
-        if triggerCount > 0 and triggerFound >= triggerCount then
-            Logger.log_verbose("ActorBuffCheck: Total triggers for %s(ID:%d): %d. Present or non-stacking triggers: %d. Ending Check.", spellName, spellId, triggerCount,
-                triggerFound)
-            return false, "Triggers Present or Don't Stack"
+    end
+
+    if skipTriggerCheck then
+        if spellPresent then
+            Logger.log_verbose("ActorBuffCheck: %s(ID:%d) present on %s(ID:%d), trigger check skipped.", spellName, spellId, targetName, targetId)
+            return false
+        end
+        Logger.log_verbose("ActorBuffCheck: %s(ID:%d) missing on %s(ID:%d) and stacks, trigger check skipped, let's do it!", spellName, spellId, targetName, targetId)
+        return true
+    end
+
+    Logger.log_verbose("ActorBuffCheck: %s(ID:%d) checking for triggers on %s(ID:%d).", spellName, spellId, targetName, targetId)
+    local numEffects = buffSpell.NumEffects()
+    local hasTriggers = false
+    for i = 1, numEffects do
+        local triggerSpell = buffSpell.Trigger(i)
+        --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
+        if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
+            Logger.log_verbose("ActorBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
+            break
+        end
+        hasTriggers = true
+
+        local triggerName = triggerSpell.Name()
+        local triggerId = triggerSpell.ID()
+        local triggerWindow = triggerSpell.DurationWindow()
+        local triggerActiveList = triggerWindow == 1 and songList or buffList
+
+        if not skipBlockCheck and Tables.TableContains(blockedList, triggerId) then
+            Logger.log_verbose("ActorBuffCheck: Trigger %s(ID:%d) is blocked on %s(ID:%d), counting as present.", triggerName, triggerId, targetName, targetId)
+        elseif Tables.TableContains(triggerActiveList, triggerId) then
+            Logger.log_verbose("ActorBuffCheck: Trigger %s(ID:%d) found on %s(ID:%d), moving on.", triggerName, triggerId, targetName, targetId)
+        elseif triggerWindow == 0 and openBuffs <= 0 then
+            -- if the trigger isn't already up and the target's buff window is full, have the PC check via DanNet to see if this could overwrite an existing spell instead of assuming it won't land
+            if Casting.PeerBuffCheck(triggerId, target, true, true) then
+                Logger.log_verbose("ActorBuffCheck: Trigger %s(ID:%d) missing and stacks on %s(ID:%d) via fallback, let's do it!", triggerName, triggerId, targetName, targetId)
+                return true
+            end
+        else
+            local stacks = true
+            for _, buffId in ipairs(triggerActiveList) do
+                ---@diagnostic disable-next-line: redundant-parameter
+                if not triggerSpell.StacksWith(buffId)() then
+                    Logger.log_verbose("ActorBuffCheck: Trigger %s(ID:%d) does not stack with %s(ID:%d) on %s(ID:%d), moving on.", triggerName, triggerId,
+                        mq.TLO.Spell(buffId).Name() or "Error", buffId, targetName, targetId)
+                    stacks = false
+                    break
+                end
+            end
+            if stacks then
+                Logger.log_verbose("ActorBuffCheck: Trigger %s(ID:%d) missing and stacks on %s(ID:%d), let's do it!", triggerName, triggerId, targetName, targetId)
+                return true
+            end
         end
     end
-    Logger.log_verbose("ActorBuffCheck: %s(ID:%d) seems to stack on %s(ID:%d), let's do it!", spellName, spellId, targetName, targetId)
-    return true, ""
+
+    if not hasTriggers and not spellPresent then
+        Logger.log_verbose("ActorBuffCheck: %s(ID:%d) missing on %s(ID:%d) and stacks with no triggers, let's do it!", spellName, spellId, targetName, targetId)
+        return true
+    end
+
+    Logger.log_verbose("ActorBuffCheck: %s(ID:%d) handled on %s(ID:%d), no need to cast.", spellName, spellId, targetName, targetId)
+    return false
 end
 
 --- Complex buff check that will check for presence and stacking of the buff (and any triggers) on an actor peer.
@@ -733,17 +723,17 @@ end
 --- @param target MQTarget|MQSpawn|MQCharacter? The target to check for the buff.
 --- @param skipBlockCheck boolean|nil whether to skip checking the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
---- @return boolean, string True if the PC checking should cast the buff, false otherwise.
+--- @return boolean True if the PC checking should cast the buff, false otherwise.
 function Casting.ActorPetBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
-    if not spellId then return false, "Invalid Spell ID" end
-    if not (target and target()) then return false, "Invalid Target" end
+    if not spellId then return false end
+    if not (target and target()) then return false end
 
     local targetName = target.Master.DisplayName()
     local targetId = target.ID()
     local buffSpell = mq.TLO.Spell(spellId)
     local spellName = buffSpell.Name() or buffSpell()
 
-    if not spellName then return false, "Invalid Spell Name" end
+    if not spellName then return false end
 
     local masterName = target.Master() and target.Master.DisplayName() or nil
 
@@ -754,7 +744,7 @@ function Casting.ActorPetBuffCheck(spellId, target, skipBlockCheck, skipTriggerC
             "ActorPetBuffCheck: Tried to check a peer's pet buff, but that peer isn't found! " ..
             "If this behavior continues, please report this. Spell:%s(ID:%d), Target:%s(ID:%d)",
             spellName, spellId, targetName, targetId)
-        return false, "Peer Not Found"
+        return false
     end
 
     local blockedList = heartbeat.Data.PetBlocked
@@ -764,78 +754,84 @@ function Casting.ActorPetBuffCheck(spellId, target, skipBlockCheck, skipTriggerC
         Logger.log_error(
             "ActorPetBuffCheck: Tried to check a peer's pet buff, but data is not available! If this behavior continues, please report this. Spell:%s(ID:%d), Target:%s(ID:%d)",
             spellName, spellId, targetName, targetId)
-        return false, "Data Not Available"
+        return false
     end
 
-    if not skipBlockCheck then
-        if Tables.TableContains(blockedList, spellId) then
-            Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) appears to be blocked on %s's pet(%s, ID:%d). Aborting Check.", spellName, spellId, masterName, targetName, targetId)
-            return false, "Spell Blocked"
-        else
-            Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) does not appear to be on %s's pet(%s, ID:%d).", spellName, spellId, masterName, targetName, targetId)
-        end
-    else
-        Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) block check skipped on %s's pet(ID:%d).", spellName, spellId, masterName, targetName, targetId)
+    local spellBlocked = not skipBlockCheck and Tables.TableContains(blockedList, spellId)
+    if spellBlocked then
+        Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) is blocked on %s's pet(%s, ID:%d), counting as present.", spellName, spellId, masterName, targetName, targetId)
     end
 
-    for _, buffId in ipairs(buffList) do
-        if buffId == spellId then
-            Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) found on %s's pet(%s, ID:%d), ending check.", spellName, spellId, masterName, targetName, targetId)
-            return false, "Buff Already Present"
-        end
-        ---@diagnostic disable-next-line: redundant-parameter
-        if not buffSpell.StacksWith(buffId)() then
-            Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) does not stack on %s's pet(%s, ID:%d), ending check.", spellName, spellId, masterName, targetName, targetId)
-            return false, "Buff Does Not Stack"
-        end
-    end
+    local spellPresent = spellBlocked or Tables.TableContains(buffList, spellId)
 
-    if not skipTriggerCheck then
-        Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) seems to stack on %s's pet(%s, ID:%d), let's check for triggers.", spellName, spellId, masterName, targetName, targetId)
-        local numEffects = buffSpell.NumEffects()
-        local triggerCount = 0
-        local triggerFound = 0
-
-        for i = 1, numEffects do
-            local triggerSpell = buffSpell.Trigger(i)
-            --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
-            if triggerSpell and triggerSpell() and triggerSpell.ID() > 0 then
-                local triggerName = triggerSpell.Name()
-                local triggerId = triggerSpell.ID()
-                triggerCount = triggerCount + 1
-                local triggerHandled = false
-                for _, buffId in ipairs(buffList) do
-                    if buffId == triggerId then
-                        Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) found on %s's pet(%s, ID:%d), moving on.", triggerName, triggerId, masterName, targetName, targetId)
-                        triggerFound = triggerFound + 1
-                        triggerHandled = true
-                        break
-                    end
-                    ---@diagnostic disable-next-line: redundant-parameter
-                    if not triggerSpell.StacksWith(buffId)() then
-                        Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) does not stack on %s's pet(%s, ID:%d), moving on.", triggerName, triggerId, masterName, targetName, targetId)
-                        triggerFound = triggerFound + 1
-                        triggerHandled = true
-                        break
-                    end
-                end
-                if not triggerHandled then
-                    Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) seems to stack on %s's pet(%s, ID:%d), let's do it!", triggerName, triggerId, masterName, targetName, targetId)
-                    return true, ""
-                end
-            else
-                Logger.log_verbose("ActorPetBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
-                break
+    if not spellPresent then
+        for _, buffId in ipairs(buffList) do
+            ---@diagnostic disable-next-line: redundant-parameter
+            if not buffSpell.StacksWith(buffId)() then
+                Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) does not stack with %s(ID:%d) on %s's pet(%s, ID:%d), ending check.", spellName, spellId,
+                    mq.TLO.Spell(buffId).Name() or "Error", buffId, masterName, targetName, targetId)
+                return false
             end
         end
-        if triggerCount > 0 and triggerFound >= triggerCount then
-            Logger.log_verbose("ActorPetBuffCheck: Total triggers for %s(ID:%d): %d. Present or non-stacking triggers: %d. Ending Check.", spellName, spellId, triggerCount,
-                triggerFound)
-            return false, "Triggers Present or Don't Stack"
+    end
+
+    if skipTriggerCheck then
+        if spellPresent then
+            Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) present on %s's pet(%s, ID:%d), trigger check skipped.", spellName, spellId, masterName, targetName, targetId)
+            return false
+        end
+        Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) missing on %s's pet(%s, ID:%d) and stacks, trigger check skipped, let's do it!", spellName, spellId, masterName, targetName,
+            targetId)
+        return true
+    end
+
+    Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) checking for triggers on %s's pet(%s, ID:%d).", spellName, spellId, masterName, targetName, targetId)
+    local numEffects = buffSpell.NumEffects()
+    local hasTriggers = false
+    for i = 1, numEffects do
+        local triggerSpell = buffSpell.Trigger(i)
+        --Some Laz spells report trigger 1 as "Unknown Spell" with an ID of 0, which always reports false on stack checks
+        if not (triggerSpell and triggerSpell() and triggerSpell.ID() > 0) then
+            Logger.log_verbose("ActorPetBuffCheck: We've checked every trigger for %s(ID:%d).", spellName, spellId)
+            break
+        end
+        hasTriggers = true
+
+        local triggerName = triggerSpell.Name()
+        local triggerId = triggerSpell.ID()
+
+        if not skipBlockCheck and Tables.TableContains(blockedList, triggerId) then
+            Logger.log_verbose("ActorPetBuffCheck: Trigger %s(ID:%d) is blocked on %s's pet(%s, ID:%d), counting as present.", triggerName, triggerId, masterName, targetName,
+                targetId)
+        elseif Tables.TableContains(buffList, triggerId) then
+            Logger.log_verbose("ActorPetBuffCheck: Trigger %s(ID:%d) found on %s's pet(%s, ID:%d), moving on.", triggerName, triggerId, masterName, targetName, targetId)
+        else
+            local stacks = true
+            for _, buffId in ipairs(buffList) do
+                ---@diagnostic disable-next-line: redundant-parameter
+                if not triggerSpell.StacksWith(buffId)() then
+                    Logger.log_verbose("ActorPetBuffCheck: Trigger %s(ID:%d) does not stack with %s(ID:%d) on %s's pet(%s, ID:%d), moving on.", triggerName, triggerId,
+                        mq.TLO.Spell(buffId).Name() or "Error", buffId, masterName, targetName, targetId)
+                    stacks = false
+                    break
+                end
+            end
+            if stacks then
+                Logger.log_verbose("ActorPetBuffCheck: Trigger %s(ID:%d) missing and stacks on %s's pet(%s, ID:%d), let's do it!", triggerName, triggerId, masterName, targetName,
+                    targetId)
+                return true
+            end
         end
     end
-    Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) seems to stack on %s's pet(%s, ID:%d), let's do it!", spellName, spellId, masterName, targetName, targetId)
-    return true, ""
+
+    if not hasTriggers and not spellPresent then
+        Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) missing on %s's pet(%s, ID:%d) and stacks with no triggers, let's do it!", spellName, spellId, masterName, targetName,
+            targetId)
+        return true
+    end
+
+    Logger.log_verbose("ActorPetBuffCheck: %s(ID:%d) handled on %s's pet(%s, ID:%d), no need to cast.", spellName, spellId, masterName, targetName, targetId)
+    return false
 end
 
 --- Checks if an aura is active by its name.
@@ -843,14 +839,30 @@ end
 --- @return boolean True if the aura is active, false otherwise.
 function Casting.AuraActiveByName(auraName)
     if not auraName then return false end
-    local auraOne = string.find(mq.TLO.Me.Aura(1)() or "", auraName) ~= nil
-    local auraTwo = string.find(mq.TLO.Me.Aura(2)() or "", auraName) ~= nil
     local stripName = string.gsub(auraName, "'", "")
+    for i = 1, Casting.MaxAuraSlots() do
+        local slot = mq.TLO.Me.Aura(i)() or ""
+        if string.find(slot, auraName) or string.find(slot, stripName) then
+            return true
+        end
+    end
+    return false
+end
 
-    auraOne = auraOne or string.find(mq.TLO.Me.Aura(1)() or "", stripName) ~= nil
-    auraTwo = auraTwo or string.find(mq.TLO.Me.Aura(2)() or "", stripName) ~= nil
+--- Returns the maximum number of aura slots the player can have active.
+--- @return integer
+function Casting.MaxAuraSlots()
+    if Core.OnLaz() then return 1 end
+    return Casting.AARank('Auroria Mastery') + 1
+end
 
-    return auraOne or auraTwo
+--- Returns true if at least one aura slot is currently empty.
+--- @return boolean
+function Casting.HasFreeAuraSlot()
+    for i = 1, Casting.MaxAuraSlots() do
+        if (mq.TLO.Me.Aura(i)() or "") == "" then return true end
+    end
+    return false
 end
 
 --- Verifies the player has the spell's expended reagent (ReagentID slot 1) and, on live servers, the non-expended reagent (NoExpendReagentID slot 1) in inventory. Announces a chat message to the group/raid if either is missing. Returns false if any required reagent is absent.
@@ -1089,8 +1101,9 @@ function Casting.GetBuffableInZoneIDs()
     for i = 1, count do
         local member = mq.TLO.Group.Member(i)
         if not member.OtherZone() then
-            if checkCorpses and Casting.HasNearbyCorpse(member.DisplayName()) then
-                Logger.log_debug("Groupmember corpse detected (%s), aborting group buff rotation.", member.DisplayName())
+            local memberName = member.DisplayName()
+            if checkCorpses and Casting.HasNearbyCorpse(memberName) then
+                Logger.log_debug("Groupmember corpse detected (%s), aborting group buff rotation.", memberName)
                 return {}
             end
             zoneIds:add(member.ID())
@@ -1169,8 +1182,9 @@ function Casting.GetBuffableRaidIDs()
     for i = 1, count do
         local member = mq.TLO.Group.Member(i)
         if not member.OtherZone() then
-            if checkCorpses and Casting.HasNearbyCorpse(member.DisplayName()) then
-                Logger.log_debug("Groupmember corpse detected (%s), aborting group buff rotation.", member.DisplayName())
+            local memberName = member.DisplayName()
+            if checkCorpses and Casting.HasNearbyCorpse(memberName) then
+                Logger.log_debug("Groupmember corpse detected (%s), aborting group buff rotation.", memberName)
                 return {}
             end
             raidIds:add(member.ID())
@@ -1246,16 +1260,18 @@ function Casting.GetBuffableGroupIDs()
     for i = 1, count do
         local member = mq.TLO.Group.Member(i)
         if not member.OtherZone() then
-            if checkCorpses and Casting.HasNearbyCorpse(member.DisplayName()) then
-                Logger.log_debug("Groupmember corpse detected (%s), aborting group buff rotation.", member.DisplayName())
+            local memberName = member.DisplayName()
+            if checkCorpses and Casting.HasNearbyCorpse(memberName) then
+                Logger.log_debug("Groupmember corpse detected (%s), aborting group buff rotation.", memberName)
                 return {}
             end
             groupIds:add(member.ID())
             if Config:GetSetting("DoActorPetBuffs") then
-                if #Comms.GetPeerHeartbeatByName(member.DisplayName()) > 0 then
-                    if member() and member.Pet.ID() > 0 then
+                if #Comms.GetPeerHeartbeatByName(memberName) > 0 then
+                    local petId = member() and member.Pet.ID() or 0
+                    if petId > 0 then
                         if not (member.Pet.CleanName() or "familiar"):lower():find("familiar") then
-                            groupIds:add(member.Pet.ID())
+                            groupIds:add(petId)
                         end
                     end
                 end
@@ -1501,9 +1517,9 @@ end
 --- DotSpellCheck for DoTs.
 ---@param spell MQSpell The detrimental spell to check.
 ---@param target MQSpawn? Defaults to auto-target or current target.
----@return boolean, string True if the det effect is not already present.
+---@return boolean True if the det effect is not already present.
 function Casting.DetSpellCheck(spell, target)
-    if not (spell and spell()) then return false, "Invalid Spell" end
+    if not (spell and spell()) then return false end
     if not target then target = Targeting.GetAutoTarget() or mq.TLO.Target end
     return Casting.TargetBuffCheck(Casting.GetUseableSpellId(spell), target)
 end
@@ -1512,9 +1528,9 @@ end
 --- AA's spell ID to confirm the det effect is not already on target.
 ---@param aaName string The AA name to check.
 ---@param target MQSpawn? Defaults to auto-target or current target.
----@return boolean, string True if the AA det effect is not already present.
+---@return boolean True if the AA det effect is not already present.
 function Casting.DetAACheck(aaName, target)
-    if not Casting.CanUseAA(aaName) then return false, "Cannot Use AA" end
+    if not Casting.CanUseAA(aaName) then return false end
     if not target then target = Targeting.GetAutoTarget() or mq.TLO.Target end
 
     return Casting.TargetBuffCheck(mq.TLO.Me.AltAbility(aaName).Spell.ID(), target)
@@ -1524,10 +1540,10 @@ end
 --- TargetBuffCheck to confirm the det effect is not already on target.
 ---@param itemName string The item name whose clicky to check.
 ---@param target MQSpawn? Defaults to auto-target or current target.
----@return boolean, string True if the item's clicky det effect is not present.
+---@return boolean True if the item's clicky det effect is not present.
 function Casting.DetItemCheck(itemName, target)
     local clickySpell = Casting.GetClickySpell(itemName)
-    if not (clickySpell and clickySpell()) then return false, "Invalid Clicky Spell" end
+    if not (clickySpell and clickySpell()) then return false end
     if not target then target = Targeting.GetAutoTarget() or mq.TLO.Target end
 
     return Casting.TargetBuffCheck(clickySpell.ID(), target)
@@ -1538,12 +1554,12 @@ end
 --- target-change and duplicate-from-self checks enabled.
 ---@param spell MQSpell The DoT spell to check.
 ---@param target MQSpawn? Defaults to auto-target or current target.
----@return boolean, string True if the DoT should be applied to the target.
+---@return boolean True if the DoT should be applied to the target.
 function Casting.DotSpellCheck(spell, target)
-    if not (spell and spell()) then return false, "Invalid Spell" end
+    if not (spell and spell()) then return false end
     if not target then target = Targeting.GetAutoTarget() or mq.TLO.Target end
 
-    if Targeting.MobHasLowHP(target) then return false, "Target Has Low HP" end
+    if Targeting.MobHasLowHP(target) then return false end
 
     return Casting.TargetBuffCheck(Casting.GetUseableSpellId(spell), target, true, true)
 end
@@ -1553,13 +1569,13 @@ end
 --- target-change and duplicate-from-self checks enabled.
 ---@param itemName string The item name whose clicky DoT to check.
 ---@param target MQSpawn? Defaults to auto-target or current target.
----@return boolean, string True if the item's clicky DoT should be applied.
+---@return boolean True if the item's clicky DoT should be applied.
 function Casting.DotItemCheck(itemName, target)
     local clickySpell = Casting.GetClickySpell(itemName)
-    if not (clickySpell and clickySpell()) then return false, "Invalid Clicky Spell" end
+    if not (clickySpell and clickySpell()) then return false end
     if not target then target = Targeting.GetAutoTarget() or mq.TLO.Target end
 
-    if Targeting.MobHasLowHP(target) then return false, "Target Has Low HP" end
+    if Targeting.MobHasLowHP(target) then return false end
 
     return Casting.TargetBuffCheck(clickySpell.ID(), target, true, true)
 end

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -581,47 +581,4 @@ function Core.GetPetBlockedTable()
     end
 end
 
-function Core.SetRotationEntryTooltip(tooltipLines)
-    Modules:ExecModule("Class", "SetRotationEntryTooltip", tooltipLines)
-end
-
--- Builds and sets a rotation entry tooltip from a compact descriptor list.
--- Each entry: { label = "Label", value = bool, detail = "...", invert = false }
---   detail : optional string shown inline in white (e.g. "(55% <= 30%)" or a reason)
---   invert : if true, colors are flipped — red=true, green=false (use for "bad when true" checks)
-function Core.BuildRotationEntryTooltip(entries)
-    local Colors = Globals.Constants.Colors
-    local lines = {}
-    for _, entry in ipairs(entries) do
-        local passColor = entry.invert and Colors.LightRed or Colors.LightGreen
-        local failColor = entry.invert and Colors.LightGreen or Colors.LightRed
-        table.insert(lines, { text = entry.label .. ": ", color = Colors.White, padAfter = 4, })
-        table.insert(lines, { text = tostring(entry.value), color = entry.value and passColor or failColor, sameLine = true, padAfter = 4, })
-        if entry.detail and entry.detail:len() > 0 then
-            local detailText = entry.detail:sub(1, 1) == "(" and entry.detail or "(" .. entry.detail .. ")"
-            table.insert(lines, { text = detailText, color = Colors.White, sameLine = true, padAfter = 4, })
-        end
-    end
-    Core.SetRotationEntryTooltip(lines)
-end
-
--- Fluent tooltip accumulator. Usage:
---   local tt = Core.NewTooltip()
---   local ok  = tt:Add("Self Buff Check", Casting.SelfBuffCheck(spell))
---   local ok2 = tt:Add("Cast Ready",      Casting.CastReady(spell))
--- tt:Add(label, value, detail?, invert?) appends the row, updates the tooltip immediately, and returns value.
--- detail : optional string shown inline in white, or a reason string from a Check function
--- invert : if true, colors flip — red=true, green=false (use for "bad when true" checks)
-function Core.NewTooltip()
-    local tt = { _entries = {}, }
-
-    function tt:Add(label, value, detail, invert)
-        table.insert(self._entries, { label = label, value = value, detail = detail, invert = invert, })
-        Core.BuildRotationEntryTooltip(self._entries)
-        return value
-    end
-
-    return tt
-end
-
 return Core

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -324,7 +324,6 @@ function Rotation.Run(caller, rotationTable, targetTable, resolvedActionMap, ste
     -- Used for bards to dynamically weave properly
     if bDoFullRotation then start_step = 1 end
     for idx, entry in ipairs(rotationTable) do
-        caller.TempSettings.CurrentRotationEntryId = idx
         if enabledRotationEntries[entry.name] ~= false then
             if idx >= start_step then
                 local tStart = string.format("%.03f", Globals.GetTimeMS())

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -2002,18 +2002,13 @@ function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotation
                     Ui.RenderText(Icons.FA_EXCLAMATION)
                 end
                 ImGui.PopStyleColor()
-                if entry.cond_tooltip and ImGui.IsItemHovered() then
-                    Ui.Tooltip(entry.cond_tooltip)
+                if entry.tooltip then
+                    Ui.Tooltip(entry.tooltip)
                 end
             end
 
             ImGui.TableNextColumn()
             if enabledRotationEntries[entry.name] == false then Ui.StrikeThroughText(entry.name) else Ui.RenderText(entry.name) end
-
-            if entry.tooltip and ImGui.IsItemHovered() then
-                Ui.Tooltip(entry.tooltip)
-            end
-
             ImGui.TableNextColumn()
             local mappedAction = resolvedActionMap[entry.name]
             local typeLower = entry.type:lower()


### PR DESCRIPTION
Clicky Module Updates
* Added support for aura clickies (aura check logic block/condition).
* Added support for "All Buffable" as a choice for items.
* * It is highly recommended that this is only used when it is not feasible to instead attach the check to a (group buff) rotation.
* Added the ability to skip trigger spell checks with clickies.
* Adjusted Clickies per cycle to return to a default of 1. Clickies attached to a rotation do not count towards this limit.

Buff Check Improvements
* Better handle edge-case blocking and duration window differences.
* Remove special actions when the caster's buff window is full (underlying MQ issue was solved).
* Revert rotation entry UI POC (hopefully we can revisit this later).