### PR TITLE
Tanking Adjustments, Level Check Fix, Stability

### DIFF
--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -379,8 +379,8 @@ local _ClassConfig = {
             local interval = (self.TempSettings.MarchDuration or 12) - threshold
             return (Globals.GetTimeSeconds() - (self.TempSettings.LastMarchCast or 0)) >= interval
         end,
-        UnwantedAggroCheck = function(self) --Self-Explanatory. Add isTanking to this if you ever make a mode for bardtanks!
-            if Targeting.GetXTHaterCount() == 0 or Core.IAmMA() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
+        UnwantedAggroCheck = function(self)
+            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
             return Targeting.IHaveAggro(100)
         end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending

--- a/class_configs/EQ Might/mnk_class_config.lua
+++ b/class_configs/EQ Might/mnk_class_config.lua
@@ -195,7 +195,7 @@ local _ClassConfig = {
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
-                    if Core.IAmMA() then return false end
+                    if Core.IsTanking() then return false end
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99)
                 end,
             },
@@ -204,7 +204,7 @@ local _ClassConfig = {
                 type = "Ability",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IAmMA()
+                    return Targeting.IHaveAggro(80) and not Core.IsTanking()
                 end,
             },
             {

--- a/class_configs/EQ Might/rog_class_config.lua
+++ b/class_configs/EQ Might/rog_class_config.lua
@@ -404,8 +404,8 @@ return {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage
 
-        UnwantedAggroCheck = function(self) --Self-Explanatory. Add isTanking to this if you ever make a mode for roguetanks!
-            if Targeting.GetXTHaterCount() == 0 or Core.IAmMA() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
+        UnwantedAggroCheck = function(self)
+            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
             return Targeting.IHaveAggro(100)
         end,
     },

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -736,8 +736,8 @@ local _ClassConfig = {
             local interval = (self.TempSettings.MarchDuration or 12) - threshold
             return (Globals.GetTimeSeconds() - (self.TempSettings.LastMarchCast or 0)) >= interval
         end,
-        UnwantedAggroCheck = function(self) --Self-Explanatory. Add isTanking to this if you ever make a mode for bardtanks!
-            if Targeting.GetXTHaterCount() == 0 or Core.IAmMA() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
+        UnwantedAggroCheck = function(self)
+            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
             return Targeting.IHaveAggro(100)
         end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -938,7 +938,7 @@ return {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99) and not Core.IAmMA()
+                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99) and not Core.IsTanking()
                 end,
             },
             {

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -362,7 +362,7 @@ local _ClassConfig = {
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
-                    if Core.IAmMA() then return false end
+                    if Core.IsTanking() then return false end
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99)
                 end,
             },
@@ -371,7 +371,7 @@ local _ClassConfig = {
                 type = "Ability",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IAmMA()
+                    return Targeting.IHaveAggro(80) and not Core.IsTanking()
                 end,
             },
             {

--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -706,8 +706,8 @@ return {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage
 
-        UnwantedAggroCheck = function(self) --Self-Explanatory. Add isTanking to this if you ever make a mode for roguetanks!
-            if Targeting.GetXTHaterCount() == 0 or Core.IAmMA() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
+        UnwantedAggroCheck = function(self)
+            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
             return Targeting.IHaveAggro(100)
         end,
     },

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -333,8 +333,8 @@ local _ClassConfig = {
             local interval = (self.TempSettings.MarchDuration or 12) - threshold
             return (Globals.GetTimeSeconds() - (self.TempSettings.LastMarchCast or 0)) >= interval
         end,
-        UnwantedAggroCheck = function(self) --Self-Explanatory. Add isTanking to this if you ever make a mode for bardtanks!
-            if Targeting.GetXTHaterCount() == 0 or Core.IAmMA() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
+        UnwantedAggroCheck = function(self)
+            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
             return Targeting.IHaveAggro(100)
         end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -171,7 +171,7 @@ local _ClassConfig = {
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
-                    if Core.IAmMA() then return false end
+                    if Core.IsTanking() then return false end
                     return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99)
                 end,
             },
@@ -180,7 +180,7 @@ local _ClassConfig = {
                 type = "Ability",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IAmMA()
+                    return Targeting.IHaveAggro(80) and not Core.IsTanking()
                 end,
             },
             {

--- a/class_configs/Project Lazarus/rog_class_config.lua
+++ b/class_configs/Project Lazarus/rog_class_config.lua
@@ -429,8 +429,8 @@ return {
         end,
         --function to make sure we don't have non-hostiles in range before we use AE damage
 
-        UnwantedAggroCheck = function(self) --Self-Explanatory. Add isTanking to this if you ever make a mode for roguetanks!
-            if Targeting.GetXTHaterCount() == 0 or Core.IAmMA() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
+        UnwantedAggroCheck = function(self)
+            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
             return Targeting.IHaveAggro(100)
         end,
     },

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2813, }
+return { version = 2814, }

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -868,10 +868,9 @@ end
 
 ---@return boolean
 function Module:IsTanking()
-    if not self.ClassConfig or not self.ClassConfig.ModeChecks or not self.ClassConfig.ModeChecks.IsTanking then
-        return false
-    end
-    return self.ClassConfig.ModeChecks.IsTanking()
+    local modeChecks = self.ClassConfig and self.ClassConfig.ModeChecks
+    local classTanking = modeChecks and modeChecks.IsTanking and modeChecks.IsTanking()
+    return classTanking or Core.IAmGroupMT()
 end
 
 ---@return boolean

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -830,7 +830,9 @@ end
 ---@param id number
 ---@return string
 function Module:getPullAbilityDisplayName(id)
-    local displayName = self.TempSettings.ValidPullAbilities[id].DisplayName
+    local entry = self.TempSettings.ValidPullAbilities[id]
+    if not entry then return "Error" end
+    local displayName = entry.DisplayName
 
     if type(displayName) == 'function' then displayName = displayName() end
 
@@ -1072,6 +1074,7 @@ function Module:Render()
         end
         if #self.TempSettings.ValidPullAbilities > 0 then
             local pullAbility = Config:GetSetting('PullAbility')
+            if not self.TempSettings.ValidPullAbilities[pullAbility] then pullAbility = 1 end
             pullAbility, pressed = ImGui.Combo("Pull Ability", pullAbility, function(id) return self:getPullAbilityDisplayName(id) end,
                 #self.TempSettings.ValidPullAbilities) --, self.TempSettings.ValidPullAbilities, #self.TempSettings.ValidPullAbilities)
             if pressed then

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -370,6 +370,7 @@ end
 ---@return boolean True if the spell should be cast on the target.
 function Casting.GroupBuffCheck(spell, target, skipBlockCheck, skipTriggerCheck)
     if not (spell and spell()) then return false end
+    if not Casting.LevelCheckPass(spell, target) then return false end
     return Casting.ResolveBuffCheck(Casting.GetUseableSpellId(spell), target, skipBlockCheck, skipTriggerCheck)
 end
 
@@ -385,6 +386,7 @@ function Casting.GroupBuffAACheck(aaName, target, skipBlockCheck, skipTriggerChe
     if not Casting.CanUseAA(aaName) then return false end
     local aaSpell = mq.TLO.Me.AltAbility(aaName).Spell
     if not aaSpell or not aaSpell() then return false end
+    if not Casting.LevelCheckPass(aaSpell, target) then return false end
     return Casting.ResolveBuffCheck(aaSpell.ID(), target, skipBlockCheck, skipTriggerCheck)
 end
 
@@ -399,6 +401,7 @@ end
 function Casting.GroupBuffItemCheck(itemName, target, skipBlockCheck, skipTriggerCheck)
     local clickySpell = Casting.GetClickySpell(itemName)
     if not (clickySpell and clickySpell()) then return false end
+    if not Casting.LevelCheckPass(clickySpell, target) then return false end
     return Casting.ResolveBuffCheck(clickySpell.ID(), target, skipBlockCheck, skipTriggerCheck)
 end
 
@@ -1782,15 +1785,10 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
 
     local targetSpawn = mq.TLO.Spawn(targetId)
 
-    if (not Config:GetSetting('IgnoreLevelCheck')) and targetSpawn() and Targeting.TargetIsType("pc", targetSpawn) then
-        local targetLevel = targetSpawn.Level() or 0
-        local spellLevel  = spell.Level() or 999
-
-        if not Casting.LevelCheckPass(targetLevel, spellLevel) then
-            Logger.log_error("\ayUseSpell(): \arCasting %s failed level check with target=%d and spell=%d", spellName,
-                targetLevel, spellLevel)
-            return false
-        end
+    if not Casting.LevelCheckPass(spell, targetSpawn) then
+        Logger.log_debug("\ayUseSpell(): \arCasting %s failed level check with target=%d and spell=%d", spellName,
+            targetSpawn.Level() or 0, spell.Level() or 999)
+        return false
     end
 
     if not Casting.ReagentCheck(spell) then
@@ -2281,15 +2279,10 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
         return false
     end
 
-    if not Config:GetSetting('IgnoreLevelCheck') and targetSpawn() and Targeting.TargetIsType("pc", targetSpawn) then
-        local targetLevel = targetSpawn.Level() or 0
-        local spellLevel  = aaSpell.Level() or 999
-
-        if spellLevel <= Globals.Constants.LiveLevelCap and not Casting.LevelCheckPass(targetLevel, spellLevel) then
-            Logger.log_error("\ayUseAA(): \arCasting %s(spell: %s) failed level check with target=%d and spell=%d", aaName, aaSpell.Name(),
-                targetLevel, spellLevel)
-            return false
-        end
+    if not Casting.LevelCheckPass(aaSpell, targetSpawn) then
+        Logger.log_debug("\ayUseAA(): \arCasting %s(spell: %s) failed level check with target=%d and spell=%d", aaName, aaSpell.Name(),
+            targetSpawn.Level() or 0, aaSpell.Level() or 999)
+        return false
     end
 
     Casting.ActionPrep()
@@ -2861,14 +2854,20 @@ function Casting.GetUseableSpellId(spell)
     return spellId > 0 and spellId or spell.ID()
 end
 
---- Applies EQ's buff level restriction table (Fanra's wiki) to
---- determine whether a spell of spellLevel can land on targetLevel.
----@param targetLevel number The target's level.
----@param spellLevel number The spell's level to check against the cap.
----@return boolean True if the target is high enough to receive the spell.
-function Casting.LevelCheckPass(targetLevel, spellLevel)
-    local maxSpellLevel
+--- Returns true if spell is allowed to land on target per EQ's buff-level restriction (only applies to persistent beneficial buffs on PC targets, global IgnoreLevelCheck bypasses).
+---@param spell MQSpell The spell to evaluate.
+---@param target MQSpawn|MQTarget The target spawn handle to check.
+---@return boolean True if the spell is allowed to land on target.
+function Casting.LevelCheckPass(spell, target)
+    if not spell or not spell() then return false end
+    if Config:GetSetting('IgnoreLevelCheck') then return true end
+    if (target.Type() or ""):lower() ~= "pc" then return true end
+    if not (spell.Beneficial() and (spell.Duration.TotalSeconds() or 0) > 0) then return true end
+    local spellLevel = spell.Level() or 999
+    if spellLevel > Globals.Constants.LiveLevelCap then return true end
 
+    local targetLevel = target.Level() or 0
+    local maxSpellLevel
     -- table data taken from https://everquest.fanra.info/wiki/Spells,_Songs,_Disciplines,_and_AAs#Buff_level_restrictions
     -- converted to perpetuate past the table limits. untested
     if targetLevel <= 39 then

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -144,7 +144,7 @@ function Combat.EngageTarget(autoTargetId)
 
                 if not mq.TLO.Me.Combat() then
                     Logger.log_debug("\awNOTICE:\ax Engaging %s in mortal combat.", Targeting.GetTargetCleanName())
-                    if Core.IAmMA() then
+                    if Core.IsTanking() then
                         Comms.HandleAnnounce(Comms.FormatChatEvent("Tanking", Targeting.GetTargetCleanName(), "Started"), Config:GetSetting('AnnounceTargetGroup'),
                             Config:GetSetting('AnnounceTarget'), Config:GetSetting('AnnounceToRaidIfInRaid'))
                     end

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -217,6 +217,12 @@ function Core.IAmMA()
     return Core.GetMainAssistId() == mq.TLO.Me.ID()
 end
 
+--- Returns true if this character is set as the EQ group's Main Tank.
+---@return boolean True if this toon holds the group MT slot.
+function Core.IAmGroupMT()
+    return (mq.TLO.Group.MainTank.ID() or 0) == mq.TLO.Me.ID()
+end
+
 --- Returns the spawn ID of the configured main assist character.
 ---@return number The spawn ID, or 0 if no main assist is set or not found.
 function Core.GetMainAssistId()

--- a/utils/events.lua
+++ b/utils/events.lua
@@ -36,7 +36,7 @@ function Events.HandleDeath()
     if Config:GetSetting('DoFellow') and not Modules:ExecModule("Movement", "InCampZone") then
         Logger.log_debug("Doing fellowship post death.")
         if mq.TLO.FindItem("Fellowship Registration Insignia").Timer.TotalSeconds() == 0 then
-            mq.delay("30s", function() return (mq.TLO.Me.CombatState():lower() == "active") end)
+            mq.delay("30s", function() return ((mq.TLO.Me.CombatState() or ""):lower() == "active") end)
             Core.DoCmd("/useitem \"Fellowship Registration Insignia\"")
             mq.delay("2s",
                 function() return (mq.TLO.FindItem("Fellowship Registration Insignia").Timer.TotalSeconds() ~= 0) end)

--- a/utils/item_manager.lua
+++ b/utils/item_manager.lua
@@ -89,9 +89,9 @@ function ItemManager.SwapItemToSlot(slot, item)
     Logger.log_verbose("\ag Found Item! Swapping item %s to %s", item, slot)
 
     Core.DoCmd("/itemnotify \"%s\" leftmouseup", item)
-    mq.delay(100, function() return mq.TLO.Cursor() and mq.TLO.Cursor.Name() == item end)
+    mq.delay(100, function() return mq.TLO.Cursor() ~= nil and mq.TLO.Cursor.Name() == item end)
     Core.DoCmd("/itemnotify %s leftmouseup", slot)
-    mq.delay(100, function() return mq.TLO.Cursor() and mq.TLO.Cursor.Name() ~= item end)
+    mq.delay(100, function() return mq.TLO.Cursor() ~= nil and mq.TLO.Cursor.Name() ~= item end)
 
     while mq.TLO.Cursor.ID() do
         mq.delay(1)

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -490,7 +490,7 @@ end
 ---@param slot number XTarget slot index to reset (1–20).
 function Targeting.ResetXTSlot(slot)
     Core.DoCmd("/xtarget set %d ET", slot)
-    mq.delay(500, function() return (mq.TLO.Me.XTarget(slot).TargetType():lower() or "empty target") == "empty target" end)
+    mq.delay(500, function() return (mq.TLO.Me.XTarget(slot).TargetType() or "") == "Empty Target" end)
     Core.DoCmd("/xtarget set %d autohater", slot)
 end
 
@@ -805,7 +805,7 @@ end
 --- either aggro throttling is off, the player is the tank, or aggro is below MobMaxAggro.
 ---@return boolean True if aggro is within acceptable limits.
 function Targeting.AggroCheckOkay()
-    if not mq.TLO.Group() or (mq.TLO.Group.MainTank.ID() or 0) == mq.TLO.Me.ID() or Core.IsTanking() then return true end
+    if not mq.TLO.Group() or Core.IsTanking() then return true end
     return (mq.TLO.Target.PctAggro() or 0) < Config:GetSetting('MobMaxAggro') or not Config:GetSetting('AggroThrottling')
 end
 


### PR DESCRIPTION
* Tanking Adjustments - PCs assigned the group main tank role will perform many actions (stick settings, etc) as a tank would.
* * Firmly decoupled MA checks from configs that were used as proxies to imply tanking.
* Fixed an issue where certain spells were falsely being gated by level checks.
* Various stability fixes.