### PR TITLE
Config Adjustments

### DIFF
--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -841,7 +841,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
                 cond = function(self, aaName)
                     if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and self.Helpers.UnwantedAggroCheck(self)
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or Globals.AutoTargetIsNamed) and self.Helpers.UnwantedAggroCheck(self)
                 end,
             },
             {

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -709,8 +709,8 @@ return {
                     (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
                         -- we have met our defense count threshold
                         self.Helpers.DefensiveDiscCheck(true) or
-                        -- we are fighting a named and we are (presumably) tanking it
-                        (Globals.AutoTargetIsNamed and Targeting.GetAutoTargetAggroPct() >= 100))
+                        -- we are fighting a named and we are tanking it
+                        Targeting.TankingXTNamed())
             end,
         },
         { --Offensive actions to temporarily boost damage dealt

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -545,8 +545,8 @@ local _ClassConfig = {
                     (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
                         -- we have met our defense count threshold
                         self.Helpers.DefensiveDiscCheck(true) or
-                        -- we are fighting a named and we are (presumably) tanking it
-                        (Globals.AutoTargetIsNamed and Targeting.GetAutoTargetAggroPct() >= 100))
+                        -- we are fighting a named and we are tanking it
+                        Targeting.TankingXTNamed())
             end,
         },
         { --Keep things from running
@@ -930,7 +930,7 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.Skin,
                 cond = function(self, spell, target)
-                    if not Core.IsTanking() or not Globals.AutoTargetIsNamed then return false end
+                    if not Core.IsTanking() or not Targeting.TankingXTNamed() then return false end
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
@@ -979,7 +979,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName, target)
                     if Config:GetSetting('HoldEpicForNoDisc') and not Casting.NoDiscActive() then return false end
-                    return self.Helpers.LeechCheck(self) or Globals.AutoTargetIsNamed
+                    return self.Helpers.LeechCheck(self) or Targeting.TankingXTNamed()
                 end,
             },
         },

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -324,8 +324,8 @@ local _ClassConfig = {
                     (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
                         -- we have met our defense count threshold
                         self.Helpers.DefensiveDiscCheck(true) or
-                        -- we are fighting a named and we are (presumably) tanking it
-                        (Globals.AutoTargetIsNamed and Targeting.GetAutoTargetAggroPct() >= 100))
+                        -- we are fighting a named and we are tanking it
+                        Targeting.TankingXTNamed())
             end,
         },
         { --Offensive actions to temporarily boost damage dealt

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -1437,7 +1437,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
                 cond = function(self, aaName)
                     if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and self.Helpers.UnwantedAggroCheck(self)
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or Globals.AutoTargetIsNamed) and self.Helpers.UnwantedAggroCheck(self)
                 end,
             },
             {
@@ -1478,7 +1478,7 @@ local _ClassConfig = {
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others
                     return (combatState == "Combat" and (mq.TLO.Me.Buff(aaBuff).Duration.TotalSeconds() or 0) < 15) or
-                    (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
+                        (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
                 end,
             },
         },

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -1050,8 +1050,8 @@ local _ClassConfig = {
                     (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
                         -- we have met our defense count threshold
                         self.Helpers.DefensiveDiscCheck(true) or
-                        -- we are fighting a named and we are (presumably) tanking it
-                        (Globals.AutoTargetIsNamed and Targeting.GetAutoTargetAggroPct() >= 100))
+                        -- we are fighting a named and we are tanking it
+                        Targeting.TankingXTNamed())
             end,
         },
         {

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -909,7 +909,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or Globals.AutoTargetIsNamed or
+                return combat_state == "Combat" and (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or Targeting.TankingXTNamed() or
                     self.Helpers.DefensiveDiscCheck(true))
             end,
         },

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -412,7 +412,7 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 --need to look at rotation and decide if it should fire during emergencies. leaning towards no
                 return combat_state == "Combat" and Core.IsTanking() and (mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') or
-                    Globals.AutoTargetIsNamed or self.Helpers.DefensiveDiscCheck(true))
+                    Targeting.TankingXTNamed() or self.Helpers.DefensiveDiscCheck(true))
             end,
         },
         { --Offensive actions to temporarily boost damage dealt

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -784,7 +784,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
                 cond = function(self, aaName)
                     if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and self.Helpers.UnwantedAggroCheck(self)
+                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or Globals.AutoTargetIsNamed) and self.Helpers.UnwantedAggroCheck(self)
                 end,
             },
             {
@@ -821,7 +821,7 @@ local _ClassConfig = {
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others
                     return (combatState == "Combat" and (mq.TLO.Me.Buff(aaName).Duration.TotalSeconds() or 0) < 15) or
-                    (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
+                        (combatState == "Downtime" and Casting.GroupBuffAACheck(aaName, target))
                 end,
             },
         },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -643,8 +643,8 @@ return {
                     (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
                         -- we have met our defense count threshold
                         self.Helpers.DefensiveDiscCheck(true) or
-                        -- we are fighting a named and we are (presumably) tanking it
-                        (Globals.AutoTargetIsNamed and Targeting.GetAutoTargetAggroPct() >= 100))
+                        -- we are fighting a named and we are tanking it
+                        Targeting.TankingXTNamed())
             end,
         },
         { --Offensive actions to temporarily boost damage dealt

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -458,8 +458,8 @@ local _ClassConfig = {
                     (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
                         -- we have met our defense count threshold
                         self.Helpers.DefensiveDiscCheck(true) or
-                        -- we are fighting a named and we are (presumably) tanking it
-                        (Globals.AutoTargetIsNamed and Targeting.GetAutoTargetAggroPct() >= 100))
+                        -- we are fighting a named and we are tanking it
+                        Targeting.TankingXTNamed())
             end,
         },
         { --Keep things from running
@@ -838,7 +838,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return Core.IsTanking() and Config:GetSetting('DoTerror') end,
                 cond = function(self, spell, target)
-                    return Globals.AutoTargetIsNamed and (Casting.CanUseAA("Cascading Theft of Defense") and not Casting.IHaveBuff("Cascading Theft of Defense"))
+                    return Targeting.TankingXTNamed() and (Casting.CanUseAA("Cascading Theft of Defense") and not Casting.IHaveBuff("Cascading Theft of Defense"))
                 end,
             },
             {
@@ -846,7 +846,7 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.Skin,
                 cond = function(self, spell, target)
-                    if not Core.IsTanking() or not Globals.AutoTargetIsNamed then return false end
+                    if not Core.IsTanking() or not Targeting.TankingXTNamed() then return false end
                     return Casting.SelfBuffCheck(spell)
                         --laz specific deconflict
                         and not Casting.IHaveBuff("Necrotic Pustules")
@@ -887,7 +887,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName, target)
-                    return self.Helpers.LeechCheck(self) or Globals.AutoTargetIsNamed
+                    return self.Helpers.LeechCheck(self) or Targeting.TankingXTNamed()
                 end,
             },
             {

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -267,8 +267,8 @@ local _ClassConfig = {
                     (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
                         -- we have met our defense count threshold
                         self.Helpers.DefensiveDiscCheck(true) or
-                        -- we are fighting a named and we are (presumably) tanking it
-                        (Globals.AutoTargetIsNamed and Targeting.GetAutoTargetAggroPct() >= 100))
+                        -- we are fighting a named and we are tanking it
+                        Targeting.TankingXTNamed())
             end,
         },
         { --Offensive actions to temporarily boost damage dealt

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2817, }
+return { version = 2818, }


### PR DESCRIPTION
* BRD(All) - fading memories no longer waits for lower health if the aggro is on a named (walkback from previous change).
* Tanks now leverage named on XT changes better for defense rotations.