### PR TITLE
Targeting, Casting Fixes, EQM Config updates

### DIFF
--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -232,10 +232,6 @@ local _ClassConfig = {
             "Aura of the Pious",  -- Level 66
             "Aura of the Zealot", -- Level 55
         },
-        ['HPAura'] = {
-            ---- Aura Buff 2 - Aura Name is the same as the buff name
-            "Aura of Divinity", -- Level 100
-        },
         ['DivineBuff'] = {
             --Divine Buffs REQUIRES extra spell slot because of the 90s recast
             "Divine Incursion",    -- Level 69 EQM Custom
@@ -903,38 +899,14 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "Spirit Mastery",
-                type = "AA",
-                pre_activate = function(self, aaName) --remove the old aura if we just purchased the AA, otherwise we will be spammed because of no focus.
-                    ---@diagnostic disable-next-line: undefined-field
-                    if not Casting.AuraActiveByName("Aura of Pious Divinity") then mq.TLO.Me.Aura(1).Remove() end
-                end,
-                cond = function(self, aaName)
-                    return not Casting.AuraActiveByName("Aura of Pious Divinity")
-                end,
-            },
-            {
                 name = "AbsorbAura",
                 type = "Spell",
-                pre_activate = function(self, spell) --remove the old aura if we leveled up (or the other aura if we just changed options), otherwise we will be spammed because of no focus.
+                pre_activate = function(self, spell) --remove the old aura if we leveled up, otherwise we will be spammed because of no focus.
                     ---@diagnostic disable-next-line: undefined-field
                     if not Casting.AuraActiveByName(spell.BaseName()) then mq.TLO.Me.Aura(1).Remove() end
                 end,
                 cond = function(self, spell)
-                    if Casting.CanUseAA('Spirit Mastery') then return false end
-                    return not Casting.AuraActiveByName(spell.BaseName()) and Config:GetSetting('UseAura') == 1
-                end,
-            },
-            {
-                name = "HPAura",
-                type = "Spell",
-                pre_activate = function(self, spell) --remove the old aura if we leveled up (or the other aura if we just changed options), otherwise we will be spammed because of no focus.
-                    ---@diagnostic disable-next-line: undefined-field
-                    if not Casting.AuraActiveByName(spell.BaseName()) then mq.TLO.Me.Aura(1).Remove() end
-                end,
-                cond = function(self, spell)
-                    if Casting.CanUseAA('Spirit Mastery') then return false end
-                    return not Casting.AuraActiveByName(spell.BaseName()) and Config:GetSetting('UseAura') == 2
+                    return not Casting.AuraActiveByName(spell.BaseName())
                 end,
             },
         },
@@ -1114,19 +1086,6 @@ local _ClassConfig = {
             Min = 1,
             Max = 3,
             RequiresLoadoutChange = true,
-        },
-        ['UseAura']           = {
-            DisplayName = "Aura Spell Choice:",
-            Group = "Abilities",
-            Header = "Buffs",
-            Category = "Group",
-            Index = 104,
-            Tooltip = "Select the Aura to be used, prior to purchasing the Spirit Mastery AA.",
-            Type = "Combo",
-            ComboOptions = { 'Absorb', 'HP', 'None', },
-            Default = 1,
-            Min = 1,
-            Max = 3,
         },
         ['DoDivineBuff']      = {
             DisplayName = "Do Divine Intervetion",

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -102,7 +102,7 @@ local _ClassConfig    = {
             "Quickness",           -- Level 15
         },
         ['ManaRegen'] = {
-            "Seer's Intuition",                  -- Level 71
+            -- "Seer's Intuition",               -- Level 71, not worth the hassle over the group item click
             "Ancient: Blessing of Clairvoyance", -- Level 70 EQM Custom
             "Voice of Clairvoyance",             -- Level 70
             "Clairvoyance",                      -- Level 68
@@ -578,6 +578,14 @@ local _ClassConfig    = {
             local tashSpell = self.ResolvedActionMap['TashSpell']
             return not (tashSpell and tashSpell() and tashSpell.Name() == "Echo of Tashan")
         end,
+        ManaBuffChoice = function()
+            if mq.TLO.Me.Level() >= 69 and mq.TLO.FindItem("=Legendary Timeless Belt of the Wise")() then
+                return "BeltItem"
+            elseif mq.TLO.Me.Level() >= 68 and mq.TLO.FindItem("=Ancient Artifact of Clairvoyance")() then
+                return "ArtifactItem"
+            end
+            return "ManaSpell"
+        end,
         DoRez = function(self, corpseId)
             local rezStaff = Core.GetResolvedActionMapItem('RezStaff')
 
@@ -775,9 +783,17 @@ local _ClassConfig    = {
         },
         ['GroupBuff']     = {
             {
+                name = "Legendary Timeless Belt of the Wise",
+                type = "Item",
+                load_cond = function(self) return self.Helpers.ManaBuffChoice() == "BeltItem" end,
+                cond = function(self, itemName, target)
+                    return Casting.GroupBuffItemCheck(itemName, target)
+                end,
+            },
+            {
                 name = "Ancient Artifact of Clairvoyance",
                 type = "Item",
-                load_cond = function() return mq.TLO.Me.Level() >= 68 and mq.TLO.FindItem("=Ancient Artifact of Clairvoyance")() end,
+                load_cond = function(self) return self.Helpers.ManaBuffChoice() == "ArtifactItem" end,
                 cond = function(self, itemName, target)
                     return Casting.GroupBuffItemCheck(itemName, target)
                 end,
@@ -785,7 +801,7 @@ local _ClassConfig    = {
             {
                 name = "ManaRegen",
                 type = "Spell",
-                load_cond = function() return mq.TLO.Me.Level() < 68 or not mq.TLO.FindItem("=Ancient Artifact of Clairvoyance")() end,
+                load_cond = function(self) return self.Helpers.ManaBuffChoice() == "ManaSpell" end,
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     if not Targeting.TargetIsACaster(target) then return false end

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2818, }
+return { version = 2819, }

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2819, }
+return { version = 2820, }

--- a/ui/target.lua
+++ b/ui/target.lua
@@ -229,6 +229,7 @@ end
 
 function TargetUI:RenderWindow(flags)
     flags = bit32.bor(flags, ImGuiWindowFlags.NoTitleBar, Config:GetSetting('LockTargetWindow') and bit32.bor(ImGuiWindowFlags.NoMove, ImGuiWindowFlags.NoResize) or 0)
+    ImGui.SetNextWindowSize(ImVec2(540, 160), ImGuiCond.FirstUseEver)
     local open, show = ImGui.Begin(Ui.GetWindowTitle("Target"), Config:GetSetting('ShowTargetWindow'), flags)
     if show then
         self:RenderContent()

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -856,7 +856,9 @@ end
 --- @return integer
 function Casting.MaxAuraSlots()
     if Core.OnLaz() then return 1 end
-    return Casting.AARank('Auroria Mastery') + 1
+    local auroriaSlots = Casting.AARank('Auroria Mastery')
+    local spiritSlots = Casting.CanUseAA('Spirit Mastery') and 1 or 0
+    return auroriaSlots + spiritSlots + 1
 end
 
 --- Returns true if at least one aura slot is currently empty.

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -591,24 +591,25 @@ function Combat.FindBestAutoTarget(validateFn)
         Globals.LastPulledID = 0
     end
 
-    -- FollowMarkTarget causes RG to have allow RG toons focus on who the group has marked. We'll exit early if this is the case.
+    local target = mq.TLO.Target
+    local assistTargetIsNamed = nil
+    local markedHandled = false
+
+    -- FollowMarkTarget: set candidate and route through the common validation below; far/invalid marks get cleared there.
     if Config:GetSetting('FollowMarkTarget') then
         local markNPC = mq.TLO.Me.GroupMarkNPC(1)
-        if markNPC and markNPC() and markNPC.ID() > 0 and Globals.AutoTargetID ~= markNPC.ID() then
-            Globals.AutoTargetID = markNPC.ID()
-            Globals.AutoTargetIsNamed = Targeting.IsNamed(markNPC)
-            Logger.log_debug("FindAutoTarget(): Following Marked Target: \ag%s\ax [ID: \ag%d\ax] Named(%s)", markNPC.CleanName() or "None", markNPC.ID(),
-                Strings.BoolToColorString(Globals.AutoTargetIsNamed))
-            return
+        if markNPC and markNPC() and markNPC.ID() > 0 then
+            if Globals.AutoTargetID ~= markNPC.ID() then
+                Globals.AutoTargetID = markNPC.ID()
+                Logger.log_debug("FindAutoTarget(): Following Marked Target: \ag%s\ax [ID: \ag%d\ax]", markNPC.CleanName() or "None", markNPC.ID())
+            end
+            assistTargetIsNamed = Targeting.IsNamed(markNPC)
+            markedHandled = true
         end
     end
 
-    local target = mq.TLO.Target
-    local targetValidated = false
-    local assistTargetIsNamed = nil
-
     -- Now handle normal situations where we need to choose a target because we don't have one.
-    if Core.IAmMA() then
+    if not markedHandled and Core.IAmMA() then
         Logger.log_verbose("FindAutoTarget() ==> I am MA!")
         if Globals.ForceTargetID ~= 0 then
             local forceSpawn = mq.TLO.Spawn(Globals.ForceTargetID)
@@ -670,7 +671,7 @@ function Combat.FindBestAutoTarget(validateFn)
                 end
             end
         end
-    else
+    elseif not markedHandled then
         local assistId = 0
 
         -- check if we are currently forcing a target, use it as the assistId to validate if so, clear the ForceTargetID if its dead.
@@ -696,15 +697,17 @@ function Combat.FindBestAutoTarget(validateFn)
             assistId, assistTargetIsNamed = Combat.GetMainAssistTargetID()
         end
 
-        if assistId > 0 and (validateFn == nil or validateFn(assistId)) then
-            targetValidated = true
+        if assistId > 0 then
             Globals.AutoTargetID = assistId
-        else
-            Globals.AutoTargetID = 0
-            assistTargetIsNamed = false
-            Globals.AutoTargetElementalImmunities = {}
-            Globals.AutoTargetStatusImmunities = {}
         end
+    end
+
+    -- Common validation: any AutoTargetID set above gets gated through validateFn once here. Failure zeroes and clears caches.
+    if Globals.AutoTargetID > 0 and validateFn and not validateFn(Globals.AutoTargetID) then
+        Globals.AutoTargetID = 0
+        assistTargetIsNamed = false
+        Globals.AutoTargetElementalImmunities = {}
+        Globals.AutoTargetStatusImmunities = {}
     end
 
     if Globals.AutoTargetID > 0 then
@@ -723,22 +726,20 @@ function Combat.FindBestAutoTarget(validateFn)
     Logger.log_verbose("FindAutoTarget(): FoundTargetID(%d) - Named(%s), myTargetId(%d)", Globals.AutoTargetID or 0, Strings.BoolToColorString(Globals.AutoTargetIsNamed),
         mq.TLO.Target.ID())
 
-    if Config:GetSetting('DoAutoTarget') then
-        local autoTargetId = Globals.AutoTargetID or 0
-        if autoTargetId > 0 and (targetValidated or (validateFn == nil or validateFn(autoTargetId))) then
-            if mq.TLO.Target.ID() ~= autoTargetId then
-                Targeting.SetTarget(autoTargetId)
-            end
+    if Config:GetSetting('DoAutoTarget') and Globals.AutoTargetID > 0 then
+        local autoTargetId = Globals.AutoTargetID
+        if mq.TLO.Target.ID() ~= autoTargetId then
+            Targeting.SetTarget(autoTargetId)
+        end
 
-            -- For Assist Lists, this ensures we correctly and quickly receive health percent to assist in a timely manner
-            -- For Emu, this helps correct for emu xtarget bugs
-            -- For Force Target, this makes sure a non-aggressive mob is added to our xtargets for tracking
-            -- Second dead check because targets were ocasionally dying between the validateFn and this check
-            if Config:GetSetting('UseAssistList') or Core.OnEMU() or autoTargetId == Globals.ForceTargetID then
-                if mq.TLO.Spawn(autoTargetId)() and not mq.TLO.Spawn(autoTargetId).Dead() and not Targeting.IsSpawnXTHater(autoTargetId) then
-                    Targeting.AddXTByID(1, Globals.AutoTargetID)
-                    Logger.log_verbose("FindAutoTarget(): FoundTargetID(%d) not on xt list, adding.", autoTargetId or 0)
-                end
+        -- For Assist Lists, this ensures we correctly and quickly receive health percent to assist in a timely manner
+        -- For Emu, this helps correct for emu xtarget bugs
+        -- For Force Target, this makes sure a non-aggressive mob is added to our xtargets for tracking
+        -- Second dead check because targets were ocasionally dying between the validateFn and this check
+        if Config:GetSetting('UseAssistList') or Core.OnEMU() or autoTargetId == Globals.ForceTargetID then
+            if mq.TLO.Spawn(autoTargetId)() and not mq.TLO.Spawn(autoTargetId).Dead() and not Targeting.IsSpawnXTHater(autoTargetId) then
+                Targeting.AddXTByID(1, Globals.AutoTargetID)
+                Logger.log_verbose("FindAutoTarget(): FoundTargetID(%d) not on xt list, adding.", autoTargetId or 0)
             end
         end
     end
@@ -795,8 +796,12 @@ function Combat.OkToEngagePreValidateId(targetId)
 
     if not Globals.BackOffFlag then
         if Core.IAmMA() then
-            Logger.log_verbose("OkToEngagePrevalidate check for %s(ID: %d) - I am MA, proceeding!", targetName, targetId)
-            return true
+            if Targeting.GetTargetDistance(target) <= Config:GetSetting('AssistRange') then
+                Logger.log_verbose("OkToEngagePrevalidate check for %s(ID: %d) - I am MA, proceeding!", targetName, targetId)
+                return true
+            end
+            Logger.log_verbose("OkToEngagePrevalidate check for %s(ID: %d) - I am MA but target beyond AssistRange.", targetName, targetId)
+            return false
         else -- can't check HP yet, as we haven't targeted
             local distanceCheck = Targeting.GetTargetDistance(target) < Config:GetSetting('AssistRange')
             local hostileCheck = Config:GetSetting('TargetNonAggressives') or target.Aggressive()
@@ -878,8 +883,12 @@ function Combat.OkToEngage(autoTargetId)
 
     if not Globals.BackOffFlag then
         if Core.IAmMA() then
-            Logger.log_verbose("OkToEngage check for %s(ID: %d) - I am MA, proceeding!", targetName, targetId)
-            return true
+            if Targeting.GetTargetDistance() <= Config:GetSetting('AssistRange') then
+                Logger.log_verbose("OkToEngage check for %s(ID: %d) - I am MA, proceeding!", targetName, targetId)
+                return true
+            end
+            Logger.log_verbose("OkToEngage check for %s(ID: %d) - I am MA but target beyond AssistRange.", targetName, targetId)
+            return false
         else
             local distanceCheck = Targeting.GetTargetDistance() < Config:GetSetting('AssistRange')
             local assistHPCheck = Targeting.GetTargetPctHPs() <= Config:GetSetting('AutoAssistAt')


### PR DESCRIPTION
* Casting - Fix for aura checks/spirit mastery (thanks rah!)
* Adjusted autotarget selection to prevent a couple of edge-case scenarios while still preserving overall intent.
* * Marked Targets are now prevalidated.
* * Prevalidation path is the same for MA/non-MA.
* * MA will no longer ignore range for pre-validation.

* ENC(EQM) - Add new group mana regen buff belt.
* CLR(EQM) - Remove Laz aura logic.

* Set initial size of rgmercs target window.

