### PR TITLE
Bard Melody Adjustment, Config Work, Performance/Bug Fixes

### DIFF
--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -6,7 +6,6 @@ local Core         = require("utils.core")
 local Globals      = require('utils.globals')
 local ItemManager  = require('utils.item_manager')
 local Logger       = require("utils.logger")
-local Strings      = require("utils.strings")
 local Targeting    = require("utils.targeting")
 
 local Tooltips     = {
@@ -46,11 +45,6 @@ local _ClassConfig = {
     ['Modes']         = { --other modes to reorder spell priorities may be added back in at a later date.
         'General',
     },
-    ['OnModeChange']  = function(self, mode)
-        --not currently accounting for the "Tune Stuck In Your Head" AA
-        self.TempSettings.MarchDuration = Casting.CanUseAA("Extended Ingenuity") and 18 or 12
-    end,
-
     ['ModeChecks']    = {
         CanMez    = function() return true end,
         CanCharm  = function() return true end,
@@ -362,22 +356,45 @@ local _ClassConfig = {
             if usestate == 4 then return not inCombat end -- Out-of-Combat Only
             return false
         end,
-        RefreshBuffSong = function(songSpell) --determine how close to a buff's expiration we will resing to maintain full uptime
+        GetSongBuffer = function() --seconds of remaining duration at which a buff song is resung
+            return Config:GetSetting('SongRefresh')
+        end,
+        RefreshBuffSong = function(self, songSpell) --true once a buff song's remaining duration drops to the resing buffer (a dropped song reads 0 and resings)
             if not songSpell or not songSpell() then return false end
             local me = mq.TLO.Me
-            local threshold = Globals.CurrentState == "Combat" and Config:GetSetting('RefreshCombat') or Config:GetSetting('RefreshDT')
-            local duration = songSpell.DurationWindow() == 1 and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
-            local ret = duration <= threshold
-            Logger.log_verbose("\ayRefreshBuffSong(%s) => memed(%s), duration(%d), threshold(%d), should refresh:(%s)", songSpell,
-                Strings.BoolToColorString(me.Gem(songSpell.RankName.Name())() ~= nil), duration, threshold, Strings.BoolToColorString(ret))
-            return ret
+            local remaining = songSpell.DurationWindow() == 1
+                and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0)
+                or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
+            if self.TempSettings.upkeepFill then
+                local full = Config:GetSetting('SongDuration', true) or songSpell.MyDuration.TotalSeconds()
+                return remaining < full - self.Helpers.GetSongBuffer()
+            end
+            return remaining <= self.Helpers.GetSongBuffer()
         end,
-        MarchTimer = function(self) --refresh duration of warmarch based on a timer when jonthan is being used
-            local jonthan = Core.GetResolvedActionMapItem('Jonthan')
-            if not (jonthan and Config:GetSetting('UseJonthan') > 1 and (mq.TLO.Me.Song(jonthan.Name()).ID() or 0) > 0) then return nil end
-            local threshold = Globals.CurrentState == "Combat" and Config:GetSetting('RefreshCombat') or Config:GetSetting('RefreshDT')
-            local interval = (self.TempSettings.MarchDuration or 12) - threshold
+        MarchTimer = function(self) --minimum gap between War March resings, from the Song Duration setting
+            local interval = Config:GetSetting('SongDuration') - self.Helpers.GetSongBuffer()
             return (Globals.GetTimeSeconds() - (self.TempSettings.LastMarchCast or 0)) >= interval
+        end,
+        RefreshExpiringSong = function(self) --idle upkeep: resing the active song closest to expiring
+            local melody = self.TempSettings.RotationTable['Melody']
+            if not melody then return false end
+            local me = mq.TLO.Me
+            local pick, pickRemaining = nil, nil
+            self.TempSettings.upkeepFill = true
+            for _, entry in ipairs(melody) do
+                local songSpell = Core.GetResolvedActionMapItem(entry.name)
+                if songSpell and songSpell() and entry.cond and Core.SafeCallFunc("upkeep want", entry.cond, self, songSpell, me) then
+                    local remaining = songSpell.DurationWindow() == 1
+                        and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0)
+                        or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
+                    if remaining > 0 and Casting.SongReady(songSpell) and (not pickRemaining or remaining < pickRemaining) then
+                        pick, pickRemaining = songSpell, remaining
+                    end
+                end
+            end
+            self.TempSettings.upkeepFill = false
+            if pick then return Casting.UseSong(pick.RankName(), me.ID(), false) end
+            return false
         end,
         UnwantedAggroCheck = function(self)
             if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
@@ -459,7 +476,9 @@ local _ClassConfig = {
             steps = 1,
             timer = 0,
             doFullRotation = true,
-            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            blockMem = true,
+            reorderable = true,
+            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 if Globals.InMedState then return false end
                 if combat_state == "Downtime" and mq.TLO.Me.Invis() then return false end
@@ -487,19 +506,10 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'CombatSongs',
-            state = 1,
-            steps = 1,
-            doFullRotation = true,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and Core.CombatActionsCheck()
-            end,
-        },
-        {
             name = 'InstantRunBuff',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableIDs() end,
             load_cond = function(self) return Casting.CanUseAA("Selo's Sonata") end,
             cond = function(self, combat_state)
@@ -629,83 +639,12 @@ local _ClassConfig = {
                 midSong = true,
             },
         },
-        ['CombatSongs'] = {
-            {
-                name = "FireDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseFireDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            {
-                name = "IceDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseIceDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            {
-                name = "PoisonDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UsePoisonDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            {
-                name = "DiseaseDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseDiseaseDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            --failsafe/fallback to fill dead space and/or refresh charges, may adjust after more testing
-            {
-                name = "AreaAriaSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('AriaChoice') == 2 end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 6
-                end,
-            },
-            {
-                name = "GroupAriaSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('AriaChoice') == 3 end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 6
-                end,
-            },
-            {
-                name = "ArcaneSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseArcane') > 1 end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 6
-                end,
-            },
-            {
-                name = "ProcSong",
-                type = "Song",
-                cond = function(self, songSpell)
-                    if Config:GetSetting("UseProcSong") == 1 then return false end
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 6
-                end,
-            },
-        },
         ['Enduring Breath'] = {
             {
                 name = "EndBreathSong",
                 type = "Song",
                 cond = function(self, songSpell)
-                    return self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
         },
@@ -715,7 +654,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('AriaChoice') == 2 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -723,7 +662,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('AriaChoice') == 3 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -732,9 +671,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('UseMarch') > 1 end,
                 cond = function(self, songSpell)
                     if not self.Helpers.CheckSongStateUse(self, "UseMarch") then return false end
-                    local marchTimer = self.Helpers.MarchTimer(self)
-                    if marchTimer ~= nil then return marchTimer end
-                    return self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.MarchTimer(self) and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
                 post_activate = function(self, songSpell, success)
                     if success then self.TempSettings.LastMarchCast = Globals.GetTimeSeconds() end
@@ -745,7 +682,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseRunBuff') > 1 and not Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseRunBuff") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseRunBuff") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -753,7 +690,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseJonthan') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseJonthan") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseJonthan") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -761,7 +698,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseProcSong') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseProcSong") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseProcSong") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -769,7 +706,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseResist') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseResist") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseResist") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -777,7 +714,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseMitigation') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseMitigation") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseMitigation") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -785,7 +722,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseArcane') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseArcane") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseArcane") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -794,7 +731,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('RegenSong') == 2 end,
                 cond = function(self, songSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return self.Helpers.RefreshBuffSong(songSpell) and
+                    return self.Helpers.RefreshBuffSong(self, songSpell) and
                         ((Config:GetSetting('UseRegen') == 1 and (mq.TLO.Group.LowMana(pct)() or 999) >= Config:GetSetting('GroupManaCt'))
                             or (Config:GetSetting('UseRegen') > 1 and self.Helpers.CheckSongStateUse(self, "UseRegen")))
                 end,
@@ -805,7 +742,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('RegenSong') == 3 end,
                 cond = function(self, songSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return self.Helpers.RefreshBuffSong(songSpell) and
+                    return self.Helpers.RefreshBuffSong(self, songSpell) and
                         ((Config:GetSetting('UseRegen') == 1 and (mq.TLO.Group.LowMana(pct)() or 999) >= Config:GetSetting('GroupManaCt'))
                             or (Config:GetSetting('UseRegen') > 1 and self.Helpers.CheckSongStateUse(self, "UseRegen")))
                 end,
@@ -815,8 +752,49 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseAmp') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAmp") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAmp") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
+            },
+            {
+                name = "FireDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseFireDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "IceDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseIceDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "PoisonDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UsePoisonDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "DiseaseDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseDiseaseDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "Refresh Expiring Song",
+                type = "customfunc",
+                custom_func = function(self) return self.Helpers.RefreshExpiringSong(self) end,
             },
         },
         ['Downtime'] = {
@@ -890,6 +868,7 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 midSong = true,
+                noWait = true,
                 cond = function(self, aaName, target)
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others
@@ -1411,37 +1390,32 @@ local _ClassConfig = {
         },
 
         -- Song Duration Adjustment
-        ['RefreshDT']       = {
-            DisplayName = "Downtime Threshold",
+        ['SongRefresh']     = {
+            DisplayName = "Song Refresh Timer",
             Group = "Abilities",
             Header = "Common",
             Category = "Under the Hood",
             Index = 101,
-            Tooltip =
-            "The duration threshold for refreshing a buff song outside of combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
-            Default = 7,
-            Min = 0,
-            Max = 30,
+            Tooltip = "Resing a song or effect once its remaining duration is at or below this many seconds.",
+            Default = 4,
+            Min = 1,
+            Max = 13,
             ConfigType = "Advanced",
-            FAQ = "Why does my bard keep singing the same two songs?",
-            Answer = "You may need to adjust your Downtime Threshold value downward at lower levels/song durations.\n" ..
-                "This needs to be carefully tailored towards your song line-up.",
+            FAQ = "Why does my bard refresh songs before the Song Refresh Timer?",
+            Answer = "Rather than stand idle, the bard keeps singing, topping off whichever song in the Melody rotation is closest to expiring, " ..
+                "so songs refresh before reaching the Song Refresh Timer and uptime stays high.",
         },
-        ['RefreshCombat']   = {
-            DisplayName = "Combat Threshold",
+        ['SongDuration']    = {
+            DisplayName = "Song Duration",
             Group = "Abilities",
             Header = "Common",
             Category = "Under the Hood",
             Index = 102,
-            Tooltip =
-            "The duration threshold for refreshing a buff song in combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
-            Default = 4,
-            Min = 0,
-            Max = 30,
+            Tooltip = "Song duration in seconds; EMU cannot autodetect it, mostly used for Jonthan and War March together.",
+            Default = mq.TLO.Me.AltAbility("Extended Ingenuity")() ~= nil and 18 or 12,
+            Min = 1,
+            Max = 60,
             ConfigType = "Advanced",
-            FAQ = "Songs are dropping regularly, what can I do?",
-            Answer = "You may need to stop using so many songs! Alternatively, try tuning your Threshold values as they determine when we will try to resing a song.\n" ..
-                "This needs to be carefully tailored towards your song line-up.",
         },
     },
     ['ClassFAQ']      = {

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -1006,7 +1006,9 @@ local _ClassConfig    = {
                     return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID
                 end,
                 post_activate = function(self, aaName, success)
-                    if success and mq.TLO.Me.Buff("Self Stasis")() then
+                    if not success then return end
+                    mq.delay(1000, function() return mq.TLO.Me.Buff("Self Stasis")() ~= nil end)
+                    if mq.TLO.Me.Buff("Self Stasis")() then
                         Comms.PrintGroupMessage("We're out of combat, removing the Self Stasis buff so we can act again.")
                         Core.DoCmd('/removebuff =Self Stasis')
                     end

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -7,7 +7,6 @@ local Core         = require("utils.core")
 local Globals      = require("utils.globals")
 local ItemManager  = require('utils.item_manager')
 local Logger       = require("utils.logger")
-local Strings      = require("utils.strings")
 local Targeting    = require("utils.targeting")
 
 local Tooltips     = {
@@ -719,22 +718,45 @@ local _ClassConfig = {
             if usestate == 4 then return not inCombat end -- Out-of-Combat Only
             return false
         end,
-        RefreshBuffSong = function(songSpell) --determine how close to a buff's expiration we will resing to maintain full uptime
+        GetSongBuffer = function() --seconds of remaining duration at which a buff song is resung
+            return Config:GetSetting('SongRefresh')
+        end,
+        RefreshBuffSong = function(self, songSpell) --true once a buff song's remaining duration drops to the resing buffer (a dropped song reads 0 and resings)
             if not songSpell or not songSpell() then return false end
             local me = mq.TLO.Me
-            local threshold = Globals.CurrentState == "Combat" and Config:GetSetting('RefreshCombat') or Config:GetSetting('RefreshDT')
-            local duration = songSpell.DurationWindow() == 1 and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
-            local ret = duration <= threshold
-            Logger.log_verbose("\ayRefreshBuffSong(%s) => memed(%s), duration(%d), threshold(%d), should refresh:(%s)", songSpell,
-                Strings.BoolToColorString(me.Gem(songSpell.RankName.Name())() ~= nil), duration, threshold, Strings.BoolToColorString(ret))
-            return ret
+            local remaining = songSpell.DurationWindow() == 1
+                and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0)
+                or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
+            if self.TempSettings.upkeepFill then
+                local full = Config:GetSetting('SongDuration', true) or songSpell.MyDuration.TotalSeconds()
+                return remaining < full - self.Helpers.GetSongBuffer()
+            end
+            return remaining <= self.Helpers.GetSongBuffer()
         end,
-        MarchTimer = function(self) --refresh duration of warmarch based on a timer when jonthan is being used
-            local jonthan = Core.GetResolvedActionMapItem('Jonthan')
-            if not (jonthan and Config:GetSetting('UseJonthan') > 1 and (mq.TLO.Me.Song(jonthan.Name()).ID() or 0) > 0) then return nil end
-            local threshold = Globals.CurrentState == "Combat" and Config:GetSetting('RefreshCombat') or Config:GetSetting('RefreshDT')
-            local interval = (self.TempSettings.MarchDuration or 12) - threshold
+        MarchTimer = function(self) --minimum gap between War March resings
+            local interval = (self.TempSettings.MarchDuration or 12) - self.Helpers.GetSongBuffer()
             return (Globals.GetTimeSeconds() - (self.TempSettings.LastMarchCast or 0)) >= interval
+        end,
+        RefreshExpiringSong = function(self) --idle upkeep: resing the active song closest to expiring
+            local melody = self.TempSettings.RotationTable['Melody']
+            if not melody then return false end
+            local me = mq.TLO.Me
+            local pick, pickRemaining = nil, nil
+            self.TempSettings.upkeepFill = true
+            for _, entry in ipairs(melody) do
+                local songSpell = Core.GetResolvedActionMapItem(entry.name)
+                if songSpell and songSpell() and entry.cond and Core.SafeCallFunc("upkeep want", entry.cond, self, songSpell, me) then
+                    local remaining = songSpell.DurationWindow() == 1
+                        and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0)
+                        or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
+                    if remaining > 0 and Casting.SongReady(songSpell) and (not pickRemaining or remaining < pickRemaining) then
+                        pick, pickRemaining = songSpell, remaining
+                    end
+                end
+            end
+            self.TempSettings.upkeepFill = false
+            if pick then return Casting.UseSong(pick.RankName(), me.ID(), false) end
+            return false
         end,
         UnwantedAggroCheck = function(self)
             if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
@@ -886,7 +908,9 @@ local _ClassConfig = {
             steps = 1,
             timer = 0,
             doFullRotation = true,
-            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            blockMem = true,
+            reorderable = true,
+            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 if Globals.InMedState then return false end
                 if combat_state == "Downtime" and mq.TLO.Me.Invis() then return false end
@@ -914,19 +938,10 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'CombatSongs',
-            state = 1,
-            steps = 1,
-            doFullRotation = true,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and Core.CombatActionsCheck()
-            end,
-        },
-        {
             name = 'InstantRunBuff',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableGroupIDs() end,
             load_cond = function(self) return Casting.CanUseAA("Selo's Sonata") end,
             cond = function(self, combat_state)
@@ -1094,127 +1109,12 @@ local _ClassConfig = {
                 load_cond = function(self) return Casting.AARank("Intimidation") > 1 end,
             },
         },
-        ['CombatSongs'] = {
-            {
-                name = "DichoSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseDicho') > 1 end,
-                cond = function(self, songSpell)
-                    return (Config:GetSetting('UseDicho') == 3 and (mq.TLO.Me.PctEndurance() > Config:GetSetting('SelfEndPct') or Casting.BurnCheck()))
-                        or (Config:GetSetting('UseDicho') == 2 and Casting.IHaveBuff(Casting.GetAASpell("Quick Time")))
-                end,
-            },
-            {
-                name = "InsultSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseInsult') > 1 and (not Config:GetSetting('UseLLInsult') or not Core.GetResolvedActionMapItem('LLInsultSong')) end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
-                end,
-            },
-            {
-                name = "LLInsultSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseInsult') > 1 and Config:GetSetting('UseLLInsult') and Core.GetResolvedActionMapItem('LLInsultSong') end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
-                end,
-            },
-            {
-                name = "FireDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseFireDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        -- If dot is about to wear off, recast
-                        self.Helpers.GetDetSongDuration(songSpell) <= 3
-                end,
-            },
-            {
-                name = "IceDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseIceDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        -- If dot is about to wear off, recast
-                        self.Helpers.GetDetSongDuration(songSpell) <= 3
-                end,
-            },
-            {
-                name = "PoisonDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UsePoisonDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        -- If dot is about to wear off, recast
-                        self.Helpers.GetDetSongDuration(songSpell) <= 3
-                end,
-            },
-            {
-                name = "DiseaseDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseDiseaseDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        -- If dot is about to wear off, recast
-                        self.Helpers.GetDetSongDuration(songSpell) <= 3
-                end,
-            },
-            {
-                name = "InsultSong2",
-                type = "Song",
-                load_cond = function(self)
-                    return Config:GetSetting('UseInsult') == 3 and (not Config:GetSetting('UseLLInsult') or not Core.GetResolvedActionMapItem('LLInsultSong'))
-                end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
-                end,
-            },
-            {
-                name = "LLInsultSong2",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseInsult') == 3 and Config:GetSetting('UseLLInsult') and Core.GetResolvedActionMapItem('LLInsultSong') end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
-                end,
-            },
-            {
-                name = "AllianceSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseAlliance') end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck()) and Casting.DetSpellCheck(songSpell)
-                end,
-            },
-            --used in combat when we have nothing else to refresh rather than standing there. Initial testing good, need more to ensure this doesn't interfere with Melody.
-            {
-                name = "AriaSong",
-                type = "Song",
-                load_cond = function(self) return Core.GetResolvedActionMapItem('AriaSong') and Config:GetSetting('UseAria') > 1 end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 18
-                end,
-            },
-            {
-                name = "WarMarchSong",
-                type = "Song",
-                load_cond = function(self) return Core.GetResolvedActionMapItem('WarMarchSong') and Config:GetSetting('UseMarch') > 1 end,
-                cond = function(self, songSpell)
-                    local marchTimer = self.Helpers.MarchTimer(self)
-                    if marchTimer ~= nil then return marchTimer end
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 18
-                end,
-                post_activate = function(self, songSpell, success)
-                    if success then self.TempSettings.LastMarchCast = Globals.GetTimeSeconds() end
-                end,
-            },
-        },
         ['Enduring Breath'] = {
             {
                 name = "EndBreathSong",
                 type = "Song",
                 cond = function(self, songSpell)
-                    return self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
         },
@@ -1224,7 +1124,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('AriaSong') and Config:GetSetting('UseAria') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1232,7 +1132,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return not Core.GetResolvedActionMapItem('AriaSong') and Config:GetSetting('LLAria') == 2 and Config:GetSetting('UseAria') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1240,7 +1140,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return not Core.GetResolvedActionMapItem('AriaSong') and Config:GetSetting('LLAria') == 3 and Config:GetSetting('UseAria') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1249,9 +1149,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Core.GetResolvedActionMapItem('WarMarchSong') and Config:GetSetting('UseMarch') > 1 end,
                 cond = function(self, songSpell)
                     if not self.Helpers.CheckSongStateUse(self, "UseMarch") then return false end
-                    local marchTimer = self.Helpers.MarchTimer(self)
-                    if marchTimer ~= nil then return marchTimer end
-                    return self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.MarchTimer(self) and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
                 post_activate = function(self, songSpell, success)
                     if success then self.TempSettings.LastMarchCast = Globals.GetTimeSeconds() end
@@ -1262,7 +1160,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('RunBuffSong') and Config:GetSetting('UseRunBuff') > 1 and not Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseRunBuff") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseRunBuff") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1270,7 +1168,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('Jonthan') and Config:GetSetting('UseJonthan') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseJonthan") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseJonthan") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1278,7 +1176,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('ArcaneSong') and Config:GetSetting('UseArcane') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseArcane") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseArcane") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1297,7 +1195,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Core.GetResolvedActionMapItem('GroupRegenSong') and Config:GetSetting('RegenSong') == 2 end,
                 cond = function(self, songSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return self.Helpers.RefreshBuffSong(songSpell) and
+                    return self.Helpers.RefreshBuffSong(self, songSpell) and
                         ((Config:GetSetting('UseRegen') == 1 and (mq.TLO.Group.LowMana(pct)() or 999) >= Config:GetSetting('GroupManaCt'))
                             or (Config:GetSetting('UseRegen') > 1 and self.Helpers.CheckSongStateUse(self, "UseRegen")))
                 end,
@@ -1308,7 +1206,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Core.GetResolvedActionMapItem('AreaRegenSong') and Config:GetSetting('RegenSong') == 3 end,
                 cond = function(self, songSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return self.Helpers.RefreshBuffSong(songSpell) and
+                    return self.Helpers.RefreshBuffSong(self, songSpell) and
                         ((Config:GetSetting('UseRegen') == 1 and (mq.TLO.Group.LowMana(pct)() or 999) >= Config:GetSetting('GroupManaCt'))
                             or (Config:GetSetting('UseRegen') > 1 and self.Helpers.CheckSongStateUse(self, "UseRegen")))
                 end,
@@ -1318,7 +1216,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('AmpSong') and Config:GetSetting('UseAmp') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAmp") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAmp") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1326,7 +1224,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('SufferingSong') and Config:GetSetting('UseSuffering') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseSuffering") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseSuffering") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1334,7 +1232,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('SpitefulSong') and Config:GetSetting('UseSpiteful') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseSpiteful") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseSpiteful") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1342,7 +1240,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('SprySonataSong') and Config:GetSetting('UseSpry') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseSpry") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseSpry") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1350,7 +1248,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('ResistSong') and Config:GetSetting('UseResist') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseResist") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseResist") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1358,7 +1256,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('RecklessSong') and Config:GetSetting('UseReckless') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseReckless") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseReckless") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1366,7 +1264,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('AccelerandoSong') and Config:GetSetting('UseAccelerando') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAccelerando") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAccelerando") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1374,7 +1272,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('FireBuffSong') and Config:GetSetting('UseFireBuff') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseFireBuff") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseFireBuff") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1382,7 +1280,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('ColdBuffSong') and Config:GetSetting('UseColdBuff') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseColdBuff") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseColdBuff") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -1390,8 +1288,107 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Core.GetResolvedActionMapItem('DotBuffSong') and Config:GetSetting('UseDotBuff') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseDotBuff") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseDotBuff") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
+            },
+            {
+                name = "DichoSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseDicho') > 1 end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    local qt = Casting.GetAASpell("Quick Time")
+                    return (Config:GetSetting('UseDicho') == 3 and (mq.TLO.Me.PctEndurance() > Config:GetSetting('SelfEndPct') or Casting.BurnCheck()))
+                        or (Config:GetSetting('UseDicho') == 2 and qt and qt() and mq.TLO.Me.Song(qt.Name())())
+                end,
+            },
+            {
+                name = "InsultSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseInsult') > 1 and (not Config:GetSetting('UseLLInsult') or not Core.GetResolvedActionMapItem('LLInsultSong')) end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                end,
+            },
+            {
+                name = "LLInsultSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseInsult') > 1 and Config:GetSetting('UseLLInsult') and Core.GetResolvedActionMapItem('LLInsultSong') end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                end,
+            },
+            {
+                name = "FireDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseFireDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "IceDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseIceDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "PoisonDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UsePoisonDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "DiseaseDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseDiseaseDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "InsultSong2",
+                type = "Song",
+                load_cond = function(self)
+                    return Config:GetSetting('UseInsult') == 3 and (not Config:GetSetting('UseLLInsult') or not Core.GetResolvedActionMapItem('LLInsultSong'))
+                end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                end,
+            },
+            {
+                name = "LLInsultSong2",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseInsult') == 3 and Config:GetSetting('UseLLInsult') and Core.GetResolvedActionMapItem('LLInsultSong') end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck())
+                end,
+            },
+            {
+                name = "AllianceSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseAlliance') end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    return (mq.TLO.Me.PctMana() > Config:GetSetting('SelfManaPct') or Casting.BurnCheck()) and Casting.DetSpellCheck(songSpell)
+                end,
+            },
+            {
+                name = "Refresh Expiring Song",
+                type = "customfunc",
+                custom_func = function(self) return self.Helpers.RefreshExpiringSong(self) end,
             },
         },
         ['Downtime'] = {
@@ -1472,6 +1469,7 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 midSong = true,
+                noWait = true,
                 cond = function(self, aaName, target)
                     -- Selo AA triggers Accelerando or Accelerato depending on rank.
                     local aaBuff = mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1)() or ""
@@ -1742,37 +1740,20 @@ local _ClassConfig = {
             Default = false,
         },
         -- Under the Hood
-        ['RefreshDT']       = {
-            DisplayName = "Downtime Threshold",
+        ['SongRefresh']     = {
+            DisplayName = "Song Refresh Timer",
             Group = "Abilities",
             Header = "Common",
             Category = "Under the Hood",
             Index = 101,
-            Tooltip =
-            "The duration threshold for refreshing a buff song outside of combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
-            Default = 12,
-            Min = 0,
-            Max = 30,
+            Tooltip = "Resing a song or effect once its remaining duration is at or below this many seconds.",
+            Default = 4,
+            Min = 1,
+            Max = 13,
             ConfigType = "Advanced",
-            FAQ = "Why does my bard keep singing the same two songs?",
-            Answer = "You may need to adjust your Downtime Threshold value downward at lower levels/song durations.\n" ..
-                "This needs to be carefully tailored towards your song line-up.",
-        },
-        ['RefreshCombat']   = {
-            DisplayName = "Combat Threshold",
-            Group = "Abilities",
-            Header = "Common",
-            Category = "Under the Hood",
-            Index = 102,
-            Tooltip =
-            "The duration threshold for refreshing a buff song in combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
-            Default = 6,
-            Min = 0,
-            Max = 30,
-            ConfigType = "Advanced",
-            FAQ = "Songs are dropping regularly, what can I do?",
-            Answer = "You may need to stop using so many songs! Alternatively, try tuning your Threshold values as they determine when we will try to resing a song.\n" ..
-                "This needs to be carefully tailored towards your song line-up.",
+            FAQ = "Why does my bard refresh songs before the Song Refresh Timer?",
+            Answer = "Rather than stand idle, the bard keeps singing, topping off whichever song in the Melody rotation is closest to expiring, " ..
+                "so songs refresh before reaching the Song Refresh Timer and uptime stays high.",
         },
         -- Self
         ['UseAmp']          = {

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -1309,7 +1309,9 @@ local _ClassConfig    = {
                     return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID
                 end,
                 post_activate = function(self, aaName, success)
-                    if success and mq.TLO.Me.Buff("Self Stasis")() then
+                    if not success then return end
+                    mq.delay(1000, function() return mq.TLO.Me.Buff("Self Stasis")() ~= nil end)
+                    if mq.TLO.Me.Buff("Self Stasis")() then
                         Comms.PrintGroupMessage("We're out of combat, removing the Self Stasis buff so we can act again.")
                         Core.DoCmd('/removebuff =Self Stasis')
                     end

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -6,7 +6,6 @@ local Core         = require("utils.core")
 local Globals      = require("utils.globals")
 local ItemManager  = require('utils.item_manager')
 local Logger       = require("utils.logger")
-local Strings      = require("utils.strings")
 local Targeting    = require("utils.targeting")
 
 local Tooltips     = {
@@ -45,11 +44,6 @@ local _ClassConfig = {
     ['Modes']         = { --other modes to reorder spell priorities may be added back in at a later date.
         'General',
     },
-    ['OnModeChange']  = function(self, mode)
-        --not currently accounting for the "Tune Stuck In Your Head" AA
-        self.TempSettings.MarchDuration = Casting.CanUseAA("Extended Ingenuity") and 18 or 12
-    end,
-
     ['ModeChecks']    = {
         CanMez    = function() return true end,
         CanCharm  = function() return true end,
@@ -316,22 +310,45 @@ local _ClassConfig = {
             if usestate == 4 then return not inCombat end -- Out-of-Combat Only
             return false
         end,
-        RefreshBuffSong = function(songSpell) --determine how close to a buff's expiration we will resing to maintain full uptime
+        GetSongBuffer = function() --seconds of remaining duration at which a buff song is resung
+            return Config:GetSetting('SongRefresh')
+        end,
+        RefreshBuffSong = function(self, songSpell) --true once a buff song's remaining duration drops to the resing buffer (a dropped song reads 0 and resings)
             if not songSpell or not songSpell() then return false end
             local me = mq.TLO.Me
-            local threshold = Globals.CurrentState == "Combat" and Config:GetSetting('RefreshCombat') or Config:GetSetting('RefreshDT')
-            local duration = songSpell.DurationWindow() == 1 and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
-            local ret = duration <= threshold
-            Logger.log_verbose("\ayRefreshBuffSong(%s) => memed(%s), duration(%d), threshold(%d), should refresh:(%s)", songSpell,
-                Strings.BoolToColorString(me.Gem(songSpell.RankName.Name())() ~= nil), duration, threshold, Strings.BoolToColorString(ret))
-            return ret
+            local remaining = songSpell.DurationWindow() == 1
+                and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0)
+                or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
+            if self.TempSettings.upkeepFill then
+                local full = Config:GetSetting('SongDuration', true) or songSpell.MyDuration.TotalSeconds()
+                return remaining < full - self.Helpers.GetSongBuffer()
+            end
+            return remaining <= self.Helpers.GetSongBuffer()
         end,
-        MarchTimer = function(self) --refresh duration of warmarch based on a timer when jonthan is being used
-            local jonthan = Core.GetResolvedActionMapItem('Jonthan')
-            if not (jonthan and Config:GetSetting('UseJonthan') > 1 and (mq.TLO.Me.Song(jonthan.Name()).ID() or 0) > 0) then return nil end
-            local threshold = Globals.CurrentState == "Combat" and Config:GetSetting('RefreshCombat') or Config:GetSetting('RefreshDT')
-            local interval = (self.TempSettings.MarchDuration or 12) - threshold
+        MarchTimer = function(self) --minimum gap between War March resings, from the Song Duration setting
+            local interval = Config:GetSetting('SongDuration') - self.Helpers.GetSongBuffer()
             return (Globals.GetTimeSeconds() - (self.TempSettings.LastMarchCast or 0)) >= interval
+        end,
+        RefreshExpiringSong = function(self) --idle upkeep: resing the active song closest to expiring
+            local melody = self.TempSettings.RotationTable['Melody']
+            if not melody then return false end
+            local me = mq.TLO.Me
+            local pick, pickRemaining = nil, nil
+            self.TempSettings.upkeepFill = true
+            for _, entry in ipairs(melody) do
+                local songSpell = Core.GetResolvedActionMapItem(entry.name)
+                if songSpell and songSpell() and entry.cond and Core.SafeCallFunc("upkeep want", entry.cond, self, songSpell, me) then
+                    local remaining = songSpell.DurationWindow() == 1
+                        and (me.Song(songSpell.Name()).Duration.TotalSeconds() or 0)
+                        or (me.Buff(songSpell.Name()).Duration.TotalSeconds() or 0)
+                    if remaining > 0 and Casting.SongReady(songSpell) and (not pickRemaining or remaining < pickRemaining) then
+                        pick, pickRemaining = songSpell, remaining
+                    end
+                end
+            end
+            self.TempSettings.upkeepFill = false
+            if pick then return Casting.UseSong(pick.RankName(), me.ID(), false) end
+            return false
         end,
         UnwantedAggroCheck = function(self)
             if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
@@ -399,7 +416,9 @@ local _ClassConfig = {
             steps = 1,
             timer = 0,
             doFullRotation = true,
-            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            blockMem = true,
+            reorderable = true,
+            targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
                 if Globals.InMedState then return false end
                 if combat_state == "Downtime" and mq.TLO.Me.Invis() then return false end
@@ -427,19 +446,10 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'CombatSongs',
-            state = 1,
-            steps = 1,
-            doFullRotation = true,
-            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
-            cond = function(self, combat_state)
-                return combat_state == "Combat" and Core.CombatActionsCheck()
-            end,
-        },
-        {
             name = 'InstantRunBuff',
             state = 1,
             steps = 1,
+            midSong = true,
             targetId = function(self) return Combat.GetCachedCombatState() == "Combat" and Targeting.CheckForAutoTargetID() or Casting.GetBuffableGroupIDs() end,
             load_cond = function(self) return Casting.CanUseAA("Selo's Sonata") end,
             cond = function(self, combat_state)
@@ -585,85 +595,12 @@ local _ClassConfig = {
                 midSong = true,
             },
         },
-        ['CombatSongs'] = {
-            {
-                name = "StormBlade",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseStormBlade') > 1 end,
-                cond = function(self, songSpell)
-                    if not Casting.BurnCheck() and mq.TLO.Me.PctMana() <= Config:GetSetting('ReserveManaPct') then return false end
-                    return Config:GetSetting('UseStormBlade') == 3 or self.Helpers.RefreshBuffSong(mq.TLO.Spell("Storm Blade"))
-                end,
-            },
-            {
-                name = "BellowSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseBellow') end,
-                cond = function(self, songSpell)
-                    if not Casting.BurnCheck() and mq.TLO.Me.PctMana() <= Config:GetSetting('ReserveManaPct') then return false end
-                    return true
-                end,
-            },
-            {
-                name = "FireDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseFireDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            {
-                name = "IceDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseIceDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            {
-                name = "PoisonDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UsePoisonDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            {
-                name = "DiseaseDotSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseDiseaseDots') end,
-                cond = function(self, songSpell)
-                    return self.Helpers.DotSongCheck(songSpell) and
-                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('RefreshCombat')
-                end,
-            },
-            --failsafe/fallback to fill dead space and/or refresh charges, may adjust after more testing
-            {
-                name = "AriaSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseAria') > 1 end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 6
-                end,
-            },
-            {
-                name = "ArcaneSong",
-                type = "Song",
-                load_cond = function(self) return Config:GetSetting('UseArcane') > 1 end,
-                cond = function(self, songSpell)
-                    return (mq.TLO.Me.Song(songSpell.Name()).Duration.TotalSeconds() or 0) <= 6
-                end,
-            },
-        },
         ['Enduring Breath'] = {
             {
                 name = "EndBreathSong",
                 type = "Song",
                 cond = function(self, songSpell)
-                    return self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
         },
@@ -673,7 +610,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseAria') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -682,9 +619,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('UseMarch') > 1 end,
                 cond = function(self, songSpell)
                     if not self.Helpers.CheckSongStateUse(self, "UseMarch") then return false end
-                    local marchTimer = self.Helpers.MarchTimer(self)
-                    if marchTimer ~= nil then return marchTimer end
-                    return self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.MarchTimer(self) and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
                 post_activate = function(self, songSpell, success)
                     if success then self.TempSettings.LastMarchCast = Globals.GetTimeSeconds() end
@@ -695,7 +630,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseRunBuff') > 1 and not Casting.CanUseAA("Selo's Sonata") end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseRunBuff") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseRunBuff") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -703,7 +638,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseJonthan') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseJonthan") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseJonthan") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -711,7 +646,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseResist') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseResist") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseResist") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -719,7 +654,7 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseArcane') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseArcane") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseArcane") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
             },
             {
@@ -728,7 +663,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('RegenSong') == 2 end,
                 cond = function(self, songSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return self.Helpers.RefreshBuffSong(songSpell) and
+                    return self.Helpers.RefreshBuffSong(self, songSpell) and
                         ((Config:GetSetting('UseRegen') == 1 and (mq.TLO.Group.LowMana(pct)() or 999) >= Config:GetSetting('GroupManaCt'))
                             or (Config:GetSetting('UseRegen') > 1 and self.Helpers.CheckSongStateUse(self, "UseRegen")))
                 end,
@@ -739,7 +674,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('RegenSong') == 3 end,
                 cond = function(self, songSpell)
                     local pct = Config:GetSetting('GroupManaPct')
-                    return self.Helpers.RefreshBuffSong(songSpell) and
+                    return self.Helpers.RefreshBuffSong(self, songSpell) and
                         ((Config:GetSetting('UseRegen') == 1 and (mq.TLO.Group.LowMana(pct)() or 999) >= Config:GetSetting('GroupManaCt'))
                             or (Config:GetSetting('UseRegen') > 1 and self.Helpers.CheckSongStateUse(self, "UseRegen")))
                 end,
@@ -749,8 +684,69 @@ local _ClassConfig = {
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseAmp') > 1 end,
                 cond = function(self, songSpell)
-                    return self.Helpers.CheckSongStateUse(self, "UseAmp") and self.Helpers.RefreshBuffSong(songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseAmp") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
+            },
+            {
+                name = "StormBlade",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseStormBlade') > 1 end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    if not Casting.BurnCheck() and mq.TLO.Me.PctMana() <= Config:GetSetting('ReserveManaPct') then return false end
+                    return Config:GetSetting('UseStormBlade') == 3 or self.Helpers.RefreshBuffSong(self, mq.TLO.Spell("Storm Blade"))
+                end,
+            },
+            {
+                name = "BellowSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseBellow') end,
+                cond = function(self, songSpell, target)
+                    if target.ID() == mq.TLO.Me.ID() then return false end
+                    if not Casting.BurnCheck() and mq.TLO.Me.PctMana() <= Config:GetSetting('ReserveManaPct') then return false end
+                    return true
+                end,
+            },
+            {
+                name = "FireDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseFireDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "IceDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseIceDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "PoisonDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UsePoisonDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "DiseaseDotSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseDiseaseDots') end,
+                cond = function(self, songSpell, target)
+                    return target.ID() ~= mq.TLO.Me.ID() and self.Helpers.DotSongCheck(songSpell) and
+                        self.Helpers.GetDetSongDuration(songSpell) <= Config:GetSetting('SongRefresh')
+                end,
+            },
+            {
+                name = "Refresh Expiring Song",
+                type = "customfunc",
+                custom_func = function(self) return self.Helpers.RefreshExpiringSong(self) end,
             },
         },
         ['Downtime'] = {
@@ -817,6 +813,7 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 midSong = true,
+                noWait = true,
                 cond = function(self, aaName, target)
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others
@@ -1357,37 +1354,32 @@ local _ClassConfig = {
         },
 
         -- Song Duration Adjustment
-        ['RefreshDT']       = {
-            DisplayName = "Downtime Threshold",
+        ['SongRefresh']     = {
+            DisplayName = "Song Refresh Timer",
             Group = "Abilities",
             Header = "Common",
             Category = "Under the Hood",
             Index = 101,
-            Tooltip =
-            "The duration threshold for refreshing a buff song outside of combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
-            Default = 7,
-            Min = 0,
-            Max = 30,
+            Tooltip = "Resing a song or effect once its remaining duration is at or below this many seconds.",
+            Default = 4,
+            Min = 1,
+            Max = 13,
             ConfigType = "Advanced",
-            FAQ = "Why does my bard keep singing the same two songs?",
-            Answer = "You may need to adjust your Downtime Threshold value downward at lower levels/song durations.\n" ..
-                "This needs to be carefully tailored towards your song line-up.",
+            FAQ = "Why does my bard refresh songs before the Song Refresh Timer?",
+            Answer = "Rather than stand idle, the bard keeps singing, topping off whichever song in the Melody rotation is closest to expiring, " ..
+                "so songs refresh before reaching the Song Refresh Timer and uptime stays high.",
         },
-        ['RefreshCombat']   = {
-            DisplayName = "Combat Threshold",
+        ['SongDuration']    = {
+            DisplayName = "Song Duration",
             Group = "Abilities",
             Header = "Common",
             Category = "Under the Hood",
             Index = 102,
-            Tooltip =
-            "The duration threshold for refreshing a buff song in combat. ***WARNING: Editing this value can drastically alter your ability to maintain buff songs!*** This needs to be carefully tailored towards your song line-up.",
-            Default = 4,
-            Min = 0,
-            Max = 30,
+            Tooltip = "Song duration in seconds; EMU cannot autodetect it, mostly used for Jonthan and War March together.",
+            Default = mq.TLO.Me.AltAbility("Extended Ingenuity")() ~= nil and 18 or 12,
+            Min = 1,
+            Max = 60,
             ConfigType = "Advanced",
-            FAQ = "Songs are dropping regularly, what can I do?",
-            Answer = "You may need to stop using so many songs! Alternatively, try tuning your Threshold values as they determine when we will try to resing a song.\n" ..
-                "This needs to be carefully tailored towards your song line-up.",
         },
         ['ReserveManaPct']  = {
             DisplayName = "Reserve Mana %",

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -803,7 +803,9 @@ local _ClassConfig = {
                     return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID
                 end,
                 post_activate = function(self, aaName, success)
-                    if success and mq.TLO.Me.Buff("Self Stasis")() then
+                    if not success then return end
+                    mq.delay(1000, function() return mq.TLO.Me.Buff("Self Stasis")() ~= nil end)
+                    if mq.TLO.Me.Buff("Self Stasis")() then
                         Comms.PrintGroupMessage("We're out of combat, removing the Self Stasis buff so we can act again.")
                         Core.DoCmd('/removebuff =Self Stasis')
                     end

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2824, }
+return { version = 2825, }

--- a/init.lua
+++ b/init.lua
@@ -412,7 +412,7 @@ local function Main()
         return
     end
 
-    Core.UpdateBuffs()
+    Core.UpdateBuffs(true)
 
     Events.DoEvents()
 

--- a/modules/charm.lua
+++ b/modules/charm.lua
@@ -10,6 +10,7 @@ local Core      = require("utils.core")
 local Globals   = require('utils.globals')
 local Logger    = require("utils.logger")
 local Modules   = require("utils.modules")
+local Rotation  = require("utils.rotation")
 local Strings   = require("utils.strings")
 local Targeting = require("utils.targeting")
 local Ui        = require("utils.ui")
@@ -525,6 +526,9 @@ function Module:RebuildCharmLists()
         PreCharm  = self:FilterLoaded(charm and charm.PreCharm),
         Assist    = self:FilterLoaded(charm and charm.Assist),
     }
+    local order = Config:GetSetting('RotationEntryOrder') or {}
+    Rotation.ApplyEntryOrder(self.TempSettings.CharmLists.PreCharm, order["CharmPreCharm"])
+    Rotation.ApplyEntryOrder(self.TempSettings.CharmLists.Assist, order["CharmAssist"])
 end
 
 function Module:GetCharmLists()
@@ -921,11 +925,16 @@ function Module:CharmAssistNeeded()
     self.TempSettings.LastCharmAssistTime = Globals.GetTimeMS()
 
     local assistOn = Config:GetSetting('DoCharmAssist')
+    if not assistOn or next(Globals.LooseCharms) == nil then
+        self.TempSettings.LastCharmAssistResult = false
+        return false
+    end
+
     local healClear = Core.OkayToNotHeal(Config:GetSetting('HealPriority', true))
     local mezClear = Core.OkayToNotMez(Config:GetSetting('PriorityMez'))
     local hpOk = (mq.TLO.Me.PctHPs() or 100) > (Config:GetSetting('HPCritical', true) or Config:GetSetting('EmergencyStart', true) or 0)
     -- only scan for a loose charm once the cheaper gates pass
-    local result = assistOn and healClear and mezClear and hpOk and self:FindLooseCharmToAssist() > 0
+    local result = healClear and mezClear and hpOk and self:FindLooseCharmToAssist() > 0
 
     Logger.log_verbose("CharmAssistNeeded - DoCharmAssist(%s) HealClear(%s) MezClear(%s) HpOk(%s) => %s",
         Strings.BoolToColorString(assistOn), Strings.BoolToColorString(healClear), Strings.BoolToColorString(mezClear),
@@ -1293,9 +1302,10 @@ function Module:Render()
                         resolvedMap[entry.name] = Modules:ExecModule("Class", "GetResolvedActionMapItem", entry.name)
                     end
                     enabled[listName] = enabled[listName] or {}
-                    local _, newEnabled, entriesChanged = Ui.RenderRotationTable("Charm" .. listName, list, resolvedMap, 0, false, enabled[listName], true)
+                    local _, newEnabled, entriesChanged, _, resetRequested = Ui.RenderRotationTable("Charm" .. listName, list, resolvedMap, 0, false, enabled[listName], true, true)
                     enabled[listName] = newEnabled
                     if entriesChanged then changed = true end
+                    if resetRequested then self:RebuildCharmLists() end
                 end
             end
             if changed then Config:SetSetting('EnabledCharmEntries', enabled) end

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -358,6 +358,12 @@ function Module:LoadSettings()
             Default = {},
         }
 
+        self.ClassConfig.DefaultConfig['RotationEntryOrder'] = {
+            DisplayName = "RotationEntryOrder",
+            Type = "Custom",
+            Default = {},
+        }
+
         self.ClassConfig.DefaultConfig[string.format("%s_Popped", self._name)] = {
             DisplayName = self._name .. " Popped",
             Type = "Custom",
@@ -630,9 +636,15 @@ function Module:RenderRotationWithToggle(r, rotationTable)
     if ImGui.CollapsingHeader(headerText) then
         if enabledRotations[r.name] ~= false then
             ImGui.Indent()
-            self.TempSettings.ShowFailedSpells, enabledRotationEntries, enabledRotationEntriesChanged = Ui.RenderRotationTable(r.name,
+            local reordered, resetRequested
+            self.TempSettings.ShowFailedSpells, enabledRotationEntries, enabledRotationEntriesChanged, reordered, resetRequested = Ui.RenderRotationTable(r.name,
                 rotationTable[r.name],
-                self.ResolvedActionMap, r.state or 0, self.TempSettings.ShowFailedSpells, enabledRotationEntries)
+                self.ResolvedActionMap, r.state or 0, self.TempSettings.ShowFailedSpells, enabledRotationEntries, nil, r.reorderable)
+            if reordered and r.state then r.state = 1 end
+            if resetRequested then
+                if r.state then r.state = 1 end
+                self:GetRotations()
+            end
 
             if enabledRotationEntriesChanged then Config:SetSetting('EnabledRotationEntries', enabledRotationEntries) end
             ImGui.Unindent()
@@ -1040,6 +1052,17 @@ function Module:GetRotations()
         end
     end
 
+    -- apply any user-defined entry order to reorderable rotations (unmapped entries keep their built order)
+    local rotationEntryOrder = Config:GetSetting('RotationEntryOrder') or {}
+    local function applyEntryOrder(states, tables)
+        for _, rotation in ipairs(states) do
+            if rotation.reorderable then
+                Rotation.ApplyEntryOrder(tables[rotation.name], rotationEntryOrder[rotation.name])
+            end
+        end
+    end
+    applyEntryOrder(self.TempSettings.RotationStates, self.TempSettings.RotationTable)
+
     -- Do it all again for heal rotations
     self.TempSettings.HealRotationStates = {} -- clear the array for loadout rescans
     self.TempSettings.HealRotationTable = {}
@@ -1062,6 +1085,7 @@ function Module:GetRotations()
                 Modules:ExecModule("Clickies", "GetClickiesForRotations", "During Heal Rotation", rname) or {})
         end
     end
+    applyEntryOrder(self.TempSettings.HealRotationStates, self.TempSettings.HealRotationTable)
 
     -- Cache the resist type on every entry so Rotation.TestConditionForEntry can gate without per-tick lookups.
     local function deriveResistType(entry)
@@ -1933,7 +1957,7 @@ function Module:GiveTime()
                         Logger.log_verbose("\aw:::RUN ROTATION::: \am%s", r.name)
                         self.CurrentRotation = { name = r.name, state = r.state or 0, }
                         local newState = Rotation.Run(self, self:GetRotationTable(r.name), targetTable,
-                            self.ResolvedActionMap, r.steps or 0, r.state or 0, self.CombatState == "Downtime", r.doFullRotation or false, r.cond,
+                            self.ResolvedActionMap, r.steps or 0, r.state or 0, self.CombatState == "Downtime" and not r.blockMem, r.doFullRotation or false, r.cond,
                             Config:GetSetting('EnabledRotationEntries') or {})
 
                         if r.state then r.state = newState end
@@ -1954,6 +1978,8 @@ function Module:GiveTime()
             end
         end
     end
+
+    self:PromptRestoreSwapSlot()
 
     self.TempSettings.CurrentRotationStateType = 0
 end

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -1984,6 +1984,7 @@ function Module:ValidateClickies()
         -- update the actual settings since we just mutated the temp reference above.
         Config:SetSetting('Clickies', clickies)
     end
+    return clickies
 end
 
 function Module:InsertDefaultClickies()
@@ -2012,12 +2013,11 @@ function Module:GiveTime()
     end
 
     -- Main Module logic goes here.
-    self:ValidateClickies()
+    local clickies = self:ValidateClickies()
 
     local maxClickiesPerCycle = Config:GetSetting('MaxClickiesPerCycle') or 0
     local clickiesUsedThisCycle = 0
     local startingClickyIdx = maxClickiesPerCycle > 0 and self.ClickyRotationIndex or 1
-    local clickies = Config:GetSetting('Clickies') or {}
     local numClickies = #clickies
     local moving = mq.TLO.Me.Moving() or mq.TLO.Navigation.Active() or mq.TLO.MoveTo.Moving()
     for clickyIdx = startingClickyIdx, numClickies do
@@ -2036,7 +2036,7 @@ function Module:GiveTime()
             self.TempSettings.ClickyState[clicky.itemName].itemFound = item() ~= nil
 
             Logger.log_verbose("\ayClicky: \awLooking for clicky item: \am%s \awfound: %s", clicky.itemName, Strings.BoolToColorString(item() ~= nil))
-            if item and item() and item.Clicky then
+            if item and item() and item.Clicky and itemSpell and itemSpell() then
                 if not moving or (item.Clicky.CastTime() or -1) == 0 then
                     if clicky.combat_state == "Any" or clicky.combat_state == combat_state then
                         local condTarget = nil
@@ -2075,16 +2075,17 @@ function Module:GiveTime()
 
                             if clicky.target == "Self" then
                                 target = mq.TLO.Me
-                                buffCheckPassed = Casting.SelfBuffItemCheck(clicky.itemName, nil, clicky.skipTriggerCheck)
+                                buffCheckPassed = Casting.LocalBuffCheck(itemSpell.ID(), nil, clicky.skipTriggerCheck)
                             elseif clicky.target == "Pet" then
                                 target = mq.TLO.Me.Pet
-                                buffCheckPassed = target and Casting.PetBuffItemCheck(clicky.itemName, nil, clicky.skipTriggerCheck)
+                                buffCheckPassed = target and Casting.LocalPetBuffCheck(itemSpell.ID(), nil, clicky.skipTriggerCheck)
                             elseif clicky.target == "Main Assist" then
                                 target = Core.GetMainAssistSpawn()
-                                buffCheckPassed = target and Casting.GroupBuffItemCheck(clicky.itemName, target, nil, clicky.skipTriggerCheck)
+                                buffCheckPassed = target and Casting.LevelCheckPass(itemSpell, target)
+                                    and Casting.ResolveBuffCheck(itemSpell.ID(), target, nil, clicky.skipTriggerCheck)
                             elseif clicky.target == "Auto Target" then
                                 target = Targeting.GetAutoTarget()
-                                buffCheckPassed = target and Casting.DetItemCheck(clicky.itemName, target)
+                                buffCheckPassed = target and Casting.TargetBuffCheck(itemSpell.ID(), target)
                             elseif clicky.target == "Mercs Peer" then
                                 targetPeer = Comms.GetPeerHeartbeatByName(clicky.mercs_peer_name or "")
                                 local peerFound = (targetPeer and targetPeer.Data
@@ -2099,10 +2100,11 @@ function Module:GiveTime()
                                     buffCheckPassed = false
                                 end
                             elseif clicky.target == "All Buffable" then
-                                local buffableIds = Casting.GetBuffableIDs()
-                                for _, peerId in ipairs(buffableIds) do
+                                local spellId = itemSpell.ID()
+                                for _, peerId in ipairs(Casting.GetBuffableIDs()) do
                                     local candidate = mq.TLO.Spawn(peerId)
-                                    if candidate() and Casting.GroupBuffItemCheck(clicky.itemName, candidate, nil, clicky.skipTriggerCheck) then
+                                    if candidate() and Casting.LevelCheckPass(itemSpell, candidate)
+                                        and Casting.ResolveBuffCheck(spellId, candidate, nil, clicky.skipTriggerCheck) then
                                         target = candidate
                                         buffCheckPassed = true
                                         break

--- a/modules/mez.lua
+++ b/modules/mez.lua
@@ -43,6 +43,7 @@ Module.CommandHandlers                  = {
 }
 
 Module.CombatState                      = "None"
+Module.LastRenderTime                   = 0
 
 Module.Constants                        = {}
 Module.Constants.MezSpawnFilter         = "targetable playerstate 4"
@@ -248,6 +249,7 @@ function Module:ShouldRender()
 end
 
 function Module:Render()
+    self.LastRenderTime = Globals.GetTimeMS()
     Base.Render(self)
 
     ImGui.NewLine()
@@ -896,15 +898,20 @@ function Module:DoMez()
 
     local crowd = self:CountCrowd()
     -- snapshot for the status panel (display only); piggybacks on the crowd scan above, no extra scan
-    self.TempSettings.Status = {
-        crowd = crowd,
-        unmezzed = self:CountUnmezzed(),
-        stReady = self:MezReady(false),
-        aeReady = self:MezReady(true),
-    }
+    local renderRecently = Globals.GetTimeMS() - self.LastRenderTime < 2000
+    if renderRecently then
+        self.TempSettings.Status = {
+            crowd = crowd,
+            unmezzed = self:CountUnmezzed(),
+            stReady = self:MezReady(false),
+            aeReady = self:MezReady(true),
+        }
+    end
 
     -- nothing to do below the start threshold; let any leftover mezzes wear off
-    if crowd < Config:GetSetting('MezStartCount') then return end
+    if crowd < Config:GetSetting('MezStartCount') then
+        return
+    end
 
     self:UpdateMezList()
 
@@ -926,7 +933,9 @@ function Module:DoMez()
     end
 
     -- refresh after the mezzing work so the panel reflects this tick's tracker, not the pre-work snapshot
-    self.TempSettings.Status.unmezzed = self:CountUnmezzed()
+    if renderRecently then
+        self.TempSettings.Status.unmezzed = self:CountUnmezzed()
+    end
 end
 
 -- ms a tracked mez must still have left to count as solidly locked (cast time + refresh lead)

--- a/modules/named.lua
+++ b/modules/named.lua
@@ -24,6 +24,7 @@ Module.CommandHandlers = {}
 
 Module.NamedList       = {}
 Module.LastNamedCheck  = 0
+Module.LastRenderTime  = 0
 
 Module.DefNamedBase    = NamedDefault or {}
 Module.DefNamedOverlay = (Core.OnMight() and NamedEQMight) or (Core.OnLaz() and NamedLazarus) or {}
@@ -115,6 +116,7 @@ function Module:New()
 end
 
 function Module:Render()
+    self.LastRenderTime = Globals.GetTimeSeconds()
     Base.Render(self)
     self:RenderZoneNamed()
     ImGui.NewLine()
@@ -123,6 +125,7 @@ end
 
 function Module:GiveTime()
     -- Main Module logic goes here.
+    if Globals.GetTimeSeconds() - self.LastRenderTime >= 2 then return end
     if Globals.GetTimeSeconds() - self.LastNamedCheck > 1 then
         self.LastNamedCheck = Globals.GetTimeSeconds()
         self:CheckZoneNamed()
@@ -190,6 +193,8 @@ end
 --- Caches the named list in the zone
 function Module:RefreshNamedCache()
     local curZone = mq.TLO.Zone.ID()
+    if self.LastZoneID == curZone and Globals.GetTimeSeconds() - (self.LastCacheRefresh or 0) < 1 then return end
+    self.LastCacheRefresh = Globals.GetTimeSeconds()
     -- LastUserList identity catches cross-instance edits; local edits invalidate via OnChange.
     local userList = Config:GetSetting('CustomNamedList') or {}
     if self.LastZoneID ~= curZone or self.LastUserList ~= userList then
@@ -250,7 +255,7 @@ function Module:CheckZoneNamed()
     local tmpTbl = {}
 
     local namedSpawns = mq.getFilteredSpawns(function(spawn)
-        return self:IsNamed(spawn) and spawn.Type() == "NPC"
+        return spawn.Type() == "NPC" and self:IsNamed(spawn)
     end)
 
     for _, spawn in ipairs(namedSpawns) do

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -294,11 +294,12 @@ function Casting.ResolveBuffCheck(spellId, target, skipBlockCheck, skipTriggerCh
     if not (target and target()) then return false end
 
     local spell = mq.TLO.Spell(spellId)
+    local targetId = target.ID()
 
-    if target.ID() == mq.TLO.Me.ID() then
+    if targetId == mq.TLO.Me.ID() then
         Logger.log_verbose("ResolveBuffCheck: Target is myself, using LocalBuffCheck.")
         return Casting.LocalBuffCheck(spellId, skipBlockCheck, skipTriggerCheck)
-    elseif target.ID() == mq.TLO.Me.Pet.ID() then
+    elseif targetId == mq.TLO.Me.Pet.ID() then
         Logger.log_verbose("ResolveBuffCheck: Target is my pet, using LocalPetBuffCheck.")
         return Casting.LocalPetBuffCheck(spellId, skipBlockCheck, skipTriggerCheck)
     else
@@ -323,28 +324,28 @@ function Casting.ResolveBuffCheck(spellId, target, skipBlockCheck, skipTriggerCh
             local petBlockedList = heartbeat.Data.PetBlocked
 
             if isPet and petBuffList and (skipBlockCheck or petBlockedList) then
-                Logger.log_verbose("ResolveBuffCheck: Target(%s) ID(%d) is an actor peer pet, using ActorPetBuffCheck.", target.DisplayName(), target.ID())
-                return Casting.ActorPetBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
+                Logger.log_verbose("ResolveBuffCheck: Target(%s) ID(%d) is an actor peer pet, using ActorPetBuffCheck.", target.DisplayName(), targetId)
+                return Casting.ActorPetBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck, heartbeat, spell)
             end
             if buffList and songList and (skipBlockCheck or blockedList) then
-                Logger.log_verbose("ResolveBuffCheck: Target(%s) ID(%d) is an actor peer, using ActorBuffCheck.", target.DisplayName(), target.ID())
-                return Casting.ActorBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
+                Logger.log_verbose("ResolveBuffCheck: Target(%s) ID(%d) is an actor peer, using ActorBuffCheck.", target.DisplayName(), targetId)
+                return Casting.ActorBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck, heartbeat, spell)
             end
         end
 
-        if mq.TLO.DanNet(mq.TLO.Spawn(target.ID()).CleanName())() then
-            Logger.log_verbose("ResolveBuffCheck: Target(%s) ID(%d) is a DanNet peer, using PeerBuffCheck.", target.DisplayName(), target.ID())
+        if mq.TLO.DanNet(mq.TLO.Spawn(targetId).CleanName())() then
+            Logger.log_verbose("ResolveBuffCheck: Target(%s) ID(%d) is a DanNet peer, using PeerBuffCheck.", target.DisplayName(), targetId)
             return Casting.PeerBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
         end
 
         local allowTargetChange = (mq.TLO.Me.CombatState() or ""):lower() ~= "combat"
-        if allowTargetChange and target.ID() ~= mq.TLO.Target.ID() then
+        if allowTargetChange and targetId ~= mq.TLO.Target.ID() then
             local now = Globals.GetTimeSeconds()
-            if now - (Globals.LastCachedBuffUpdate[target.ID()] or 0) < Config:GetSetting('BuffTargetingInterval') then
-                Logger.log_verbose("ResolveBuffCheck: Throttled target-change for %s(ID:%d).", target.CleanName(), target.ID())
+            if now - (Globals.LastCachedBuffUpdate[targetId] or 0) < Config:GetSetting('BuffTargetingInterval') then
+                Logger.log_verbose("ResolveBuffCheck: Throttled target-change for %s(ID:%d).", target.CleanName(), targetId)
                 return false
             end
-            Globals.LastCachedBuffUpdate[target.ID()] = now
+            Globals.LastCachedBuffUpdate[targetId] = now
         end
         Logger.log_verbose("ResolveBuffCheck: Target is not myself or a DanNet peer, using TargetBuffCheck.")
         return Casting.TargetBuffCheck(spellId, target, allowTargetChange, false, skipTriggerCheck)
@@ -600,18 +601,18 @@ end
 --- @param skipBlockCheck boolean|nil whether to skip checking the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
 --- @return boolean True if the PC checking should cast the buff, false otherwise.
-function Casting.ActorBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
+function Casting.ActorBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck, heartbeat, spell)
     if not spellId then return false end
     if not (target and target()) then return false end
 
     local targetName = target.DisplayName()
     local targetId = target.ID()
-    local buffSpell = mq.TLO.Spell(spellId)
+    local buffSpell = spell or mq.TLO.Spell(spellId)
     local spellName = buffSpell.Name() or buffSpell()
 
     if not spellName then return false end
 
-    local heartbeat = Comms.GetPeerHeartbeatByName(targetName)
+    local heartbeat = heartbeat or Comms.GetPeerHeartbeatByName(targetName)
 
     if not heartbeat or not heartbeat.Data then
         Logger.log_error(
@@ -727,20 +728,20 @@ end
 --- @param skipBlockCheck boolean|nil whether to skip checking the peers blocked spells, this needs to be skipped for certain manual stacking checks
 --- @param skipTriggerCheck boolean|nil whether to skip a check for spell triggers, to be used for cost savings when we know the spell does not have triggers
 --- @return boolean True if the PC checking should cast the buff, false otherwise.
-function Casting.ActorPetBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck)
+function Casting.ActorPetBuffCheck(spellId, target, skipBlockCheck, skipTriggerCheck, heartbeat, spell)
     if not spellId then return false end
     if not (target and target()) then return false end
 
     local targetName = target.Master.DisplayName()
     local targetId = target.ID()
-    local buffSpell = mq.TLO.Spell(spellId)
+    local buffSpell = spell or mq.TLO.Spell(spellId)
     local spellName = buffSpell.Name() or buffSpell()
 
     if not spellName then return false end
 
     local masterName = target.Master() and target.Master.DisplayName() or nil
 
-    local heartbeat = masterName and Comms.GetPeerHeartbeatByName(masterName) or nil
+    local heartbeat = heartbeat or (masterName and Comms.GetPeerHeartbeatByName(masterName) or nil)
 
     if not heartbeat or not heartbeat.Data then
         Logger.log_error(
@@ -1756,7 +1757,7 @@ end
 --- @param retryCount number? The number of times to retry casting the spell if it fails.
 --- @return boolean success Returns true if the spell was successfully cast, false otherwise.
 --- @return boolean|nil isGroup Returns true if the spell is a group-affecting target type.
-function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount)
+function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount, noWait)
     local me = mq.TLO.Me
     if not targetId then targetId = mq.TLO.Target.ID() end
     -- Immediately send bards to the song handler.
@@ -1819,6 +1820,12 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         return false
     end
 
+    local spellRange = Casting.GetSpellRange(spell)
+    if targetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
+        Logger.log_debug("\ayUseSpell(): \arTried to cast %s on %s but they are too far away", spellName, targetSpawn.DisplayName() or "None")
+        return false
+    end
+
     if (Targeting.GetXTHaterCount() > 0 or not bAllowMem) and (not Casting.CastReady(spell) or not me.Gem(spellName)()) then
         Logger.log_debug("\ayUseSpell(): \ayI tried to cast %s but it was not ready and we are in combat - moving on.",
             spellName)
@@ -1871,9 +1878,10 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         actionName = spellName,
         targetId = targetId,
         bAllowDead = bAllowDead or false,
-        spellRange = Casting.GetSpellRange(spell),
+        spellRange = spellRange,
         castTime = castTime,
         retryCount = retryCount,
+        noWait = noWait,
     })
     if Globals.StopCast then return false end
 
@@ -1921,6 +1929,12 @@ function Casting.UseSong(songName, targetId, bAllowMem, retryCount)
 
     local targetSpawn = mq.TLO.Spawn(targetId)
 
+    local spellRange = Casting.GetSpellRange(songSpell)
+    if targetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
+        Logger.log_debug("\ayUseSong(): \arTried to cast %s on %s but they are too far away", songName, targetSpawn.DisplayName() or "None")
+        return false
+    end
+
     if (Targeting.GetXTHaterCount() > 0 or not bAllowMem) and (not Casting.CastReady(songSpell) or not me.Gem(songName)()) then
         Logger.log_debug("\ayUseSong(): I tried to sing %s but it was not ready and we are in combat - moving on.",
             songName)
@@ -1963,9 +1977,8 @@ function Casting.UseSong(songName, targetId, bAllowMem, retryCount)
 
     Core.SafeCallClassHelper("SwapInst", "SwapInst", songSpell.Skill())
 
-    retryCount = retryCount or 0
+    retryCount = retryCount or Config:GetSetting('CastRetryCount')
 
-    local spellRange = Casting.GetSpellRange(songSpell)
     local cancel = false
     local castStarted = false
     local readyCheck = function() return me.SpellReady(songName)() end
@@ -2079,7 +2092,7 @@ end
 --- @param targetId? number The ID of the target on which to use the discipline spell.
 --- @return boolean success True if we were able to fire the Disc, false otherwise.
 --- @return boolean|nil isGroup True if the disc is a group-affecting target type.
-function Casting.UseDisc(discSpell, targetId)
+function Casting.UseDisc(discSpell, targetId, noWait)
     local me = mq.TLO.Me
     if not targetId then targetId = mq.TLO.Target.ID() end
 
@@ -2096,6 +2109,15 @@ function Casting.UseDisc(discSpell, targetId)
     if me.CurrentEndurance() < discSpell.EnduranceCost() then
         Logger.log_debug("\ayUseDisc(): \arCan't use %s - insufficient endurance", discName)
         return false
+    end
+
+    local spellRange = Casting.GetSpellRange(discSpell)
+    if targetId ~= me.ID() then
+        local targetSpawn = mq.TLO.Spawn(targetId)
+        if targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
+            Logger.log_debug("\ayUseDisc(): \arTried to cast %s on %s but they are too far away", discName, targetSpawn.DisplayName() or "None")
+            return false
+        end
     end
 
     Logger.log_debug("\ayUseDisc(): trying %s", discName)
@@ -2130,9 +2152,10 @@ function Casting.UseDisc(discSpell, targetId)
         actionName = discName,
         targetId = targetId,
         bAllowDead = true,
-        spellRange = Casting.GetSpellRange(discSpell),
+        spellRange = spellRange,
         castTime = castTime,
         retryCount = 0,
+        noWait = noWait,
     })
     if Globals.StopCast then return false end
 
@@ -2192,17 +2215,18 @@ function Casting.RunCastLoop(opts)
     local castTime = opts.castTime or 0
     local retryCount = opts.retryCount or Config:GetSetting('CastRetryCount')
 
-    -- bard firing a 0-cast action mid-song: fire-and-return so we don't wait on or clip the in-progress song.
-    if castTime == 0 and (mq.TLO.Window("CastingWindow").Open() or mq.TLO.Me.Casting()) then
+    Casting.SetLastCastResult(Globals.Constants.CastResults.CAST_RESULT_NONE)
+
+    -- Instants that opt out (noWait) or are woven mid-song fire and assume success; anything else confirms via the loop below.
+    if castTime == 0 and (opts.noWait or mq.TLO.Window("CastingWindow").Open() or mq.TLO.Me.Casting()) then
         Core.DoCmd(cmd)
+        Casting.SetLastCastResult(Globals.Constants.CastResults.CAST_SUCCESS)
         return
     end
 
     -- give a small delay for when we need to rely on an action changing to "not ready" to detect success, this is data from the server. values tested on laz/might numerous times
     local floor = math.max(300, 3 * (mq.TLO.EverQuest.Ping() or 0))
     local delay = castTime < floor and floor or castTime
-
-    Casting.SetLastCastResult(Globals.Constants.CastResults.CAST_RESULT_NONE)
 
     repeat
         Logger.log_verbose("\ayRunCastLoop(): Attempting to cast: %s", actionName)
@@ -2239,7 +2263,7 @@ end
 --- @param retryCount number? The number of times to retry if the cast fails.
 --- @return boolean success True if the AA ability was successfully used, false otherwise.
 --- @return boolean|nil isGroup True if the AA is a group-affecting target type.
-function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
+function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, noWait)
     local me = mq.TLO.Me
     if not targetId then targetId = mq.TLO.Target.ID() end
 
@@ -2287,6 +2311,12 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
         return false
     end
 
+    local spellRange = Casting.GetSpellRange(aaSpell)
+    if targetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
+        Logger.log_debug("\ayUseAA(): \arTried to cast %s on %s but they are too far away", aaName, targetSpawn.DisplayName() or "None")
+        return false
+    end
+
     Casting.ActionPrep()
 
     local oldTargetId = mq.TLO.Target.ID()
@@ -2312,9 +2342,10 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount)
         actionName = aaName,
         targetId = targetId,
         bAllowDead = bAllowDead or false,
-        spellRange = Casting.GetSpellRange(aaSpell),
+        spellRange = spellRange,
         castTime = castTime,
         retryCount = retryCount,
+        noWait = noWait,
     })
     if Globals.StopCast then return false end
 
@@ -2373,9 +2404,10 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount)
         return false
     end
 
-    if targetId and targetId ~= me.ID() and (itemSpell.MyRange() or 0) > 0 then
+    local spellRange = Casting.GetSpellRange(itemSpell)
+    if targetId and targetId ~= me.ID() then
         local targetSpawn = mq.TLO.Spawn(targetId)
-        if targetSpawn and targetSpawn() and targetSpawn.Distance() > (itemSpell.MyRange() or 100) then
+        if targetSpawn and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
             Logger.log_debug("\ayUseItem(): \arTried to use %s on %s but they are too far away", itemName, targetSpawn and targetSpawn.DisplayName() or "None")
             return false
         end
@@ -2426,7 +2458,7 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount)
         targetId = targetId,
         -- default true (unlike UseAA/UseSpell) so rez clickies still fire on dead targets
         bAllowDead = bAllowDead ~= false,
-        spellRange = Casting.GetSpellRange(itemSpell),
+        spellRange = spellRange,
         castTime = castTime,
         retryCount = retryCount,
     })
@@ -2861,9 +2893,9 @@ end
 ---@param target MQSpawn|MQTarget|nil The target spawn handle to check.
 ---@return boolean True if the spell is allowed to land on target.
 function Casting.LevelCheckPass(spell, target)
+    if Config:GetSetting('IgnoreLevelCheck') then return true end
     if not spell or not spell() then return false end
     if not target or not target() then return false end
-    if Config:GetSetting('IgnoreLevelCheck') then return true end
     if (target.Type() or ""):lower() ~= "pc" then return true end
     if not (spell.Beneficial() and (spell.Duration.TotalSeconds() or 0) > 0) then return true end
     local spellLevel = spell.Level() or 999

--- a/utils/comms.lua
+++ b/utils/comms.lua
@@ -21,7 +21,7 @@ Comms.OutgoingToasts       = {}
 --- @param peerServer string? Server name; defaults to the local server.
 --- @return string The formatted "Name (Server)" peer identifier.
 function Comms.GetPeerName(peerName, peerServer)
-    local server = peerServer or mq.TLO.EverQuest.Server()
+    local server = peerServer or Globals.CurServer
     --upper first letter if it isnt (Live)
     if server:len() > 0 then
         server = server:sub(1, 1):upper() .. server:sub(2)

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1259,8 +1259,8 @@ Config.DefaultConfig                                     = {
         Header = "Common",
         Category = "Under the Hood",
         Index = 1,
-        Tooltip = "The amount of times to try to recast a spell, AA, or item due to a fizzle, interrupt, or similar. Note that queued actions already have a retry built-in.",
-        Default = 0,
+        Tooltip = "The amount of times to try to recast a spell, song, AA, or item due to a fizzle, interrupt, or similar. Note that queued actions already have a retry built-in.",
+        Default = Globals.CurLoadedClass == "BRD" and 1 or 0,
         Min = 0,
         Max = 5,
         ConfigType = "Advanced",
@@ -3345,7 +3345,11 @@ function Config:SetSetting(setting, value, tempOnly, noCallback)
             self.moduleTempSettings[settingModuleName][setting] = cleanValue
         else
             self:SettingDbWrite(settingModuleName, setting, cleanValue)
-            self.moduleTempSettings[settingModuleName][setting] = nil
+            if Config.TempSettings.SettingToScopeCache[setting] == "server" then
+                self.moduleTempSettings[settingModuleName][setting] = nil
+            else
+                self.moduleTempSettings[settingModuleName][setting] = cleanValue
+            end
         end
     else
         Logger.log_info("\ayFailed to update setting %s, invalid value supplied.", setting)
@@ -3402,6 +3406,11 @@ end
 function Config:ClearAllTempSettings()
     for module, _ in pairs(self.moduleTempSettings) do
         self.moduleTempSettings[module] = {}
+        for setting, _ in pairs(self.moduleDefaultSettings[module] or {}) do
+            if Config.TempSettings.SettingToScopeCache[setting] ~= "server" then
+                self.moduleTempSettings[module][setting] = self:SettingDbRead(module, setting)
+            end
+        end
     end
 end
 
@@ -3529,6 +3538,10 @@ function Config:RegisterModuleSettings(module, settings, defaultSettings, faq, f
         end
 
         Config.TempSettings.SettingToScopeCache[setting] = v.Scope
+
+        if v.Scope ~= "server" then
+            self.moduleTempSettings[module][setting] = resolvedSettings[setting]
+        end
     end
 
     if firstSaveRequired or settingsChanged then
@@ -3825,7 +3838,7 @@ end
 --- Moves the PC at the given index down.
 --- @param id number The index of the PC to move.
 --- @param listName string: The list to adjust.
-function Config:AssistMoveDown(id, listName)
+function Config:ListMoveDown(id, listName)
     if not id then
         Logger.log_error("\ar%s Move Down: this command requires a valid argument!", listName)
         return

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -515,10 +515,11 @@ function Core.GetChaseTarget()
     return Modules:ExecModule("Movement", "GetChaseTarget")
 end
 
---- Refreshes all buff/song/blocked/pet-buff tables in Globals by
---- re-reading every slot from TLO.
-function Core.UpdateBuffs()
+--- Refreshes buff/song/blocked/pet-buff tables in Globals by re-reading every slot from TLO.
+--- @param countOnly boolean? Rebuild only the buff table (for CurrentBuffCount); skip the songs/blocked/pet tables that only the heartbeat sender reads.
+function Core.UpdateBuffs(countOnly)
     Core.GetBuffTable()
+    if countOnly then return end
     Core.GetSongTable()
     Core.GetBlockedTable()
     if Config:GetSetting('DoActorPetBuffs') then

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -167,7 +167,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.SpellReady(spell, bAllowMem) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseSpell(spell.RankName(), targetId, bAllowMem, entry.allowDead, entry.retries)
+            ret, isGroup = Casting.UseSpell(spell.RankName(), targetId, bAllowMem, entry.allowDead, entry.retries, entry.noWait)
         end
         Logger.log_verbose("(Spell) Trying to use %s - %s :: %s", entry.name, spell.RankName(), ret and "\agSuccess" or "\arFailed!")
     end
@@ -191,7 +191,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.DiscReady(discSpell) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseDisc(discSpell, targetId)
+            ret, isGroup = Casting.UseDisc(discSpell, targetId, entry.noWait)
         end
         Logger.log_verbose("(Disc) Trying to use %s - %s :: %s", entry.name, discSpell.RankName(), ret and "\agSuccess" or "\arFailed!")
     end
@@ -203,7 +203,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.AAReady(aaName) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseAA(aaName, targetId, entry.allowDead, entry.retries)
+            ret, isGroup = Casting.UseAA(aaName, targetId, entry.allowDead, entry.retries, entry.noWait)
         end
         Logger.log_verbose("(AA) Trying to use %s :: %s", aaName, ret and "\agSuccess" or "\arFailed!")
     end
@@ -424,8 +424,6 @@ function Rotation.Run(caller, rotationTable, targetTable, resolvedActionMap, ste
         end
     end
 
-    Modules:ExecModule("Class", "PromptRestoreSwapSlot")
-
     lastStepIdx = lastStepIdx + 1
 
     if lastStepIdx > #rotationTable then
@@ -436,6 +434,28 @@ function Rotation.Run(caller, rotationTable, targetTable, resolvedActionMap, ste
         lastStepIdx)
 
     return lastStepIdx, anySuccess
+end
+
+--- Reorders entryList in place to match a saved order of entry names, keying by name+occurrence so duplicate names stay distinct.
+---@param entryList table Array of rotation entry descriptors, reordered in place.
+---@param savedOrder table? Array of entry names defining the desired order; entries absent from it keep their built order at the end. Nil/empty is a no-op.
+function Rotation.ApplyEntryOrder(entryList, savedOrder)
+    if not savedOrder or #savedOrder == 0 then return end
+    local pos = {}
+    local savedSeen = {}
+    for i, entryName in ipairs(savedOrder) do
+        savedSeen[entryName] = (savedSeen[entryName] or 0) + 1
+        pos[entryName .. "\0" .. savedSeen[entryName]] = i
+    end
+    local base = #savedOrder
+    local liveSeen = {}
+    local keyed = {}
+    for i, entry in ipairs(entryList) do
+        liveSeen[entry.name] = (liveSeen[entry.name] or 0) + 1
+        keyed[i] = { entry = entry, key = pos[entry.name .. "\0" .. liveSeen[entry.name]] or (base + i), }
+    end
+    table.sort(keyed, function(a, b) return a.key < b.key end)
+    for i, k in ipairs(keyed) do entryList[i] = k.entry end
 end
 
 --- Builds and returns a resolvedActionMap by calling GetBestItem, GetBestSpell,

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -1926,12 +1926,23 @@ end
 ---@return boolean showFailed The (potentially toggled) showFailed value.
 ---@return table enabledRotationEntries Updated enablement map.
 ---@return boolean changed True if any enablement setting was toggled this frame.
-function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotationState, showFailed, enabledRotationEntries, hideRotationCols)
+---@return boolean reordered True if an entry was reordered this frame.
+---@return boolean resetRequested True if the user reset this list to default order this frame.
+function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotationState, showFailed, enabledRotationEntries, hideRotationCols, reorderable)
     local enabledRotationEntriesChanged = false
     local showDebugTiming = Config:GetSetting('ShowDebugTiming')
+    local pendingSwap = nil
+    local resetRequested = false
+    local function persistRotationOrder()
+        local order = Config:GetSetting('RotationEntryOrder') or {}
+        local names = {}
+        for _, e in ipairs(rotationTable or {}) do names[#names + 1] = e.name end
+        order[name] = names
+        Config:SetSetting('RotationEntryOrder', order)
+    end
 
     -- non-rotation callers (mez/charm) drive their own resolvers, so the rotation-only Cur ("-") and always-red "Condition Met" columns are noise - let them hide both
-    local numCols = (hideRotationCols and 4 or 6) + (showDebugTiming and 1 or 0)
+    local numCols = (hideRotationCols and 4 or 6) + (showDebugTiming and 1 or 0) + (reorderable and 1 or 0)
     local resolvedColIdx = hideRotationCols and 3 or 5
 
     if ImGui.BeginTable("Rotation_" .. name, numCols, bit32.bor(ImGuiTableFlags.Resizable, ImGuiTableFlags.Borders)) then
@@ -1950,6 +1961,9 @@ function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotation
         if showDebugTiming then
             ImGui.TableSetupColumn('Timing', ImGuiTableColumnFlags.WidthStretch, 250.0)
         end
+        if reorderable then
+            ImGui.TableSetupColumn("##reorder", ImGuiTableColumnFlags.WidthFixed, 55.0)
+        end
 
         ImGui.TableHeadersRow()
 
@@ -1960,6 +1974,16 @@ function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotation
             ImGui.SameLine()
             Ui.RenderText(Icons.MD_INFO_OUTLINE)
             Ui.Tooltip("Click a resolved action to inspect the spell/item/AA effect.")
+        end
+
+        if reorderable and (Config:GetSetting('RotationEntryOrder') or {})[name] and ImGui.TableSetColumnIndex(numCols - 1) then
+            if ImGui.SmallButton(Icons.MD_REFRESH .. "##reset_" .. name) then
+                local order = Config:GetSetting('RotationEntryOrder') or {}
+                order[name] = nil
+                Config:SetSetting('RotationEntryOrder', order)
+                resetRequested = true
+            end
+            Ui.Tooltip("Reset this list to its default order.")
         end
 
         for idx, entry in ipairs(rotationTable or {}) do
@@ -2099,12 +2123,38 @@ function Ui.RenderRotationTable(name, rotationTable, resolvedActionMap, rotation
                     Strings.FormatTimeMS((entry.lastFollowTimeSpent or 0) * 1000),
                     Strings.FormatTimeMS((entry.lastTotalTimeSpent or 0) * 1000))
             end
+
+            if reorderable then
+                ImGui.TableNextColumn()
+                if idx > 1 then
+                    ImGui.PushID(string.format("rot_%s_up_%d", name, idx))
+                    if ImGui.SmallButton(Icons.FA_CHEVRON_UP) then pendingSwap = { idx, idx - 1, } end
+                    ImGui.PopID()
+                else
+                    ImGui.InvisibleButton("##rot_upspace_" .. idx, ImVec2(22, 1))
+                end
+                ImGui.SameLine()
+                if idx < #rotationTable then
+                    ImGui.PushID(string.format("rot_%s_dn_%d", name, idx))
+                    if ImGui.SmallButton(Icons.FA_CHEVRON_DOWN) then pendingSwap = { idx, idx + 1, } end
+                    ImGui.PopID()
+                else
+                    ImGui.InvisibleButton("##rot_dnspace_" .. idx, ImVec2(22, 1))
+                end
+            end
         end
 
         ImGui.EndTable()
     end
 
-    return showFailed, enabledRotationEntries, enabledRotationEntriesChanged
+    local reordered = false
+    if pendingSwap and rotationTable then
+        rotationTable[pendingSwap[1]], rotationTable[pendingSwap[2]] = rotationTable[pendingSwap[2]], rotationTable[pendingSwap[1]]
+        persistRotationOrder()
+        reordered = true
+    end
+
+    return showFailed, enabledRotationEntries, enabledRotationEntriesChanged, reordered, resetRequested
 end
 
 --- Renders an animated fancy toggle switch with optional label and color options.


### PR DESCRIPTION
Some rotation-based windows are now reorderable in the UI. Rotations will be adjusted to process in that order. Others may follow: Charm (Assist, PreCharm), Melody(Bard Rotation). Note that some entry conditions make this a very bad idea on the defaults: tread carefully.

Bard
* Melody and Combat Songs are now combined into a single rotation.
* A fallback entry in the rotation handles topping off songs if none are in immediate need of refreshing.

Performance/Bug Fixes:
* Variety of minor tweaks to claw back MS to pay for other shiny new things.
* Fixes for some DB lookup caching.
* Stopped duplicate work for buff table creation.
* Certain UI elements no longer update if they are not open/drawing.

Config Work
* Added the noWait flag to entries, instant AA/disc entries can enable this to bypass the small delay to ensure an ability was used (by checking for the buff, checking for it going on cooldown, etc). Safe to use anywhere the fidelity is unimportant (e.g, Selo's), but could compromise tank disc selection, etc, if used improperly.
* Added the blockMem flag, which stops spells in that rotation from memorized by the UseSpell when conditions are met.