### PR TITLE
Casting Adjustments

### DIFF
--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -901,7 +901,6 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 midSong = true,
-                noWait = true,
                 cond = function(self, aaName, target)
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -1469,7 +1469,6 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 midSong = true,
-                noWait = true,
                 cond = function(self, aaName, target)
                     -- Selo AA triggers Accelerando or Accelerato depending on rank.
                     local aaBuff = mq.TLO.Me.AltAbility(aaName).Spell.Trigger(1)() or ""

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -813,7 +813,6 @@ local _ClassConfig = {
                 name = "Selo's Sonata",
                 type = "AA",
                 midSong = true,
-                noWait = true,
                 cond = function(self, aaName, target)
                     local combatState = Combat.GetCachedCombatState()
                     -- if in combat, check self, out of combat, also check others

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2828, }
+return { version = 2829, }

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -1202,6 +1202,10 @@ function Module:LoadSettings()
                 clicky.skipTriggerCheck = false
                 settingsChanged = true
             end
+            if clicky.mustWait == nil then
+                clicky.mustWait = false
+                settingsChanged = true
+            end
             settingsChanged = self:ValidateClickyRotationSettings(clicky) or settingsChanged
         end
 
@@ -1475,11 +1479,13 @@ end
 
 function Module:RenderClickyToggles(clicky, clickyIdx)
     local isRotationTarget = clicky.target == "Rotation Target"
-    if ImGui.BeginTable("##clicky_toggles_table_" .. clickyIdx, 4, bit32.bor(ImGuiTableFlags.None)) then
+    if ImGui.BeginTable("##clicky_toggles_table_" .. clickyIdx, 6, bit32.bor(ImGuiTableFlags.None)) then
         ImGui.TableSetupColumn("Key1", ImGuiTableColumnFlags.WidthFixed, 140)
         ImGui.TableSetupColumn("Value1", ImGuiTableColumnFlags.WidthFixed, 40)
         ImGui.TableSetupColumn("Key2", ImGuiTableColumnFlags.WidthFixed, 140)
-        ImGui.TableSetupColumn("Value2", ImGuiTableColumnFlags.WidthStretch, 0)
+        ImGui.TableSetupColumn("Value2", ImGuiTableColumnFlags.WidthFixed, 40)
+        ImGui.TableSetupColumn("Key3", ImGuiTableColumnFlags.WidthFixed, 140)
+        ImGui.TableSetupColumn("Value3", ImGuiTableColumnFlags.WidthStretch, 0)
 
         ImGui.TableNextColumn()
         ImGui.AlignTextToFramePadding()
@@ -1514,6 +1520,20 @@ function Module:RenderClickyToggles(clicky, clickyIdx)
             Config:SetSetting('Clickies', Config:GetSetting('Clickies'))
         end
         Ui.Tooltip("Only check the clicky buff for stacking, ignoring any secondary spell effects triggered by the clicky spell.")
+
+        ImGui.TableNextColumn()
+        ImGui.AlignTextToFramePadding()
+        Ui.RenderText("Confirm Cast")
+        ImGui.TableNextColumn()
+        ImGui.BeginGroup()
+        local newMustWait, mustWaitClicked = Ui.RenderOptionToggle("##clicky_must_wait_" .. clickyIdx, "",
+            clicky.mustWait or false)
+        ImGui.EndGroup()
+        if mustWaitClicked then
+            clicky.mustWait = newMustWait
+            Config:SetSetting('Clickies', Config:GetSetting('Clickies'))
+        end
+        Ui.Tooltip("Wait and confirm that item use has started by checking that it has gone on cooldown or that a cast success is reported. Generally not needed.")
 
         ImGui.EndTable()
     end
@@ -2139,7 +2159,7 @@ function Module:GiveTime()
 
                             if buffCheckPassed and distanceCheckPassed and readyCheckPassed and elementCheckPassed then
                                 Logger.log_verbose("\ayClicky: \awItem \am%s\aw Clicky Spell: \at%s\ag!", item.Name(), item.Clicky.Spell.RankName.Name())
-                                Casting.UseItem(item.Name(), targetId)
+                                Casting.UseItem(item.Name(), targetId, nil, nil, not clicky.mustWait)
                                 self.TempSettings.ClickyState[clicky.itemName].lastUsed = Globals.GetTimeSeconds()
                                 clickiesUsedThisCycle = clickiesUsedThisCycle + 1
                                 if maxClickiesPerCycle > 0 and clickiesUsedThisCycle >= maxClickiesPerCycle then

--- a/namedlist/named_eqmight.lua
+++ b/namedlist/named_eqmight.lua
@@ -225,6 +225,7 @@ return {
         "The Fabled Master of Spite",
     },
     ["hateplaneb"] = {
+        "A timeless golem of spite",
         { name = "The Timeless Deathrot Knight", elementalImmunities = { Magic = true, }, },
         "The Ultrafabled Master of Spite",
         { name = "Timeless Arcanist V`Gimis",    statusImmunities = { Slow = true, }, },

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1757,7 +1757,7 @@ end
 --- @param retryCount number? The number of times to retry casting the spell if it fails.
 --- @return boolean success Returns true if the spell was successfully cast, false otherwise.
 --- @return boolean|nil isGroup Returns true if the spell is a group-affecting target type.
-function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount, noWait)
+function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount)
     local me = mq.TLO.Me
     if not targetId then targetId = mq.TLO.Target.ID() end
     -- Immediately send bards to the song handler.
@@ -1881,7 +1881,6 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         spellRange = spellRange,
         castTime = castTime,
         retryCount = retryCount,
-        noWait = noWait,
     })
     if Globals.StopCast then return false end
 
@@ -2092,7 +2091,7 @@ end
 --- @param targetId? number The ID of the target on which to use the discipline spell.
 --- @return boolean success True if we were able to fire the Disc, false otherwise.
 --- @return boolean|nil isGroup True if the disc is a group-affecting target type.
-function Casting.UseDisc(discSpell, targetId, noWait)
+function Casting.UseDisc(discSpell, targetId, fireAndForget)
     local me = mq.TLO.Me
     if not targetId then targetId = mq.TLO.Target.ID() end
 
@@ -2155,7 +2154,7 @@ function Casting.UseDisc(discSpell, targetId, noWait)
         spellRange = spellRange,
         castTime = castTime,
         retryCount = 0,
-        noWait = noWait,
+        fireAndForget = fireAndForget,
     })
     if Globals.StopCast then return false end
 
@@ -2217,8 +2216,7 @@ function Casting.RunCastLoop(opts)
 
     Casting.SetLastCastResult(Globals.Constants.CastResults.CAST_RESULT_NONE)
 
-    -- Instants that opt out (noWait) or are woven mid-song fire and assume success; anything else confirms via the loop below.
-    if castTime == 0 and (opts.noWait or mq.TLO.Window("CastingWindow").Open() or mq.TLO.Me.Casting()) then
+    if castTime == 0 and not Casting.IsActiveDisc(actionName) and (opts.fireAndForget or mq.TLO.Window("CastingWindow").Open() or mq.TLO.Me.Casting()) then
         Core.DoCmd(cmd)
         Casting.SetLastCastResult(Globals.Constants.CastResults.CAST_SUCCESS)
         return
@@ -2230,9 +2228,18 @@ function Casting.RunCastLoop(opts)
 
     repeat
         Logger.log_verbose("\ayRunCastLoop(): Attempting to cast: %s", actionName)
+        -- Active discs hold for discs to become active; other instants only hold until they go on cooldown.
+        local isActiveDisc = castTime == 0 and Casting.IsActiveDisc(actionName)
+        local confirmOnDisc = isActiveDisc and not mq.TLO.Me.ActiveDisc.ID()
         Core.DoCmd(cmd)
         Logger.log_verbose("\ayRunCastLoop(): Waiting to start cast: %s (delay=%dms)", actionName, delay)
         mq.delay(delay, function()
+            if castTime == 0 then mq.doevents('Success1') end -- check for cast message on items (it seems to be sent from the server, not client/instant like spells)
+            if isActiveDisc then
+                if confirmOnDisc and (mq.TLO.Me.ActiveDisc.ID() or 0) > 0 then return true end
+            elseif castTime == 0 and not readyCheck() then
+                return true
+            end
             return mq.TLO.Me.Casting() ~= nil
                 or Globals.Constants.CastCompleted:contains(Casting.GetLastCastResultName())
         end)
@@ -2263,7 +2270,7 @@ end
 --- @param retryCount number? The number of times to retry if the cast fails.
 --- @return boolean success True if the AA ability was successfully used, false otherwise.
 --- @return boolean|nil isGroup True if the AA is a group-affecting target type.
-function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, noWait)
+function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, fireAndForget)
     local me = mq.TLO.Me
     if not targetId then targetId = mq.TLO.Target.ID() end
 
@@ -2345,7 +2352,7 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, noWait)
         spellRange = spellRange,
         castTime = castTime,
         retryCount = retryCount,
-        noWait = noWait,
+        fireAndForget = fireAndForget,
     })
     if Globals.StopCast then return false end
 
@@ -2375,7 +2382,7 @@ end
 --- @param retryCount number? The number of times to retry if the use fails.
 --- @return boolean success True if the item was successfully used, false otherwise.
 --- @return boolean|nil isGroup True if the item's spell is a group-affecting target type.
-function Casting.UseItem(itemName, targetId, bAllowDead, retryCount)
+function Casting.UseItem(itemName, targetId, bAllowDead, retryCount, fireAndForget)
     local me = mq.TLO.Me
 
     if not itemName then
@@ -2461,6 +2468,7 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount)
         spellRange = spellRange,
         castTime = castTime,
         retryCount = retryCount,
+        fireAndForget = fireAndForget,
     })
     if Globals.StopCast then return false end
 

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -138,7 +138,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.ItemReady(itemName) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseItem(itemName, entry.no_target == true and nil or targetId)
+            ret, isGroup = Casting.UseItem(itemName, entry.no_target == true and nil or targetId, nil, nil, not entry.mustWait)
         end
         Logger.log_verbose("Trying to use item %s :: %s", itemName, ret and "\agSuccess" or "\arFailed!")
     end
@@ -151,7 +151,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.ItemReady(itemName) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseItem(itemName, entry.no_target == true and nil or targetId)
+            ret, isGroup = Casting.UseItem(itemName, entry.no_target == true and nil or targetId, nil, nil, not entry.mustWait)
         end
         Logger.log_verbose("Trying to use clickyitem %s :: %s", itemName, ret and "\agSuccess" or "\arFailed!")
     end
@@ -167,7 +167,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.SpellReady(spell, bAllowMem) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseSpell(spell.RankName(), targetId, bAllowMem, entry.allowDead, entry.retries, entry.noWait)
+            ret, isGroup = Casting.UseSpell(spell.RankName(), targetId, bAllowMem, entry.allowDead, entry.retries)
         end
         Logger.log_verbose("(Spell) Trying to use %s - %s :: %s", entry.name, spell.RankName(), ret and "\agSuccess" or "\arFailed!")
     end
@@ -191,7 +191,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.DiscReady(discSpell) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseDisc(discSpell, targetId, entry.noWait)
+            ret, isGroup = Casting.UseDisc(discSpell, targetId, not entry.mustWait)
         end
         Logger.log_verbose("(Disc) Trying to use %s - %s :: %s", entry.name, discSpell.RankName(), ret and "\agSuccess" or "\arFailed!")
     end
@@ -203,7 +203,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if Casting.AAReady(aaName) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret, isGroup = Casting.UseAA(aaName, targetId, entry.allowDead, entry.retries, entry.noWait)
+            ret, isGroup = Casting.UseAA(aaName, targetId, entry.allowDead, entry.retries, not entry.mustWait)
         end
         Logger.log_verbose("(AA) Trying to use %s :: %s", aaName, ret and "\agSuccess" or "\arFailed!")
     end


### PR DESCRIPTION
* No longer wait for confirmation on most instant actions/discs/items .
* The mustWait flag on entry rotations will force a confirmation (cooldown triggered, cast success message, etc).
* Remove the noWait entry flag.
* Allowed early return in many cases when cooldown is triggered even if we must wait.