### PR TITLE
Stick, Chase and Tank Reposition Changes

### DIFF
--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -393,11 +393,16 @@ return {
                     end
                 elseif (mq.TLO.Stick.StickTarget() or 0) ~= Globals.AutoTargetID or (mq.TLO.Stick.Status() or "off"):lower() == "off" then
                     Core.DoCmd('/squelch /face fast')
+                    -- DEPRECATED 7/26 - sunset 9/1/26. StickHow passthrough, mirroring DoStick.
                     local stickHow = Config:GetSetting('StickHow') or ""
                     if #stickHow > 0 then
                         Movement:DoStickCmd("%s", stickHow)
                     else
-                        Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                        local stickDist = Config:GetSetting('StickDistance') or ""
+                        if stickDist == "" then stickDist = tostring(bowRange) end
+                        local stickArgs = Config:GetSetting('StickArgs') or ""
+                        if stickArgs == "" then stickArgs = "moveback uw" end
+                        Movement:DoStickCmd("%s id %d %s", stickDist, Globals.AutoTargetID, stickArgs)
                     end
                 end
             else -- Loose: react to the game's own range messages, one-shot, no held position.

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -1681,11 +1681,16 @@ local _ClassConfig = {
                     end
                 elseif (mq.TLO.Stick.StickTarget() or 0) ~= Globals.AutoTargetID or (mq.TLO.Stick.Status() or "off"):lower() == "off" then
                     Core.DoCmd('/squelch /face fast')
+                    -- DEPRECATED 7/26 - sunset 9/1/26. StickHow passthrough, mirroring DoStick.
                     local stickHow = Config:GetSetting('StickHow') or ""
                     if #stickHow > 0 then
                         Movement:DoStickCmd("%s", stickHow)
                     else
-                        Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                        local stickDist = Config:GetSetting('StickDistance') or ""
+                        if stickDist == "" then stickDist = tostring(bowRange) end
+                        local stickArgs = Config:GetSetting('StickArgs') or ""
+                        if stickArgs == "" then stickArgs = "moveback uw" end
+                        Movement:DoStickCmd("%s id %d %s", stickDist, Globals.AutoTargetID, stickArgs)
                     end
                 end
             else -- Loose: react to the game's own range messages, one-shot, no held position.

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -372,11 +372,16 @@ return {
                     end
                 elseif (mq.TLO.Stick.StickTarget() or 0) ~= Globals.AutoTargetID or (mq.TLO.Stick.Status() or "off"):lower() == "off" then
                     Core.DoCmd('/squelch /face fast')
+                    -- DEPRECATED 7/26 - sunset 9/1/26. StickHow passthrough, mirroring DoStick.
                     local stickHow = Config:GetSetting('StickHow') or ""
                     if #stickHow > 0 then
                         Movement:DoStickCmd("%s", stickHow)
                     else
-                        Movement:DoStickCmd("%d id %d moveback uw", bowRange, Globals.AutoTargetID)
+                        local stickDist = Config:GetSetting('StickDistance') or ""
+                        if stickDist == "" then stickDist = tostring(bowRange) end
+                        local stickArgs = Config:GetSetting('StickArgs') or ""
+                        if stickArgs == "" then stickArgs = "moveback uw" end
+                        Movement:DoStickCmd("%s id %d %s", stickDist, Globals.AutoTargetID, stickArgs)
                     end
                 end
             else -- Loose: react to the game's own range messages, one-shot, no held position.

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2840, }
+return { version = 2841, }

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2842, }
+return { version = 2843, }

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2843, }
+return { version = 2844, }

--- a/extras/version.lua
+++ b/extras/version.lua
@@ -1,1 +1,1 @@
-return { version = 2841, }
+return { version = 2842, }

--- a/modules/class.lua
+++ b/modules/class.lua
@@ -2368,7 +2368,7 @@ function Module:GiveTime()
         self:RunCounterRotation()
     end
 
-    if self:IsTanking() and Config:GetSetting('KeepMobsInFront') and Movement:DetectMobBehind() then
+    if self:IsTanking() and Config:GetSetting('KeepMobsInFront') and Movement:CanReposition() and Movement:DetectMobBehind() then
         Movement:TankReposition()
     end
 

--- a/modules/move.lua
+++ b/modules/move.lua
@@ -125,6 +125,11 @@ Module.DefaultConfig   = {
         Index = 1,
         Tooltip = "Follow the Chase target using MQ2Nav. Requires navmeshes!",
         Default = false,
+        OnChange = function(oldVal, newVal)
+            if newVal then
+                Config:SetSetting('ManualMode', false, false, true)
+            end
+        end,
     },
     ['RunMovePaused']                          = {
         DisplayName = "Chase or Camp While Paused",
@@ -231,6 +236,15 @@ Module.DefaultConfig   = {
         Min = 1,
         Max = 600,
         ConfigType = "Advanced",
+    },
+    ['ChaseInCombat']                          = {
+        DisplayName = "Chase In Combat",
+        Group = "Movement",
+        Header = "Following",
+        Category = "Chase",
+        Index = 11,
+        Tooltip = "Continue chase movement even while an XTarget hater is within Assist Range.",
+        Default = false,
     },
 
 
@@ -361,16 +375,17 @@ function Module:ChaseOn(nameParam)
     -- if no name passed, use current chase target
     local targetName = nameParam or (currentChase ~= "" and currentChase)
 
-    -- if we end up chasing our tails then use the MA.
+    -- being told to chase ourselves means we're the chase target; stop chasing whoever we were following.
     if targetName == mq.TLO.Me.CleanName() then
-        Logger.log_warn("\ayWarning: Attempting to chase yourself, defaulting to Main Assist.")
-        targetName = Core.GetGroupMainAssistName()
+        Logger.log_warn("\ayWarning: Attempting to chase yourself, stopping chase instead.")
+        self:ChaseOff()
+        return
     end
 
     -- if no current chase target, use MA
     local chaseTarget = targetName and mq.TLO.Spawn("pc =" .. targetName) or Core.GetMainAssistSpawn()
 
-    if chaseTarget and chaseTarget() and chaseTarget.ID() > 0 then
+    if chaseTarget and chaseTarget() and chaseTarget.ID() > 0 and chaseTarget.ID() ~= mq.TLO.Me.ID() then
         self:CampOff()
         Config:SetSetting('ChaseOn', true)
         Config:SetSetting('ChaseTarget', chaseTarget.CleanName())
@@ -685,7 +700,20 @@ function Module:OnDeath()
 end
 
 function Module:ShouldFollow()
-    return not mq.TLO.MoveTo.Moving() and (not mq.TLO.Me.Casting() or Core.MyClassIs("brd"))
+    if mq.TLO.MoveTo.Moving() or (mq.TLO.Me.Casting() and not Core.MyClassIs("brd")) then return false end
+
+    if not Config:GetSetting('ChaseInCombat') and not Config:GetSetting('PriorityFollow') and Config:GetSetting('DoAutoEngage')
+        and not Globals.PauseMain and not Config:GetSetting('ManualMode')
+        and Targeting.XTHaterInRange(Config:GetSetting('AssistRange')) then
+        local autoTarget = Targeting.GetAutoTarget()
+        local autoTargetOutOfReach = autoTarget() and not autoTarget.Dead() and (autoTarget.Distance3D() or 0) > Config:GetSetting('AssistRange')
+        if not autoTargetOutOfReach then
+            Logger.log_super_verbose("ShouldFollow(): chase paused, XTarget hater within Assist Range.")
+            return false
+        end
+    end
+
+    return true
 end
 
 function Module:OnZone()

--- a/modules/move.lua
+++ b/modules/move.lua
@@ -705,9 +705,11 @@ function Module:ShouldFollow()
     if not Config:GetSetting('ChaseInCombat') and not Config:GetSetting('PriorityFollow') and Config:GetSetting('DoAutoEngage')
         and not Globals.PauseMain and not Config:GetSetting('ManualMode')
         and Targeting.XTHaterInRange(Config:GetSetting('AssistRange')) then
-        local autoTarget = Targeting.GetAutoTarget()
-        local autoTargetOutOfReach = autoTarget() and not autoTarget.Dead() and (autoTarget.Distance3D() or 0) > Config:GetSetting('AssistRange')
-        if not autoTargetOutOfReach then
+        -- Hold unless the MA's fight has moved out of our reach (they were summoned, or we were left behind).
+        local maTargetId = Globals.MATargetID
+        local separated = maTargetId > 0 and Targeting.IsSpawnXTHater(maTargetId, true)
+            and (mq.TLO.Spawn(maTargetId).Distance3D() or 9999) > Config:GetSetting('AssistRange')
+        if not separated then
             Logger.log_super_verbose("ShouldFollow(): chase paused, XTarget hater within Assist Range.")
             return false
         end

--- a/modules/move.lua
+++ b/modules/move.lua
@@ -612,6 +612,16 @@ function Module:Render()
 
         if ImGui.BeginTable("ChaseInfoTable", 2, bit32.bor(ImGuiTableFlags.Borders)) then
             ImGui.TableNextColumn()
+            Ui.RenderText("Chase Status")
+            ImGui.TableNextColumn()
+            if not Config:GetSetting('ChaseOn') then
+                Ui.RenderColoredText(Globals.Constants.BasicColors.Red, "Off")
+            elseif self.TempSettings.ChaseSuppressed then
+                Ui.RenderColoredText(Globals.Constants.BasicColors.Yellow, "Suppressed (Combat)")
+            else
+                Ui.RenderColoredText(Globals.Constants.BasicColors.Green, "Chasing")
+            end
+            ImGui.TableNextColumn()
             Ui.RenderText("Chase Target")
             ImGui.TableNextColumn()
             Ui.RenderText(self:GetChaseTarget())
@@ -710,11 +720,13 @@ function Module:ShouldFollow()
         local separated = maTargetId > 0 and Targeting.IsSpawnXTHater(maTargetId, true)
             and (mq.TLO.Spawn(maTargetId).Distance3D() or 9999) > Config:GetSetting('AssistRange')
         if not separated then
+            self.TempSettings.ChaseSuppressed = true
             Logger.log_super_verbose("ShouldFollow(): chase paused, XTarget hater within Assist Range.")
             return false
         end
     end
 
+    self.TempSettings.ChaseSuppressed = false
     return true
 end
 

--- a/ui/options.lua
+++ b/ui/options.lua
@@ -628,7 +628,8 @@ function OptionsUI:RenderCategorySettings(category)
                                 setting,
                                 id,
                                 settingDefaults.RequiresLoadoutChange or false,
-                                settingDefaults.ComboOptions or settingDefaults.Min, settingDefaults.Max, settingDefaults.Step or 1)
+                                settingDefaults.ComboOptions or settingDefaults.Min or (type(settingDefaults.Hint) == "function" and settingDefaults.Hint() or settingDefaults.Hint),
+                                settingDefaults.Max, settingDefaults.Step or 1)
                             new_loadout = new_loadout or loadout_change
                             any_pressed = any_pressed or pressed
 

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -134,10 +134,10 @@ function Combat.EngageTarget(autoTargetId)
                     Movement:NavInCombat(autoTargetId, Targeting.GetTargetMaxRangeTo(target), false, false, true)
                 else
                     Logger.log_verbose("EngageTarget(): Target is in range moving to combat")
-                    if mq.TLO.Navigation.Active() then
+                    if mq.TLO.Navigation.Active() and Config:GetSetting('DoAutoNav') then
                         Movement:DoNav(false, "stop log=off")
                     end
-                    if mq.TLO.Stick.Status():lower() == "off" or (mq.TLO.Stick.StickTarget() or autoTargetId) ~= autoTargetId then
+                    if not mq.TLO.Navigation.Active() and (mq.TLO.Stick.Status():lower() == "off" or (mq.TLO.Stick.StickTarget() or autoTargetId) ~= autoTargetId) then
                         Movement:DoStick(autoTargetId)
                     end
                 end

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -699,6 +699,7 @@ function Combat.FindBestAutoTarget(validateFn)
 
         if assistId > 0 then
             Globals.AutoTargetID = assistId
+            Globals.MATargetID = assistId -- Capture MA target for edge-case combat chase handling
         end
     end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1041,29 +1041,37 @@ Config.DefaultConfig                                     = {
             Config:SetSetting('ManualMode', false, false, true)
         end,
     },
-    ['StickHow']                   = {
-        DisplayName = "Stick How",
+    ['StickDistance']              = {
+        DisplayName = "Stick Distance",
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
         Index = 2,
-        Tooltip = "Custom arguments for /stick command, used in melee or ranged combat. Leave blank for default (varies on class).",
+        Tooltip = "Stick distance or percentage; leave blank to set it automatically by target size.",
         Default = "",
+        Hint = "Automatic: 10 / 15 / 20 by target size",
+        ConfigType = "Advanced",
+    },
+    ['StickArgs']                  = {
+        DisplayName = "Stick Arguments",
+        Group = "Combat",
+        Header = "Positioning",
+        Category = "General Positioning",
+        Index = 3,
+        Tooltip = "Custom /stick flags, not including distance; leave blank to use role-based defaults.",
+        Default = "",
+        Hint = function() return require('utils.movement').GetDefaultStickArgs() .. " (default)" end,
         ConfigType = "Advanced",
         FAQ = "What are the default stick settings?",
-        Answer = "   If the Stick How entry is left blank, we will use default stick settings as follows:\n" ..
-            "If MA: < 10 moveback* uw >\n" ..
-            "Others: < 10** behindonce moveback uw >\n" ..
-            "Ranged (Use Ranged Stick): < <bowrangesetting> moveback uw >\n\n" ..
-            "* - Optional moveback flag (if 'Moveback As Tank' is enabled).\n" ..
-            "** - On larger targets this value becomes 20.",
+        Answer = "Your current defaults are shown as hint text in the empty Stick Distance and Stick Arguments fields.\n" ..
+            "Ranged sticks (Use Ranged Stick) use these settings as well, but default their distance to Bow Range.",
     },
     ['BellyCastStick']             = {
         DisplayName = "Stick for Belly Cast",
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 3,
+        Index = 4,
         Tooltip = "If Melee Combat is disabled, pin at 40 units on named with a dragon bodytype in case of possible bellycaster.",
         Default = false,
         ConfigType = "Advanced",
@@ -1073,7 +1081,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 4,
+        Index = 5,
         Tooltip = "Stand up if feigning at the start of combat.",
         Default = true,
         ConfigType = "Advanced",
@@ -1083,7 +1091,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 5,
+        Index = 6,
         Tooltip = "Attempt to adjust positioning if you receive a 'cannot see your target' message.",
         Default = true,
         ConfigType = "Advanced",
@@ -1096,7 +1104,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 6,
+        Index = 7,
         Tooltip = "Attempt to adjust positioning if you receive a 'too close to use a ranged weapon' message.",
         Default = true,
         ConfigType = "Advanced",
@@ -1109,7 +1117,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 7,
+        Index = 8,
         Tooltip = "Attempt to adjust positioning if you receive a 'too far away' or 'cant hit them from here' message.",
         Default = true,
         ConfigType = "Advanced",
@@ -1122,7 +1130,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 8,
+        Index = 9,
         Tooltip = "Enables RGMercs to issue Navigation Commands in Combat. Disable if you wish to manually control movement.",
         Default = true,
         ConfigType = "Advanced",
@@ -1135,7 +1143,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 8,
+        Index = 10,
         Tooltip = "Enables RGMercs to issue Stick Commands in Combat. Disable if you wish to manually control movement.",
         Default = true,
         ConfigType = "Advanced",
@@ -1148,7 +1156,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 9,
+        Index = 11,
         Tooltip =
         "This will disable all automated movement on your character but not using abilities.",
         Default = false,
@@ -1157,6 +1165,10 @@ Config.DefaultConfig                                     = {
 
             for _, setting in ipairs(settings) do
                 Config:SetSetting(setting, not newVal, false, true)
+            end
+
+            if newVal then
+                Config:SetSetting('ChaseOn', false, false, true)
             end
 
             Logger.log_info("Manual Mode has been " .. (newVal and "enabled" or "disabled"))
@@ -1170,7 +1182,7 @@ Config.DefaultConfig                                     = {
         Group = "Combat",
         Header = "Positioning",
         Category = "General Positioning",
-        Index = 10,
+        Index = 12,
         Tooltip = "Use summon and move AA to reposition your pet to avoid ripostes. (We will always summon a far out-of-range pet during combat if able).",
         Default = false,
     },
@@ -2814,6 +2826,13 @@ Config.DefaultConfig                                     = {
         Type = "Custom",
         Default = true,
     },
+    -- DEPRECATED 7/26 - sunset 9/1/26. Split into StickDistance/StickArgs (auto-migrated by Config:MigrateStickHow at load);
+    -- non-blank values set mid-session are honored verbatim by DoStick until sunset. DELETE at sunset with MigrateStickHow.
+    ['StickHow']                         = {
+        DisplayName = "Stick How",
+        Type = "Custom",
+        Default = "",
+    },
     ['FullUI']                           = {
         DisplayName = "Use Full UI",
         Group = "General",
@@ -2911,6 +2930,33 @@ function Config.GetConfigFileName(moduleName, returnExisting)
     return latest
 end
 
+-- DEPRECATED 7/26 - sunset 9/1/26. Splits legacy StickHow into StickDistance + StickArgs. DELETE at sunset.
+function Config:MigrateStickHow()
+    local stickHow = Config:GetSetting('StickHow') or ""
+    if stickHow == "" then return end
+
+    local distance = nil
+    local argTokens = {}
+    local lastToken = ""
+    for token in stickHow:gmatch("%S+") do
+        if not distance and lastToken:lower() ~= "id" and (token:match("^%d+$") or token:match("^%d+%%$")) then
+            distance = token
+        else
+            table.insert(argTokens, token)
+        end
+        lastToken = token
+    end
+
+    local migratedArgs = table.concat(argTokens, " ")
+    -- distance-only strings had no flags; bare uw keeps them positionally identical (blank would add role defaults)
+    if migratedArgs == "" and distance then migratedArgs = "uw" end
+
+    Config:SetSetting('StickDistance', distance or "")
+    Config:SetSetting('StickArgs', migratedArgs)
+    Config:SetSetting('StickHow', "")
+    Logger.log_info("\ayStick How has been split: Stick Distance = '\at%s\ay', Stick Arguments = '\at%s\ay'.", distance or "", migratedArgs)
+end
+
 function Config:LoadSettings()
     -- handle update to db before anything else.
     if not self:CharacterExistsInDb() then
@@ -2942,6 +2988,8 @@ function Config:LoadSettings()
     end
 
     Config:RegisterModuleSettings(coreModuleName, settings, Config.DefaultConfig, Config.FAQ, firstSaveRequired)
+
+    Config:MigrateStickHow()
 
     -- setup our script path for later usage since getting it kind of sucks, but only on the first run (personas)
     if Globals.ScriptDir == "" then

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -15,6 +15,7 @@ Globals.MainAssist                    = ""
 Globals.ScriptDir                     = ""
 Globals.AutoTargetID                  = 0
 Globals.AggroTargetID                 = 0
+Globals.MATargetID                    = 0
 Globals.ForceTargetID                 = 0
 Globals.ForceCharmID                  = 0
 Globals.AutoTargetIsNamed                  = false

--- a/utils/movement.lua
+++ b/utils/movement.lua
@@ -268,21 +268,19 @@ function Movement:NavAroundCircle(target, radius)
 
         Logger.log_debug("\aw%d\ax tmp_degrees \aw%d\ax tgt_x \aw%0.2f\ax tgt_y \aw%02.f\ax", steps, tmp_degrees,
             tgt_x, tgt_y)
-        -- First check that we can navigate to our new target
-        if mq.TLO.Navigation.PathExists(string.format("locyxz %0.2f %0.2f %0.2f", tgt_y, tgt_x, spawn_z))() then
-            -- Then check if our new spots has line of sight to our target.
+        -- Cheapest gate first: valid loc, then LoS raycast, then the expensive pathfind.
+        if mq.TLO.EverQuest.ValidLoc(string.format("%0.2f %0.2f %0.2f", tgt_x, tgt_y, spawn_z))() then
             if mq.TLO.LineOfSight(string.format("%0.2f,%0.2f,%0.2f:%0.2f,%0.2f,%0.2f", tgt_y, tgt_x, spawn_z, spawn_y, spawn_x, spawn_z))() then
-                -- Make sure it's a valid loc...
-                if mq.TLO.EverQuest.ValidLoc(string.format("%0.2f %0.2f %0.2f", tgt_x, tgt_y, spawn_z))() then
+                if mq.TLO.Navigation.PathExists(string.format("locyxz %0.2f %0.2f %0.2f", tgt_y, tgt_x, spawn_z))() then
                     Logger.log_debug(" \ag--> Found Valid Circling Loc: %0.2f %0.2f %0.2f", tgt_x, tgt_y, spawn_z)
                     Movement:DoNav(false, "locyxz %0.2f %0.2f %0.2f", tgt_y, tgt_x, spawn_z)
                     mq.delay("2s", function() return mq.TLO.Navigation.Active() end)
                     mq.delay("5s", function() return not mq.TLO.Navigation.Active() end)
                     Core.DoCmd("/squelch /face fast")
                     return true
-                else
-                    Logger.log_debug(" \ar--> Invalid Loc: %0.2f %0.2f %0.2f", tgt_x, tgt_y, spawn_z)
                 end
+            else
+                Logger.log_debug(" \ar--> No LoS: %0.2f %0.2f %0.2f", tgt_x, tgt_y, spawn_z)
             end
         end
     end
@@ -338,9 +336,10 @@ function Movement:DetectMobBehind()
 
     for i = 1, xtCount do
         local xtSpawn = me.XTarget(i)
-        if xtSpawn and (xtSpawn.ID() or 0) > 0 and not xtSpawn.Dead() and not xtSpawn.Fleeing()
+        local xtId = (xtSpawn and xtSpawn.ID()) or 0
+        if xtId > 0 and not xtSpawn.Dead() and not xtSpawn.Fleeing()
             and (math.ceil(xtSpawn.PctHPs() or 0)) > 0
-            and (xtSpawn.Aggressive() or (xtSpawn.TargetType() or ""):lower() == "auto hater" or xtSpawn.ID() == Globals.ForceTargetID)
+            and (xtSpawn.Aggressive() or (xtSpawn.TargetType() or ""):lower() == "auto hater" or xtId == Globals.ForceTargetID)
             and Globals.Constants.RGNotMezzedAnims:contains(xtSpawn.Animation())
             and (xtSpawn.PctAggro() or 0) >= 100 then
             local theirHeadingTo = xtSpawn.HeadingTo.DegreesCCW() or 0
@@ -369,36 +368,36 @@ end
 ---@return boolean
 function Movement:CanReposition()
     if not Core.IsTanking() then
-        Logger.log_debug("\ayReposition skipped: not tanking.")
+        Logger.log_super_verbose("\ayReposition skipped: not tanking.")
         return false
     end
     if Config:GetSetting('ManualMode') then
-        Logger.log_debug("\ayReposition skipped: Manual Mode on.")
+        Logger.log_super_verbose("\ayReposition skipped: Manual Mode on.")
         return false
     end
     if not Config:GetSetting('DoAutoNav') then
-        Logger.log_debug("\ayReposition skipped: DoAutoNav off.")
+        Logger.log_super_verbose("\ayReposition skipped: DoAutoNav off.")
         return false
     end
     if not Config:GetSetting('DoAutoStick') then
-        Logger.log_debug("\ayReposition skipped: DoAutoStick off.")
+        Logger.log_super_verbose("\ayReposition skipped: DoAutoStick off.")
         return false
     end
     if Config:GetSetting('ChaseOn') then
-        Logger.log_debug("\ayReposition skipped: ChaseOn enabled.")
+        Logger.log_super_verbose("\ayReposition skipped: ChaseOn enabled.")
         return false
     end
     if Globals.BackOffFlag then
-        Logger.log_debug("\ayReposition skipped: BackOffFlag set.")
+        Logger.log_super_verbose("\ayReposition skipped: BackOffFlag set.")
         return false
     end
     if Modules:ExecModule("Pull", "IsPullState", "PULL_PULLING") or Modules:ExecModule("Pull", "IsPullState", "PULL_RETURN_TO_CAMP") then
-        Logger.log_debug("\ayReposition skipped: in pull state.")
+        Logger.log_super_verbose("\ayReposition skipped: in pull state.")
         return false
     end
     local sinceReposition = Globals.GetTimeSeconds() - self.LastReposition
     if sinceReposition < 0.5 then
-        Logger.log_debug("\ayReposition skipped: rate-limit (%0.2fs since last reposition).", sinceReposition)
+        Logger.log_super_verbose("\ayReposition skipped: rate-limit (%0.2fs since last reposition).", sinceReposition)
         return false
     end
     return true
@@ -410,16 +409,16 @@ function Movement:TankReposition()
 
     local autoTargetId = Globals.AutoTargetID or 0
     if autoTargetId <= 0 then
-        Logger.log_debug("\ayReposition skipped: no autotarget.")
+        Logger.log_verbose("\ayReposition skipped: no autotarget.")
         return
     end
     local engaged = mq.TLO.Spawn("id " .. autoTargetId)
     if not engaged() or engaged.Dead() then
-        Logger.log_debug("\ayReposition skipped: engaged spawn invalid or dead.")
+        Logger.log_verbose("\ayReposition skipped: engaged spawn invalid or dead.")
         return
     end
     if not mq.TLO.Navigation.MeshLoaded() then
-        Logger.log_debug("\ayReposition skipped: no navmesh loaded.")
+        Logger.log_verbose("\ayReposition skipped: no navmesh loaded.")
         return
     end
 
@@ -463,6 +462,7 @@ function Movement:TankReposition()
         local headingCCW = me.Heading.DegreesCCW() or 0
         local engX = engaged.X() or 0
         local engY = engaged.Y() or 0
+        local engZ = engaged.Z() or meZ
         local maxRange = engaged.MaxRangeTo() or 15
         local distNow = engaged.Distance3D() or maxRange
         local strX = stray.X() or 0
@@ -488,21 +488,24 @@ function Movement:TankReposition()
         -- Ideal 75° first, then ±10° on the same side; switching sides would defeat the diameter-circle pick and undo the move.
         for _, lateralAngle in ipairs({ 75, 85, 65, }) do
             local destX, destY = self:LateralDestFromFacing(meX, meY, headingCCW, lateralAngle, moveDir, stepLength)
-            local distToEngaged = math.sqrt((destX - engX) ^ 2 + (destY - engY) ^ 2)
-            if distToEngaged > maxRange then
-                local scale = (maxRange - 1) / distToEngaged
-                destX = engX + (destX - engX) * scale
-                destY = engY + (destY - engY) * scale
+            local dxE, dyE = destX - engX, destY - engY
+            if dxE * dxE + dyE * dyE > maxRange * maxRange then
+                local scale = (maxRange - 1) / math.sqrt(dxE * dxE + dyE * dyE)
+                destX = engX + dxE * scale
+                destY = engY + dyE * scale
             end
-            local stepDist = math.sqrt((destX - meX) ^ 2 + (destY - meY) ^ 2)
-            if stepDist >= 2
-                and mq.TLO.Navigation.PathExists(string.format("locyxz %0.2f %0.2f %0.2f", destY, destX, meZ))()
-                and (mq.TLO.Navigation.PathLength(string.format("locyxz %0.2f %0.2f %0.2f", destY, destX, meZ))() or 999) <= stepDist + 10
-                and mq.TLO.LineOfSight(string.format("%0.2f,%0.2f,%0.2f:%0.2f,%0.2f,%0.2f", destY, destX, meZ, engY, engX, engaged.Z() or meZ))() then
-                Logger.log_debug("\arReposition step %d: lateral %ddeg dir=%d L=%.1f -> %.1f %.1f", stepCount + 1, lateralAngle, moveDir, stepLength, destX, destY)
-                self:DoNav(false, "locyxz %0.2f %0.2f %0.2f facing=backward log=off", destY, destX, meZ)
-                navIssued = true
-                break
+            local dxM, dyM = destX - meX, destY - meY
+            local stepDistSq = dxM * dxM + dyM * dyM
+            -- Cheap LoS raycast gates the expensive pathfind; PathLength is also the path-exists check (returns -1 when none).
+            if stepDistSq >= 2 * 2
+                and mq.TLO.LineOfSight(string.format("%0.2f,%0.2f,%0.2f:%0.2f,%0.2f,%0.2f", destY, destX, meZ, engY, engX, engZ))() then
+                local pathLen = mq.TLO.Navigation.PathLength(string.format("locyxz %0.2f %0.2f %0.2f", destY, destX, meZ))() or -1
+                if pathLen > 0 and pathLen <= math.sqrt(stepDistSq) + 10 then
+                    Logger.log_debug("\arReposition step %d: lateral %ddeg dir=%d L=%.1f -> %.1f %.1f", stepCount + 1, lateralAngle, moveDir, stepLength, destX, destY)
+                    self:DoNav(false, "locyxz %0.2f %0.2f %0.2f facing=backward log=off", destY, destX, meZ)
+                    navIssued = true
+                    break
+                end
             end
         end
 
@@ -518,8 +521,8 @@ function Movement:TankReposition()
                 local backY = meY - slide * fy
                 -- The stray stands roughly where we land, so its floor samples the destination height (stairs/slopes).
                 local backZ = stray.FloorZ() or stray.Z() or meZ
-                if mq.TLO.Navigation.PathExists(string.format("locyxz %0.2f %0.2f %0.2f", backY, backX, backZ))()
-                    and (mq.TLO.Navigation.PathLength(string.format("locyxz %0.2f %0.2f %0.2f", backY, backX, backZ))() or 999) <= slide + 10 then
+                local backPathLen = mq.TLO.Navigation.PathLength(string.format("locyxz %0.2f %0.2f %0.2f", backY, backX, backZ))() or -1
+                if backPathLen > 0 and backPathLen <= slide + 10 then
                     Logger.log_debug("\arReposition step %d: backslide fallback %0.1fu (rear-offset %0.1f, lateral blocked).", stepCount + 1, slide, rearOffset)
                     self:DoNav(false, "locyxz %0.2f %0.2f %0.2f facing=backward log=off", backY, backX, backZ)
                     navIssued = true
@@ -539,9 +542,9 @@ function Movement:TankReposition()
             Core.DoCmd("/squelch /face fast id %d", autoTargetId)
             mq.delay(50)
             stepCount = stepCount + 1
-            local moved = math.sqrt(((me.X() or meX) - meX) ^ 2 + ((me.Y() or meY) - meY) ^ 2)
-            if moved < 1.5 then
-                Logger.log_debug("\ayReposition step %d: no displacement (%.1fu moved), ending series.", stepCount, moved)
+            local dxMoved, dyMoved = (me.X() or meX) - meX, (me.Y() or meY) - meY
+            if dxMoved * dxMoved + dyMoved * dyMoved < 1.5 * 1.5 then
+                Logger.log_debug("\ayReposition step %d: no displacement (%.1fu moved), ending series.", stepCount, math.sqrt(dxMoved * dxMoved + dyMoved * dyMoved))
                 break
             end
         else

--- a/utils/movement.lua
+++ b/utils/movement.lua
@@ -35,16 +35,34 @@ function Movement:DoStick(targetId)
         return
     end
 
-    if Config:GetSetting('StickHow'):len() > 0 then
+    -- DEPRECATED 7/26 - sunset 9/1/26. StickHow is auto-migrated at load; honor mid-session sets verbatim until sunset.
+    if (Config:GetSetting('StickHow') or ""):len() > 0 then
         self:DoStickCmd("%s", Config:GetSetting('StickHow'))
     else
-        if Core.IsTanking() then
-            self:DoStickCmd("10 id %d %s uw", targetId, Config:GetSetting('MovebackWhenTank') and "moveback" or "")
-        else
-            local stickDist = (mq.TLO.Spawn(targetId).Height() or 5) > 15 and 20 or 10
-            self:DoStickCmd("%d id %d behindonce moveback uw", stickDist, targetId)
-        end
+        local stickDist = Config:GetSetting('StickDistance') or ""
+        if stickDist == "" then stickDist = tostring(Movement.GetDefaultStickDistance(targetId)) end
+        local stickArgs = Config:GetSetting('StickArgs') or ""
+        if stickArgs == "" then stickArgs = Movement.GetDefaultStickArgs() end
+        self:DoStickCmd("%s id %d %s", stickDist, targetId, stickArgs)
     end
+end
+
+function Movement.GetDefaultStickDistance(spawnId)
+    local height = mq.TLO.Spawn(spawnId).Height() or 5
+    if height > 10 then return 20 end
+    if height > 6 then return 15 end
+    return 10
+end
+
+function Movement.GetDefaultStickArgs()
+    if Core.IsTanking() then
+        return Config:GetSetting('MovebackWhenTank') and "moveback uw" or "uw"
+    end
+    if Core.MyClassIs("ROG") then return "behind moveback uw" end
+    if Globals.Constants.RGMelee:contains(mq.TLO.Me.Class.ShortName()) then
+        return "!front moveback uw"
+    end
+    return "behindonce moveback uw"
 end
 
 function Movement:MoveToLoc(locX, locY)
@@ -331,7 +349,7 @@ function Movement:DetectMobBehind()
             if diff > 90 then
                 local maxRange = xtSpawn.MaxRangeTo() or 15
                 local distance = xtSpawn.Distance3D() or 999
-                if distance <= maxRange then
+                if distance <= maxRange + 3 then
                     Logger.log_debug("\arXT(%s) is behind us! \awMyHeading(\am%d\aw) BearingToMob(\am%d\aw) Diff(\am%d\aw) Distance(\am%d\aw)",
                         xtSpawn.DisplayName() or "", myHeading, theirHeadingTo, diff, distance)
                     local distSq = distance * distance
@@ -391,10 +409,19 @@ function Movement:TankReposition()
     if not self:CanReposition() then return end
 
     local autoTargetId = Globals.AutoTargetID or 0
-    if autoTargetId <= 0 then return end
+    if autoTargetId <= 0 then
+        Logger.log_debug("\ayReposition skipped: no autotarget.")
+        return
+    end
     local engaged = mq.TLO.Spawn("id " .. autoTargetId)
-    if not engaged() or engaged.Dead() then return end
-    if not mq.TLO.Navigation.MeshLoaded() then return end
+    if not engaged() or engaged.Dead() then
+        Logger.log_debug("\ayReposition skipped: engaged spawn invalid or dead.")
+        return
+    end
+    if not mq.TLO.Navigation.MeshLoaded() then
+        Logger.log_debug("\ayReposition skipped: no navmesh loaded.")
+        return
+    end
 
     local engagedBearing = engaged.HeadingTo.DegreesCCW() or 0
     local myHeading = mq.TLO.Me.Heading.DegreesCCW() or 0
@@ -403,6 +430,7 @@ function Movement:TankReposition()
     if headingDiff > 30 then
         Logger.log_debug("\ayReposition: /face fast id %d (heading diff %d).", autoTargetId, headingDiff)
         Core.DoCmd("/squelch /face fast id %d", autoTargetId)
+        mq.delay(50)
         -- The /face may have shifted what's behind us; if rotation alone solved it, skip the maneuver entirely.
         local stillBehind = self:DetectMobBehind()
         if not stillBehind or (stillBehind.ID() or 0) == 0 then
@@ -431,7 +459,7 @@ function Movement:TankReposition()
         local me = mq.TLO.Me
         local meX = me.X() or 0
         local meY = me.Y() or 0
-        local meZ = me.Z() or 0
+        local meZ = me.FloorZ() or me.Z() or 0
         local headingCCW = me.Heading.DegreesCCW() or 0
         local engX = engaged.X() or 0
         local engY = engaged.Y() or 0
@@ -468,10 +496,10 @@ function Movement:TankReposition()
             end
             local stepDist = math.sqrt((destX - meX) ^ 2 + (destY - meY) ^ 2)
             if stepDist >= 2
-                and mq.TLO.EverQuest.ValidLoc(string.format("%0.2f %0.2f %0.2f", destX, destY, meZ))()
                 and mq.TLO.Navigation.PathExists(string.format("locyxz %0.2f %0.2f %0.2f", destY, destX, meZ))()
-                and mq.TLO.LineOfSight(string.format("%0.2f,%0.2f,%0.2f:%0.2f,%0.2f,%0.2f", destY, destX, meZ, engY, engX, meZ))() then
-                Logger.log_debug("\arReposition step %d: lateral %d° dir=%d L=%.1f -> %.1f %.1f", stepCount + 1, lateralAngle, moveDir, stepLength, destX, destY)
+                and (mq.TLO.Navigation.PathLength(string.format("locyxz %0.2f %0.2f %0.2f", destY, destX, meZ))() or 999) <= stepDist + 10
+                and mq.TLO.LineOfSight(string.format("%0.2f,%0.2f,%0.2f:%0.2f,%0.2f,%0.2f", destY, destX, meZ, engY, engX, engaged.Z() or meZ))() then
+                Logger.log_debug("\arReposition step %d: lateral %ddeg dir=%d L=%.1f -> %.1f %.1f", stepCount + 1, lateralAngle, moveDir, stepLength, destX, destY)
                 self:DoNav(false, "locyxz %0.2f %0.2f %0.2f facing=backward log=off", destY, destX, meZ)
                 navIssued = true
                 break
@@ -485,19 +513,22 @@ function Movement:TankReposition()
                 local fx, fy = math.sin(facingRad), math.cos(facingRad)
                 -- Pull back only as far as needed to flip the stray into front-arc; backsliding farther than necessary risks losing melee on the engaged mob.
                 local rearOffset = -((strX - meX) * fx + (strY - meY) * fy)
-                local slide = math.min(math.max(2, rearOffset + 2), room + maxRange * 0.5)
+                local slide = math.min(math.max(2, rearOffset + 2), room + maxRange * 0.5, Movement.GetDefaultStickDistance(autoTargetId) + 10)
                 local backX = meX - slide * fx
                 local backY = meY - slide * fy
-                if mq.TLO.EverQuest.ValidLoc(string.format("%0.2f %0.2f %0.2f", backX, backY, meZ))()
-                    and mq.TLO.Navigation.PathExists(string.format("locyxz %0.2f %0.2f %0.2f", backY, backX, meZ))() then
+                -- The stray stands roughly where we land, so its floor samples the destination height (stairs/slopes).
+                local backZ = stray.FloorZ() or stray.Z() or meZ
+                if mq.TLO.Navigation.PathExists(string.format("locyxz %0.2f %0.2f %0.2f", backY, backX, backZ))()
+                    and (mq.TLO.Navigation.PathLength(string.format("locyxz %0.2f %0.2f %0.2f", backY, backX, backZ))() or 999) <= slide + 10 then
                     Logger.log_debug("\arReposition step %d: backslide fallback %0.1fu (rear-offset %0.1f, lateral blocked).", stepCount + 1, slide, rearOffset)
-                    self:DoNav(false, "locyxz %0.2f %0.2f %0.2f facing=backward log=off", backY, backX, meZ)
+                    self:DoNav(false, "locyxz %0.2f %0.2f %0.2f facing=backward log=off", backY, backX, backZ)
                     navIssued = true
                 end
             end
         end
 
         if navIssued then
+            mq.delay(250, function() return mq.TLO.Navigation.Active() end)
             local stepDeadline = mq.gettime() + 600
             while mq.TLO.Navigation.Active() and (mq.TLO.Navigation.Velocity() or 0) > 0
                 and mq.gettime() < stepDeadline and (mq.gettime() - seriesStartMs) < 2000 do
@@ -506,7 +537,13 @@ function Movement:TankReposition()
                 Events.DoEvents()
             end
             Core.DoCmd("/squelch /face fast id %d", autoTargetId)
+            mq.delay(50)
             stepCount = stepCount + 1
+            local moved = math.sqrt(((me.X() or meX) - meX) ^ 2 + ((me.Y() or meY) - meY) ^ 2)
+            if moved < 1.5 then
+                Logger.log_debug("\ayReposition step %d: no displacement (%.1fu moved), ending series.", stepCount, moved)
+                break
+            end
         else
             Logger.log_debug("\ayReposition step %d: no viable nav (lateral + backslide both blocked), ending series.", stepCount + 1)
             break

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -418,6 +418,22 @@ function Targeting.GetXTHaterCount(printDebug)
     return #Targeting.GetXTHaterIDs(printDebug)
 end
 
+--- Returns true if any XTarget hater is within range units of us.
+---@param range number Distance in units to check against.
+---@return boolean True if a hater is within range.
+function Targeting.XTHaterInRange(range)
+    local xtCount = mq.TLO.Me.XTarget() or 0
+
+    for i = 1, xtCount do
+        local xtarg = mq.TLO.Me.XTarget(i)
+        if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater" or xtarg.ID() == Globals.ForceTargetID) then
+            if (xtarg.Distance3D() or 999) <= range then return true end
+        end
+    end
+
+    return false
+end
+
 --- Returns true if any current XTarget hater ID is not in t (new hater appeared).
 ---@param t number[] Previously known hater ID list to compare against.
 ---@param printDebug boolean? If true, logs each comparison.

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -78,6 +78,7 @@ function Targeting.ClearTarget()
     if Config:GetSetting('DoAutoTarget') then
         Logger.log_debug("Clearing Target")
         Globals.AutoTargetID = 0
+        Globals.MATargetID = 0
         Globals.AutoTargetIsNamed = false
         Globals.AutoTargetElementalImmunities = {}
         Globals.AutoTargetStatusImmunities = {}

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -2849,6 +2849,32 @@ function Ui.MarqueeButton(text, height, width)
     return ImGui.IsItemClicked()
 end
 
+--- Draws grayed hint text over the last drawn (empty) input, scrolling it when too wide to fit.
+---@param id string Unique key for the scroll state.
+---@param text string Hint text to display.
+function Ui.MarqueeHint(id, text)
+    ---@diagnostic disable-next-line: undefined-field
+    local scale = ImGui.GetIO().FontGlobalScale
+    local draw_list = ImGui.GetWindowDrawList()
+    local rectMin = ImGui.GetItemRectMinVec()
+    local rectMax = ImGui.GetItemRectMaxVec()
+    local pad = ImGui.GetStyle().FramePadding.x
+    local width = rectMax.x - rectMin.x - pad * 2
+    local textSize = ImGui.CalcTextSizeVec(text)
+    local textY = rectMin.y + ((rectMax.y - rectMin.y) - ImGui.GetFontSize() * scale) * 0.5
+
+    local scrollX = 0
+    if textSize.x > width then
+        scrollX = (Ui.TempSettings.MarqueeScrollX["hint_" .. id] or 0) - Ui.GetDeltaTime() * 25.0 * scale
+        if scrollX < -textSize.x then scrollX = width end
+        Ui.TempSettings.MarqueeScrollX["hint_" .. id] = scrollX
+    end
+
+    ImGui.PushClipRect(ImVec2(rectMin.x + pad, rectMin.y), ImVec2(rectMax.x - pad, rectMax.y), true)
+    draw_list:AddText(ImVec2(rectMin.x + pad + scrollX, textY), IM_COL32(150, 150, 150, 255), text)
+    ImGui.PopClipRect()
+end
+
 --- Renders a typed config option widget (Combo, Toggle, Color, number, etc.).
 ---@param type string Widget type: "Combo", "Toggle", "Color", "number", "string",
 ---   "ClickyItem", "ClickyItemWithConditions", "Custom", "SpellSlot", "ImVec2".
@@ -2955,8 +2981,13 @@ function Ui.RenderOption(type, setting, id, requiresLoadoutChange, ...)
     elseif type == 'string' then -- display only
         ImGui.SetNextItemWidth(-1)
         setting, pressed = ImGui.InputText("##" .. id, setting)
+        if (setting or "") == "" and (args[1] or "") ~= "" and not ImGui.IsItemActive() then
+            Ui.MarqueeHint(id, args[1])
+        end
         any_pressed = any_pressed or (pressed or false)
-        Ui.Tooltip(setting)
+        if (setting or "") ~= "" then
+            Ui.Tooltip(setting)
+        end
     end
 
     return setting, new_loadout, any_pressed


### PR DESCRIPTION
* Converted StickHow to separate settings:
* Stick Distance accepts values or percentages, and can be kept blank for a default based on target size.
* * Stick Args accepts non-distance args and can be left blank for a default based on class/role.
* * A one-time migration of stickhow into the two new settings will be made at startup.
* Chase will now pause while you engage xtarget haters that are in range.
* * You can enable "Chase In Combat" if you prefer the old behavior.
* Small improvements to the Tank Reposition code.