### PR TITLE
chore(ci): bump version in CI instead of the pre-commit hook

### DIFF
--- a/.githooks/pre-commit.sh
+++ b/.githooks/pre-commit.sh
@@ -1,23 +1,9 @@
 #!/usr/bin/env bash
-set -e
-
-set -euo pipefail
-
-FILE="extras/version.lua"
-
-# Extract current version
-VERSION=$(sed -n 's/.*version *= *\([0-9]\+\).*/\1/p' "$FILE")
-
-if [[ -z "$VERSION" ]]; then
-  echo "Error: version not found in $FILE"
-  exit 1
-fi
-
-NEW_VERSION=$((VERSION + 1))
-
-# Replace version in file
-sed -i.bak "s/version *= *$VERSION/version = $NEW_VERSION/" "$FILE"
-
-rm -f "$FILE.bak"
-
-git add extras/version.lua
+# Version bumping moved to CI (.github/workflows/package-main.yaml).
+#
+# This script is intentionally a no-op. It is kept (rather than deleted) so that
+# any already-installed .git/hooks/pre-commit that shells to it keeps succeeding
+# instead of erroring on a missing file. .git/hooks/ is not tracked, so removing
+# this file cannot disarm hooks already installed on contributors' machines --
+# you must delete your own .git/hooks/pre-commit to stop bumping locally.
+exit 0

--- a/.github/workflows/package-main.yaml
+++ b/.github/workflows/package-main.yaml
@@ -8,6 +8,14 @@ on:
 permissions:
   contents: write
 
+# Serialize release runs. Two pushes to main in quick succession would otherwise
+# race: both bump from the same base and the slower push-back is rejected as
+# non-fast-forward. cancel-in-progress:false lets the first run finish (tag +
+# release) before the second starts, so the second bumps on top of it.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 jobs:
   release:
     if: github.repository == 'DerpleDude/rgmercs'
@@ -15,25 +23,50 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Read version
-        id: version
+      # Bump extras/version.lua here instead of in the local pre-commit hook.
+      # version.lua is CI-only now (no human ever edits it), so the freshest
+      # main always holds the current number: we reset onto origin/main, bump,
+      # and push. The retry covers a concurrent push landing between fetch and
+      # push despite the concurrency group (belt and suspenders).
+      - name: Bump version
+        id: bump
         run: |
-          VERSION=$(sed -n 's/.*version *= *\([0-9]\+\).*/\1/p' extras/version.lua)
-          [ -z "$VERSION" ] && exit 1
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          for attempt in 1 2 3; do
+            git fetch --quiet origin main
+            git reset --hard --quiet origin/main
+            VERSION=$(sed -n 's/.*version *= *\([0-9]\+\).*/\1/p' extras/version.lua)
+            [ -z "$VERSION" ] && { echo "::error::version not found in extras/version.lua"; exit 1; }
+            NEW=$((VERSION + 1))
+            sed -i "s/version *= *$VERSION/version = $NEW/" extras/version.lua
+            git add extras/version.lua
+            git commit --quiet -m "chore: bump version to $NEW"
+            if git push origin HEAD:main; then
+              echo "version=$NEW" >> "$GITHUB_OUTPUT"
+              echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+              echo "Bumped version to $NEW"
+              exit 0
+            fi
+            echo "::warning::push rejected (attempt $attempt/3); refetching and retrying"
+          done
+          echo "::error::failed to bump version after 3 attempts"
+          exit 1
 
       # Create a file to upload
       - name: Create artifact
         run: |
           mkdir dist
-          echo "Build from commit $GITHUB_SHA" > dist/info.txt
+          echo "Build from commit ${{ steps.bump.outputs.sha }}" > dist/info.txt
           zip -r dist/rgmercs.zip .
 
-      # Create release + upload asset
+      # Create release + upload asset. Tag the bump commit explicitly so the tag
+      # sits on the commit whose version.lua actually matches it.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: Release v${{ steps.version.outputs.version }}
+          tag_name: v${{ steps.bump.outputs.version }}
+          name: Release v${{ steps.bump.outputs.version }}
+          target_commitish: ${{ steps.bump.outputs.sha }}
           files: |
             dist/rgmercs.zip

--- a/.github/workflows/redguides-publish.yml
+++ b/.github/workflows/redguides-publish.yml
@@ -13,6 +13,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Full history + tags so `git describe HEAD^` resolves the previous
+          # release tag (depth-1 has no HEAD^ and no tags -> PREV was always
+          # empty -> notes were only ever the tip commit).
+          #
+          # Do NOT pin ref to workflow_run.head_sha: that is the commit that
+          # TRIGGERED package-main (pre-bump), not the bump commit it pushed.
+          # The default (latest default-branch HEAD) is the bump commit, which
+          # is what we want to read, archive, and describe against.
+          fetch-depth: 0
 
       - name: Read version
         id: version
@@ -29,7 +39,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           PREV=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          git log --no-merges --pretty=format:"- [%s](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/%H)%n%n%b%n~%an" ${PREV:+$PREV..}HEAD \
+          # HEAD is the CI bump commit; exclude it (and any future bump commits
+          # in-range) so the notes are the real changelog, not "bump version".
+          git log --no-merges --invert-grep --grep='^chore: bump version' \
+            --pretty=format:"- [%s](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/%H)%n%n%b%n~%an" ${PREV:+$PREV..}HEAD \
           | awk '/^~/{print ""; print; next} /^$/{if(!blank){print}; blank=1; next} {blank=0; print}' > rg_release_notes.md
           cat rg_release_notes.md
 


### PR DESCRIPTION
## Summary

Moves the `extras/version.lua` bump out of `.githooks/pre-commit.sh` and into `package-main.yaml`, so the build number increments **once per release** (on push to `main`) instead of once per local commit. Based on [Algar's proposal](#); verified against the actual workflow files before implementing.

**Opened as a draft for review — nothing here runs until it's merged to `main`.**

## Why

- `version.lua` changed on *every* commit, making it a permanent merge/rebase conflict magnet between forks and upstream.
- The bump only fired where someone had manually installed the hook (`.git/hooks/` isn't tracked, `core.hooksPath` unset), so the number was non-sequential — e.g. releases `2841`–`2843` never existed.
- Bumping in CI makes the number gap-free and **identical to the release tag**, so a user reporting `[Build: N]` in the title bar is unambiguously on release `vN`. (Only runtime consumer is `ui/standard.lua:353`.)

## Changes

**`.githooks/pre-commit.sh`** — reduced to a no-op `exit 0`. Kept rather than deleted so any already-installed `.git/hooks/pre-commit` that shells to it keeps succeeding. ⚠️ This does **not** disarm hooks already installed locally — delete your own `.git/hooks/pre-commit` to stop bumping on commit.

**`package-main.yaml`**
- New `Bump version` step: `fetch → reset --hard origin/main → bump → commit → push`, wrapped in a 3-attempt retry.
- `concurrency:` group (`cancel-in-progress: false`) so two quick pushes to `main` serialize instead of racing on the push-back.
- Tags the bump commit explicitly via `target_commitish` so the tag sits on the commit whose `version.lua` matches it.

**`redguides-publish.yml`** *(mandatory — would break otherwise)*
- `fetch-depth: 0` so `git describe HEAD^` resolves the previous tag. On the current depth-1 checkout `HEAD^` doesn't exist, so `PREV` was silently always empty and notes were only ever the tip commit.
- Exclude the bump commit from notes via `--invert-grep --grep='^chore: bump version'`. Without this, every RedGuides release note would become just "bump version".
- Side effect: also fixes a **latent pre-existing bug** where multi-commit direct pushes to `main` lost everything but the tip commit in the RedGuides notes.

## Design notes / subtleties

- **No infinite loop:** pushes made with the default `GITHUB_TOKEN` don't trigger new workflow runs, so the bump commit won't re-trigger `package-main.yaml`.
- **Don't "fix" the redguides checkout** to pin `ref: workflow_run.head_sha` — that SHA is the commit that *triggered* `package-main` (pre-bump), not the bump commit it pushed. The default (latest `main` HEAD = bump commit) is correct. Documented inline to prevent a well-meaning regression.
- **Branch protection:** `main` is currently unprotected, so the bot push goes through as-is. If protection is enabled later, the token needs a bypass.

## Decisions worth a look

1. **Bump commit message** is `chore: bump version to <N>`; `redguides-publish.yml` filters on `^chore: bump version`. If you want a different message, both must stay in sync.
2. **The bot commit lives on `main` forever.** Kept the committed-file approach (vs. deriving the number from the tag/commit-count) because people run from source and need `[Build: N]` accurate. Reopen if you'd rather not have bot commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
