### PR TITLE
Add option to disable hate rotations on a per-target basis

### DIFF
--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -864,7 +864,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
-                return combat_state == "Combat" and (mq.TLO.Me.PctAggro() < 100 or (mq.TLO.Target.SecondaryPctAggro() or 0) > 60 or Globals.AutoTargetIsNamed)
+                return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
         { --Actions that establish or maintain hatred

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -369,7 +369,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
+                return combat_state == "Combat" and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout') and Targeting.HateToolsNeeded()
             end,
         },
         { --Actions that establish or maintain hatred

--- a/init.lua
+++ b/init.lua
@@ -475,6 +475,8 @@ local function Main()
         end
     end
 
+    Targeting.PruneNoHateTargets()
+
     if mq.TLO.MacroQuest.GameState() ~= "INGAME" then return end
 
     if Globals.CurLoadedChar ~= mq.TLO.Me.DisplayName() then

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -129,6 +129,28 @@ Binds.Handlers    = {
             Logger.log_info("\awIgnored targets cleared.")
         end,
     },
+    ['nohate'] = {
+        usage = "/rgl nohate <id?>",
+        about =
+        "Will prevent this character from using hate abilities on the target or <id>. If no ID is supplied, uses the current target's ID.",
+        handler = function(targetId)
+            targetId = targetId and tonumber(targetId) or mq.TLO.Target.ID()
+            if targetId > 0 then
+                Logger.log_info("\awNo Hate Target: %d", targetId)
+                Globals.NoHateTargetIDs:add(targetId)
+            else
+                Logger.log_info("\awMarking a no hate target requires a valid supplied ID or target!")
+            end
+        end,
+    },
+    ['nohateclear'] = {
+        usage = "/rgl nohateclear",
+        about = "Will clear all no hate targets.",
+        handler = function()
+            Globals.NoHateTargetIDs = Set.new({})
+            Logger.log_info("\awNo hate targets cleared.")
+        end,
+    },
     ['forcetarget'] = {
         usage = "/rgl forcetarget <id?>",
         about =

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1855,7 +1855,7 @@ function Casting.UseEntry(entryType, name, targetId, opts)
     if entryType == "item" then return Casting.UseItem(name, targetId, opts.allowDead) end
     if entryType == "song" then return Casting.UseSong(name, targetId, opts.allowMem) end
     if entryType == "disc" then return Casting.UseDisc(opts.spell, targetId) end
-    if entryType == "ability" then return Casting.UseAbility(name) end
+    if entryType == "ability" then return Casting.UseAbility(name, targetId) end
     return Casting.UseSpell(name, targetId, opts.allowMem, opts.allowDead)
 end
 
@@ -2482,11 +2482,24 @@ end
 --- Fires a combat ability (e.g., Taunt, Kick) via /doability.
 --- @param abilityName string The name of the ability to use.
 --- @return boolean
-function Casting.UseAbility(abilityName)
+function Casting.UseAbility(abilityName, targetId)
     local me = mq.TLO.Me
+
+    local oldTargetId = mq.TLO.Target.ID()
+    if (targetId or 0) > 0 and targetId ~= oldTargetId then
+        Logger.log_debug("\awUseAbility():NOTICE:\ax Swapping target to %s [%d] to use %s", mq.TLO.Spawn(targetId).DisplayName() or "None", targetId, abilityName)
+        Targeting.SetTarget(targetId, true)
+    end
+
     Core.DoCmd("/doability %s", abilityName)
     mq.delay(50, function() return me.AbilityReady(abilityName) ~= true end)
     Logger.log_debug("Using Ability \ao =>> \ag %s \ao <<=", abilityName)
+
+    if mq.TLO.Target.ID() ~= oldTargetId and Combat.ValidCombatTarget(oldTargetId) and (oldTargetId == Globals.AutoTargetID or not Config:GetSetting('DoAutoTarget')) then
+        Logger.log_debug("UseAbility(): Retargeting previous target after ability use.")
+        Targeting.SetTarget(oldTargetId, true)
+    end
+
     return true
 end
 

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -471,7 +471,7 @@ function Combat.TankAggroScan()
         local xtarg = mq.TLO.Me.XTarget(i)
         if xtarg() then
             local xtId = xtarg.ID() or 0
-            if xtId > 0 and xtId ~= Globals.AutoTargetID and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) then
+            if xtId > 0 and xtId ~= Globals.AutoTargetID and not Globals.NoHateTargetIDs:contains(xtId) and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) then
                 if xtarg.PctAggro() < 100 and (xtarg.Distance() or 999) <= assistRange and Globals.Constants.RGNotMezzedAnims:contains(xtarg.Animation()) then
                     if Combat.OkToEngagePreValidateId(xtId) then
                         Logger.log_verbose("TankAggroScan: Found Aggro Target: %s (id %d).", xtarg.DisplayName(), xtId)
@@ -1368,6 +1368,7 @@ end
 ---@param printDebug boolean If true, logs verbose information about each candidate.
 ---@return boolean
 function Combat.AETauntCheck(printDebug)
+    if Globals.NoHateTargetIDs:contains(Globals.AutoTargetID) then return false end
     local xtCount = mq.TLO.Me.XTarget() or 0
     if xtCount < Config:GetSetting('AETauntCnt') then return false end
 

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -27,6 +27,7 @@ Globals.LastPulledID                  = 0
 Globals.CurrentState                  = "None"
 Globals.LastCombatTime                = 0
 Globals.IgnoredTargetIDs              = Set.new({})
+Globals.NoHateTargetIDs               = Set.new({})
 Globals.CharmedPetIDs                 = Set.new({})
 Globals.LooseCharms                   = {}
 -- our own single charm ids: staged for the heartbeat, which reads them cross-process via the RGMercs.Globals() scalar bridge
@@ -327,6 +328,10 @@ function Globals.SetForcedTargetId(targetId)
     if targetId and targetId > 0 then
         Globals.ForceTargetID = targetId
         if Globals.Logger then Globals.Logger.log_debug("SetForcedTargetId(): Force Target set to %d", targetId) end
+        if Globals.NoHateTargetIDs:contains(targetId) then
+            Globals.NoHateTargetIDs:remove(targetId)
+            Globals.Logger.log_debug("SetForcedTargetId(): Removed %d from no hate targets.", targetId)
+        end
     else
         if Globals.Logger then Globals.Logger.log_debug("SetForcedTargetId(): Force Target cleared from %d", Globals.ForceTargetID) end
         Globals.ForceTargetID = 0

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -211,7 +211,7 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
     if entry.type:lower() == "ability" then
         if Casting.AbilityReady(entry.name, mq.TLO.Spawn(targetId)) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
-            ret = Casting.UseAbility(entry.name)
+            ret = Casting.UseAbility(entry.name, targetId)
         end
         Logger.log_verbose("(Ability) Trying to use %s :: %s", entry.name, ret and "\agSuccess" or "\arFailed!")
     end

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -893,7 +893,19 @@ end
 ---@return boolean True if hate generation is appropriate this frame.
 function Targeting.HateToolsNeeded()
     if Globals.AutoTargetID == 0 or mq.TLO.Target.ID() ~= Globals.AutoTargetID then return false end
+    if Globals.NoHateTargetIDs:contains(Globals.AutoTargetID) then return false end
     return mq.TLO.Me.PctAggro() < 100 or (mq.TLO.Target.SecondaryPctAggro() or 0) > 60 or Globals.AutoTargetIsNamed
+end
+
+--- Removes no hate target IDs whose spawns are confirmed dead.
+function Targeting.PruneNoHateTargets()
+    for _, id in ipairs(Globals.NoHateTargetIDs:toList()) do
+        local spawn = mq.TLO.Spawn(id)
+        if spawn() and (spawn.Dead() or (spawn.Type() or "") == "Corpse") then
+            Logger.log_debug("PruneNoHateTargets(): %d is dead, removing from no hate targets.", id)
+            Globals.NoHateTargetIDs:remove(id)
+        end
+    end
 end
 
 --- Returns true if spawn's surname contains "'s Pet", "`s Pet", or "Doppelganger",

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -1448,13 +1448,19 @@ function Ui.RenderForceTargetList(showPopout)
     end
 
     if Config:GetSetting('ShowFTControls') then
-        if ImGui.Button("Clear Forced Target", ImGui.GetWindowWidth() * .4, 18) then
+        local btnWidth = (ImGui.GetContentRegionAvailVec().x - ImGui.GetStyle().ItemSpacing.x * 2) / 3
+        if ImGui.Button("Clear Forced Target", btnWidth, 18) then
             Globals.SetForcedTargetId(0)
         end
         ImGui.SameLine()
 
-        if ImGui.Button("Clear Ignored Targets", ImGui.GetWindowWidth() * .4, 18) then
+        if ImGui.Button("Clear Ignored Targets", btnWidth, 18) then
             Globals.IgnoredTargetIDs = Set.new({})
+        end
+        ImGui.SameLine()
+
+        if ImGui.Button("Clear NoHate Targets", btnWidth, 18) then
+            Globals.NoHateTargetIDs = Set.new({})
         end
     end
 
@@ -1524,6 +1530,41 @@ function Ui.RenderForceTargetList(showPopout)
                         end
                     end)
 
+
+                if not checked then
+                    ImGui.PopStyleColor()
+                end
+
+                local min = ImGui.GetItemRectMinVec()
+                local max = ImGui.GetItemRectMaxVec()
+                local draw = ImGui.GetWindowDrawList()
+                draw:AddRect(min, max, IM_COL32(180, 180, 180, 180), 0.5)
+                ImGui.PopStyleVar(1)
+            end,
+        },
+        {
+            name = "NH",
+            flags = bit32.bor(ImGuiTableColumnFlags.WidthFixed),
+            width = 16.0,
+            sort = function(a, b)
+                return Globals.NoHateTargetIDs:contains(a.ID()) and 1 or 0, Globals.NoHateTargetIDs:contains(b.ID()) and 1 or 0
+            end,
+            render = function(xtarg, i)
+                local checked = Globals.NoHateTargetIDs:contains(xtarg.ID())
+                ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0))
+
+                if not checked then
+                    ImGui.PushStyleColor(ImGuiCol.Text, IM_COL32(52, 52, 52, 0))
+                end
+
+                Ui.InvisibleWithButtonText("##nh_btn_" .. tostring(i), Icons.FA_BAN, ImVec2(ICON_SIZE, ImGui.GetTextLineHeight()),
+                    function()
+                        if checked then
+                            Globals.NoHateTargetIDs:remove(xtarg.ID())
+                        else
+                            Globals.NoHateTargetIDs:add(xtarg.ID())
+                        end
+                    end)
 
                 if not checked then
                     ImGui.PopStyleColor()
@@ -1655,7 +1696,7 @@ function Ui.RenderForceTargetList(showPopout)
         },
     }
 
-    Ui.RenderTableData("XTargs", tableColumns,
+    Ui.RenderTableData("ForceTarget", tableColumns,
         bit32.bor(ImGuiTableFlags.NoBordersInBody, ImGuiTableFlags.Resizable, ImGuiTableFlags.RowBg, ImGuiTableFlags.Sortable, ImGuiTableFlags
             .Hideable,
             ImGuiTableFlags.Reorderable),
@@ -1707,6 +1748,12 @@ function Ui.RenderForceTargetList(showPopout)
                 ImGui.SameLine()
                 Ui.RenderText("     ")
                 Ui.Tooltip("Click here to ignore this target.")
+            end
+
+            if ImGui.TableSetColumnIndex(2) then
+                ImGui.SameLine()
+                Ui.RenderText("     ")
+                Ui.Tooltip("Click here to prevent using hate abilities on this target.")
                 ImGui.TableNextRow()
             end
 


### PR DESCRIPTION
* Select the no hate block in the force target window or use /rgl nohate <id>.
* This applies to all three hate tool rotations, and any rotation/entry calling AETauntCheck or HateToolsNeeded.

* Allowed ablities to pass target for target changes.