### PR TITLE
Pet Affinity logic fix

### DIFF
--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -1106,7 +1106,7 @@ local _ClassConfig = {
                 type = "Spell",
                 load_cond = function() return Config:GetSetting('DoHaste') and not Casting.CanUseAA("Talisman of Celerity") end,
                 cond = function(self, spell, target)
-                    if Casting.CanUseAA("Pet Affinity") then return false end
+                    if not Casting.CanUseAA("Pet Affinity") then return false end
                     return Casting.PetBuffCheck(spell)
                 end,
             },

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -951,7 +951,7 @@ local _ClassConfig = {
                 type = "Spell",
                 active_cond = function(self, aaName) return mq.TLO.Me.Haste() end,
                 cond = function(self, spell, target)
-                    if Casting.CanUseAA("Pet Affinity") then return false end
+                    if not Casting.CanUseAA("Pet Affinity") then return false end
                     return Casting.PetBuffCheck(spell)
                 end,
             },


### PR DESCRIPTION
My shaman was continuously casting Talisman of Celerity on the pet.
Found the issue I was missing Pet Affinity AA and the check for that was inverted