### PR TITLE
Laz Configs - Initial Level 71 Update

### DIFF
--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -2,12 +2,13 @@ local mq        = require('mq')
 local Casting   = require("utils.casting")
 local Combat    = require("utils.combat")
 local Config    = require('utils.config')
+local Core      = require("utils.core")
 local Globals   = require("utils.globals")
 local Logger    = require("utils.logger")
 local Targeting = require("utils.targeting")
 
 return {
-    _version          = "2.0 - Project Lazarus",
+    _version          = "2.1 - Project Lazarus",
     _author           = "Algar, Derple",
     ['Modes']         = {
         'DPS',
@@ -45,7 +46,8 @@ return {
     },
     ['AbilitySets']   = {
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70 Laz Custom
+            "Fourth Wind Discipline", -- Level 71 Laz Custom
+            "Third Wind Discipline",  -- Level 70 Laz Custom
             -- "Second Wind",        -- Level 65
         },
         ['BerAura'] = {
@@ -56,20 +58,24 @@ return {
             "Overpowering Frenzy", -- Level 65
         },
         ['VolleyDisc'] = {
+            -- "Ancient: Annihilator's Volley", -- Level 71 Laz Custom, verify existence and source
             "Destroyer's Volley", -- Level 69
             "Rage Volley",        -- Level 61
         },
         ['FlurryDisc'] = {
-            "Vengeful Flurry Discipline", -- Level 70
+            "Rancorous Flurry Discipline", -- Level 71 Laz Custom
+            "Vengeful Flurry Discipline",  -- Level 70
         },
         ['RageDisc'] = {
-            "Blind Rage Discipline",    -- Level 58
-            "Cleaving Rage Discipline", -- Level 54
+            "Cleaving Madness Discipline", -- Level 71 Laz Custom
+            -- "Blind Rage Discipline",       -- Level 58
+            "Cleaving Rage Discipline",    -- Level 54
         },
         ['AngerDisc'] = {
             "Cleaving Anger Discipline", -- Level 65
         },
         ['CryDisc'] = {
+            "Cry of Catastrophe",        -- Level 71 Laz Custom
             "Battle Cry of the Mastruq", -- Level 65
             "Ancient: Cry of Chaos",     -- Level 65
             "War Cry of Dravel",         -- Level 64
@@ -78,10 +84,10 @@ return {
             "Battle Cry",                -- Level 30
         },
         ['GroupCrit'] = {
-            "Cry Havoc", -- Level 65
+            "Cry Havoc",            -- Level 65
         },
-        ['Scream'] = { -- Stun, Throwing/Archery Dmg taken debuff
-            "Bloodcurdling Scream", -- Level 70 Laz Custom
+        ['Scream'] = {              -- Stun, Throwing/Archery Dmg taken debuff
+            "Bloodcurdling Scream", -- Level 71 Laz Custom
             "Bewildering Scream",   -- Level 70 Laz Custom
             "Unsettling Scream",    -- Level 65
         },
@@ -97,11 +103,19 @@ return {
             "Leg Cut",          -- Level 32
             "Leg Strike",       -- Level 8
         },
-        ['DmgModProc'] = {
-            "Unpredictable Rage Discipline", -- Level 66
+        ['Timer6Disc'] = {
+            "Wounding Rage",                 -- Level 71 Laz Custom, offensive attack-proc buff
+            "Unpredictable Rage Discipline", -- Level 66, defensive proc when struck
         },
         ['BattleFocus'] = {
+            -- "Combat Focus Discipline", -- Level 71 Laz Custom, verify existence and source
             "Battle Focus Discipline", -- Level 59
+        },
+        ['ReprisalDisc'] = {           -- Manual use only for now, reprisal does not fire unless the rune is broken
+            "Arcane Reprisal",         -- Level 71 Laz Custom
+        },
+        ['AxeThrow'] = {
+            "Vigorous Axe Throw", -- Level 71 Laz Custom
         },
     },
     ['AASets']        = {
@@ -266,7 +280,7 @@ return {
                 type = "AA",
             },
             {
-                name = "DmgModProc",
+                name = "Timer6Disc",
                 type = "Disc",
             },
         },
@@ -348,8 +362,17 @@ return {
                 end,
             },
             {
+                name = "AxeThrow",
+                type = "Disc",
+                load_cond = function(self) return Config:GetSetting('UseAxeThrow') and Core.GetResolvedActionMapItem('AxeThrow') end,
+                cond = function(self, discSpell, target)
+                    return Casting.DetSpellCheck(discSpell, target)
+                end,
+            },
+            {
                 name = "FrenzyDisc",
                 type = "Disc",
+                load_cond = function(self) return not (Config:GetSetting('UseAxeThrow') and Core.GetResolvedActionMapItem('AxeThrow')) end,
                 cond = function(self, discSpell, target)
                     return Casting.DetSpellCheck(discSpell, target)
                 end,
@@ -427,6 +450,16 @@ return {
             Index = 101,
             Tooltip = "Use the Battle Leap AA on cooldown.",
             Default = true,
+        },
+        ['UseAxeThrow']    = {
+            DisplayName = "Use Axe Throw",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 102,
+            Tooltip = "Use Vigorous Axe Throw as your timer-10 disc instead of Frenzy (falls back to Frenzy if unavailable).",
+            Default = true,
+            RequiresLoadoutChange = true,
         },
         ['DoSnare']        = {
             DisplayName = "Do Snare",

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -39,7 +39,7 @@ local Tooltips     = {
 }
 
 local _ClassConfig = {
-    _version              = "3.2 - Project Lazarus",
+    _version              = "3.3 - Project Lazarus",
     _author               = "Algar, Derple, Grimmier, Tiddliestix, SonicZentropy",
     ['Modes']             = { --other modes to reorder spell priorities may be added back in at a later date.
         'General',
@@ -98,6 +98,7 @@ local _ClassConfig = {
             "Tarew's Aquatic Ayre", -- Level 16
         },
         ['AriaSong'] = {
+            -- "Ancient: Draconic Might", -- Level 71 Laz Custom, verify existence and source
             "Ancient: Call of Power",    -- Level 70
             "Eriki's Psalm of Power",    -- Level 69
             "Yelhun's Mystic Call",      -- Level 68
@@ -116,6 +117,7 @@ local _ClassConfig = {
             "Aura of Insight",  -- Level 55
         },
         ['GroupRegenSong'] = {
+            "Cantata of Nife",               -- Level 71 Laz Custom
             "Cantata of Life",               -- Level 67
             "Wind of Marr",                  -- Level 62
             "Cantata of Replenishment",      -- Level 55
@@ -125,6 +127,7 @@ local _ClassConfig = {
             "Hymn of Restoration",           -- Level 6, hp only
         },
         ['AreaRegenSong'] = {
+            "Chorus of Nife",          -- Level 71 Laz Custom
             "Chorus of Life",          -- Level 69
             "Chorus of Marr",          -- Level 64
             "Ancient: Lcea's Lament",  -- Level 60
@@ -222,21 +225,35 @@ local _ClassConfig = {
             "Kelin's Lugubrious Lament", -- Level 8, (Max Mob Level of 60)
         },
         ['ThousandBlades'] = {
+            "Endless Blades",  -- Level 71 Laz Custom
             "Thousand Blades", -- Level 69
         },
         ['StormBlade'] = {
-            "Storm Blade Flourish", -- Level 69 Laz Custom
+            "Squall Blade Flourish", -- Level 71 Laz Custom
+            "Storm Blade Flourish",  -- Level 69 Laz Custom
         },
         ['SpellAbsorbSong'] = {
-            "Echoes of the Past", -- Level 70 Laz Custom
+            "Echoes of the Ancient", -- Level 71 Laz Custom
+            "Echoes of the Past",    -- Level 70 Laz Custom
         },
         ['ResistDebuff'] = {
+            "Symphony of Sound",  -- Level 71 Laz Custom
             "Harmony of Sound",   -- Level 65
             "Occlusion of Sound", -- Level 55
         },
         ['BellowSong'] = {
+            -- "Bellow of Shadows", -- Level 71 Laz Custom, verify existence and source
             "Bellow of Chaos", -- Level 66
         },
+        ['ReprisalDisc'] = {   -- Manual use only for now, reprisal does not fire unless the rune is broken
+            "Arcane Reprisal", -- Level 71 Laz Custom
+        },
+        ['SpellMitSong'] = {
+            "Niv's Symphonic", -- Level 71 Laz Custom
+        },
+        -- ['Doppelganger'] = {
+        --     "One Bard Band", -- Level 71 Laz Custom, verify existence and source
+        -- },
     },
     ['Charm']             = {
         ['Abilities'] = {
@@ -635,6 +652,14 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "SpellMitSong",
+                type = "Song",
+                load_cond = function(self) return Config:GetSetting('UseSpellMit') > 1 end,
+                cond = function(self, songSpell)
+                    return self.Helpers.CheckSongStateUse(self, "UseSpellMit") and self.Helpers.RefreshBuffSong(self, songSpell)
+                end,
+            },
+            {
                 name = "RunBuff",
                 type = "Song",
                 load_cond = function(self) return Config:GetSetting('UseRunBuff') > 1 and not Casting.CanUseAA("Selo's Sonata") end,
@@ -703,7 +728,7 @@ local _ClassConfig = {
                 cond = function(self, songSpell, target)
                     if target.ID() == mq.TLO.Me.ID() then return false end
                     if not Casting.BurnCheck() and mq.TLO.Me.PctMana() <= Config:GetSetting('ReserveManaPct') then return false end
-                    return Config:GetSetting('UseStormBlade') == 3 or self.Helpers.RefreshBuffSong(self, mq.TLO.Spell("Storm Blade"))
+                    return Config:GetSetting('UseStormBlade') == 3 or self.Helpers.RefreshBuffSong(self, mq.TLO.Spell(songSpell.Name():match("(.+) Flourish")))
                 end,
             },
             {
@@ -849,6 +874,7 @@ local _ClassConfig = {
                 -- major group buffs
                 { name = "AriaSong",        cond = function(self) return Config:GetSetting('UseAria') > 1 end, },
                 { name = "WarMarchSong",    cond = function(self) return Config:GetSetting('UseMarch') > 1 end, },
+                { name = "SpellMitSong",    cond = function(self) return Config:GetSetting('UseSpellMit') > 1 end, },
                 { name = "StormBlade",      cond = function(self) return Config:GetSetting('UseStormBlade') > 1 end, },
                 { name = "ArcaneSong",      cond = function(self) return Config:GetSetting('UseArcane') > 1 end, },
                 { name = "ResistSong",      cond = function(self) return Config:GetSetting('UseResist') > 1 end, },
@@ -1267,12 +1293,12 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
         },
         ['UseStormBlade']   = {
-            DisplayName = "Use Storm Blade Flourish",
+            DisplayName = "Use Storm Blade Line",
             Group = "Abilities",
             Header = "Buffs",
             Category = "Group",
             Index = 107,
-            Tooltip = "Use your Storm Blade Flourish (on hit, triggers a proc buff).\n We will only use this song when over the Reserve Mana Pct, unless we are burning.",
+            Tooltip = "Use your Storm Blade line (on hit, triggers a proc buff).\n We will only use this song when over the Reserve Mana Pct, unless we are burning.",
             Type = "Combo",
             ComboOptions = { 'Never', 'To Maintain Buff', 'Whenever Possible', },
             Default = 2,
@@ -1287,6 +1313,20 @@ local _ClassConfig = {
             Category = "Group",
             Index = 106,
             Tooltip = Tooltips.ArcaneSong,
+            Type = "Combo",
+            ComboOptions = { 'Never', 'In-Combat Only', 'Always', 'Out-of-Combat Only', },
+            Default = 1,
+            Min = 1,
+            Max = 4,
+            RequiresLoadoutChange = true,
+        },
+        ['UseSpellMit']     = {
+            DisplayName = "Use Spell Mit",
+            Group = "Abilities",
+            Header = "Buffs",
+            Category = "Group",
+            Index = 108,
+            Tooltip = "Sing your group spell-damage mitigation song.",
             Type = "Combo",
             ComboOptions = { 'Never', 'In-Combat Only', 'Always', 'Out-of-Combat Only', },
             Default = 1,

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -7,7 +7,7 @@ local Globals   = require("utils.globals")
 local Targeting = require("utils.targeting")
 
 return {
-    _version              = "1.5 - Project Lazarus",
+    _version              = "1.6 - Project Lazarus",
     _author               = "Derple, Algar",
     ['Modes']             = {
         'DPS',
@@ -73,10 +73,15 @@ return {
         },
         ['Icelance2'] = {
             -- Lance 2 Timer 11 Ice Nuke Fast Cast
+            "Roaring Sleet",   -- Level 71 Laz Custom, - Timer 11
             "Glacier Spear",   -- Level 69, - Timer 11
             "Trushar's Frost", -- Level 65, - Timer 11
             "Ice Shard",       -- Level 54, - Timer 11
             "Ice Spear",       -- Level 33, - Timer 11
+        },
+        ['IceLance3'] = {
+            -- Lance 3 Timer 11 Ice Nuke - opt-in Ravenous Ice (higher damage/hate) via UseRavenousIce
+            "Ravenous Ice", -- Level 71 Laz Custom, - Timer 11
         },
         ['EndemicDot'] = {
             -- Disease DoT Instant Cast
@@ -103,17 +108,19 @@ return {
             "Drowsy",          -- Level 20
         },
         ['HealSpell'] = {
-            "Muada's Mending",   -- Level 67
-            "Trushar's Mending", -- Level 65
-            "Chloroblast",       -- Level 62
-            "Greater Healing",   -- Level 57
-            "Spirit Salve",      -- Level 48
-            "Healing",           -- Level 36
-            "Light Healing",     -- Level 20
-            "Minor Healing",     -- Level 6
-            "Salve",             -- Level 1
+            "Swift Salve of the Stillmoon", -- Level 71 Laz Custom
+            "Muada's Mending",              -- Level 67
+            "Trushar's Mending",            -- Level 65
+            "Chloroblast",                  -- Level 62
+            "Greater Healing",              -- Level 57
+            "Spirit Salve",                 -- Level 48
+            "Healing",                      -- Level 36
+            "Light Healing",                -- Level 20
+            "Minor Healing",                -- Level 6
+            "Salve",                        -- Level 1
         },
         ['PetHealSpell'] = {
+            "Sha's Urgent Renewal",    -- Level 71 Laz Custom
             "Healing of Mikkily",      -- Level 66
             "Healing of Sorsha",       -- Level 61
             "Sha's Restoration",       -- Level 55
@@ -152,34 +159,37 @@ return {
             "Spirit of Sha", -- Level 70 Laz Custom
         },
         ['PetGrowl'] = {
-            "Growl of the Panther", -- Level 69
-            "Growl of the Leopard", -- Level 61
+            "Growl of the Mountain Puma", -- Level 71 Laz Custom
+            "Growl of the Panther",       -- Level 69
+            "Growl of the Leopard",       -- Level 61
         },
         ['PetDamageProc'] = {
-            "Spirit of Oroshar",      -- Level 70
-            "Spirit of Irionu",       -- Level 68
-            "Spirit of Rellic",       -- Level 63
-            "Spirit of Flame",        -- Level 56
-            "Spirit of Snow",         -- Level 54
-            "Spirit of the Storm",    -- Level 53
-            "Spirit of Wind",         -- Level 51
-            "Spirit of Vermin",       -- Level 46
-            "Spirit of the Scorpion", -- Level 38
-            "Spirit of Inferno",      -- Level 28
-            "Spirit of the Blizzard", -- Level 18
-            "Spirit of Lightning",    -- Level 13
+            "Roaring Spirit of Tirranun", -- Level 71 Laz Custom
+            "Spirit of Oroshar",          -- Level 70
+            "Spirit of Irionu",           -- Level 68
+            "Spirit of Rellic",           -- Level 63
+            "Spirit of Flame",            -- Level 56
+            "Spirit of Snow",             -- Level 54
+            "Spirit of the Storm",        -- Level 53
+            "Spirit of Wind",             -- Level 51
+            "Spirit of Vermin",           -- Level 46
+            "Spirit of the Scorpion",     -- Level 38
+            "Spirit of Inferno",          -- Level 28
+            "Spirit of the Blizzard",     -- Level 18
+            "Spirit of Lightning",        -- Level 13
         },
         ['RunSpeedBuff'] = {
             "Spirit of Wolf", -- Level 24
         },
         ['ManaRegenBuff'] = {
             --Mana/Hp/End Regen Buff*
-            "Spiritual Rejuvenation", -- Level 70 Laz Custom
-            "Spiritual Ascendance",   -- Level 69
-            "Spiritual Dominion",     -- Level 64
-            "Spiritual Purity",       -- Level 59
-            "Spiritual Radiance",     -- Level 52
-            "Spiritual Light",        -- Level 41
+            "Spiritual Enlightenment", -- Level 71 Laz Custom
+            "Spiritual Rejuvenation",  -- Level 70 Laz Custom
+            "Spiritual Ascendance",    -- Level 69
+            "Spiritual Dominion",      -- Level 64
+            "Spiritual Purity",        -- Level 59
+            "Spiritual Radiance",      -- Level 52
+            "Spiritual Light",         -- Level 41
         },
         ['PetBlockSpell'] = {
             "Feral Guard",           -- Level 69
@@ -200,6 +210,7 @@ return {
             "Inner Fire",         -- Level 7
         },
         ['AtkHPBuff'] = {
+            "Spiritual Vibrance", -- Level 71 Laz Custom
             "Spiritual Vitality", -- Level 67
             "Spiritual Vigor",    -- Level 62
             "Spiritual Strength", -- Level 60
@@ -220,8 +231,15 @@ return {
             "Protective Spirit Discipline", -- Level 55
         },
         ['VigorBuff'] = {
-            "Feral Vigor", -- Level 69
+            "Feral Mettle", -- Level 71 Laz Custom
+            "Feral Vigor",  -- Level 69
         },
+        ['BurstHeal'] = {
+            "Feral Exigency", -- Level 71 Laz Custom
+        },
+        -- ['DrakeNuke'] = {
+        --     "Ancient: Drake's Breath", -- Level 71 Laz Custom, verify existence and source
+        -- },
     },
     ['HealRotationOrder'] = {
         { -- configured as a backup healer, will not cast in the mainpoint
@@ -235,6 +253,11 @@ return {
     },
     ['HealRotations']     = {
         ['BigHealPoint'] = {
+            {
+                name = "BurstHeal",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoBurstHeal') end,
+            },
             {
                 name = "HealSpell",
                 type = "Spell",
@@ -549,8 +572,17 @@ return {
                 end,
             },
             {
+                name = "IceLance3",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('UseRavenousIce') and Core.GetResolvedActionMapItem('IceLance3') end,
+                cond = function(self, spell, target)
+                    return Casting.OkayToNuke()
+                end,
+            },
+            {
                 name = "Icelance2",
                 type = "Spell",
+                load_cond = function(self) return not (Config:GetSetting('UseRavenousIce') and Core.GetResolvedActionMapItem('IceLance3')) end,
                 cond = function(self, spell, target)
                     return Casting.OkayToNuke()
                 end,
@@ -735,6 +767,13 @@ return {
                 end,
             },
             {
+                name = "PetBlockSpell",
+                type = "Spell",
+                cond = function(self, spell)
+                    return Casting.CastReady(spell) and Casting.PetBuffCheck(spell)
+                end,
+            },
+            {
                 name = "Fortify Companion",
                 type = "AA",
                 active_cond = function(self, aaName) return mq.TLO.Me.PetBuff(aaName)() ~= nil end,
@@ -774,11 +813,13 @@ return {
             name = "Default Mode",
             -- cond = function(self) return true end, --Code kept here for illustration, if there is no condition to check, this line is not required
             spells = {
+                { name = "BurstHeal",     cond = function(self) return Config:GetSetting('DoBurstHeal') end, },
                 { name = "HealSpell",     cond = function(self) return Config:GetSetting('DoHeals') end, },
                 { name = "PetHealSpell",  cond = function(self) return Config:GetSetting('DoPetHealSpell') end, },
                 { name = "SlowSpell",     cond = function(self) return Config:GetSetting('DoSlow') end, },
                 { name = "Icelance1", },
-                { name = "Icelance2", },
+                { name = "IceLance3",     cond = function(self) return Config:GetSetting('UseRavenousIce') and Core.GetResolvedActionMapItem('IceLance3') end, },
+                { name = "Icelance2",     cond = function(self) return not (Config:GetSetting('UseRavenousIce') and Core.GetResolvedActionMapItem('IceLance3')) end, },
                 { name = "BloodDot",      cond = function(self) return Config:GetSetting('DoDot') end, },
                 { name = "EndemicDot",    cond = function(self) return Config:GetSetting('DoDot') end, },
                 { name = "SwarmPet", },
@@ -878,6 +919,16 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
+        ['DoBurstHeal']    = {
+            DisplayName = "Do Burst Heal",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "General Healing",
+            Index = 103,
+            Tooltip = "Mem and cast Feral Exigency, a large single-target burst heal, at your big-heal point.",
+            Default = true,
+            RequiresLoadoutChange = true,
+        },
         ['PetHealPct']     = {
             DisplayName = "Pet Heal Spell HP%",
             Group = "Abilities",
@@ -957,6 +1008,16 @@ return {
             Index = 101,
             Tooltip = "Enable casting Damage Over Time spells.",
             Default = true,
+            RequiresLoadoutChange = true,
+        },
+        ['UseRavenousIce'] = {
+            DisplayName = "Use Ravenous Ice",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 101,
+            Tooltip = "If available, use Ravenous Ice as your timer 11 nuke (higher damage, higher mana cost, added hate).",
+            Default = false,
             RequiresLoadoutChange = true,
         },
         ['DotNamedOnly']   = {

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -7,7 +7,7 @@ local Globals      = require("utils.globals")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version              = "2.2 - Project Lazarus",
+    _version              = "2.3 - Project Lazarus",
     _author               = "Algar, Derple, Robban",
     ['ModeChecks']        = {
         IsHealing = function() return true end,
@@ -102,6 +102,7 @@ local _ClassConfig = {
         --     "Ward of Retribution", -- Level 69
         -- },
         ['HealingLight'] = {
+            -- "Ancient: Sacred Remedy", -- Level 71, verify existence and source
             "Ancient: Hallowed Light", -- Level 70
             "Pious Light",             -- Level 68
             "Holy Light",              -- Level 65
@@ -122,6 +123,7 @@ local _ClassConfig = {
             "Remedy",                  -- Level 51
         },
         ['Renewal'] = {                -- Level 70 +, large heal, slower cast
+            "Urgent Renewal",          -- Level 71 Laz Custom
             "Desperate Renewal",       -- Level 70
         },
         ['GroupHeal'] = {
@@ -136,6 +138,7 @@ local _ClassConfig = {
         },
         ['SelfHPBuff'] = {
             --Self Buff for Mana Regen and armor
+            "Armor of the Sacred",            -- Level 71 Laz Custom
             "Armor of the Pious",             -- Level 70
             "Armor of the Zealot",            -- Level 65
             "Ancient: High Priest's Bulwark", -- Level 60
@@ -144,6 +147,7 @@ local _ClassConfig = {
         },
         ['AegoBuff'] = {
             ----Use HP Type one until Temperance at 40... Group Buff at 45 (Blessing of Temperance)
+            "Hand of Allegiance",     -- Level 71 Laz Custom
             "Hand of Conviction",     -- Level 70
             "Hand of Virtue",         -- Level 65
             "Blessing of Aegolism",   -- Level 60
@@ -166,6 +170,7 @@ local _ClassConfig = {
             "Holy Armor",        -- Level 1
         },
         ['SingleVieBuff'] = {
+            "Aegis of Vie",      -- Level 71 Laz Custom
             "Panoply of Vie",    -- Level 67
             "Bulwark of Vie",    -- Level 62
             "Protection of Vie", -- Level 54
@@ -174,6 +179,7 @@ local _ClassConfig = {
         },
         ['GroupSymbolBuff'] = {
             ----Group Symbols
+            "Symbol of Elushar", -- Level 71
             "Balikor's Mark",    -- Level 70
             "Kazad's Mark",      -- Level 63
             "Marzin's Mark",     -- Level 60
@@ -195,11 +201,13 @@ local _ClassConfig = {
         },
         ['DivineBuff'] = {
             --Divine Buffs REQUIRES extra spell slot because of the 90s recast
+            "Divine Redemption",   -- Level 71 Laz Custom
             "Divine Intervention", -- Level 60
             "Death Pact",          -- Level 51
         },
         ['TwinHealNuke'] = {
-            "Vigilant Condemnation", -- Level 71 Laz Custom
+            "Vigilant Censure",      -- Level 71 Laz Custom
+            "Vigilant Condemnation", -- Level 70 Laz Custom
         },
         ['RezSpell'] = {
             "Spiritual Awakening", -- Level 65 Laz Custom
@@ -223,8 +231,9 @@ local _ClassConfig = {
             "Celestial Remedy",  -- Level 19
         },
         ['GroupElixir'] = {
-            "Elixir of Divinity", -- Level 70
-            "Ethereal Elixir",    -- Level 60
+            "Elixir of Redemption", -- Level 71 Laz Custom
+            "Elixir of Divinity",   -- Level 70
+            "Ethereal Elixir",      -- Level 60
         },
         ['SpellBlessing'] = {
             "Aura of Devotion",      -- Level 69
@@ -262,6 +271,7 @@ local _ClassConfig = {
             "Yaulp V",           -- Level 56, first rank with haste/mana regen. We won't use it before this.
         },
         ['StunTimer6'] = {       -- Timer 6 Stun, Fast Cast, Level 63+ (with ToT Heal 88+)
+            "Sound of Zeal",     -- Level 71 Laz Custom
             "Sound of Divinity", -- Level 68, works up to level 70
             "Sound of Might",    -- Level 63
             --Filler before this
@@ -283,6 +293,7 @@ local _ClassConfig = {
             "Ward Undead",       -- Level 4
         },
         ['MagicNuke'] = {
+            "Chromablast",  -- Level 71 Laz Custom
             "Chromastrike", -- Level 69, Laz specific
             -- "Calamity",  -- Level 69, Chroma is better
             "Reproach",     -- Level 67

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -7,7 +7,7 @@ local Globals      = require("utils.globals")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version              = "2.0 - Lazarus",
+    _version              = "2.1 - Lazarus",
     _author               = "Algar",
     ['ModeChecks']        = {
         CanCharm = function() return true end,
@@ -113,6 +113,7 @@ local _ClassConfig = {
         },
         ['HealSpell'] = {
             -- Long Heal >= 1 -- skipped 10s cast heals.
+            -- "Ancient: Chlorobalm", -- Level 71 Laz Custom, verify existence and source
             "Ancient: Chlorobon",          -- Level 70
             "Chlorotrope",                 -- Level 68
             "Sylvan Infusion",             -- Level 65
@@ -137,6 +138,7 @@ local _ClassConfig = {
             "Word of Health",              -- Level 40
         },
         ['ATKDebuff'] = {                  -- ATK Debuff
+            "Sun's Blistering Corona",     -- Level 71 Laz Custom
             "Sun's Corona",                -- Level 67
             "Ro's Illumination",           -- Level 62
         },
@@ -149,6 +151,7 @@ local _ClassConfig = {
             "Ro's Fiery Sundering",        -- Level 37
         },
         ['ColdDebuff'] = {                 -- Cold/AC Debuff
+            "Breath of the Ascent",        -- Level 71 Laz Custom
             "Glacier Breath",              -- Level 67
             "E`ci's Frosty Breath",        -- Level 63
         },
@@ -212,6 +215,7 @@ local _ClassConfig = {
             "Burst of Flame",          -- Level 1
         },
         ['IceNuke'] = {
+            "Ascent Frost",           -- Level 71 Laz Custom
             "Ancient: Glacier Frost", -- Level 70
             "Glitterfrost",           -- Level 70
             "Ancient: Chaos Frost",   -- Level 65
@@ -244,6 +248,7 @@ local _ClassConfig = {
             "Mask of the Stalker", -- Level 60
         },
         ['HPTypeOne'] = {
+            "Blessing of Spiritoak",    -- Level 71 Laz Custom
             "Blessing of Steeloak",     -- Level 70 Group
             -- "Steeloak Skin",            -- Level 68 Single
             "Blessing of the Nine",     -- Level 65 Group
@@ -262,6 +267,7 @@ local _ClassConfig = {
             "Skin like Wood",           -- Level 1 Single
         },
         ['GroupRegenBuff'] = {
+            "Blessing of Moss",          -- Level 71 Laz Custom
             "Blessing of Oak",           -- Level 69
             "Blessing of Replenishment", -- Level 63
             "Regrowth of the Grove",     -- Level 58
@@ -297,10 +303,12 @@ local _ClassConfig = {
             "Spirit of Wolf",   -- Level 10
         },
         ['PetSpell'] = {
+            "Nature Seeker's Behest",   -- Level 71 Laz Custom
             "Nature Wanderer's Behest", -- Level 70 Laz Custom
             "Nature Walker's Behest",   -- Level 55
         },
         ['Dawnstrike'] = {              -- I think better to just spam solstice strike
+            "Dawnflame",                -- Level 71 Laz Custom
             "Dawnstrike",               -- Level 70
         },
         -- ['BurstDS'] = { -- Laz specific, short duration 210pt damge shield
@@ -335,6 +343,9 @@ local _ClassConfig = {
         ['TwinHealNuke'] = {
             "Sunburst Blessing", -- Level 70, Laz Custom, description wrong, target mob
         },
+        ['HealBoostNuke'] = {
+            "Sunburst Devotion", -- Level 71 Laz Custom
+        },
         ['PBAEMagic'] = {
             "Earth Shiver", -- Level 66
             "Catastrophe",  -- Level 61
@@ -361,7 +372,8 @@ local _ClassConfig = {
             "Lesser Succor", -- Level 18
         },
         ['QuickGroupHeal'] = {
-            "Moon Shadow", -- Level 70 Laz Custom
+            "Lunar Shadow", -- Level 71 Laz Custom
+            "Moon Shadow",  -- Level 70 Laz Custom
         },
     },
     ['AASets']            = {
@@ -656,6 +668,15 @@ local _ClassConfig = {
                 cond = function(self, spell, target)
                     if Config:GetSetting('StunNukeUse') == 2 and not mq.TLO.Me.Song("Wrath of the Wilderness")() then return false end
                     return Casting.HaveManaToNuke() and Targeting.TargetNotStunned() and not Globals.AutoTargetIsNamed
+                end,
+            },
+            {
+                name = "HealBoostNuke",
+                type = "Spell",
+                load_cond = function() return Config:GetSetting('HealBoostNukeUse') > 1 end,
+                cond = function(self, spell, target)
+                    if Config:GetSetting('HealBoostNukeUse') == 2 and not mq.TLO.Me.Song("Wrath of the Wilderness")() then return false end
+                    return Casting.OkayToNuke()
                 end,
             },
             { -- in-game description is incorrect, mob must be targeted.
@@ -1041,6 +1062,7 @@ local _ClassConfig = {
                 { name = "CureCurse",      cond = function(self) return Config:GetSetting('KeepCurseMemmed') end, },
                 { name = "EvacSpell",      cond = function(self) return Config:GetSetting('KeepEvacMemmed') and not Casting.CanUseAA("Exodus") end, },
                 { name = "StunNuke",       cond = function(self) return Config:GetSetting('StunNukeUse') > 1 end, },
+                { name = "HealBoostNuke",  cond = function(self) return Config:GetSetting('HealBoostNukeUse') > 1 end, },
                 { name = "TwinHealNuke",   cond = function(self) return Config:GetSetting('TwinHealNukeUse') > 1 end, },
                 { name = "Dawnstrike",     cond = function(self) return Config:GetSetting('DawnstrikeUse') > 1 end, },
                 { name = "FireNuke",       cond = function(self) return Config:GetSetting('FireNukeUse') > 1 end, },
@@ -1288,6 +1310,20 @@ local _ClassConfig = {
             Category = "Direct",
             Index = 105,
             Tooltip = "Use your Dawnstrike spell (quick nuke with a chance to proc a self- beneficial or detrimental spell damage buff.).",
+            RequiresLoadoutChange = true,
+            Type = "Combo",
+            ComboOptions = { 'Never', 'Epic Procs Only', 'All Combat', },
+            Default = 3,
+            Min = 1,
+            Max = 3,
+        },
+        ['HealBoostNukeUse']  = {
+            DisplayName = "Heal Boost Nuke",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 106,
+            Tooltip = "Use your Sunburst Devotion nuke (fire damage that also buffs your healing for a short time).",
             RequiresLoadoutChange = true,
             Type = "Combo",
             ComboOptions = { 'Never', 'Epic Procs Only', 'All Combat', },

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -10,7 +10,7 @@ local Logger       = require("utils.logger")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version          = "1.4 - Project Lazarus",
+    _version          = "1.5 - Project Lazarus",
     _author           = "Derple, Grimmier, Algar, Robban",
     ['ModeChecks']    = {
         CanMez    = function() return true end,
@@ -67,11 +67,13 @@ local _ClassConfig = {
             "Aura of Endless Glamour", -- Level 65
         },
         ['GroupHasteBuff'] = {
-            "Hastening of Salik",  -- Level 70
-            "Vallon's Quickening", -- Level 65
-            "Speed of the Brood",  -- Level 60
+            "Hastening of Ellowind", -- Level 71 Laz Custom
+            "Hastening of Salik",    -- Level 70
+            "Vallon's Quickening",   -- Level 65
+            "Speed of the Brood",    -- Level 60
         },
         ['SingleHasteBuff'] = {
+            "Speed of Ellowind",   -- Level 71 Laz Custom
             "Speed of Salik",      -- Level 67
             "Speed of Vallon",     -- Level 62
             "Visions of Grandeur", -- Level 60
@@ -83,6 +85,7 @@ local _ClassConfig = {
             "Quickness",           -- Level 15
         },
         ['ManaRegen'] = {
+            "Voice of Intuition",         -- Level 71 Laz Custom
             "Voice of Clairvoyance",      -- Level 70
             "Clairvoyance",               -- Level 68
             "Voice of Quellious",         -- Level 65
@@ -98,11 +101,13 @@ local _ClassConfig = {
             "Ward of Bedazzlement", -- Level 65
         },
         ['NdtBuff'] = {
-            "Boon of the Legion",  -- Level 67 Laz Custom
-            "Night's Dark Terror", -- Level 63
-            "Boon of the Garou",   -- Level 40
+            "Boon of the Sentinel", -- Level 71 Laz Custom
+            "Boon of the Legion",   -- Level 67 Laz Custom
+            "Night's Dark Terror",  -- Level 63
+            "Boon of the Garou",    -- Level 40
         },
         ['SelfHPBuff'] = {
+            "Presidio of the Seer", -- Level 71 Laz Custom
             "Mystic Shield",        -- Level 66
             "Shield of Maelin",     -- Level 64
             "Shield of the Arcane", -- Level 61
@@ -162,6 +167,7 @@ local _ClassConfig = {
         },
         ['CharmSpell'] = {
             --  "Ancient: Voice of Muram", -- Level 70 3m dur/10m reuse
+            "Whispers of Emoush", -- Level 71 Laz Custom
             "True Name",          -- Level 70
             "Compel",             -- Level 68
             "Command of Druzzil", -- Level 64
@@ -199,12 +205,13 @@ local _ClassConfig = {
             "Taper Enchantment",       -- Level 1
         },
         ['TashSpell'] = {
-            "Echo of Tashan", -- Level 70
-            "Howl of Tashan", -- Level 61
-            "Tashanian",      -- Level 57
-            "Tashania",       -- Level 41
-            "Tashani",        -- Level 18
-            "Tashina",        -- Level 2
+            "Edict of Tashan", -- Level 71 Laz Custom
+            "Echo of Tashan",  -- Level 70
+            "Howl of Tashan",  -- Level 61
+            "Tashanian",       -- Level 57
+            "Tashania",        -- Level 41
+            "Tashani",         -- Level 18
+            "Tashina",         -- Level 2
         },
         -- ['ManaDrainNuke'] = {
         --     "Torment of Scio",   -- Level 63
@@ -224,9 +231,11 @@ local _ClassConfig = {
             "Shallow Breath",     -- Level 1
         },
         ['MindDot'] = {
+            -- "Ancient: Mind Implosion", -- Level 71 Laz Custom, verify existence and source
             "Mind Shatter", -- Level 70
         },
         ['MagicNuke'] = {
+            "Hysteria",                 -- Level 71 Laz Custom
             "Ancient: Neurosis",        -- Level 70
             "Psychosis",                -- Level 68
             "Ancient: Chaos Madness",   -- Level 65
@@ -323,10 +332,14 @@ local _ClassConfig = {
             "Unified Alacrity", -- Level 71 Laz Custom
         },
         ['ColoredNuke'] = {
-            "Colored Chaos", -- Level 69
+            "Chromatic Chaos", -- Level 71 Laz Custom
+            "Colored Chaos",   -- Level 69
         },
         ['Chromaburst'] = {
             "Chromaburst", -- Level 70
+        },
+        ['UrgentRune'] = {
+            "Urgent Rune of Destiny", -- Level 71 Laz Custom
         },
     },
     ['AASets']        = {
@@ -377,6 +390,20 @@ local _ClassConfig = {
             targetId = function(self) return Casting.GetBuffableIDs() end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and Casting.OkayToBuff()
+            end,
+        },
+        { -- Dual-state emergency group rune: tanks in combat, whole group in downtime
+            name = 'UrgentRune',
+            state = 1,
+            steps = 1,
+            load_cond = function() return Config:GetSetting('DoUrgentRune') end,
+            targetId = function(self)
+                return Globals.CurrentState == "Combat" and Casting.GetBuffableTankingIDs() or Casting.GetBuffableIDs()
+            end,
+            cond = function(self, combat_state)
+                local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
+                local combat = combat_state == "Combat"
+                return (downtime or combat) and Core.CombatActionsCheck()
             end,
         },
         { --Pet Buffs if we have one, timer because we don't need to constantly check this
@@ -746,6 +773,16 @@ local _ClassConfig = {
                 end,
             },
         },
+        ['UrgentRune'] = {
+            {
+                name = "UrgentRune",
+                type = "Spell",
+                active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
+                cond = function(self, spell, target)
+                    return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
+                end,
+            },
+        },
         ['CombatSupport'] = {
             {
                 name = "Fundament: Second Spire of Enchantment",
@@ -1089,6 +1126,7 @@ local _ClassConfig = {
                 { name = "MindDot",          cond = function(self) return Config:GetSetting('DoMindDot') end, },
                 { name = "StrangleDot",      cond = function(self) return Config:GetSetting('DoStrangleDot') end, },
                 { name = "HateBuff",         cond = function(self) return Config:GetSetting('DoHateBuff') end, },
+                { name = "UrgentRune",       cond = function(self) return Config:GetSetting('DoUrgentRune') end, },
                 { name = "SingleRune",       cond = function(self) return Config:GetSetting('RuneChoice') == 1 end, },
                 { name = "GroupRune",        cond = function(self) return Config:GetSetting('RuneChoice') == 2 end, },
                 { name = "GroupSpellShield", cond = function(self) return Config:GetSetting('DoGroupSpellShield') end, },
@@ -1167,7 +1205,7 @@ local _ClassConfig = {
             Tooltip = "Select which line of Rune spells you prefer to use.\nPlease note that after level 73, the group rune has a built-in hate reduction when struck.",
             Type = "Combo",
             ComboOptions = { 'Single Target', 'Group', 'Off', },
-            Default = 2,
+            Default = 3,
             Min = 1,
             Max = 3,
             RequiresLoadoutChange = true,
@@ -1199,6 +1237,16 @@ local _ClassConfig = {
             Category = "Group",
             Index = 105,
             Tooltip = "Enable casting your Melee Proc Buff (Night's Dark Terror Line) on melee.",
+            RequiresLoadoutChange = true,
+            Default = true,
+        },
+        ['DoUrgentRune']       = {
+            DisplayName = "Cast Urgent Rune",
+            Group = "Abilities",
+            Header = "Buffs",
+            Category = "Group",
+            Index = 107,
+            Tooltip = "Cast Urgent Rune of Destiny, an instant emergency group melee absorb (tank in combat, group in downtime).",
             RequiresLoadoutChange = true,
             Default = true,
         },

--- a/class_configs/Project Lazarus/mag_class_config.lua
+++ b/class_configs/Project Lazarus/mag_class_config.lua
@@ -11,7 +11,7 @@ local Logger      = require("utils.logger")
 local Targeting   = require("utils.targeting")
 
 _ClassConfig      = {
-    _version          = "1.4 - Project Lazarus",
+    _version          = "1.5 - Project Lazarus",
     _author           = "Derple, Morisato, Algar",
     ['Modes']         = {
         'DPS',
@@ -76,9 +76,11 @@ _ClassConfig      = {
             "Raging Servant", -- Level 70
         },
         ['SpearNuke'] = {
+            -- "Ancient: Spear of Molten Slag", -- Level 71 Laz Custom, verify existence and source
             "Spear of Ro", -- Level 70
         },
         ['ChaoticNuke'] = {
+            "Fickle Inferno",          -- Level 71 Laz Custom
             "Fickle Fire",             -- Level 69
         },
         ['FireDD'] = {                 --Mix of Fire Nukes and Bolts appropriate for use at lower levels.
@@ -105,10 +107,12 @@ _ClassConfig      = {
             "Shock of Blades",         -- Level 7
         },
         ['QuickMagicDD'] = {
+            "Blade Rend",   -- Level 71 Laz Custom
             "Blade Strike", -- Level 68
             "Black Steel",  -- Level 63
         },
         ['SelfShield'] = {
+            "Ward of the Conjurer", -- Level 71 Laz Custom
             "Elemental Aura",       -- Level 66
             "Shield of Maelin",     -- Level 64
             "Shield of the Arcane", -- Level 61
@@ -125,6 +129,7 @@ _ClassConfig      = {
             "Pyrilen Skin",               -- Level 68
         },
         ['LongDurDmgShield'] = {
+            "Circle of Magmaskin",   -- Level 71 Laz Custom
             "Circle of Fireskin",    -- Level 70
             "Fireskin",              -- Level 66
             "Maelstrom of Ro",       -- Level 63
@@ -144,13 +149,15 @@ _ClassConfig      = {
             "Transon's Phantasmal Protection", -- Level 58
         },
         ['PetAura'] = {
-            "Rathe's Strength", -- Level 70
-            "Earthen Strength", -- Level 55
+            "Monolithic Strength", -- Level 71 Laz Custom
+            "Rathe's Strength",    -- Level 70
+            "Earthen Strength",    -- Level 55
         },
         ['FireShroud'] = {
             "Burning Aura", -- Level 68
         },
         ['PetHealSpell'] = {
+            "Goner's Urgent Renewal",       -- Level 71 Laz Custom
             "Renewal of Jerikor",           -- Level 69
             "Planar Renewal",               -- Level 64
             "Transon's Elemental Renewal",  -- Level 60
@@ -274,6 +281,7 @@ _ClassConfig      = {
             "Summon Orb", -- Level 45
         },
         ['Bladegusts'] = {
+            "Burning Bladestorm", -- Level 71 Laz Custom
             "Burning Bladegusts", -- Level 69 Laz Custom
         },
         ['PBAE2'] = {
@@ -286,7 +294,8 @@ _ClassConfig      = {
             "Shock of Myriad Minions", -- Level 70 Laz Custom
         },
         ['FranticDS'] = {
-            "Frantic Flames", -- Level 71 Laz Custom
+            "Frantic Blaze",  -- Level 71 Laz Custom
+            "Frantic Flames", -- Level 70 Laz Custom
         },
     },
     ['AASets']        = {

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -8,7 +8,7 @@ local Logger       = require("utils.logger")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version          = "2.1 - Project Lazarus",
+    _version          = "2.2 - Project Lazarus",
     _author           = "Algar, Derple",
     ['Modes']         = {
         'DPS',
@@ -55,19 +55,23 @@ local _ClassConfig = {
     },
     ['AbilitySets']   = {
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70 Laz Custom
-            -- "Second Wind",        -- Level 65
+            "Fourth Wind Discipline", -- Level 71 Laz Custom
+            "Third Wind Discipline",  -- Level 70 Laz Custom
+            -- "Second Wind",         -- Level 65
         },
         ['MonkAura'] = {
-            "Master's Aura",   -- Level 65
-            "Disciple's Aura", -- Level 55
+            "Grandmaster's Aura", -- Level 71 Laz Custom
+            "Master's Aura",      -- Level 65
+            "Disciple's Aura",    -- Level 55
         },
         ['Fang'] = {
+            -- "Ancient: Arachnid Fang", -- Level 71 Laz Custom, verify existence and source
             "Dragon Fang",          -- Level 69
             "Clawstriker's Flurry", -- Level 65
         },
         ['FistsOfWu'] = {
-            "Fists of Wu", -- Level 65
+            "Fists of Thundercrest", -- Level 71 Laz Custom
+            "Fists of Wu",           -- Level 65
         },
         ['MeleeMit'] = {
             "Impenetrable Discipline", -- Level 65
@@ -75,6 +79,7 @@ local _ClassConfig = {
             "Stonestance Discipline",  -- Level 51
         },
         ['FistDisc'] = {
+            "Stormfist Discipline",   -- Level 71 Laz Custom
             "Scaledfist Discipline",  -- Level 65
             "Ashenhand Discipline",   -- Level 60
             "Thunderkick Discipline", -- Level 52
@@ -84,7 +89,8 @@ local _ClassConfig = {
             "Heel of Kanji", -- Level 65
         },
         ['Speed'] = {
-            "Speed Focus Discipline", -- Level 63
+            "Velocity Focus Discipline", -- Level 71 Laz Custom
+            "Speed Focus Discipline",    -- Level 63
         },
         ['Palm'] = {
             "Crystalpalm Discipline",   -- Level 70
@@ -92,7 +98,14 @@ local _ClassConfig = {
             "Innerflame Discipline",    -- Level 56
         },
         ['Voiddance'] = {
-            "Voiddance Discipline", -- Level 54
+            "Dragondance Discipline", -- Level 71 Laz Custom
+            "Voiddance Discipline",   -- Level 54
+        },
+        ['ReprisalDisc'] = {          -- Manual use only for now, reprisal does not fire unless the rune is broken
+            "Arcane Reprisal",        -- Level 71 Laz Custom
+        },
+        ['Fists'] = {
+            "Wheel of Fists", -- Level 71 Laz Custom
         },
         -- ['ResistantDisc'] = {
         --     "Dreamwalk Discipline", -- Level 66
@@ -100,6 +113,11 @@ local _ClassConfig = {
         -- },
     },
     ['Helpers']       = {
+        DodgeDiscActive = function(self)
+            local dodgeDisc = Core.GetResolvedActionMapItem('Voiddance')
+            if not dodgeDisc then return false end
+            return Casting.IHaveBuff(dodgeDisc.Trigger(1))
+        end,
     },
     ['RotationOrder'] = {
         {
@@ -200,7 +218,7 @@ local _ClassConfig = {
                 name = "MeleeMit",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 35 and not mq.TLO.Me.Buff("Voiddance Effect")()
+                    return mq.TLO.Me.PctHPs() < 35 and not self.Helpers.DodgeDiscActive(self)
                 end,
             },
             {
@@ -208,7 +226,7 @@ local _ClassConfig = {
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35 and not mq.TLO.Me.Buff("Voiddance Effect")()
+                    return mq.TLO.Me.PctHPs() < 35 and not self.Helpers.DodgeDiscActive(self)
                 end,
             },
             {
@@ -325,6 +343,10 @@ local _ClassConfig = {
                 cond = function(self, aaName, target)
                     return Casting.DetAACheck(aaName, target)
                 end,
+            },
+            {
+                name = "Fists",
+                type = "Disc",
             },
             {
                 name = "Fang",

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -7,7 +7,7 @@ local Globals      = require("utils.globals")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version            = "2.0 - Project Lazarus",
+    _version            = "2.1 - Project Lazarus",
     _author             = "Algar, Derple",
     ['Modes']           = {
         'DPS',
@@ -75,18 +75,20 @@ local _ClassConfig = {
     },
     ['AbilitySets']     = {
         ['SelfHPBuff'] = {
-            "Shadow Guard",         -- Level 66
-            "Shield of Maelin",     -- Level 64
-            "Shield of the Arcane", -- Level 61
-            "Shield of the Magi",   -- Level 54
-            "Arch Shielding",       -- Level 41
-            "Greater Shielding",    -- Level 33
-            "Major Shielding",      -- Level 24
-            "Shielding",            -- Level 16
-            "Lesser Shielding",     -- Level 8
-            "Minor Shielding",      -- Level 1
+            "Sacrilege of the Wraith", -- Level 71 Laz Custom
+            "Shadow Guard",            -- Level 66
+            "Shield of Maelin",        -- Level 64
+            "Shield of the Arcane",    -- Level 61
+            "Shield of the Magi",      -- Level 54
+            "Arch Shielding",          -- Level 41
+            "Greater Shielding",       -- Level 33
+            "Major Shielding",         -- Level 24
+            "Shielding",               -- Level 16
+            "Lesser Shielding",        -- Level 8
+            "Minor Shielding",         -- Level 1
         },
         ['SelfRune'] = {
+            "Dull Agony",   -- Level 71 Laz Custom
             "Dull Pain",    -- Level 69
             "Force Shield", -- Level 63
             "Manaskin",     -- Level 52
@@ -105,6 +107,7 @@ local _ClassConfig = {
             "Dominate Undead", -- Level 18
         },
         ['LifeTap'] = {
+            -- "Ancient: Despair of Vishimtar", -- Level 71 Laz Custom, verify existence and source
             "Ancient: Touch of Orshilak", -- Level 70
             "Soulspike",                  -- Level 67
             "Touch of Mujaki",            -- Level 61
@@ -119,18 +122,20 @@ local _ClassConfig = {
             "Lifespike",                  -- Level 3
             "Lifetap",                    -- Level 1
         },
-        -- ['DurationTap'] = {
-        --     "Fang of Death",        -- Level 68
-        --     "Night's Beckon",       -- Level 65
-        --     "Saryrn's Kiss",        -- Level 62
-        --     "Vexing Replenishment", -- Level 57
-        --     "Bond of Death",        -- Level 49
-        --     "Auspice",              -- Level 45
-        --     "Vampiric Curse",       -- Level 29
-        --     "Shadow Compact",       -- Level 17
-        --     "Leech",                -- Level 9
-        -- },
+        ['DurationTap'] = {
+            "Yearning of Death", -- Level 71 Laz Custom
+            -- "Fang of Death",        -- Level 68
+            -- "Night's Beckon",       -- Level 65
+            -- "Saryrn's Kiss",        -- Level 62
+            -- "Vexing Replenishment", -- Level 57
+            -- "Bond of Death",        -- Level 49
+            -- "Auspice",              -- Level 45
+            -- "Vampiric Curse",       -- Level 29
+            -- "Shadow Compact",       -- Level 17
+            -- "Leech",                -- Level 9
+        },
         ['PoisonNuke'] = {
+            "Ritual of Blood",      -- Level 71 Laz Custom
             "Call for Blood",       -- Level 68
             "Acikin",               -- Level 66
             "Neurotoxin",           -- Level 61
@@ -141,6 +146,7 @@ local _ClassConfig = {
             "Shock of Poison",      -- Level 21
         },
         ['FireDot'] = {
+            "Molten Pyre",             -- Level 71 Laz Custom
             "Dread Pyre",              -- Level 70
             "Pyre of Mori",            -- Level 69
             "Night Fire",              -- Level 65
@@ -168,6 +174,7 @@ local _ClassConfig = {
             "Dark Nightmare",         -- Level 67
         },
         ['PlagueDot'] = {
+            "Malignant Plague", -- Level 71 Laz Custom
             "Chaos Plague",     -- Level 66
             "Dark Plague",      -- Level 61
             "Cessation of Cor", -- Level 56
@@ -182,7 +189,8 @@ local _ClassConfig = {
         --     "Disease Cloud",    -- Level 1
         -- },
         ['PoisonDotDD'] = {
-            "Venom of Anguish", -- Level 69
+            "Venom of the Accursed Nest", -- Level 71 Laz Custom
+            "Venom of Anguish",           -- Level 69
         },
         ['PoisonDot'] = {
             "Chaos Venom",        -- Level 70
@@ -278,14 +286,16 @@ local _ClassConfig = {
         --     "Guard of Calliav",      -- Level 58
         --     "Ward of Calliav",       -- Level 49
         -- },
-        ['PetHealSpell'] = {  -- Also has cure effect for pet
-            "Dark Salve",     -- Level 69
-            "Touch of Death", -- Level 64
-            "Renew Bones",    -- Level 26
-            "Mend Bones",     -- Level 7
+        ['PetHealSpell'] = {          -- Also has cure effect for pet
+            "Goner's Urgent Renewal", -- Level 71 Laz Custom
+            "Dark Salve",             -- Level 69
+            "Touch of Death",         -- Level 64
+            "Renew Bones",            -- Level 26
+            "Mend Bones",             -- Level 7
         },
         ['Pustules'] = {
-            "Necrotic Pustules", -- Level 65
+            "Pestilent Pustules", -- Level 71 Laz Custom
+            "Necrotic Pustules",  -- Level 65
         },
         -- ['GroupLeech'] = {
         --     "Night Stalker",            -- Level 65
@@ -571,12 +581,18 @@ local _ClassConfig = {
                 name = "PoisonDotDD",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    if Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell, target)
                 end,
             },
             {
                 name = "FireDot",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.DotSpellCheck(spell, target)
+                end,
+            },
+            {
+                name = "PlagueDot",
                 type = "Spell",
                 cond = function(self, spell, target)
                     return Casting.DotSpellCheck(spell, target)
@@ -597,17 +613,9 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "PlagueDot",
+                name = "DurationTap",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.DotSpellCheck(spell, target)
-                end,
-            },
-            {
-                name = "PoisonDotDD",
-                type = "Spell",
-                cond = function(self, spell, target)
-                    if not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell, target)
                 end,
             },
@@ -930,16 +938,17 @@ local _ClassConfig = {
                 { name = "PoisonNuke", },
                 { name = "PoisonDotDD", },
                 { name = "FireDot", },
-                { name = "FireDot2",     cond = function(self) return mq.TLO.Me.Book("Dread Pyre")() end, },
-                { name = "CurseDot", },
-                { name = "CurseDot2",    cond = function(self) return mq.TLO.Me.Book("Ancient: Curse of Mori")() end, },
-                { name = "PoisonDot", },
                 { name = "PlagueDot", },
+                { name = "CurseDot", },
+                { name = "PoisonDot", },
+                { name = "DurationTap", },
                 { name = "LichSpell",    cond = function(self) return Config:GetSetting('DoLich') end, },
                 { name = "Pustules",     cond = function(self) return Config:GetSetting('DoPustules') end, },
                 { name = "OrbNuke",      cond = function(self) return Config:GetSetting('DoOrbNuke') end, },
                 { name = "LifeTap",      cond = function(self) return Config:GetSetting('DoLifetap') end, },
                 { name = "UndeadNuke",   cond = function(self) return Config:GetSetting('DoUndeadNuke') end, },
+                { name = "FireDot2",     cond = function(self) return mq.TLO.Me.Book("Dread Pyre")() end, },
+                { name = "CurseDot2",    cond = function(self) return mq.TLO.Me.Book("Ancient: Curse of Mori")() end, },
             },
         },
     },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -10,7 +10,7 @@ local Logger      = require("utils.logger")
 local Targeting   = require("utils.targeting")
 
 return {
-    _version              = "2.0 - Project Lazarus",
+    _version              = "2.1 - Project Lazarus",
     _author               = "Derple, Algar",
     ['ModeChecks']        = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -120,10 +120,11 @@ return {
         },
         ['DDProc'] = {
             --- Fury Proc Strike
-            "Pious Fury",   -- Level 68, 250pt, + 250pt if undead
-            "Holy Order",   -- Level 65, 180pt
-            "Pious Might",  -- Level 63, 150pt
-            "Divine Might", -- Level 45, 65pt
+            "Virtuous Fervor", -- Level 71 Laz Custom
+            "Pious Fury",      -- Level 68, 250pt, + 250pt if undead
+            "Holy Order",      -- Level 65, 180pt
+            "Pious Might",     -- Level 63, 150pt
+            "Divine Might",    -- Level 45, 65pt
         },
         ['UndeadProc'] = {
             --- Undead Proc Strike : does not stack with Fury Proc, will be used until Fury is available even if setting not enabled.
@@ -132,6 +133,7 @@ return {
             "Instrument of Nife", -- Level 26, 243pt
         },
         ['StunTimer5'] = {
+            "Force of the Sentinel",   -- Level 71 Laz Custom
             "Ancient: Force of Jeron", -- Level 70
             "Ancient: Force of Chaos", -- Level 65
             "Force of Akera",          -- Level 53
@@ -139,10 +141,11 @@ return {
             "Desist",                  -- Level 13, - Not Timer 5, use for TLP Low Level Stun
         },
         ['StunTimer4'] = {
-            "Force of Piety",  -- Level 66
-            "Force of Akilae", -- Level 62
-            "Force",           -- Level 52, - Not Timer 4, use for TLP Low Level Stun
-            "Cease",           -- Level 7, - Not Timer 4, use for TLP Low Level Stun
+            "Force of the Sacred", -- Level 71 Laz Custom
+            "Force of Piety",      -- Level 66
+            "Force of Akilae",     -- Level 62
+            "Force",               -- Level 52, - Not Timer 4, use for TLP Low Level Stun
+            "Cease",               -- Level 7, - Not Timer 4, use for TLP Low Level Stun
         },
         ['AegoBuff'] = {
             --- Pally Aegolism
@@ -163,13 +166,15 @@ return {
         --     "Resolution",        -- Level 60
         -- },
         ['Brells'] = {
-            "Brell's Vibrant Barricade",   -- Level 70 Laz Custom
-            "Brell's Brawny Bulwark",      -- Level 69
-            "Brell's Stalwart Shield",     -- Level 65
-            "Brell's Mountainous Barrier", -- Level 60
-            "Brell's Steadfast Aegis",     -- Level 49
+            "Brell's Unshakable Barricade", -- Level 71 Laz Custom
+            "Brell's Vibrant Barricade",    -- Level 70 Laz Custom
+            "Brell's Brawny Bulwark",       -- Level 69
+            "Brell's Stalwart Shield",      -- Level 65
+            "Brell's Mountainous Barrier",  -- Level 60
+            "Brell's Steadfast Aegis",      -- Level 49
         },
         ['WaveHeal'] = {
+            "Wave of the Stillmoon",  -- Level 71 Laz Custom
             "Wave of Piety",          -- Level 70
             "Wave of Trushar",        -- Level 65
             "Wave of Marr",           -- Level 65
@@ -178,6 +183,7 @@ return {
             "Wave of Life",           -- Level 44
         },
         ['WaveHeal2'] = {
+            "Wave of the Stillmoon",  -- Level 71 Laz Custom
             "Wave of Piety",          -- Level 70
             "Wave of Trushar",        -- Level 65
             "Wave of Marr",           -- Level 65
@@ -193,6 +199,7 @@ return {
         },
         ['ArmorSelfBuff'] = {
             --- Self Buff Armor Line Ac/Hp/Mana regen
+            "Armor of the Savior",   -- Level 71 Laz Custom
             "Armor of the Champion", -- Level 69
             "Armor of the Crusader", -- Level 64 Laz Custom
             "Armor of the Divine",   -- Level 60 Laz Custom
@@ -250,8 +257,9 @@ return {
         },
         ['HealReceivedAura'] = {
             -- Aura Buffs
-            "Blessed Aura", -- Level 70
-            "Holy Aura",    -- Level 55
+            "Benevolent Aura", -- Level 71 Laz Custom
+            "Blessed Aura",    -- Level 70
+            "Holy Aura",       -- Level 55
         },
         ['UndeadNuke'] = {
             -- Undead Nuke
@@ -283,6 +291,7 @@ return {
             "Reanimation",    -- Level 22
         },
         ['PBAEStun'] = {
+            "The Silent Decree",  -- Level 71 Laz Custom
             "The Silent Command", -- Level 65, does damage
         },
         ['AEStun'] = {            --Targeted AE
@@ -297,9 +306,11 @@ return {
             "Sanctification Discipline", -- Level 60
         },
         ['TwinHealNuke'] = {
-            "Justice of Marr", -- Level 71 Laz Custom
+            -- "Ancient: Justice of Firiona", -- Level 71 Laz Custom, verify existence and source
+            "Justice of Marr", -- Level 70
         },
         ['GuardDisc'] = {
+            "Aegis of Righteousness", -- Level 71 Laz Custom
             "Guard of Righteousness", -- Level 69
             "Guard of Humility",      -- Level 61
             "Guard of Piety",         -- Level 56

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -9,7 +9,7 @@ local Movement  = require("utils.movement")
 local Targeting = require("utils.targeting")
 
 return {
-    _version              = "2.0 - Project Lazarus",
+    _version              = "2.1 - Project Lazarus",
     _author               = "Algar",
     ['ModeChecks']        = {
         IsHealing = function() return Config:GetSetting('DoHeals') end,
@@ -50,6 +50,7 @@ return {
     },
     ['AbilitySets']       = {
         ['PredatorBuff'] = {          -- Groupv2 Atk Buff
+            "Snarl of the Predator",  -- Level 71 Laz Custom
             "Howl of the Predator",   -- Level 69
             "Spirit of the Predator", -- Level 64
             "Call of the Predator",   -- Level 60
@@ -70,17 +71,20 @@ return {
             "Skin like Wood",         -- Level 7
         },
         ['EyeBuff'] = {               -- Self Archery Buff
+            "Eyes of the Drake",      -- Level 71 Laz Custom
             "Eyes of the Hawk",       -- Level 70 Laz Custom
             "Eyes of the Owl",        -- Level 65
             "Eyes of the Eagle",      -- Level 59 Laz Custom
         },
         ['FireNukeT1'] = {            -- ST Fire DD, Timer 1, 30s Recast
+            "Embers of the Delve",    -- Level 71 Laz Custom
             "Hearth Embers",          -- Level 69
             "Sylvan Burn",            -- Level 65
             "Call of Flame",          -- Level 49
             "Flaming Arrow",          -- Level 29
         },
         ['ColdNukeT2'] = {            -- ST Cold DD, Timer 2, 30s Recast
+            "Frost of the Ascent",    -- Level 71 Laz Custom
             "Frost Wind",             -- Level 68
             "Icewind",                -- Level 52
         },
@@ -95,6 +99,7 @@ return {
             "Burning Arrow",          -- Level 39
         },
         ['DDProc'] = {
+            "Call of Storms",    -- Level 71 Laz Custom
             "Call of Lightning", -- Level 70, Double damage against humanoids on Laz
             "Cry of Thunder",    -- Level 65
             "Call of Ice",       -- Level 58
@@ -106,6 +111,7 @@ return {
         --     "Nature's Rebuke", -- Level 64
         -- },
         ['SelfBuff'] = {
+            "Ward of the Stalker",    -- Level 71 Laz Custom
             "Ward of the Hunter",     -- Level 70
             "Protection of the Wild", -- Level 65
             "Warder's Protection",    -- Level 60
@@ -116,6 +122,7 @@ return {
             "Hail of Arrows",         -- Level 65
         },
         ['FocusedHail'] = {           -- ST multihit archery attack
+            -- "Ancient: Focused Barrage of Arrows", -- Level 71 Laz Custom, verify existence and source
             "Focused Hail of Arrows", -- Level 69 Laz Custom
         },
         ['Dispel'] = {
@@ -125,8 +132,9 @@ return {
             "Cancel Magic",     -- Level 30
         },
         ['Heartshot'] = {
-            "Heartslit", -- Level 68 Laz Custom
-            "Heartshot", -- Level 65
+            "Heartshatter", -- Level 71 Laz Custom
+            "Heartslit",    -- Level 68 Laz Custom
+            "Heartshot",    -- Level 65
         },
         ['RegenBuff'] = {
             "Hunter's Vigor",        -- Level 68
@@ -143,20 +151,22 @@ return {
             "Thistlecoat",           -- Level 13
         },
         ['GuardBuff'] = {            -- ST AC DS Buff
+            "Guard of Thundercrest", -- Level 71 Laz Custom
             "Guard of the Earth",    -- Level 67
             "Call of the Rathe",     -- Level 62
             "Call of Earth",         -- Level 50
             "Riftwind's Protection", -- Level 25
         },
         ['HealSpell'] = {
-            "Sylvan Water",    -- Level 67
-            "Sylvan Light",    -- Level 65
-            "Chloroblast",     -- Level 62
-            "Greater Healing", -- Level 57
-            "Healing",         -- Level 38
-            "Light Healing",   -- Level 21
-            "Minor Healing",   -- Level 8
-            "Salve",           -- Level 1
+            "Swift Salve of the Stillmoon", -- Level 71 Laz Custom
+            "Sylvan Water",                 -- Level 67
+            "Sylvan Light",                 -- Level 65
+            "Chloroblast",                  -- Level 62
+            "Greater Healing",              -- Level 57
+            "Healing",                      -- Level 38
+            "Light Healing",                -- Level 21
+            "Minor Healing",                -- Level 8
+            "Salve",                        -- Level 1
         },
         ['SwarmDot'] = {
             "Locust Swarm",      -- Level 67
@@ -167,6 +177,7 @@ return {
             "Stinging Swarm",    -- Level 25
         },
         ['KickDisc'] = {         -- 2-hit kick attack
+            -- "Jolting Thunderkicks", -- Level 71 Laz Custom, verify existence and source
             "Jolting Snapkicks", -- Level 66
         },
         ['Bullseye'] = {
@@ -329,6 +340,10 @@ return {
         },
     },
     ['Helpers']           = {
+        HaveSelfWard = function(self)
+            local ward = Core.GetResolvedActionMapItem('SelfBuff')
+            return ward and Casting.IHaveBuff(ward) or false
+        end,
         rangedNav = function(reason)
             if Config:GetSetting('DoMelee') then return false end
             if (Globals.AutoTargetID or 0) == 0 then return false end
@@ -624,7 +639,7 @@ return {
                 name = "PredatorBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GroupBuffCheck(spell, target) and not (Targeting.TargetIsMyself(target) and mq.TLO.Me.Buff("Ward of the Hunter")())
+                    return Casting.GroupBuffCheck(spell, target) and not (Targeting.TargetIsMyself(target) and self.Helpers.HaveSelfWard(self))
                 end,
             },
             {
@@ -632,14 +647,14 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoStrengthBuff') then return false end
-                    return Casting.GroupBuffCheck(spell, target) and not (Targeting.TargetIsMyself(target) and mq.TLO.Me.Buff("Ward of the Hunter")())
+                    return Casting.GroupBuffCheck(spell, target) and not (Targeting.TargetIsMyself(target) and self.Helpers.HaveSelfWard(self))
                 end,
             },
             {
                 name = "GuardBuff",
                 type = "Spell",
                 cond = function(self, spell, target)
-                    return Casting.GroupBuffCheck(spell, target) and not (Targeting.TargetIsMyself(target) and mq.TLO.Me.Buff("Ward of the Hunter")())
+                    return Casting.GroupBuffCheck(spell, target) and not (Targeting.TargetIsMyself(target) and self.Helpers.HaveSelfWard(self))
                 end,
             },
             {

--- a/class_configs/Project Lazarus/rog_class_config.lua
+++ b/class_configs/Project Lazarus/rog_class_config.lua
@@ -9,7 +9,7 @@ local Strings   = require("utils.strings")
 local Targeting = require("utils.targeting")
 
 return {
-    _version          = "2.1 - Project Lazarus",
+    _version          = "2.2 - Project Lazarus",
     _author           = "Derple, Algar, mackal",
     ['Modes']         = {
         'DPS',
@@ -56,6 +56,7 @@ return {
     },
     ['AbilitySets']   = {
         ['ThiefBuff'] = {
+            "Outlaw's Glare", -- Level 71 Laz Custom
             "Brigand's Gaze", -- Level 70 Laz Custom
             "Thief's Eyes",   -- Level 65
         },
@@ -63,13 +64,16 @@ return {
             "Kinesthetics Discipline", -- Level 57
         },
         ['Duelist'] = {
-            "Duelist Discipline", -- Level 59
+            "Assailant Discipline", -- Level 71 Laz Custom
+            "Duelist Discipline",   -- Level 59
         },
         ['ChanceDisc'] = {
-            "Twisted Chance Discipline", -- Level 65
-            "Deadeye Discipline",        -- Level 54
+            "Twisted Fortune Discipline", -- Level 71 Laz Custom
+            "Twisted Chance Discipline",  -- Level 65
+            "Deadeye Discipline",         -- Level 54
         },
         ['Frenzied'] = {
+            "Frenetic Stabbing Discipline", -- Level 71 Laz Custom
             "Frenzied Stabbing Discipline", -- Level 70
         },
         ['SneakAttack'] = {
@@ -82,13 +86,16 @@ return {
             "Sneak Attack",          -- Level 20
         },
         ['FellStrike'] = {
+            -- "Ancient: Incursion", -- Level 71 Laz Custom, verify existence and source
             "Assault", -- Level 70, on Laz
         },
         ['Pinpoint'] = {
+            "Pinpoint Weakness",      -- Level 71 Laz Custom
             "Pinpoint Vulnerability", -- Level 69, on Laz
         },
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70 Laz Custom
+            "Fourth Wind Discipline", -- Level 71 Laz Custom
+            "Third Wind Discipline",  -- Level 70 Laz Custom
             -- "Second Wind",        -- Level 65
         },
         ['CADisc'] = {
@@ -101,7 +108,14 @@ return {
             "Deadly Precision Discipline", -- Level 63
         },
         ['Nimble'] = {
+            "Lithe Discipline",  -- Level 71 Laz Custom
             "Nimble Discipline", -- Level 55
+        },
+        ['ReprisalDisc'] = {     -- Manual use only for now, reprisal does not fire unless the rune is broken
+            "Arcane Reprisal",   -- Level 71 Laz Custom
+        },
+        ['DaggerThrow'] = {
+            "Vigorous Dagger Throw", -- Level 71 Laz Custom
         },
     },
     ['RotationOrder'] = {
@@ -284,6 +298,10 @@ return {
                 type = "Disc",
             },
             {
+                name = "DaggerThrow",
+                type = "Disc",
+            },
+            {
                 name = "Twisted Shank",
                 type = "AA",
             },
@@ -315,7 +333,8 @@ return {
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35 and not mq.TLO.Me.Buff("Nimble Effect")()
+                    local nimble = Core.GetResolvedActionMapItem('Nimble')
+                    return mq.TLO.Me.PctHPs() < 35 and not (nimble and Casting.IHaveBuff(nimble.Trigger(1)))
                 end,
             },
             {

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -78,7 +78,7 @@ local Tooltips     = {
 }
 
 local _ClassConfig = {
-    _version          = "2.5 - Project Lazarus",
+    _version          = "2.6 - Project Lazarus",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -153,9 +153,10 @@ local _ClassConfig = {
     },
     ['AbilitySets']   = {
         ['Mantle'] = {
-            "Soul Shield", -- Level 69
-            "Soul Guard",  -- Level 61
-            "Ichor Guard", -- Level 56, Timer 5
+            "Soul Carapace", -- Level 71 Laz Custom
+            "Soul Shield",   -- Level 69
+            "Soul Guard",    -- Level 61
+            "Ichor Guard",   -- Level 56, Timer 5
         },
         ['BlockDisc'] = {
             "Rampart Discipline",    -- Level 70 Laz Custom
@@ -176,20 +177,21 @@ local _ClassConfig = {
             "Leering Corpse", -- Level 7
         },
         ['PetHaste'] = {
-            "Rune of Decay",         -- Level 69
-            "Augmentation of Death", -- Level 64
-            "Augment Death",         -- Level 60
-            "Strengthen Death",      -- Level 29
+            "Rune of Decay",          -- Level 69
+            "Augmentation of Death",  -- Level 64
+            "Augment Death",          -- Level 60
+            "Strengthen Death",       -- Level 29
         },
-        ['Shroud'] = {               -- HP Tap Proc
-            "Shroud of Discord",     -- Level 67, -- Buff Slot 1 <
-            "Black Shroud",          -- Level 65
-            "Shroud of Chaos",       -- Level 63
-            "Shroud of Death",       -- Level 55
+        ['Shroud'] = {                -- HP Tap Proc
+            "Shroud of the Accursed", -- Level 71 Laz Custom
+            "Shroud of Discord",      -- Level 67, -- Buff Slot 1 <
+            "Black Shroud",           -- Level 65
+            "Shroud of Chaos",        -- Level 63
+            "Shroud of Death",        -- Level 55
         },
-        ['Mental'] = {               -- Mana Tap Proc
-            "Mental Horror",         -- Level 65, --Buff Slot 1 >
-            "Mental Corruption",     -- Level 52
+        ['Mental'] = {                -- Mana Tap Proc
+            "Mental Horror",          -- Level 65, --Buff Slot 1 >
+            "Mental Corruption",      -- Level 52
         },
         ['Skin'] = {
             "Decrepit Skin", -- Level 70
@@ -198,9 +200,10 @@ local _ClassConfig = {
             "Banshee Aura", -- Level 54
         },
         ['CloakHP'] = {
-            "Cloak of Discord",    -- Level 70
-            "Cloak of Luclin",     -- Level 65
-            "Cloak of the Akheva", -- Level 60
+            "Cloak of the Corrupter", -- Level 71 Laz Custom
+            "Cloak of Discord",       -- Level 70
+            "Cloak of Luclin",        -- Level 65
+            "Cloak of the Akheva",    -- Level 60
         },
         ['CallAtk'] = {
             "Call of Darkness", -- Level 54
@@ -214,7 +217,8 @@ local _ClassConfig = {
             "Blood of Pain",    -- Level 41
         },
         ['AEPoisonDot'] = {
-            "Blood of Inruku", -- Level 68
+            "Blood of the Harbinger", -- Level 71 Laz Custom
+            "Blood of Inruku",        -- Level 68
         },
         ['SpearNuke'] = {
             "Spear of Plague",  -- Level 54
@@ -223,6 +227,7 @@ local _ClassConfig = {
             "Spike of Disease", -- Level 1
         },
         ['AESpearNuke'] = {
+            -- "Ancient: Spear of Lanys", -- Level 71 Laz Custom, verify existence and source
             "Spear of Muram", -- Level 69
             "Miasmic Spear",  -- Level 65
             "Spear of Decay", -- Level 64
@@ -233,6 +238,7 @@ local _ClassConfig = {
             "Vampiric Curse", -- Level 57
         },
         ['LifeTap'] = {
+            "Touch of the Shadows",  -- Level 71 Laz Custom
             "Touch of the Devourer", -- Level 70
             "Touch of Inruku",       -- Level 67
             "Touch of Innoruuk",     -- Level 65
@@ -247,6 +253,7 @@ local _ClassConfig = {
             "Lifetap",               -- Level 8
         },
         ['LifeTap2'] = {
+            "Touch of the Shadows",  -- Level 71 Laz Custom
             "Touch of the Devourer", -- Level 70
             "Touch of Inruku",       -- Level 67
             "Touch of Innoruuk",     -- Level 65
@@ -261,6 +268,7 @@ local _ClassConfig = {
             "Lifetap",               -- Level 8
         },
         ['AELifeTap'] = {
+            "Grasp of Ju'rek", -- Level 71 Laz Custom
             "Grasp of Lhranc", -- Level 69 Laz Custom
         },
         ['BiteTap'] = {
@@ -270,22 +278,25 @@ local _ClassConfig = {
             "Zevfeer's Bite",         -- Level 62
         },
         ['Terror'] = {
-            "Terror of Discord",  -- Level 67
-            "Terror of Thule",    -- Level 63
-            "Terror of Terris",   -- Level 59
-            "Terror of Death",    -- Level 53
-            "Terror of Shadows",  -- Level 42
-            "Terror of Darkness", -- Level 33
+            "Terror of Lavaspinner's Lair", -- Level 71 Laz Custom
+            "Terror of Discord",            -- Level 67
+            "Terror of Thule",              -- Level 63
+            "Terror of Terris",             -- Level 59
+            "Terror of Death",              -- Level 53
+            "Terror of Shadows",            -- Level 42
+            "Terror of Darkness",           -- Level 33
         },
         ['Terror2'] = {
-            "Terror of Discord",  -- Level 67
-            "Terror of Thule",    -- Level 63
-            "Terror of Terris",   -- Level 59
-            "Terror of Death",    -- Level 53
-            "Terror of Shadows",  -- Level 42
-            "Terror of Darkness", -- Level 33
+            "Terror of Lavaspinner's Lair", -- Level 71 Laz Custom
+            "Terror of Discord",            -- Level 67
+            "Terror of Thule",              -- Level 63
+            "Terror of Terris",             -- Level 59
+            "Terror of Death",              -- Level 53
+            "Terror of Shadows",            -- Level 42
+            "Terror of Darkness",           -- Level 33
         },
         ['PowerTapAC'] = {
+            "Theft of Misery", -- Level 71 Laz Custom
             "Theft of Agony",  -- Level 70
             "Theft of Pain",   -- Level 68
             "Aura of Pain",    -- Level 63
@@ -314,6 +325,7 @@ local _ClassConfig = {
             "Disease Cloud",     -- Level 5
         },
         ['HateBuff'] = {         --9 minute reuse makes these somewhat ridiculous to gem on the fly.
+            "Voice of Emoush",   -- Level 71 Laz Custom
             "Voice of Innoruuk", -- Level 70, 15% hate, 150pt DS (slot 9), 15% decrease DS Mit (VoT AA is still better for tanking at 24%, but they stack. DS smexy) Laz Custom
             "Voice of Thule",    -- Level 65, 12% hate
             "Voice of Terris",   -- Level 60, 10% hate

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -7,7 +7,7 @@ local Globals      = require("utils.globals")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version              = "3.0 - Project Lazarus",
+    _version              = "3.1 - Project Lazarus",
     _author               = "Algar, Derple",
     ['ModeChecks']        = {
         IsHealing = function() return true end,
@@ -131,10 +131,11 @@ local _ClassConfig = {
     ['AbilitySets']       = {
         ['GroupFocusSpell'] = {
             -- Focus Spell - Group Spells will be used on everyone
-            "Talisman of Wunshi",   -- Level 70, - Group
-            "Focus of the Seventh", -- Level 65, - Group
-            "Khura's Focusing",     -- Level 60, - Group
-            "Infusion of Spirit",   -- Level 49, Str/Dex/Sta, can use HP buff. Not sure if this is the final home for this one or not.
+            "Talisman of the Stillmoon", -- Level 71 Laz Custom
+            "Talisman of Wunshi",        -- Level 70, - Group
+            "Focus of the Seventh",      -- Level 65, - Group
+            "Khura's Focusing",          -- Level 60, - Group
+            "Infusion of Spirit",        -- Level 49, Str/Dex/Sta, can use HP buff. Not sure if this is the final home for this one or not.
         },
         ['RunSpeedBuff'] = {
             -- Run Speed Buff - 9 - 74
@@ -152,6 +153,7 @@ local _ClassConfig = {
             "Talisman of Celerity",    -- Level 64
         },
         ['Unification'] = {            -- Many buffs combined: 75 Sta, 50 sta cap, 7% evasion, 5% damage
+            "Talisman of Coalescence", -- Level 71 Laz Custom
             "Talisman of Unification", -- Level 70 Laz Custom
         },
         ['LowLvlStaBuff'] = {
@@ -254,13 +256,15 @@ local _ClassConfig = {
             "Listless Power",    -- Level 29, Definitely not worth
         },
         ['MeleeProcBuff'] = {
-            "Talisman of the Panther", -- Level 71
+            "Talisman of the Cougar",  -- Level 71 Laz Custom
+            "Talisman of the Panther", -- Level 70
             "Spirit of the Panther",   -- Level 69
             "Spirit of the Leopard",   -- Level 61
             "Spirit of the Jaguar",    -- Level 57
             "Spirit of the Puma",      -- Level 50
         },
         ['SlowProcBuff'] = {
+            "Shadowy Sloth",   -- Level 71 Laz Custom
             "Lingering Sloth", -- Level 68
         },
         ['RezSpell'] = {
@@ -270,6 +274,7 @@ local _ClassConfig = {
             'Reanimation',    -- Level 29 Laz Custom
         },
         ['HealSpell'] = {
+            -- "Ancient: Emoush's Mending", -- Level 71 Laz Custom, verify existence and source
             "Ancient: Wilslik's Mending", -- Level 70
             "Yoppa's Mending",            -- Level 68
             "Daluda's Mending",           -- Level 65
@@ -296,18 +301,19 @@ local _ClassConfig = {
             "Ghost of Renewal", -- Level 70
         },
         ['SnareHot'] = {
-            "Transcendent Torpor", -- Level 70 Laz Custom
-            "Torpor",              -- Level 60
-            "Stoicism",            -- Level 44
+            "Transcendental Torpor", -- Level 71 Laz Custom
+            "Transcendent Torpor",   -- Level 70 Laz Custom
+            "Torpor",                -- Level 60
+            "Stoicism",              -- Level 44
         },
-        ['SingleHot'] = {          -- some elixirs given to shm/dru on laz
-            "Spiritual Serenity",  -- Level 70
-            "Breath of Trushar",   -- Level 65
-            "Quiescence",          -- Level 65
+        ['SingleHot'] = {            -- some elixirs given to shm/dru on laz
+            "Spiritual Serenity",    -- Level 70
+            "Breath of Trushar",     -- Level 65
+            "Quiescence",            -- Level 65
             -- "Celestial Elixir", -- Level 65, Quiescence same level and better
-            "Celestial Healing",   -- Level 49
-            "Celestial Health",    -- Level 35
-            "Celestial Remedy",    -- Level 25
+            "Celestial Healing",     -- Level 49
+            "Celestial Health",      -- Level 35
+            "Celestial Remedy",      -- Level 25
         },
         ['CanniSpell'] = {
             -- Convert Health to Mana - Level  23 -
@@ -349,6 +355,7 @@ local _ClassConfig = {
         },
         ['CurseDot'] = {
             -- Curse Dot 1 Stacking: Curse - Long Dot(30s) - Level 34+
+            "Curse of Emoush",  -- Level 71 Laz Custom
             "Curse of Sisslak", -- Level 69
             "Bane",             -- Level 64
             "Anathema",         -- Level 54
@@ -357,6 +364,7 @@ local _ClassConfig = {
         },
         ['SaryrnDot'] = {
             -- Stacking: Blood of Saryrn - Long Dot(42s) - Level 8+
+            "Blood of Volkara",         -- Level 71 Laz Custom
             "Nectar of Pain",           -- Level 70
             "Blood of Saryrn",          -- Level 65
             "Ancient: Scourge of Nife", -- Level 60
@@ -368,19 +376,26 @@ local _ClassConfig = {
         },
         ['UltorDot'] = {
             ---, Stacking: Breath of Ultor - Long Dot(84s) - Level 4+
-            "Breath of Wunshi",      -- Level 67
-            "Breath of Ultor",       -- Level 64
-            "Pox of Bertoxxulous",   -- Level 59
-            "Plague",                -- Level 49
-            "Scourge",               -- Level 31
-            "Affliction",            -- Level 19
-            "Sicken",                -- Level 4
+            "Breath of Shadows",       -- Level 71 Laz Custom
+            "Breath of Wunshi",        -- Level 67
+            "Breath of Ultor",         -- Level 64
+            "Pox of Bertoxxulous",     -- Level 59
+            "Plague",                  -- Level 49
+            "Scourge",                 -- Level 31
+            "Affliction",              -- Level 19
+            "Sicken",                  -- Level 4
         },
-        ['AEDot'] = {                -- do homework for Laz
-            "Blood of Yoppa",        -- Level 70
+        ['AEDot'] = {                  -- do homework for Laz
+            "Blood of Yoppa",          -- Level 70
         },
-        ['PetSpell'] = {             --We need to add handling for commune to get the mammoth/etc
+        ['PetSpell'] = {               --We need to add handling for commune to get the mammoth/etc
             -- Pet Spell - 32+
+            "Gray Elephant Companion", -- Level 71 Laz Custom
+            -- "Cunning Lioness Companion", -- Level 71 Laz Custom
+            -- "Black Scorpion Companion",  -- Level 71 Laz Custom
+            -- "Wooly Rhino Companion",     -- Level 71 Laz Custom
+            -- "Blood Raptor Companion",    -- Level 71 Laz Custom
+            -- "Sea Cow Companion",         -- Level 71 Laz Custom
             "Commune with the Wild", -- Level 70 Laz Custom
             "Farrel's Companion",    -- Level 67
             "True Spirit",           -- Level 61

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -10,7 +10,7 @@ local Logger       = require("utils.logger")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version          = "3.0 - Project Lazarus",
+    _version          = "3.1 - Project Lazarus",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -73,24 +73,29 @@ local _ClassConfig = {
         },
     },
     ['AbilitySets']   = {
-        ['StandDisc'] = {           -- Timer 2
-            "Stonewall Discipline", -- Level 65, no lost movement on laz, more mitigation than defensive
-            "Defensive Discipline", -- Level 55
-            "Evasive Discipline",   -- Level 52
+        ['StandDisc'] = {             -- Timer 1
+            "Final Stand Discipline", -- Level 71 Laz Custom
+            "Stonewall Discipline",   -- Level 65, no lost movement on laz, more mitigation than defensive
+            "Defensive Discipline",   -- Level 55
+            "Evasive Discipline",     -- Level 52
         },
-        ['Fortitude'] = {           -- Timer 3
-            "Fortitude Discipline", -- Level 59
-            "Furious Discipline",   -- Level 56
+        ['Fortitude'] = {             -- Timer 2
+            -- "Ancient: Impervious Discipline", -- Level 71 Laz Custom, verify existence and source
+            "Fortitude Discipline",   -- Level 59
+            "Furious Discipline",     -- Level 56
         },
-        ['GroupACBuff'] = {         -- Has Commanding Voice (Dodge Buff) baked in
-            "Field Armorer",        -- Level 65
+        ['GroupACBuff'] = {           -- Has Commanding Voice (Dodge Buff) baked in
+            "Field Conqueror",        -- Level 71 Laz Custom
+            "Field Armorer",          -- Level 65
         },
         ['AEBlades'] = {
+            "Maelstrom Blade", -- Level 71 Laz Custom
             "Vortex Blade",    -- Level 69
             "Cyclone Blade",   -- Level 65
             "Whirlwind Blade", -- Level 61
         },
         ['AddHate'] = {
+            "Roaring Hatred",        -- Level 71 Laz Custom
             "Ancient: Chaos Cry",    -- Level 65
             "Bellow of the Mastruq", -- Level 65
             "Incite",                -- Level 63
@@ -99,21 +104,25 @@ local _ClassConfig = {
             "Provoke",               -- Level 20
         },
         ['AbsorbTaunt'] = {
+            "Jeer", -- Level 71 Laz Custom
             "Mock", -- Level 65
         },
         ['EndRegen'] = {
-            "Third Wind Discipline", -- Level 70, also does HP Laz Custom
-            "Second Wind",           -- Level 65
+            "Fourth Wind Discipline", -- Level 71 Laz Custom
+            "Third Wind Discipline",  -- Level 70, also does HP Laz Custom
+            "Second Wind",            -- Level 65
         },
         ['AuraBuff'] = {
-            "Champion's Aura", -- Level 70
-            "Myrmidon's Aura", -- Level 55
+            "Vanquisher's Aura", -- Level 71 Laz Custom
+            "Champion's Aura",   -- Level 70
+            "Myrmidon's Aura",   -- Level 55
         },
         ['Attention'] = {
             "Unyielding Attention", -- Level 71
             "Undivided Attention",  -- Level 65
         },
         ['Onslaught'] = {
+            -- "Ancient: Malicious Onslaught", -- Level 71 Laz Custom, verify existence and source
             "Brutal Onslaught Discipline", -- Level 68
             "Savage Onslaught Discipline", -- Level 65
         },
@@ -125,10 +134,16 @@ local _ClassConfig = {
             "Throat Jab", -- Level 69
         },
         ['Flaunt'] = {
-            "Flaunt",                      -- Level 70 Laz Custom
+            "Flaunt", -- Level 70 Laz Custom
         },
-        ['ShockDisc'] = {                  -- Timer 7, defensive stun proc
-            "Shocking Defense Discipline", -- Level 70
+        -- ['ShockDisc'] = {                  -- Timer 6, defensive stun proc
+        --     "Shocking Defense Discipline", -- Level 70
+        -- },
+        ['Scowl'] = {                    -- Timer 8, opt-in taunt + melee absorb via UseScowl (shares timer with AddHate)
+            "Scowl",                     -- Level 71 Laz Custom
+        },
+        ['MaxEffort'] = {                -- Timer 6, endurance-fueled melee absorb
+            "Maximum Effort Discipline", -- Level 71 Laz Custom
         },
     },
     ['AASets']        = {
@@ -332,8 +347,17 @@ local _ClassConfig = {
                 type = "AA",
             },
             {
+                name = "Scowl",
+                type = "Disc",
+                load_cond = function(self) return Config:GetSetting('UseScowl') and Core.GetResolvedActionMapItem('Scowl') end,
+                cond = function(self, discSpell)
+                    return Casting.DetSpellCheck(discSpell)
+                end,
+            },
+            {
                 name = "AddHate",
                 type = "Disc",
+                load_cond = function(self) return not (Config:GetSetting('UseScowl') and Core.GetResolvedActionMapItem('Scowl')) end,
                 cond = function(self, discSpell)
                     return Casting.DetSpellCheck(discSpell)
                 end,
@@ -366,8 +390,17 @@ local _ClassConfig = {
                 type = "AA",
             },
             {
+                name = "Scowl",
+                type = "Disc",
+                load_cond = function(self) return Config:GetSetting('UseScowl') and Core.GetResolvedActionMapItem('Scowl') end,
+                cond = function(self, discSpell)
+                    return Casting.DetSpellCheck(discSpell)
+                end,
+            },
+            {
                 name = "AddHate",
                 type = "Disc",
+                load_cond = function(self) return not (Config:GetSetting('UseScowl') and Core.GetResolvedActionMapItem('Scowl')) end,
                 cond = function(self, discSpell)
                     return Casting.DetSpellCheck(discSpell)
                 end,
@@ -492,6 +525,13 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName)
                     return self.Helpers.DefenseBuffCheck(self)
+                end,
+            },
+            {
+                name = "MaxEffort",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Casting.NoDiscActive() and self.Helpers.DefenseBuffCheck(self)
                 end,
             },
             {
@@ -734,6 +774,16 @@ local _ClassConfig = {
             Tooltip = "Use AE hatred Discs and AA (see FAQ for specifics).",
             RequiresLoadoutChange = true,
             Default = true,
+        },
+        ['UseScowl']        = {
+            DisplayName = "Use Scowl",
+            Group = "Abilities",
+            Header = "Tanking",
+            Category = "Hate Tools",
+            Index = 102,
+            Tooltip = "Use Scowl for a taunt and melee absorb instead of your timer 8 hate disc.",
+            RequiresLoadoutChange = true,
+            Default = false,
         },
 
         --Defenses

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -13,7 +13,7 @@ local Logger    = require("utils.logger")
 local Targeting = require("utils.targeting")
 
 return {
-    _version          = "2.0 - Project Lazarus",
+    _version          = "2.1 - Project Lazarus",
     _author           = "Derple, Algar",
     ['Modes']         = {
         'DPS',
@@ -79,12 +79,15 @@ return {
         --     "Claw of Frost", -- Level 61
         -- },
         ['FireEtherealNuke'] = {
+            "Ether Blaze", -- Level 71 Laz Custom
             "Ether Flame", -- Level 70
         },
         ['ChaosNuke'] = {
+            -- "Ancient: Chaos Elements", -- Level 71 Laz Custom, verify existence and source
             "Chaos Flame", -- Level 70
         },
         ['WildNuke'] = {
+            "Wildmagic Salvo", -- Level 71 Laz Custom
             "Wildmagic Burst", -- Level 68
         },
         ['FireNuke'] = {
@@ -148,16 +151,17 @@ return {
             "Tishan's Clash",   -- Level 19
         },
         ['SelfHPBuff'] = {
-            "Ether Shield",         -- Level 66
-            "Shield of Maelin",     -- Level 64
-            "Shield of the Arcane", -- Level 61
-            "Shield of the Magi",   -- Level 54
-            "Arch Shielding",       -- Level 44
-            "Greater Shielding",    -- Level 33
-            "Major Shielding",      -- Level 23
-            "Shielding",            -- Level 15
-            "Lesser Shielding",     -- Level 6
-            "Minor Shielding",      -- Level 1
+            "Bolster of the Sorcerer", -- Level 71 Laz Custom
+            "Ether Shield",            -- Level 66
+            "Shield of Maelin",        -- Level 64
+            "Shield of the Arcane",    -- Level 61
+            "Shield of the Magi",      -- Level 54
+            "Arch Shielding",          -- Level 44
+            "Greater Shielding",       -- Level 33
+            "Major Shielding",         -- Level 23
+            "Shielding",               -- Level 15
+            "Lesser Shielding",        -- Level 6
+            "Minor Shielding",         -- Level 1
         },
         ['FamiliarBuff'] = {
             "Greater Familiar", -- Level 60
@@ -166,8 +170,12 @@ return {
             "Minor Familiar",   -- Level 25
         },
         ['SelfRune1'] = {
-            "Ether Skin",   -- Level 68
-            "Force Shield", -- Level 63
+            "Supernal Skin", -- Level 71 Laz Custom
+            "Ether Skin",    -- Level 68
+            "Force Shield",  -- Level 63
+        },
+        ['ArcaneSanctuary'] = {
+            "Arcane Sanctuary", -- Level 71 Laz Custom
         },
         -- ['Dispel'] = {
         --     "Annul Magic",   -- Level 53
@@ -191,7 +199,8 @@ return {
             "Lesser Evacuate", -- Level 18
         },
         ['HarvestSpell'] = {
-            "Harvest", -- Level 32
+            "Serenity Harvest", -- Level 71 Laz Custom
+            "Harvest",          -- Level 32
         },
         ['JoltSpell'] = {
             "Ancient: Greater Concussion", -- Level 60
@@ -261,13 +270,18 @@ return {
         ['MagicJyll'] = {
             "Jyll's Static Pulse", -- Level 53
         },
-        ['ManaWeave'] = {
-            "Mana Weave", -- Level 69
+        ['WeaveNuke'] = {
+            "Ethereal Weave", -- Level 71 Laz Custom
+            "Mana Weave",     -- Level 69
         },
-        -- ['SwarmPet'] = {
-        --     -- "Solist's Frozen Sword", -- Level 69, Bugged, does not attack on Laz/Emu
-        --     "Flaming Sword of Xuzl", -- Level 59, homework
-        -- },
+        ['AEStunNuke'] = {
+            "Eruption of Telakemara", -- Level 71 Laz Custom
+        },
+        ['SwarmPet'] = {
+            "Evoker's Pyromantic Blade", -- Level 71 Laz Custom
+            -- "Solist's Frozen Sword", -- Level 69, Bugged, does not attack on Laz/Emu
+            -- "Flaming Sword of Xuzl", -- Level 59, homework
+        },
     },
     ['AASets']        = {
         ['Devastation'] = {
@@ -305,7 +319,11 @@ return {
             return Targeting.GetTargetDistance() >= Config:GetSetting('RainDistance') and Targeting.MobNotLowHP(target)
         end,
         HasWeaveRotation = function()
-            return Core.GetResolvedActionMapItem('ManaWeave') and Core.GetResolvedActionMapItem('FireEtherealNuke')
+            return Core.GetResolvedActionMapItem('WeaveNuke') and Core.GetResolvedActionMapItem('FireEtherealNuke')
+        end,
+        UseHarvestSpell = function()
+            local harvest = Core.GetResolvedActionMapItem('HarvestSpell')
+            return (harvest and harvest.RankName.Name() == "Serenity Harvest") or not Casting.CanUseAA("Harvest of Druzzil")
         end,
     },
     ['RotationOrder'] = {
@@ -358,7 +376,7 @@ return {
             end,
         },
         {
-            name = 'DPS(Level70)',
+            name = 'DPS(HighLevel)',
             state = 1,
             steps = 1,
             load_cond = function(self) return self.Helpers.HasWeaveRotation() end,
@@ -587,7 +605,7 @@ return {
             {
                 name = "HarvestSpell",
                 type = "Spell",
-                load_cond = function(self) return not Casting.CanUseAA("Harvest of Druzzil") end,
+                load_cond = function(self) return self.Helpers.UseHarvestSpell() end,
                 allowDead = true,
                 cond = function(self)
                     return mq.TLO.Me.PctMana() < Config:GetSetting('CombatHarvestManaPct')
@@ -600,13 +618,26 @@ return {
                 type = "AA",
             },
         },
-        ['DPS(Level70)'] = {
+        ['DPS(HighLevel)'] = {
             {
-                name = "ManaWeave",
+                name = "WeaveNuke",
                 type = "Spell",
                 cond = function(self, spell, target)
                     return not Casting.IHaveBuff("Weave of Power")
                 end,
+            },
+            {
+                name = "AEStunNuke",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoAEStunNuke') end,
+                cond = function(self, spell, target)
+                    return Combat.AETargetCheck(true)
+                end,
+            },
+            {
+                name = "SwarmPet",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoSwarmPet') end,
             },
             {
                 name = "ChaosNuke",
@@ -692,6 +723,11 @@ return {
         },
         ['DPS(PBAE)'] = {
             {
+                name = "AEStunNuke",
+                type = "Spell",
+                allowDead = true,
+            },
+            {
                 name = "PBTimer4",
                 type = "Spell",
                 allowDead = true,
@@ -741,6 +777,14 @@ return {
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
+            {
+                name = "ArcaneSanctuary",
+                type = "Spell",
+                active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
+                cond = function(self, spell)
+                    return Casting.SelfBuffCheck(spell)
+                end,
+            },
             { --Familiar AA, will use the first(best) one found
                 name = "FamiliarAA",
                 type = "AA",
@@ -769,7 +813,7 @@ return {
             {
                 name = "HarvestSpell",
                 type = "Spell",
-                load_cond = function(self) return not Casting.CanUseAA("Harvest of Druzzil") end,
+                load_cond = function(self) return self.Helpers.UseHarvestSpell() end,
                 cond = function(self, spell)
                     return Casting.CastReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('HarvestManaPct')
                 end,
@@ -803,7 +847,7 @@ return {
         {
             name = "Default Mode",
             spells = {
-                { name = "ManaWeave",        cond = function(self) return self.Helpers.HasWeaveRotation() end, },
+                { name = "WeaveNuke",        cond = function(self) return self.Helpers.HasWeaveRotation() end, },
                 { name = "FireNuke",         cond = function(self) return not self.Helpers.HasWeaveRotation() and Config:GetSetting('ElementChoice') == 1 end, },
                 { name = "IceNuke",          cond = function(self) return not self.Helpers.HasWeaveRotation() and Config:GetSetting('ElementChoice') == 2 end, },
                 { name = "MagicNuke",        cond = function(self) return not self.Helpers.HasWeaveRotation() and Config:GetSetting('ElementChoice') == 3 end, },
@@ -825,10 +869,12 @@ return {
                     end,
                 },
                 { name = "ChaosNuke",    cond = function(self) return self.Helpers.HasWeaveRotation() end, },
-                { name = "HarvestSpell", cond = function() return not Casting.CanUseAA("Harvest of Druzzil") end, },
+                { name = "HarvestSpell", cond = function(self) return self.Helpers.UseHarvestSpell() end, },
                 { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
                 { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
                 { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
+                { name = "SwarmPet",     cond = function() return Config:GetSetting('DoSwarmPet') end, },
+                { name = "AEStunNuke",   cond = function() return Config:GetSetting('DoAEStunNuke') end, },
                 { name = "PBTimer4",     cond = function() return Core.IsModeActive('PBAE') end, },
                 { name = "FireJyll",     cond = function() return Core.IsModeActive('PBAE') end, },
                 { name = "IceJyll",      cond = function() return Core.IsModeActive('PBAE') end, },
@@ -904,6 +950,26 @@ return {
             Min = 0,
             Max = 100,
         },
+        ['DoAEStunNuke']         = {
+            DisplayName = "Do AE Stun Nuke",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 105,
+            Tooltip = "Use your targeted AE stun nuke on clustered mobs during your main rotation.",
+            RequiresLoadoutChange = true,
+            Default = true,
+        },
+        ['DoSwarmPet']           = {
+            DisplayName = "Do Swarm Pet",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "Direct",
+            Index = 106,
+            Tooltip = "Use your swarm pet spell.",
+            RequiresLoadoutChange = true,
+            Default = false,
+        },
 
         -- Utility
         ['JoltAggro']            = {
@@ -969,7 +1035,7 @@ return {
             Index = 102,
             ConfigType = "Advanced",
             Tooltip = "What Mana % to hit before using a harvest spell or aa in Combat.",
-            Default = 60,
+            Default = 40,
             Min = 1,
             Max = 99,
         },


### PR DESCRIPTION
* First pass at level 71 abilities.
* Some spells remain commented until sourcing is verified (mostly Ancients).
* Playtesting for rotation/entry shifting will follow; feedback is reqeuested. The user should be able to reorder anything necessary.