### PR TITLE
Spell/Casting Fixes

### DIFF
--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -963,7 +963,6 @@ local _ClassConfig = {
                 end,
                 load_cond = function(self) return Config:GetSetting('DoSTSlow') and (not Casting.CanUseAA("Turgur's Swarm") or Config:GetSetting('DoDiseaseSlow')) end,
                 type = "Spell",
-                waitReadyTime = function() return Config:GetSetting('DiseaseSlowWaitTime') end,
                 cond = function(self, spell, target)
                     return Casting.DetSpellCheck(spell) and (spell and spell.RankName.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and not Casting.SlowImmuneTarget(target)
                 end,
@@ -1369,7 +1368,7 @@ local _ClassConfig = {
         },
     },
     ['DefaultConfig']     = {
-        ['Mode']                = {
+        ['Mode']              = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -1384,7 +1383,7 @@ local _ClassConfig = {
         },
 
         -- Damage
-        ['DoColdNuke']          = {
+        ['DoColdNuke']        = {
             DisplayName = "Cold Nuke",
             Group = "Abilities",
             Header = "Damage",
@@ -1394,7 +1393,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoPoisonNuke']        = {
+        ['DoPoisonNuke']      = {
             DisplayName = "Poison Nuke",
             Group = "Abilities",
             Header = "Damage",
@@ -1404,7 +1403,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoSaryrnDot']         = {
+        ['DoSaryrnDot']       = {
             DisplayName = "Poison Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1414,7 +1413,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['DoUltorDot']          = {
+        ['DoUltorDot']        = {
             DisplayName = "Disease Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1424,7 +1423,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['DoCurseDot']          = {
+        ['DoCurseDot']        = {
             DisplayName = "Magic Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1434,7 +1433,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['DotNamedOnly']        = {
+        ['DotNamedOnly']      = {
             DisplayName = "Only Dot Named",
             Group = "Abilities",
             Header = "Damage",
@@ -1445,7 +1444,7 @@ local _ClassConfig = {
         },
 
         -- Healing
-        ['DoSingleHot']         = {
+        ['DoSingleHot']       = {
             DisplayName = "Use Single HoT",
             Group = "Abilities",
             Header = "Recovery",
@@ -1456,7 +1455,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['DoSnareHot']          = {
+        ['DoSnareHot']        = {
             DisplayName = "Use Snare HoT",
             Group = "Abilities",
             Header = "Recovery",
@@ -1467,7 +1466,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['KeepPoisonMemmed']    = {
+        ['KeepPoisonMemmed']  = {
             DisplayName = "Mem Cure Poison",
             Group = "Abilities",
             Header = "Recovery",
@@ -1479,7 +1478,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['KeepDiseaseMemmed']   = {
+        ['KeepDiseaseMemmed'] = {
             DisplayName = "Mem Cure Disease",
             Group = "Abilities",
             Header = "Recovery",
@@ -1491,7 +1490,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['KeepCurseMemmed']     = {
+        ['KeepCurseMemmed']   = {
             DisplayName = "Mem Remove Curse",
             Group = "Abilities",
             Header = "Recovery",
@@ -1503,7 +1502,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['KeepCorruptMemmed']   = {
+        ['KeepCorruptMemmed'] = {
             DisplayName = "Mem Cure Corruption",
             Group = "Abilities",
             Header = "Recovery",
@@ -1517,7 +1516,7 @@ local _ClassConfig = {
         },
 
         -- Canni
-        ['DoAACanni']           = {
+        ['DoAACanni']         = {
             DisplayName = "Use AA Canni",
             Group = "Abilities",
             Header = "Recovery",
@@ -1528,7 +1527,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['AACanniManaPct']      = {
+        ['AACanniManaPct']    = {
             DisplayName = "AA Canni Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1540,7 +1539,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['AACanniMinHP']        = {
+        ['AACanniMinHP']      = {
             DisplayName = "AA Canni HP %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1552,7 +1551,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['DoSpellCanni']        = {
+        ['DoSpellCanni']      = {
             DisplayName = "Use Spell Canni",
             Group = "Abilities",
             Header = "Recovery",
@@ -1563,7 +1562,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['SpellCanniManaPct']   = {
+        ['SpellCanniManaPct'] = {
             DisplayName = "Spell Canni Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1575,7 +1574,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['SpellCanniMinHP']     = {
+        ['SpellCanniMinHP']   = {
             DisplayName = "Spell Canni HP %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1587,7 +1586,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['DoCombatCanni']       = {
+        ['DoCombatCanni']     = {
             DisplayName = "Canni in Combat",
             Group = "Abilities",
             Header = "Recovery",
@@ -1599,7 +1598,7 @@ local _ClassConfig = {
         },
 
         -- Buffs
-        ['UseEpic']             = {
+        ['UseEpic']           = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -1613,7 +1612,7 @@ local _ClassConfig = {
             Max = 3,
             ConfigType = "Advanced",
         },
-        ['DoRunSpeed']          = {
+        ['DoRunSpeed']        = {
             DisplayName = "Do Run Speed",
             Group = "Abilities",
             Header = "Buffs",
@@ -1625,7 +1624,7 @@ local _ClassConfig = {
             FAQ = "Why are my buffers in a run speed buff war?",
             Answer = "Many run speed spells freely stack and overwrite each other, you will need to disable Run Speed Buffs on some of the buffers.",
         },
-        ['DoGroupShrink']       = {
+        ['DoGroupShrink']     = {
             DisplayName = "Group Shrink",
             Group = "Abilities",
             Header = "Buffs",
@@ -1638,7 +1637,7 @@ local _ClassConfig = {
             Answer =
             "For simplicity, the check to use it is keyed to the Shaman's height, rather than checking each group member.",
         },
-        ['DoRegenBuff']         = {
+        ['DoRegenBuff']       = {
             DisplayName = "Regen Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -1650,7 +1649,7 @@ local _ClassConfig = {
             FAQ = "Why am I spamming my Group Regen buff?",
             Answer = "Certain Shaman and Druid group regen buffs report cross-stacking. You should deselect the option on one of the PCs if they are grouped together.",
         },
-        ['DoHaste']             = {
+        ['DoHaste']           = {
             DisplayName = "Use Haste",
             Group = "Abilities",
             Header = "Buffs",
@@ -1661,7 +1660,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
         },
-        ['DoMeleeBuff']         = {
+        ['DoMeleeBuff']       = {
             DisplayName = "Use Melee Skill Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -1673,7 +1672,7 @@ local _ClassConfig = {
         },
 
         -- Debuffs
-        ['DoSTMalo']            = {
+        ['DoSTMalo']          = {
             DisplayName = "Do ST Malo",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1683,7 +1682,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoAEMalo']            = {
+        ['DoAEMalo']          = {
             DisplayName = "Do AE Malo",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1693,7 +1692,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoSTSlow']            = {
+        ['DoSTSlow']          = {
             DisplayName = "Do ST Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1704,7 +1703,7 @@ local _ClassConfig = {
             Default = true,
 
         },
-        ['DoAESlow']            = {
+        ['DoAESlow']          = {
             DisplayName = "Do AE Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1714,7 +1713,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['AESlowCount']         = {
+        ['AESlowCount']       = {
             DisplayName = "AE Slow Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1726,7 +1725,7 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['AEMaloCount']         = {
+        ['AEMaloCount']       = {
             DisplayName = "AE Malo Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1738,7 +1737,7 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['DoDiseaseSlow']       = {
+        ['DoDiseaseSlow']     = {
             DisplayName = "Disease Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1752,19 +1751,7 @@ local _ClassConfig = {
             Answer =
             "During early eras of play, a slow that checked against disease resist was added to slow magic-resistant mobs. If selected, this will be used instead of a magic-based slow until the Turgur's AA becomes available.",
         },
-        ['DiseaseSlowWaitTime'] = {
-            DisplayName = "Disease Slow Wait",
-            Group = "Abilities",
-            Header = "Debuffs",
-            Category = "Slow",
-            Index = 105,
-            Tooltip = "Maximum amount of time (in miliseconds) to wait for Disease Slow to be ready before giving up.",
-            Default = 100,
-            Min = 0,
-            Max = 10000,
-            ConfigType = "Advanced",
-        },
-        ['DoPutrid']            = {
+        ['DoPutrid']          = {
             DisplayName = "Putrid Decay",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1775,7 +1762,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['DoCripple']           = {
+        ['DoCripple']         = {
             DisplayName = "Cast Cripple",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1787,7 +1774,7 @@ local _ClassConfig = {
         },
 
         -- Low Level Buffs
-        ['DoLLHPBuff']          = {
+        ['DoLLHPBuff']        = {
             DisplayName = "HP Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1798,7 +1785,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLAgiBuff']         = {
+        ['DoLLAgiBuff']       = {
             DisplayName = "Agility Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1809,7 +1796,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLStaBuff']         = {
+        ['DoLLStaBuff']       = {
             DisplayName = "Stamina Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1820,7 +1807,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLStrBuff']         = {
+        ['DoLLStrBuff']       = {
             DisplayName = "Strength Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1833,7 +1820,7 @@ local _ClassConfig = {
         },
 
         --Damage(AE)
-        ['DoPBAE']              = {
+        ['DoPBAE']            = {
             DisplayName = "Use PBAE Spells",
             Group = "Abilities",
             Header = "Damage",
@@ -1845,7 +1832,7 @@ local _ClassConfig = {
             Default = false,
         },
 
-        ['UseDonorPet']         = {
+        ['UseDonorPet']       = {
             DisplayName = "Summon Nature Spirit",
             Group = "Abilities",
             Header = "Pet",
@@ -1855,7 +1842,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true, -- this is a load condition
             Default = true,
         },
-        ['HealPriority']        = {
+        ['HealPriority']      = {
             DisplayName = "Healing Priority",
             Group = "Abilities",
             Header = "Recovery",

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -387,13 +387,14 @@ return {
             "Growl of the Clouded Leopard", -- Level 119
             "Growl of the Lioness",         -- Level 114
             "Growl of the Sabretooth",      -- Level 109
+            "45152",                        -- Level 104, Growl of the Leopard - deconflicts duplicate at Level 61
             "Growl of the Snow Leopard",    -- Level 99
             "Growl of the Lion",            -- Level 94
             "Growl of the Tiger",           -- Level 89
             "Growl of the Jaguar",          -- Level 84
             "Growl of the Puma",            -- Level 79
             "Growl of the Panther",         -- Level 69
-            "Growl of the Leopard",         -- Level 61
+            "6740",                         -- Level 61, Growl of the Leopard - deconflicts duplicate at Level 104
         },
         ['PetHealProc'] = {
             --Pet Heal proc buff*
@@ -436,22 +437,22 @@ return {
         },
         ['UnityBuff'] = {
             -- --Combined ManaRegenBuff and AtkHPBuff
-            "Feralist's Unity VII", -- Level 130
-            "Wildfang's Unity",     -- Level 125
-            "Chieftain's Unity",    -- Level 120
-            "Reclaimer's Unity",    -- Level 115
-            "Feralist's Unity",     -- Level 110
-            "Stormblood's Unity",   -- Level 105
-            "Spiritual Unity",      -- Level 100
+            "73030",              -- Level 130, Feralist's Unity VII - deconflicts duplicate granted by AA/item
+            "Wildfang's Unity",   -- Level 125
+            "Chieftain's Unity",  -- Level 120
+            "Reclaimer's Unity",  -- Level 115
+            "Feralist's Unity",   -- Level 110
+            "Stormblood's Unity", -- Level 105
+            "Spiritual Unity",    -- Level 100
         },
         ['KillShotBuff'] = {
             --Pet Dmg Absorb + HoT buff*
             "Warder's Alliance",     -- Level 121
             "Symbiotic Alliance",    -- Level 116
             "Natural Alliance",      -- Level 111
+            "57344",                 -- Level 106, Natural Cooperation - deconflicts duplicate at Level 96
             "Natural Affiliation",   -- Level 101
-            "Natural Cooperation",   -- Level 96
-            "Natural Cooperation",   -- Level 96
+            "36456",                 -- Level 96, Natural Cooperation - deconflicts duplicate at Level 106
             "Natural Collaboration", -- Level 91
         },
         ['RunSpeedBuff'] = {
@@ -570,6 +571,7 @@ return {
         ['AtkHPBuff'] = {
             "Spiritual Vigor XV",     -- Level 127
             "Spiritual Valiancy",     -- Level 122
+            "64092",                  -- Level 117, Spiritual Vigor - deconflicts duplicate at Level 62
             "Spiritual Vehemence",    -- Level 112
             "Spiritual Vibrancy",     -- Level 107
             "Spiritual Vivification", -- Level 102
@@ -580,8 +582,7 @@ return {
             "Spiritual Vivacity",     -- Level 77
             "Spiritual Vim",          -- Level 72
             "Spiritual Vitality",     -- Level 67
-            "Spiritual Vigor",        -- Level 62
-            "Spiritual Vigor",        -- Level 62
+            "3456",                   -- Level 62, Spiritual Vigor - deconflicts duplicate at Level 117
             "Spiritual Strength",     -- Level 60
             --Single Target Atk+HP Buff* - Does Not Stack with Pally brells or Ranger Buff - is Middle ground Buff has HP & Atk
             "Spiritual Brawn",        -- Level 42

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -365,10 +365,11 @@ local _ClassConfig = {
             "Sunflame",              -- Level 109
             "Sunflash",              -- Level 104
             "Sunblaze",              -- Level 99
+            "28948",                 -- Level 94, Sunscorch - deconflicts duplicate at Level 74
             "Sunbrand",              -- Level 89
             "Sunsinge",              -- Level 84
             "Sunsear",               -- Level 79
-            "Sunscorch",             -- Level 74
+            "9902",                  -- Level 74, Sunscorch - deconflicts duplicate at Level 94
             "Vengeance of the Sun",  -- Level 69
             "Vengeance of Tunare",   -- Level 64
             "Vengeance of Nature",   -- Level 55
@@ -751,6 +752,7 @@ local _ClassConfig = {
             "Beast's Beckoning XVIII", -- Level 126
             "Beast's Bestowing",       -- Level 121
             "Beast's Bellowing",       -- Level 116
+            "59263",                   -- Level 111, Beast's Beckoning - deconflicts duplicate at Level 71
             "Beast's Beseeching",      -- Level 106
             "Beast's Bidding",         -- Level 101
             "Beast's Bespelling",      -- Level 96
@@ -758,7 +760,7 @@ local _ClassConfig = {
             "Beast's Beguiling",       -- Level 86
             "Beast's Befriending",     -- Level 81
             "Beast's Bewitching",      -- Level 76
-            "Beast's Beckoning",       -- Level 71
+            "9923",                    -- Level 71, Beast's Beckoning - deconflicts duplicate at Level 111
             "Nature's Beckon",         -- Level 70
             "Command of Tunare",       -- Level 63
             "Tunare's Request",        -- Level 55

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -777,6 +777,7 @@ local _ClassConfig    = {
         ['MezPBAESpell'] = {
             "Docility XII",        -- Level 128
             "Wonderment",          -- Level 123
+            "63916",               -- Level 118, Bewilderment - deconflicts duplicate at Level 72
             "Neutralize",          -- Level 113
             "Perplex",             -- Level 108
             "Bafflement",          -- Level 103
@@ -786,7 +787,6 @@ local _ClassConfig    = {
             "Docility",            -- Level 83
             "Visions of Kirathas", -- Level 78
             "Dreams of Veldyn",    -- Level 73
-            "Bewilderment",        -- Level 72
             "Circle of Dreams",    -- Level 68
             "Word of Morell",      -- Level 62
             "Entrancing Lights",   -- Level 30
@@ -803,7 +803,7 @@ local _ClassConfig    = {
             "Baffle",                   -- Level 87
             "Befuddle",                 -- Level 82
             "Mystify",                  -- Level 77
-            "Bewilderment",             -- Level 72
+            "10647",                    -- Level 72, Bewilderment - deconflicts duplicate at Level 118
             "Euphoria",                 -- Level 69
             "Felicity",                 -- Level 67
             "Bliss",                    -- Level 64

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -370,7 +370,7 @@ _ClassConfig      = {
             -- Use at the start of the DPS loop
             "Searing Skin XI",            -- Level 128
             "Boiling Skin",               -- Level 123
-            "Scorching Skin",             -- Level 118
+            "63715",                      -- Level 118, Scorching Skin - deconflicts duplicate at Level 73
             "Burning Skin",               -- Level 113
             "Blistering Skin",            -- Level 108
             "Coronal Skin",               -- Level 103
@@ -379,7 +379,7 @@ _ClassConfig      = {
             "Blazing Skin",               -- Level 88
             "Torrid Skin",                -- Level 83
             "Searing Skin",               -- Level 78
-            -- "Scorching Skin",          -- Level 73, shares its name with the 118 rank; only the book's first match resolves
+            "10720",                      -- Level 73, Scorching Skin - deconflicts duplicate at Level 118
             "Ancient: Veil of Pyrilonus", -- Level 70
             "Pyrilen Skin",               -- Level 68
         },

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -299,11 +299,11 @@ local _ClassConfig = {
             "Protective Acceptance",   -- Level 125
             "Protective Revelation",   -- Level 120
             "Protective Consecration", -- Level 115
+            "55488",                   -- Level 110, Protective Devotion - deconflicts duplicate at Level 90
             "Protective Proclamation", -- Level 105
             "Protective Allegiance",   -- Level 100
             "Protective Dedication",   -- Level 95
-            "Protective Devotion",     -- Level 90
-            "Protective Devotion",     -- Level 90
+            "25390",                   -- Level 90, Protective Devotion - deconflicts duplicate at Level 110
             "Protective Confession",   -- Level 85
         },
         ['Aego'] = {
@@ -548,13 +548,14 @@ local _ClassConfig = {
         --     "Assuring Words",  -- Level 121
         --     "Tranquil Words",  -- Level 116
         --     "Placating Words", -- Level 111
+        --     "55347",           -- Level 106, Soothe - deconflicts duplicate at Level 25
         --     "Dulcify",         -- Level 101
         --     "Reconcile",       -- Level 96
         --     "Mollify",         -- Level 91
         --     "Propitiate",      -- Level 86
         --     "Pacify",          -- Level 49
         --     "Calm",            -- Level 43
-        --     "Soothe",          -- Level 25
+        --     "501",             -- Level 25, Soothe - deconflicts duplicate at Level 106
         --     "Lull",            -- Level 10
         -- },
         ['TouchHeal'] = {

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -178,7 +178,7 @@ local _ClassConfig = {
         ['ColdNukeT2'] = {
             "Gelid Wind",      -- Level 122
             "Restless Wind",   -- Level 112
-            "Frozen Wind",     -- Level 102, name is shared with a Level 63 timer 3 spell
+            "43478",           -- Level 102, Frozen Wind - deconflicts duplicate in ColdNukeT3
             "Rime-Laced Wind", -- Level 92
             "Windwhip Bite",   -- Level 82
             "Icefall Chill",   -- Level 72
@@ -193,7 +193,7 @@ local _ClassConfig = {
             "Biting Wind",         -- Level 87
             "Rimefall Bite",       -- Level 77
             "Ancient: North Wind", -- Level 70
-            "Frozen Wind",         -- Level 63, name is shared with a Level 102 timer 2 spell
+            "3418",                -- Level 63, Frozen Wind - deconflicts duplicate in ColdNukeT2
         },
         ['SummerNuke'] = {
             "Summer's Dew XII",  -- Level 129

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -1218,7 +1218,6 @@ local _ClassConfig = {
                 name = "DiseaseSlow",
                 type = "Spell",
                 load_cond = function(self) return Config:GetSetting('DoDiseaseSlow') end,
-                waitReadyTime = function() return Config:GetSetting('DiseaseSlowWaitTime') end,
                 cond = function(self, spell, target)
                     return not mq.TLO.Target.Slowed() and Casting.DetSpellCheck(spell) and not Casting.SlowImmuneTarget(target)
                 end,
@@ -1757,7 +1756,7 @@ local _ClassConfig = {
         },
     },
     ['DefaultConfig']     = {
-        ['Mode']                = {
+        ['Mode']              = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -1772,7 +1771,7 @@ local _ClassConfig = {
         },
 
         --DPS
-        ['DoHealDPS']           = {
+        ['DoHealDPS']         = {
             DisplayName = "Heal Mode DPS",
             Group = "Abilities",
             Header = "Common",
@@ -1784,7 +1783,7 @@ local _ClassConfig = {
             FAQ = "I feel that my Shaman is too concerned with DPS, dots and nukes, what can be done?",
             Answer = "Disabling Use HealDPS will stop the use of these spells. You can control which individual spells you mem with their respective settings.",
         },
-        ['DoNuke']              = {
+        ['DoNuke']            = {
             DisplayName = "Use Nukes",
             Group = "Abilities",
             Header = "Damage",
@@ -1796,7 +1795,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoTwinHealNuke']      = {
+        ['DoTwinHealNuke']    = {
             DisplayName = "Twin Heal Nuke",
             Group = "Abilities",
             Header = "Damage",
@@ -1810,7 +1809,7 @@ local _ClassConfig = {
             Answer =
             "Due to the nature of automation, we are likely to have the time to do so, and it helps hedge our bets against spike damage. Drivers that manually target switch may wish to disable this setting to allow for more cross-dotting. ",
         },
-        ['DoPoisonDot']         = {
+        ['DoPoisonDot']       = {
             DisplayName = "Use Poison DoTs",
             Group = "Abilities",
             Header = "Damage",
@@ -1822,7 +1821,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoDiseaseDot']        = {
+        ['DoDiseaseDot']      = {
             DisplayName = "Use Disease DoTs",
             Group = "Abilities",
             Header = "Damage",
@@ -1834,7 +1833,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoCurseDot']          = {
+        ['DoCurseDot']        = {
             DisplayName = "Use Curse DoTs",
             Group = "Abilities",
             Header = "Damage",
@@ -1848,7 +1847,7 @@ local _ClassConfig = {
         },
 
         -- Healing
-        ['DoHealOverTime']      = {
+        ['DoHealOverTime']    = {
             DisplayName = "Use HoTs",
             Group = "Abilities",
             Header = "Recovery",
@@ -1861,7 +1860,7 @@ local _ClassConfig = {
             FAQ = "Why does my Shaman randomly use HoTs in downtime?",
             Answer = "Maintaining HoTs prevents emergencies and hopefully allows for better DPS. It also grants Synergy Procs at high level.",
         },
-        ['MemCureSpell']        = {
+        ['MemCureSpell']      = {
             DisplayName = "Mem Cure Spell",
             Group = "Abilities",
             Header = "Recovery",
@@ -1874,7 +1873,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['DoChestClick']        = {
+        ['DoChestClick']      = {
             DisplayName = "Do Chest Click",
             Group = "Items",
             Header = "Clickies",
@@ -1886,7 +1885,7 @@ local _ClassConfig = {
             Answer = "Most classes have useful abilities on their equipped chest after level 75 or so. The SHM's is generally a healing tool (emergency group heal).",
         },
         --Canni
-        ['DoAACanni']           = {
+        ['DoAACanni']         = {
             DisplayName = "Use AA Canni",
             Group = "Abilities",
             Header = "Recovery",
@@ -1896,7 +1895,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['AACanniManaPct']      = {
+        ['AACanniManaPct']    = {
             DisplayName = "AA Canni Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1908,7 +1907,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['AACanniMinHP']        = {
+        ['AACanniMinHP']      = {
             DisplayName = "AA Canni HP %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1920,7 +1919,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['DoSpellCanni']        = {
+        ['DoSpellCanni']      = {
             DisplayName = "Use Spell Canni",
             Group = "Abilities",
             Header = "Recovery",
@@ -1931,7 +1930,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['SpellCanniManaPct']   = {
+        ['SpellCanniManaPct'] = {
             DisplayName = "Spell Canni Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1943,7 +1942,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['SpellCanniMinHP']     = {
+        ['SpellCanniMinHP']   = {
             DisplayName = "Spell Canni HP %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1955,7 +1954,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['DoCombatCanni']       = {
+        ['DoCombatCanni']     = {
             DisplayName = "Canni in Combat",
             Group = "Abilities",
             Header = "Recovery",
@@ -1967,7 +1966,7 @@ local _ClassConfig = {
             ConfigType = "Advanced",
         },
         --Buffs
-        ['UseEpic']             = {
+        ['UseEpic']           = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -1981,7 +1980,7 @@ local _ClassConfig = {
             Max = 3,
             ConfigType = "Advanced",
         },
-        ['DoRunSpeed']          = {
+        ['DoRunSpeed']        = {
             DisplayName = "Do Run Speed",
             Group = "Abilities",
             Header = "Buffs",
@@ -1993,7 +1992,7 @@ local _ClassConfig = {
             FAQ = "Why are my buffers in a run speed buff war?",
             Answer = "Many run speed spells freely stack and overwrite each other, you will need to disable Run Speed Buffs on some of the buffers.",
         },
-        ['DoGroupShrink']       = {
+        ['DoGroupShrink']     = {
             DisplayName = "Group Shrink",
             Group = "Abilities",
             Header = "Buffs",
@@ -2006,7 +2005,7 @@ local _ClassConfig = {
             Answer =
             "For simplicity, the check to use it is keyed to the Shaman's height, rather than checking each group member. Also, the AA isn't available until level 80 (on official servers).",
         },
-        ['DoTempHP']            = {
+        ['DoTempHP']          = {
             DisplayName = "Temp HP Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -2016,7 +2015,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoAura']              = {
+        ['DoAura']            = {
             DisplayName = "Use Aura",
             Group = "Abilities",
             Header = "Buffs",
@@ -2026,7 +2025,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['DoRegenBuff']         = {
+        ['DoRegenBuff']       = {
             DisplayName = "Regen Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -2038,7 +2037,7 @@ local _ClassConfig = {
             FAQ = "Why am I spamming my Group Regen buff?",
             Answer = "Certain Shaman and Druid group regen buffs report cross-stacking. You should deselect the option on one of the PCs if they are grouped together.",
         },
-        ['DoHaste']             = {
+        ['DoHaste']           = {
             DisplayName = "Use Haste",
             Group = "Abilities",
             Header = "Buffs",
@@ -2050,7 +2049,7 @@ local _ClassConfig = {
             FAQ = "Why aren't I casting Talisman of Celerity or other haste buffs?",
             Answer = "Even with Use Haste enabled, these buffs are part of your Focus spell (Unity) at very high levels, so they may not be needed.",
         },
-        ['DoSelfWard']          = {
+        ['DoSelfWard']        = {
             DisplayName = "Do Self Ward",
             Group = "Abilities",
             Header = "Buffs",
@@ -2059,7 +2058,7 @@ local _ClassConfig = {
             Tooltip = "Use your Ward of... self-heal ward buff line.",
             Default = true,
         },
-        ['DoVetAA']             = {
+        ['DoVetAA']           = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -2071,7 +2070,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
         },
         --Debuffs
-        ['DoSTMalo']            = {
+        ['DoSTMalo']          = {
             DisplayName = "Do ST Malo",
             Group = "Abilities",
             Header = "Debuffs",
@@ -2081,7 +2080,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoAEMalo']            = {
+        ['DoAEMalo']          = {
             DisplayName = "Do AE Malo",
             Group = "Abilities",
             Header = "Debuffs",
@@ -2091,7 +2090,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoSTSlow']            = {
+        ['DoSTSlow']          = {
             DisplayName = "Do ST Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -2101,7 +2100,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoAESlow']            = {
+        ['DoAESlow']          = {
             DisplayName = "Do AE Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -2111,7 +2110,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['AESlowCount']         = {
+        ['AESlowCount']       = {
             DisplayName = "AE Slow Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -2123,7 +2122,7 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['AEMaloCount']         = {
+        ['AEMaloCount']       = {
             DisplayName = "AE Malo Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -2135,7 +2134,7 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['DoDiseaseSlow']       = {
+        ['DoDiseaseSlow']     = {
             DisplayName = "Disease Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -2146,19 +2145,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DiseaseSlowWaitTime'] = {
-            DisplayName = "Disease Slow Wait",
-            Group = "Abilities",
-            Header = "Debuffs",
-            Category = "Slow",
-            Index = 105,
-            Tooltip = "Maximum amount of time (in miliseconds) to wait for Disease Slow to be ready before giving up.",
-            Default = 100,
-            Min = 0,
-            Max = 10000,
-            ConfigType = "Advanced",
-        },
-        ['DoLLHPBuff']          = {
+        ['DoLLHPBuff']        = {
             DisplayName = "HP Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -2168,7 +2155,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLAgiBuff']         = {
+        ['DoLLAgiBuff']       = {
             DisplayName = "Agility Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -2178,7 +2165,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLStaBuff']         = {
+        ['DoLLStaBuff']       = {
             DisplayName = "Stamina Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -2188,7 +2175,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLStrBuff']         = {
+        ['DoLLStrBuff']       = {
             DisplayName = "Strength Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -2198,7 +2185,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['HealPriority']        = {
+        ['HealPriority']      = {
             DisplayName = "Healing Priority",
             Group = "Abilities",
             Header = "Recovery",

--- a/class_configs/Live/wiz_class_config.lua
+++ b/class_configs/Live/wiz_class_config.lua
@@ -104,9 +104,9 @@ return {
             "Cloudburst Lightningstrike", -- Level 122
             "Cloudburst Joltstrike",      -- Level 117
             "Cloudburst Stormbolt",       -- Level 112
+            "56794",                      -- Level 107, Cloudburst Thunderbolt - deconflicts duplicate at Level 97
             "Cloudburst Stormstrike",     -- Level 102
-            "Cloudburst Thunderbolt",     -- Level 97
-            "Cloudburst Thunderbolt",     -- Level 97
+            "35876",                      -- Level 97, Cloudburst Thunderbolt - deconflicts duplicate at Level 107
             "Cloudburst Tempest",         -- Level 92
             "Cloudburst Storm",           -- Level 87
             "Cloudburst Levin",           -- Level 82
@@ -294,6 +294,7 @@ return {
             "Lightning Maelstrom",           -- Level 118
             "Lightning Roar",                -- Level 113
             "Lightning Tempest",             -- Level 108
+            "44623",                         -- Level 103, Lightning Storm - deconflicts duplicate at Level 23
             "Lightning Squall",              -- Level 98
             "Lightning Swarm",               -- Level 93
             "Lightning Helix",               -- Level 88
@@ -305,7 +306,6 @@ return {
             "Voltaic Draught",               -- Level 54
             "Rend",                          -- Level 47
             "Lightning Shock",               -- Level 37
-            "Lightning Storm",               -- Level 23
             "Garrison's Mighty Mana Shock",  -- Level 18
             "Shock of Lightning",            -- Level 10
         },
@@ -377,6 +377,7 @@ return {
         ['SelfRune1'] = {
             "Aegis of Feish",             -- Level 126
             "Aegis of Remembrance",       -- Level 121
+            "63576",                      -- Level 118, Scales of the Crystalwing - deconflicts duplicate at Level 73
             "Aegis of the Umbra",         -- Level 116
             "Aegis of the Crystalwing",   -- Level 113
             "Armor of Wirn",              -- Level 108
@@ -386,7 +387,7 @@ return {
             "Dermis of the Crystalwing",  -- Level 88
             "Squamae of the Crystalwing", -- Level 83
             "Laminae of the Crystalwing", -- Level 78
-            "Scales of the Crystalwing",  -- Level 73
+            "10810",                      -- Level 73, Scales of the Crystalwing - deconflicts duplicate at Level 118
             "Ether Skin",                 -- Level 68
             "Force Shield",               -- Level 63
         },
@@ -456,6 +457,7 @@ return {
         ['JoltSpell'] = {
             "Mindfreeze X",                -- Level 127
             "Spinalfreeze",                -- Level 122
+            "67443",                       -- Level 121, Concussive Blast - deconflicts duplicate at Level 71
             "Cerebrumfreeze",              -- Level 117
             "Neurofreeze",                 -- Level 112
             "Cortexfreeze",                -- Level 107
@@ -463,10 +465,11 @@ return {
             "Skullfreeze",                 -- Level 97
             "Thoughtfreeze",               -- Level 92
             "Brainfreeze",                 -- Level 87
+            "26523",                       -- Level 86, Concussive Burst - deconflicts duplicate at Level 76
             "Mindfreeze",                  -- Level 82
             "Concussive Flash",            -- Level 81
-            "Concussive Burst",            -- Level 76
-            "Concussive Blast",            -- Level 71
+            "15393",                       -- Level 76, Concussive Burst - deconflicts duplicate at Level 86
+            "10782",                       -- Level 71, Concussive Blast - deconflicts duplicate at Level 121
             "Ancient: Greater Concussion", -- Level 60
             "Concussion",                  -- Level 37
         },

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -818,7 +818,6 @@ local _ClassConfig = {
                 end,
                 load_cond = function(self) return Config:GetSetting('DoSTSlow') and (not Casting.CanUseAA("Turgur's Swarm") or Config:GetSetting('DoDiseaseSlow')) end,
                 type = "Spell",
-                waitReadyTime = function() return Config:GetSetting('DiseaseSlowWaitTime') end,
                 cond = function(self, spell, target)
                     return Casting.DetSpellCheck(spell) and (spell and spell.RankName.SlowPct() or 0) > Targeting.GetTargetSlowedPct() and not Casting.SlowImmuneTarget(target)
                 end,
@@ -1246,7 +1245,7 @@ local _ClassConfig = {
         },
     },
     ['DefaultConfig']     = {
-        ['Mode']                = {
+        ['Mode']              = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -1261,7 +1260,7 @@ local _ClassConfig = {
         },
 
         -- Damage
-        ['DoColdNuke']          = {
+        ['DoColdNuke']        = {
             DisplayName = "Cold Nuke",
             Group = "Abilities",
             Header = "Damage",
@@ -1271,7 +1270,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoPoisonNuke']        = {
+        ['DoPoisonNuke']      = {
             DisplayName = "Poison Nuke",
             Group = "Abilities",
             Header = "Damage",
@@ -1281,7 +1280,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoTwinHealNuke']      = {
+        ['DoTwinHealNuke']    = {
             DisplayName = "Twinheal Nuke",
             Group = "Abilities",
             Header = "Damage",
@@ -1291,7 +1290,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoSaryrnDot']         = {
+        ['DoSaryrnDot']       = {
             DisplayName = "Poison Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1301,7 +1300,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['DoUltorDot']          = {
+        ['DoUltorDot']        = {
             DisplayName = "Disease Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1311,7 +1310,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['DoCurseDot']          = {
+        ['DoCurseDot']        = {
             DisplayName = "Magic Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1321,7 +1320,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['DotNamedOnly']        = {
+        ['DotNamedOnly']      = {
             DisplayName = "Only Dot Named",
             Group = "Abilities",
             Header = "Damage",
@@ -1332,7 +1331,7 @@ local _ClassConfig = {
         },
 
         -- Healing
-        ['DoSingleHot']         = {
+        ['DoSingleHot']       = {
             DisplayName = "Use Single HoT",
             Group = "Abilities",
             Header = "Recovery",
@@ -1343,7 +1342,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['DoSnareHot']          = {
+        ['DoSnareHot']        = {
             DisplayName = "Use Snare HoT",
             Group = "Abilities",
             Header = "Recovery",
@@ -1354,7 +1353,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['KeepPoisonMemmed']    = {
+        ['KeepPoisonMemmed']  = {
             DisplayName = "Mem Cure Poison",
             Group = "Abilities",
             Header = "Recovery",
@@ -1366,7 +1365,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['KeepDiseaseMemmed']   = {
+        ['KeepDiseaseMemmed'] = {
             DisplayName = "Mem Cure Disease",
             Group = "Abilities",
             Header = "Recovery",
@@ -1378,7 +1377,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['KeepCurseMemmed']     = {
+        ['KeepCurseMemmed']   = {
             DisplayName = "Mem Remove Curse",
             Group = "Abilities",
             Header = "Recovery",
@@ -1390,7 +1389,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['GroupHealAsCure']     = {
+        ['GroupHealAsCure']   = {
             DisplayName = "Use Group Heal to Cure",
             Group = "Abilities",
             Header = "Recovery",
@@ -1404,7 +1403,7 @@ local _ClassConfig = {
         },
 
         -- Canni
-        ['DoAACanni']           = {
+        ['DoAACanni']         = {
             DisplayName = "Use AA Canni",
             Group = "Abilities",
             Header = "Recovery",
@@ -1415,7 +1414,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['AACanniManaPct']      = {
+        ['AACanniManaPct']    = {
             DisplayName = "AA Canni Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1427,7 +1426,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['AACanniMinHP']        = {
+        ['AACanniMinHP']      = {
             DisplayName = "AA Canni HP %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1439,7 +1438,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['DoSpellCanni']        = {
+        ['DoSpellCanni']      = {
             DisplayName = "Use Spell Canni",
             Group = "Abilities",
             Header = "Recovery",
@@ -1450,7 +1449,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['SpellCanniManaPct']   = {
+        ['SpellCanniManaPct'] = {
             DisplayName = "Spell Canni Mana %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1462,7 +1461,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['SpellCanniMinHP']     = {
+        ['SpellCanniMinHP']   = {
             DisplayName = "Spell Canni HP %",
             Group = "Abilities",
             Header = "Recovery",
@@ -1474,7 +1473,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['DoCombatCanni']       = {
+        ['DoCombatCanni']     = {
             DisplayName = "Canni in Combat",
             Group = "Abilities",
             Header = "Recovery",
@@ -1486,7 +1485,7 @@ local _ClassConfig = {
         },
 
         -- Buffs
-        ['UseEpic']             = {
+        ['UseEpic']           = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -1500,7 +1499,7 @@ local _ClassConfig = {
             Max = 3,
             ConfigType = "Advanced",
         },
-        ['DoRunSpeed']          = {
+        ['DoRunSpeed']        = {
             DisplayName = "Do Run Speed",
             Group = "Abilities",
             Header = "Buffs",
@@ -1512,7 +1511,7 @@ local _ClassConfig = {
             FAQ = "Why are my buffers in a run speed buff war?",
             Answer = "Many run speed spells freely stack and overwrite each other, you will need to disable Run Speed Buffs on some of the buffers.",
         },
-        ['DoGroupShrink']       = {
+        ['DoGroupShrink']     = {
             DisplayName = "Group Shrink",
             Group = "Abilities",
             Header = "Buffs",
@@ -1525,7 +1524,7 @@ local _ClassConfig = {
             Answer =
             "For simplicity, the check to use it is keyed to the Shaman's height, rather than checking each group member.",
         },
-        ['DoRegenBuff']         = {
+        ['DoRegenBuff']       = {
             DisplayName = "Regen Buff",
             Group = "Abilities",
             Header = "Buffs",
@@ -1537,7 +1536,7 @@ local _ClassConfig = {
             FAQ = "Why am I spamming my Group Regen buff?",
             Answer = "Certain Shaman and Druid group regen buffs report cross-stacking. You should deselect the option on one of the PCs if they are grouped together.",
         },
-        ['DoHaste']             = {
+        ['DoHaste']           = {
             DisplayName = "Use Haste",
             Group = "Abilities",
             Header = "Buffs",
@@ -1548,7 +1547,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             ConfigType = "Advanced",
         },
-        ['DoArcanumWeave']      = {
+        ['DoArcanumWeave']    = {
             DisplayName = "Weave Arcanums",
             Group = "Abilities",
             Header = "Buffs",
@@ -1558,7 +1557,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true, --this setting is used as a load condition
             Default = true,
         },
-        ['DoVetAA']             = {
+        ['DoVetAA']           = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -1571,7 +1570,7 @@ local _ClassConfig = {
         },
 
         -- Debuffs
-        ['DoSTMalo']            = {
+        ['DoSTMalo']          = {
             DisplayName = "Do ST Malo",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1581,7 +1580,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoAEMalo']            = {
+        ['DoAEMalo']          = {
             DisplayName = "Do AE Malo",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1591,7 +1590,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoSTSlow']            = {
+        ['DoSTSlow']          = {
             DisplayName = "Do ST Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1602,7 +1601,7 @@ local _ClassConfig = {
             Default = true,
 
         },
-        ['DoAESlow']            = {
+        ['DoAESlow']          = {
             DisplayName = "Do AE Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1612,7 +1611,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['AESlowCount']         = {
+        ['AESlowCount']       = {
             DisplayName = "AE Slow Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1624,7 +1623,7 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['AEMaloCount']         = {
+        ['AEMaloCount']       = {
             DisplayName = "AE Malo Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1636,7 +1635,7 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['DoDiseaseSlow']       = {
+        ['DoDiseaseSlow']     = {
             DisplayName = "Disease Slow",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1650,19 +1649,7 @@ local _ClassConfig = {
             Answer =
             "During early eras of play, a slow that checked against disease resist was added to slow magic-resistant mobs. If selected, this will be used instead of a magic-based slow until the Turgur's AA becomes available.",
         },
-        ['DiseaseSlowWaitTime'] = {
-            DisplayName = "Disease Slow Wait",
-            Group = "Abilities",
-            Header = "Debuffs",
-            Category = "Slow",
-            Index = 105,
-            Tooltip = "Maximum amount of time (in miliseconds) to wait for Disease Slow to be ready before giving up.",
-            Default = 100,
-            Min = 0,
-            Max = 10000,
-            ConfigType = "Advanced",
-        },
-        ['DoPutrid']            = {
+        ['DoPutrid']          = {
             DisplayName = "Putrid Decay",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1675,7 +1662,7 @@ local _ClassConfig = {
         },
 
         -- Low Level Buffs
-        ['DoLLHPBuff']          = {
+        ['DoLLHPBuff']        = {
             DisplayName = "HP Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1685,7 +1672,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLAgiBuff']         = {
+        ['DoLLAgiBuff']       = {
             DisplayName = "Agility Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1695,7 +1682,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLStaBuff']         = {
+        ['DoLLStaBuff']       = {
             DisplayName = "Stamina Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1705,7 +1692,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['DoLLStrBuff']         = {
+        ['DoLLStrBuff']       = {
             DisplayName = "Strength Buff (LowLvl)",
             Group = "Abilities",
             Header = "Buffs",
@@ -1715,7 +1702,7 @@ local _ClassConfig = {
             Default = false,
             ConfigType = "Advanced",
         },
-        ['HealPriority']        = {
+        ['HealPriority']      = {
             DisplayName = "Healing Priority",
             Group = "Abilities",
             Header = "Recovery",

--- a/docs/CUSTOMIZING_WITH_AI.md
+++ b/docs/CUSTOMIZING_WITH_AI.md
@@ -92,6 +92,8 @@ Two key relationships:
 
 Reordering a spell/disc set does **not** change which one is used — the highest-level usable option always wins (listed highest-first only for readability). AA and item sets *do* go by list order. See "Change which option a set uses" below to change a pick.
 
+A member may be a **spell ID in quotes** — `"43478", -- Level 102, Frozen Wind`. Use it where two spells share one name: a name resolves to the lowest-ID match, which may be the wrong level. The ID still upgrades to your highest known rank.
+
 ### `Rotations` example
 
 ```lua

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -1840,7 +1840,7 @@ function Module:RenderClickiesWithConditions(type, clickies)
                 target = 'Self',
                 iconId = tonumber((mq.TLO.Cursor.Icon() or 500) - 500) or 0,
                 combat_state = 'Any',
-                no_target_change = targetType == "Self" or targetType == "Group v1" or targetType == "AE v1",
+                no_target_change = targetType == "Self" or targetType == "Group v1" or targetType == "AE PC v1",
                 skipTriggerCheck = true,
                 conditions = {},
             })
@@ -2222,15 +2222,9 @@ function Module:GiveTime()
 
                             -- distance check
                             local distanceCheckPassed = true
-                            if targetId and targetId ~= mq.TLO.Me.ID() then
-                                local spellRange = itemSpell.MyRange() or 0
-
-                                if spellRange == 0 then
-                                    local aeRange = itemSpell.AERange() or 0
-                                    spellRange = aeRange > 0 and aeRange or 200
-                                end
-
-                                if Targeting.GetTargetDistance(target) > spellRange then
+                            local spellTargetId = Casting.IsSelfSpell(itemSpell and itemSpell.TargetType()) and mq.TLO.Me.ID() or targetId
+                            if spellTargetId and spellTargetId ~= mq.TLO.Me.ID() then
+                                if Targeting.GetTargetDistance(target) > Casting.GetSpellRange(itemSpell) then
                                     Logger.log_verbose("\ayClicky: \arTried to use item on targetId %s they are too far away!!", target and target.DisplayName() or "None")
                                     distanceCheckPassed = false
                                 end

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -14,7 +14,7 @@ local Strings      = require("utils.strings")
 local Tables       = require("utils.tables")
 local Targeting    = require("utils.targeting")
 
-local Casting      = { _version = '2.0', _name = "Casting", _author = 'Derple, Algar', }
+local Casting      = { _version = '2.1', _name = "Casting", _author = 'Derple, Algar', }
 Casting.__index    = Casting
 Casting.Memorizing = false
 
@@ -27,6 +27,14 @@ Casting.UseGem     = mq.TLO.Me.NumGems()
 function Casting.IsGroupSpell(targetType)
     if not targetType then return false end
     return Globals.Constants.GroupTargetTypes:contains(targetType)
+end
+
+--- Checks if a spell target type is self.
+--- @param targetType string|nil The TargetType() value from a spell.
+--- @return boolean
+function Casting.IsSelfSpell(targetType)
+    if not targetType then return false end
+    return targetType:lower() == "self"
 end
 
 --- Simple (no trigger or stacking checks) check to see if the player has a buff. Can pass a spell(userdata), ID, or effect name(string).
@@ -1445,6 +1453,9 @@ function Casting.MemorizeSpell(gem, spell, waitSpellReady, maxWait)
     end
     local aggressiveMem      = Config:GetSetting('AggressivelyMemorizeSpells')
     local aggressiveMemTimer = Config:GetSetting('AggressivelyMemorizeTimer') * 1000
+
+    -- Algarnote: Not sure where to put this, but there is a very edge-case bug that can cause us to memorize a lower level spell of the same name, since we can't use ID.
+    -- /memspell (MQ) and /memspellslot (EQ) will memorize the first available by book position, which is generally the low level spell. Delete old spell, or swap positions in book to resolve... or add ID to /memspell
     local cmd                = string.format("/memspell %d \"%s\"", gem, spell)
 
     Logger.log_info("\atMemorizeSpell\aw():\ag Meming \aw%s in \agslot %d", spell, gem)
@@ -1686,16 +1697,17 @@ end
 function Casting.SpellReady(spell, skipGemTimer)
     if not spell or not spell() then return false end
 
-    local ready = mq.TLO.Me.SpellReady(spell.RankName.Name())()
-    local bookCheck = (mq.TLO.Me.Book(spell.RankName.Name())() or 0) > 0
+    local rankSpell = spell.RankName
+    local ready = mq.TLO.Me.SpellReady(rankSpell.Name())()
+    local bookCheck = (mq.TLO.Me.Book(rankSpell.Name())() or 0) > 0
     local silenced = mq.TLO.Me.Silenced() ~= nil
 
-    Logger.log_verbose("SpellReady for %s(%d): Silenced (%s), BookCheck(%s), ReadyCheck(%s), Memorization Allowed (%s).", spell.RankName(), spell.ID(),
+    Logger.log_verbose("SpellReady for %s(%d): Silenced (%s), BookCheck(%s), ReadyCheck(%s), Memorization Allowed (%s).", rankSpell.Name(), rankSpell.ID(),
         Strings.BoolToColorString(silenced), Strings.BoolToColorString(bookCheck), Strings.BoolToColorString(ready), Strings.BoolToColorString(skipGemTimer or false))
 
     if silenced or not bookCheck or (not ready and not skipGemTimer) then return false end
 
-    return Casting.CastCheck(spell)
+    return Casting.CastCheck(rankSpell)
 end
 
 --- Checks if a given song is ready to be sung: verifies the player is not silenced, has the song in their spellbook, and that the gem timer has expired (unless skipGemTimer is true), then runs CastCheck for mana/endurance/control/movement conditions.
@@ -1705,16 +1717,17 @@ end
 function Casting.SongReady(songSpell, skipGemTimer)
     if not songSpell or not songSpell() then return false end
 
-    local ready = mq.TLO.Me.SpellReady(songSpell.RankName.Name())()
-    local bookCheck = mq.TLO.Me.Book(songSpell.RankName.Name())() ~= nil
+    local rankSong = songSpell.RankName
+    local ready = mq.TLO.Me.SpellReady(rankSong.Name())()
+    local bookCheck = mq.TLO.Me.Book(rankSong.Name())() ~= nil
     local silenced = mq.TLO.Me.Silenced() ~= nil
 
-    Logger.log_verbose("SongReady for %s(%d): Silenced (%s), BookCheck(%s), ReadyCheck(%s), Memorization Allowed (%s).", songSpell.RankName(), songSpell.ID(),
+    Logger.log_verbose("SongReady for %s(%d): Silenced (%s), BookCheck(%s), ReadyCheck(%s), Memorization Allowed (%s).", rankSong.Name(), rankSong.ID(),
         Strings.BoolToColorString(silenced), Strings.BoolToColorString(bookCheck), Strings.BoolToColorString(ready), Strings.BoolToColorString(skipGemTimer or false))
 
     if silenced or not bookCheck or (not ready and not skipGemTimer) then return false end
 
-    return Casting.CastCheck(songSpell)
+    return Casting.CastCheck(rankSong)
 end
 
 --- True if the spell's gem is off its own recast timer (it may still be briefly blocked by the global cooldown).
@@ -1744,13 +1757,14 @@ end
 function Casting.DiscReady(discSpell)
     if not discSpell or not discSpell() then return false end
 
-    local ready = mq.TLO.Me.CombatAbilityReady(discSpell.RankName.Name())()
+    local rankDisc = discSpell.RankName
+    local ready = mq.TLO.Me.CombatAbilityReady(rankDisc.Name())()
 
-    Logger.log_verbose("DiscReady for %s(%d): Ready(%s)", discSpell.RankName.Name(), discSpell.ID(), Strings.BoolToColorString(ready))
+    Logger.log_verbose("DiscReady for %s(%d): Ready(%s)", rankDisc.Name(), rankDisc.ID(), Strings.BoolToColorString(ready))
 
     if not ready then return false end
 
-    return Casting.CastCheck(discSpell, true)
+    return Casting.CastCheck(rankDisc, true)
 end
 
 --- Verifies AltAbilityReady is true for the named AA and then runs CastCheck against the AA's associated spell to confirm mana/endurance/movement/control conditions are met.
@@ -1896,7 +1910,9 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         Core.DoCmd("/autoinv")
     end
 
-    local targetSpawn = mq.TLO.Spawn(targetId)
+    local selfTargeted = Casting.IsSelfSpell(spell.TargetType())
+    local spellTargetId = selfTargeted and me.ID() or targetId
+    local targetSpawn = mq.TLO.Spawn(spellTargetId)
 
     if not Casting.LevelCheckPass(spell, targetSpawn) then
         Logger.log_debug("\ayUseSpell(): \arCasting %s failed level check with target=%d and spell=%d", spellName,
@@ -1931,7 +1947,7 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
     end
 
     local spellRange = Casting.GetSpellRange(spell)
-    if targetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
+    if spellTargetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
         Logger.log_debug("\ayUseSpell(): \arTried to cast %s on %s but they are too far away", spellName, targetSpawn.DisplayName() or "None")
         return false
     end
@@ -1965,7 +1981,7 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
     Casting.ActionPrep()
 
     local oldTargetId = mq.TLO.Target.ID()
-    if targetId > 0 and targetId ~= oldTargetId then
+    if not selfTargeted and targetId > 0 and targetId ~= oldTargetId then
         if Config:GetSetting('StopAttackForPCs') and me.Combat() and (targetSpawn.Type() or ""):lower() == "pc" then -- don't use helper here, don't want fallback to current target
             Logger.log_debug("\awUseSpell():NOTICE:\ax Turning off autoattack to cast on a PC.")
             Core.DoCmd("/attack off")
@@ -1986,7 +2002,7 @@ function Casting.UseSpell(spellName, targetId, bAllowMem, bAllowDead, retryCount
         cmd = cmd,
         readyCheck = readyCheck,
         actionName = spellName,
-        targetId = targetId,
+        targetId = spellTargetId,
         bAllowDead = bAllowDead or false,
         spellRange = spellRange,
         castTime = castTime,
@@ -2036,10 +2052,12 @@ function Casting.UseSong(songName, targetId, bAllowMem, retryCount)
         Core.DoCmd("/autoinv")
     end
 
-    local targetSpawn = mq.TLO.Spawn(targetId)
+    local selfTargeted = Casting.IsSelfSpell(songSpell.TargetType())
+    local spellTargetId = selfTargeted and me.ID() or targetId
+    local targetSpawn = mq.TLO.Spawn(spellTargetId)
 
     local spellRange = Casting.GetSpellRange(songSpell)
-    if targetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
+    if spellTargetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
         Logger.log_debug("\ayUseSong(): \arTried to cast %s on %s but they are too far away", songName, targetSpawn.DisplayName() or "None")
         return false
     end
@@ -2071,7 +2089,7 @@ function Casting.UseSong(songName, targetId, bAllowMem, retryCount)
     Casting.ActionPrep()
 
     local oldTargetId = mq.TLO.Target.ID()
-    if targetId > 0 and targetId ~= oldTargetId and targetId ~= me.ID() then
+    if not selfTargeted and targetId > 0 and targetId ~= oldTargetId and targetId ~= me.ID() then
         if Config:GetSetting('StopAttackForPCs') and me.Combat() and (targetSpawn.Type() or ""):lower() == "pc" then -- don't use helper here, don't want fallback to current target
             Logger.log_debug("\awUseSong():NOTICE:\ax Turning off autoattack to cast on a PC.")
             Core.DoCmd("/attack off")
@@ -2159,8 +2177,8 @@ function Casting.UseSong(songName, targetId, bAllowMem, retryCount)
         local clipDelay = mq.TLO.EverQuest.Ping() * Config:GetSetting('SongClipDelayFact')
 
         -- for performance, lets check for the buffs on buffsongs and exit this delay early if possible.
-        -- -- If it is targeting me but doesn't have a buff (or doesn't have a properly detected buff), we are no worse off than the static delay.
-        if targetId == me.ID() then
+        -- -- If it lands on me but doesn't have a buff (or doesn't have a properly detected buff), we are no worse off than the static delay.
+        if spellTargetId == me.ID() or Casting.IsGroupSpell(songSpell.TargetType()) then
             -- For expediency, just check for the base rank in case they are f2p without unlockers and rk2 spells scribed. If we need the exact spell later, GetUseableSpellId will check their unlocker status and get the correct ID
             local buffName = songSpell.BaseName()
             local durWindow = songSpell.DurationWindow()
@@ -2211,22 +2229,25 @@ function Casting.UseDisc(discSpell, targetId, fireAndForget)
 
     if not discSpell or not discSpell() then return false end
 
-    local discName = discSpell.RankName.Name()
-    local castTime = discSpell.MyCastTime() or 0
+    local rankDisc = discSpell.RankName
+    local discName = rankDisc.Name()
+    local castTime = rankDisc.MyCastTime() or 0
+    local selfTargeted = Casting.IsSelfSpell(rankDisc.TargetType())
+    local spellTargetId = selfTargeted and me.ID() or targetId
 
     if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not Casting.CanActMidSong(castTime) then
         Logger.log_debug("\ayUseDisc(): \arCan't use %s - Casting Window Open", discName)
         return false
     end
 
-    if me.CurrentEndurance() < discSpell.EnduranceCost() then
+    if me.CurrentEndurance() < rankDisc.EnduranceCost() then
         Logger.log_debug("\ayUseDisc(): \arCan't use %s - insufficient endurance", discName)
         return false
     end
 
-    local spellRange = Casting.GetSpellRange(discSpell)
-    if targetId ~= me.ID() then
-        local targetSpawn = mq.TLO.Spawn(targetId)
+    local spellRange = Casting.GetSpellRange(rankDisc)
+    if spellTargetId ~= me.ID() then
+        local targetSpawn = mq.TLO.Spawn(spellTargetId)
         if targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
             Logger.log_debug("\ayUseDisc(): \arTried to cast %s on %s but they are too far away", discName, targetSpawn.DisplayName() or "None")
             return false
@@ -2244,7 +2265,7 @@ function Casting.UseDisc(discSpell, targetId, fireAndForget)
     end
 
     local oldTargetId = mq.TLO.Target.ID()
-    if targetId > 0 and targetId ~= oldTargetId then
+    if not selfTargeted and targetId > 0 and targetId ~= oldTargetId then
         local targetSpawn = mq.TLO.Spawn(targetId)
         if Config:GetSetting('StopAttackForPCs') and me.Combat() and (targetSpawn.Type() or ""):lower() == "pc" then -- don't use helper here, don't want fallback to current target
             Logger.log_debug("\awUseDisc():NOTICE:\ax Turning off autoattack to cast on a PC.")
@@ -2263,7 +2284,7 @@ function Casting.UseDisc(discSpell, targetId, fireAndForget)
         cmd = cmd,
         readyCheck = readyCheck,
         actionName = discName,
-        targetId = targetId,
+        targetId = spellTargetId,
         bAllowDead = true,
         spellRange = spellRange,
         castTime = castTime,
@@ -2277,7 +2298,7 @@ function Casting.UseDisc(discSpell, targetId, fireAndForget)
         Targeting.SetTarget(oldTargetId, true)
     end
 
-    return Casting.CastSucceeded(readyCheck, false), Casting.IsGroupSpell(discSpell.TargetType())
+    return Casting.CastSucceeded(readyCheck, false), Casting.IsGroupSpell(rankDisc.TargetType())
 end
 
 function Casting.GetSpellRange(spell)
@@ -2413,7 +2434,9 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, fireAndForget)
         return false
     end
 
-    local targetSpawn = mq.TLO.Spawn(targetId)
+    local selfTargeted = Casting.IsSelfSpell(aaSpell.TargetType())
+    local spellTargetId = selfTargeted and me.ID() or targetId
+    local targetSpawn = mq.TLO.Spawn(spellTargetId)
 
     -- TEMP 6/26: FeetWet swim-state check disabled - a flyer flying above a pool (e.g. Hartini in Stillmoon) reports FeetWet but its feet aren't actually wet, blocking all casts. Not a verified EQ mechanic.
     -- if targetSpawn() and targetSpawn.FeetWet() ~= me.FeetWet() then
@@ -2434,7 +2457,7 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, fireAndForget)
     end
 
     local spellRange = Casting.GetSpellRange(aaSpell)
-    if targetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
+    if spellTargetId ~= me.ID() and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
         Logger.log_debug("\ayUseAA(): \arTried to cast %s on %s but they are too far away", aaName, targetSpawn.DisplayName() or "None")
         return false
     end
@@ -2442,7 +2465,7 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, fireAndForget)
     Casting.ActionPrep()
 
     local oldTargetId = mq.TLO.Target.ID()
-    if targetId > 0 and targetId ~= oldTargetId then
+    if not selfTargeted and targetId > 0 and targetId ~= oldTargetId then
         if Config:GetSetting('StopAttackForPCs') and me.Combat() and (targetSpawn.Type() or ""):lower() == "pc" then -- don't use helper here, don't want fallback to current target
             Logger.log_debug("\awUseAA():NOTICE:\ax Turning off autoattack to cast on a PC.")
             Core.DoCmd("/attack off")
@@ -2462,7 +2485,7 @@ function Casting.UseAA(aaName, targetId, bAllowDead, retryCount, fireAndForget)
         cmd = cmd,
         readyCheck = readyCheck,
         actionName = aaName,
-        targetId = targetId,
+        targetId = spellTargetId,
         bAllowDead = bAllowDead or false,
         spellRange = spellRange,
         castTime = castTime,
@@ -2531,8 +2554,10 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount, fireAndForg
     end
 
     local castTime = (item.Clicky() and item.Clicky.CastTime()) or item.CastTime() or 0
-    local itemSpell = item.Spell
+    local itemSpell = item.Clicky.Spell
     local targetType = itemSpell and itemSpell.TargetType()
+    local selfTargeted = Casting.IsSelfSpell(targetType)
+    local spellTargetId = selfTargeted and me.ID() or targetId
 
     if (mq.TLO.Window("CastingWindow").Open() or me.Casting()) and not Casting.CanActMidSong(castTime) then
         Logger.log_debug("\ayUseItem(): \arCan't use %s - Casting Window Open", itemName)
@@ -2540,15 +2565,15 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount, fireAndForg
     end
 
     local spellRange = Casting.GetSpellRange(itemSpell)
-    if targetId and targetId ~= me.ID() then
-        local targetSpawn = mq.TLO.Spawn(targetId)
+    if spellTargetId and spellTargetId ~= me.ID() then
+        local targetSpawn = mq.TLO.Spawn(spellTargetId)
         if targetSpawn and targetSpawn() and Targeting.GetTargetDistance(targetSpawn) > spellRange then
             Logger.log_debug("\ayUseItem(): \arTried to use %s on %s but they are too far away", itemName, targetSpawn and targetSpawn.DisplayName() or "None")
             return false
         end
     end
 
-    if targetId and targetId == me.ID() then
+    if spellTargetId and spellTargetId == me.ID() then
         if Casting.IHaveBuff(item.Clicky.SpellID()) then
             Logger.log_debug("\ayUseItem(): \arTried to use %s - clicky already active or won't stack", itemName)
             return false
@@ -2570,7 +2595,7 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount, fireAndForg
     Casting.ActionPrep()
 
     local oldTargetId = mq.TLO.Target.ID()
-    if targetId and targetId > 0 and targetId ~= oldTargetId then
+    if not selfTargeted and targetId and targetId > 0 and targetId ~= oldTargetId then
         local targetSpawn = mq.TLO.Spawn(targetId)
         if Config:GetSetting('StopAttackForPCs') and me.Combat() and (targetSpawn.Type() or ""):lower() == "pc" then -- don't use helper here, don't want fallback to current target
             Logger.log_debug("\awUseItem():NOTICE:\ax Turning off autoattack to cast on a PC.")
@@ -2590,7 +2615,7 @@ function Casting.UseItem(itemName, targetId, bAllowDead, retryCount, fireAndForg
         cmd = cmd,
         readyCheck = readyCheck,
         actionName = itemName,
-        targetId = targetId,
+        targetId = spellTargetId,
         -- default true (unlike UseAA/UseSpell) so rez clickies still fire on dead targets
         bAllowDead = bAllowDead ~= false,
         spellRange = spellRange,
@@ -2652,7 +2677,7 @@ function Casting.WaitCastFinish(targetId, bAllowDead, spellRange, castTime)
                 Logger.log_debug("WaitCastFinish(): Canceled casting %s because spellTarget(%d, range %d) is out of spell range(%d)", currentCast, target.ID(),
                     Targeting.GetTargetDistance(), spellRange)
                 return
-            elseif target() and target.ID() ~= Targeting.GetTargetID() then
+            elseif target() and not Targeting.TargetIsMyself(target) and target.ID() ~= Targeting.GetTargetID() then
                 Logger.log_debug("WaitCastFinish(): Warning your spellTarget(%d) for %s is no longer your currentTarget(%d)", target.ID(), currentCast, Targeting.GetTargetID())
             end
         end
@@ -2695,17 +2720,15 @@ function Casting.WaitCastFinish(targetId, bAllowDead, spellRange, castTime)
     end
 end
 
---- Polls Me.SpellReady every 1 ms until the spell's gem timer has cleared or maxWait (ms) expires; aborts early if combat begins (unless ignoreCombat is true) or if the spell leaves the player's book due to a persona change. Adds a ping-scaled delay after the spell becomes ready to account for server lag.
+--- Polls Me.SpellReady every 20 ms until the spell's gem timer has cleared or maxWait (ms) expires; aborts early if combat begins or if the spell leaves the player's book due to a persona change. Adds a ping-scaled delay after the spell becomes ready to account for server lag.
 --- @param spell string The name of the spell to wait for.
 --- @param maxWait number The maximum amount of time (in miliseconds) to wait for the spell to be ready.
---- @param ignoreCombat? boolean Whether to ignore combat status while waiting.
-function Casting.WaitCastReady(spell, maxWait, ignoreCombat)
-    if not ignoreCombat then ignoreCombat = false end
+function Casting.WaitCastReady(spell, maxWait)
     while not mq.TLO.Me.SpellReady(spell)() and maxWait > 0 do
         mq.delay(20)
         mq.doevents()
         Events.DoEvents()
-        if not ignoreCombat and Targeting.GetXTHaterCount() > 0 then
+        if Targeting.GetXTHaterCount() > 0 then
             Logger.log_debug("I was interrupted by combat while waiting to cast %s.", spell)
             return
         end

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -161,10 +161,6 @@ function Rotation.ExecEntry(caller, entry, targetId, resolvedActionMap, bAllowMe
 
         if not spell or not spell() then return false end
 
-        if entry.waitReadyTime then
-            Casting.WaitCastReady(spell, type(entry.waitReadyTime) == "function" and entry.waitReadyTime() or entry.waitReadyTime, true)
-        end
-
         if Casting.SpellReady(spell, bAllowMem) then
             Rotation.RunPreActivate(caller, resolvedActionMap, entry)
             ret, isGroup = Casting.UseSpell(spell.RankName(), targetId, bAllowMem, entry.allowDead, entry.retries)


### PR DESCRIPTION
* Ability sets can now take a spell ID to deconflict for duplicates.
* * Resolves #102
* Fixed some adjacent issues with Name/RankName use.
* Fixed some issues with safety checks for spells with a target type of "self".
* * As a result, we will no longer frequently target ourself to use self-buffs that don't require it.