### PR TITLE
Emergency Rotation Adjustments

### DIFF
--- a/class_configs/EQ Might/ber_class_config.lua
+++ b/class_configs/EQ Might/ber_class_config.lua
@@ -159,14 +159,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         { --Keep things from running
@@ -209,7 +218,7 @@ return {
         },
     },
     ['Rotations']     = {
-        ['Buffs'] = {
+        ['Buffs']              = {
             {
                 name = "BerAura",
                 type = "Disc",
@@ -225,38 +234,31 @@ return {
                 end,
             },
         },
-        ['Emergency'] = {
+        ['Emergency(Health)']  = {
             {
                 name = "Revitalize",
                 type = "Disc",
-                cond = function(self, discSpell, target)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "Uncanny Resilience",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
-                end,
             },
             {
                 name = "HealingDisc",
                 type = "Disc",
                 load_cond = function(self) return Config:GetSetting('DoHealingDisc') end,
-                cond = function(self, discName)
-                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
-                end,
             },
+        },
+        ['Emergency(Aggro)']   = {
             {
                 name = "Self Preservation",
                 type = "AA",
                 cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
+                    return Casting.OkayToCombatEscape()
                 end,
             },
+            {
+                name = "Uncanny Resilience",
+                type = "AA",
+            },
         },
-        ['Snare'] = {
+        ['Snare']              = {
             {
                 name = "SnareStrike",
                 type = "Disc",
@@ -291,7 +293,7 @@ return {
                 type = "Disc",
             },
         },
-        ['Burn'] = {
+        ['Burn']               = {
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -347,7 +349,7 @@ return {
                 end,
             },
         },
-        ['DPS'] = {
+        ['DPS']                = {
             {
                 name = "Epic",
                 type = "Item",
@@ -386,14 +388,14 @@ return {
                 end,
             },
         },
-        ['GroupBuff'] = { -- Added to anchor clickies to
+        ['GroupBuff']          = { -- Added to anchor clickies to
 
         },
     },
     ['Helpers']       = {
     },
     ['DefaultConfig'] = {
-        ['Mode']           = {
+        ['Mode']          = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -407,7 +409,7 @@ return {
         },
 
         --Equipment
-        ['UseEpic']        = {
+        ['UseEpic']       = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -423,7 +425,7 @@ return {
         },
 
         -- Combat
-        ['DoBattleLeap']   = {
+        ['DoBattleLeap']  = {
             DisplayName = "Do Battle Leap",
             Group = "Abilities",
             Header = "Damage",
@@ -432,7 +434,7 @@ return {
             Tooltip = "Use the Battle Leap AA on cooldown.",
             Default = true,
         },
-        ['DoSnare']        = {
+        ['DoSnare']       = {
             DisplayName = "Do Snare",
             Group = "Abilities",
             Header = "Debuffs",
@@ -441,7 +443,7 @@ return {
             Tooltip = "Snare opponents with low health.",
             Default = false,
         },
-        ['SnareCount']     = {
+        ['SnareCount']    = {
             DisplayName = "Snare Max Mob Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -452,7 +454,7 @@ return {
             Min = 1,
             Max = 99,
         },
-        ['DoStun']         = {
+        ['DoStun']        = {
             DisplayName = "Do Stun",
             Group = "Abilities",
             Header = "Debuffs",
@@ -463,24 +465,12 @@ return {
             FAQ = "Why am I using Stun discs on an immune mob?",
             Answer = "If enabled, these abilities fires blindly. You can turn it off in your Class options.",
         },
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['DoHealingDisc']  = {
+        ['DoHealingDisc'] = {
             DisplayName = "Do Healing Disc",
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use the EQM Custom 'Healing Will/Determination' Disc to heal yourself in emergencies.",
             Default = false,
             RequiresLoadoutChange = true,

--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -413,10 +413,6 @@ local _ClassConfig = {
             end
             return false
         end,
-        UnwantedAggroCheck = function(self)
-            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
-            return Targeting.IHaveAggro(100)
-        end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending
             if not songSpell or not songSpell() then return false end
             return songSpell.StacksTarget() and Targeting.MobNotLowHP(Targeting.GetAutoTarget())
@@ -467,14 +463,25 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             midSong = true,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or self.Helpers.UnwantedAggroCheck(self))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            midSong = true,
+            doFullRotation = true,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -547,7 +554,7 @@ local _ClassConfig = {
         },
     },
     ['Rotations']         = {
-        ['Burn'] = { --Order is heavy WIP
+        ['Burn']              = { --Order is heavy WIP
             {
                 name = "Quick Time",
                 type = "AA",
@@ -615,7 +622,7 @@ local _ClassConfig = {
                 midSong = true,
             },
         },
-        ['Debuff'] = {
+        ['Debuff']            = {
             {
                 name = "AESlowSong",
                 type = "Song",
@@ -650,7 +657,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']            = {
             {
                 name = "Epic",
                 type = "Item",
@@ -675,7 +682,7 @@ local _ClassConfig = {
                 midSong = true,
             },
         },
-        ['Enduring Breath'] = {
+        ['Enduring Breath']   = {
             {
                 name = "EndBreathSong",
                 type = "Song",
@@ -684,7 +691,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Melody'] = {
+        ['Melody']            = {
             {
                 name = "AreaAriaSong",
                 type = "Song",
@@ -851,7 +858,7 @@ local _ClassConfig = {
                 custom_func = function(self) return self.Helpers.RefreshExpiringSong(self) end,
             },
         },
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "DPSAura",
                 type = "Song",
@@ -865,40 +872,32 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
+        ['Emergency(Health)'] = {
+            {
+                name = "Revitalize",
+                type = "Disc",
+                midSong = true,
+            },
+            {
+                name = "Hymn of the Last Stand",
+                type = "AA",
+                midSong = true,
+            },
+        },
+        ['Emergency(Aggro)']  = {
             {
                 name = "Fading Memories",
                 type = "AA",
                 midSong = true,
                 load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
                 cond = function(self, aaName)
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or Globals.AutoTargetIsNamed) and self.Helpers.UnwantedAggroCheck(self)
-                end,
-            },
-            {
-                name = "Revitalize",
-                type = "Disc",
-                midSong = true,
-                cond = function(self, discSpell, target)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "Hymn of the Last Stand",
-                type = "AA",
-                midSong = true,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                    return Casting.OkayToCombatEscape()
                 end,
             },
             {
                 name = "Shield of Notes",
                 type = "AA",
                 midSong = true,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
             },
             {
                 name = "Protective",
@@ -917,7 +916,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['InstantRunBuff'] = {
+        ['InstantRunBuff']    = {
             {
                 name = "Selo's Sonata",
                 type = "AA",
@@ -929,7 +928,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['GroupBuff'] = { -- Added to anchor clickies to
+        ['GroupBuff']         = { -- Added to anchor clickies to
 
         },
     },
@@ -1146,25 +1145,13 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use Fading Memories when you have aggro and you aren't the Main Assist.",
             Default = true,
             ConfigType = "Advanced",
             FAQ = "Why is my Bard regularly using Fading Memories",
             Answer = "When Use Combat Escape is enabled, Fading Memories will be used when the Bard has any unwanted aggro.\n" ..
                 "This helps the common issue of bards gaining aggro from singing before a tank has the chance to secure it.",
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
 
         -- Healing

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -322,14 +322,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -413,7 +422,7 @@ return {
         end,
     },
     ['Rotations']         = {
-        ['Burn']           = {
+        ['Burn']              = {
             {
                 name = "Bestial Bloodrage",
                 type = "AA",
@@ -474,7 +483,7 @@ return {
                 type = "Spell",
             },
         },
-        ['Slow']           = {
+        ['Slow']              = {
             {
                 name = "Legendary Armband of Muada",
                 type = "Item",
@@ -497,7 +506,7 @@ return {
                 end,
             },
         },
-        ['Emergency']      = {
+        ['Emergency(Health)'] = {
             {
                 name = "Warder's Gift",
                 type = "AA",
@@ -505,12 +514,11 @@ return {
                     return (mq.TLO.Me.Pet.PctHPs() or 0) > 50
                 end,
             },
+        },
+        ['Emergency(Aggro)']  = {
             {
                 name = "Protection of the Warder",
                 type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
-                end,
             },
             {
                 name = "ProtDisc",
@@ -520,7 +528,7 @@ return {
                 end,
             },
         },
-        ['PetHealing']     = {
+        ['PetHealing']        = {
             {
                 name = "Companion's Blessing",
                 type = "AA",
@@ -538,13 +546,13 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['FocusedParagon'] = {
+        ['FocusedParagon']    = {
             {
                 name = "Focused Paragon of Spirits",
                 type = "AA",
             },
         },
-        ['Growl']          = {
+        ['Growl']             = {
             {
                 name = "PetGrowl",
                 type = "Spell",
@@ -553,7 +561,7 @@ return {
                 end,
             },
         },
-        ['DPS']            = {
+        ['DPS']               = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -620,7 +628,7 @@ return {
                 end,
             },
         },
-        ['Weaves']         = {
+        ['Weaves']            = {
             {
                 name = "Roar of Thunder",
                 type = "AA",
@@ -658,7 +666,7 @@ return {
                 type = "AA",
             },
         },
-        ['GroupBuff']      = {
+        ['GroupBuff']         = {
             {
                 name = "RunSpeedBuff",
                 type = "Spell",
@@ -729,7 +737,7 @@ return {
                 end,
             },
         },
-        ['PetSummon']      = {
+        ['PetSummon']         = {
             {
                 name = "Razorclaw",
                 type = "Item",
@@ -757,7 +765,7 @@ return {
                 end,
             },
         },
-        ['Downtime']       = {
+        ['Downtime']          = {
             {
                 name = "Gelid Rending",
                 type = "AA",
@@ -770,7 +778,7 @@ return {
                 end,
             },
         },
-        ['PetBuff']        = {
+        ['PetBuff']           = {
             {
                 name = "Epic",
                 type = "Item",
@@ -1102,18 +1110,6 @@ return {
         },
         --Combat
 
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['HealPriority']   = {
             DisplayName = "Healing Priority",
             Group = "Abilities",

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -521,14 +521,13 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -631,7 +630,7 @@ local _ClassConfig = {
         },
     },
     ['Rotations']         = {
-        ['DPS']            = {
+        ['DPS']              = {
             {
                 name = "Epic",
                 type = "Item",
@@ -728,7 +727,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(AE)']        = {
+        ['DPS(AE)']          = {
             {
                 name = "PBAEMagic",
                 type = "Spell",
@@ -748,7 +747,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn']           = {
+        ['Burn']             = {
             {
                 name = "Improved Twincast",
                 type = "AA",
@@ -797,13 +796,16 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ['Emergency']      = {
+        ['Emergency(Aggro)'] = {
             {
                 name = "Cover Tracks",
                 type = "AA",
+                cond = function(self, aaName)
+                    return Casting.OkayToCombatEscape()
+                end,
             },
         },
-        ['Slow']           = {
+        ['Slow']             = {
             {
                 name = "ColdSlow",
                 type = "Spell",
@@ -812,7 +814,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Debuff']         = {
+        ['Debuff']           = {
             { -- Fire Debuff AA, will use the first(best) available
                 name = "FireDebuffAA",
                 type = "AA",
@@ -846,7 +848,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare']          = {
+        ['Snare']            = {
             {
                 name = "Entrap",
                 type = "AA",
@@ -864,7 +866,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['GroupBuff']      = {
+        ['GroupBuff']        = {
             {
                 name = "Flight of Eagles",
                 type = "AA",
@@ -942,7 +944,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Downtime']       = {
+        ['Downtime']         = {
             {
                 name = "HealingAura",
                 type = "Spell",
@@ -976,7 +978,7 @@ local _ClassConfig = {
                 cond = function(self, spell) return Casting.SelfBuffCheck(spell) end,
             },
         },
-        ['PetSummon']      = {
+        ['PetSummon']        = {
             {
                 name = "Artifact of Nature Spirit",
                 type = "Item",
@@ -1004,7 +1006,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff']        = {
+        ['PetBuff']          = {
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -1019,7 +1021,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['InstantRunBuff'] = {
+        ['InstantRunBuff']   = {
             {
                 name = "Communion of the Cheetah",
                 type = "AA",
@@ -1030,7 +1032,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['CombatBuffs']    = {
+        ['CombatBuffs']      = {
             {
                 name = "ReptileBuff",
                 type = "Spell",
@@ -1422,22 +1424,10 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Keep (Lesser) Succor memorized.",
             Default = false,
             RequiresLoadoutChange = true,
-        },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
         ['UseDonorPet']       = {
             DisplayName = "Summon Nature Spirit",

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -544,14 +544,13 @@ local _ClassConfig    = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         { --AA Stuns, Runes, etc, moved from previous home in DPS
@@ -657,7 +656,7 @@ local _ClassConfig    = {
         end,
     },
     ['Rotations']     = {
-        ['Downtime']      = {
+        ['Downtime']         = {
             {
                 name = "Eldritch Rune",
                 type = "AA",
@@ -740,7 +739,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetSummon']     = {
+        ['PetSummon']        = {
             {
                 name = "Asterion",
                 type = "Item",
@@ -766,7 +765,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetBuff']       = {
+        ['PetBuff']          = {
             {
                 name = "HasteBuff",
                 type = "Spell",
@@ -791,7 +790,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['GroupBuff']     = {
+        ['GroupBuff']        = {
             {
                 name = "Legendary Timeless Belt of the Wise",
                 type = "Item",
@@ -942,7 +941,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['CombatSupport'] = {
+        ['CombatSupport']    = {
             {
                 name = "Spire",
                 type = "AA",
@@ -994,7 +993,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetHealing']    = {
+        ['PetHealing']       = {
             {
                 name = "Companion's Blessing",
                 type = "AA",
@@ -1008,13 +1007,12 @@ local _ClassConfig    = {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['Emergency']     = {
+        ['Emergency(Aggro)'] = {
             {
                 name = "Self Stasis",
                 type = "AA",
                 cond = function(self, aaName)
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID
+                    return Casting.OkayToCombatEscape()
                 end,
                 post_activate = function(self, aaName, success)
                     if not success then return end
@@ -1024,42 +1022,6 @@ local _ClassConfig    = {
                         Core.DoCmd('/removebuff =Self Stasis')
                     end
                 end,
-            },
-            {
-                name = "Veil of Mindshadow",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Beguiler's Directed Banishment",
-                type = "AA",
-                load_cond = function() return Config:GetSetting("DoBeguilers") end,
-                cond = function(self, aaName, target)
-                    if target.ID() == Globals.AutoTargetID then return false end
-                    return Targeting.IHaveAggro(100) and not Globals.AutoTargetIsNamed
-                end,
-            },
-            {
-                name = "Beguiler's Banishment",
-                type = "AA",
-                load_cond = function() return Config:GetSetting("DoBeguilers") end,
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.SpawnCount("npc radius 20")() > 2
-                end,
-            },
-
-            {
-                name = "Doppelganger",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
-                end,
-            },
-            {
-                name = "Color Shock",
-                type = "AA",
             },
             {
                 name = "Arcane Whisper",
@@ -1075,8 +1037,31 @@ local _ClassConfig    = {
                     return Casting.SelfBuffAACheck(aaName)
                 end,
             },
+            {
+                name = "Veil of Mindshadow",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
+            },
+            {
+                name = "Color Shock",
+                type = "AA",
+            },
+            {
+                name = "Doppelganger",
+                type = "AA",
+            },
+            {
+                name = "Beguiler's Banishment",
+                type = "AA",
+                load_cond = function() return Config:GetSetting("DoBeguilers") end,
+                cond = function(self, aaName)
+                    return mq.TLO.SpawnCount("npc radius 20")() > 2
+                end,
+            },
         },
-        ['Dispel']        = {
+        ['Dispel']           = {
             {
                 name = "Dispel",
                 type = "Spell",
@@ -1086,7 +1071,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['DPS']           = {
+        ['DPS']              = {
             {
                 name = "Epic",
                 type = "Item",
@@ -1149,7 +1134,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Burn']          = {
+        ['Burn']             = {
             {
                 name = "Illusions of Grandeur",
                 type = "AA",
@@ -1197,7 +1182,7 @@ local _ClassConfig    = {
                 type = "Item",
             },
         },
-        ['Tash']          = {
+        ['Tash']             = {
             {
                 name = "Bite of Tashani",
                 type = "AA",
@@ -1223,7 +1208,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Cripple']       = {
+        ['Cripple']          = {
             {
                 name = "CrippleSpell",
                 type = "Spell",
@@ -1232,7 +1217,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Slow']          = {
+        ['Slow']             = {
             {
                 name = "Enveloping Helix",
                 type = "AA",
@@ -1507,18 +1492,6 @@ local _ClassConfig    = {
             Max = 3,
             ConfigType = "Advanced",
         },
-        ['EmergencyStart']     = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "The HP % emergency abilities will be used (Abilities used depend on whose health is low, the ENC or the MA).",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['DoSoothing']         = {
             DisplayName = "Do Soothing Words",
             Group = "Abilities",
@@ -1534,9 +1507,9 @@ local _ClassConfig    = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             RequiresLoadoutChange = true,
-            Tooltip = "Use Beguiler's (Directed) Banishment AA when you have aggro.",
+            Tooltip = "Use Beguiler's Banishment AA when you have aggro.",
             Default = false,
         },
 

--- a/class_configs/EQ Might/mnk_class_config.lua
+++ b/class_configs/EQ Might/mnk_class_config.lua
@@ -134,14 +134,23 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -150,7 +159,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and not Casting.IAmFeigning()
+                return combat_state == "Combat" and Casting.BurnCheck() and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -169,7 +178,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -178,12 +187,12 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "MonkAura",
                 type = "Disc",
@@ -195,14 +204,35 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
+        ['Emergency(Health)'] = {
+            {
+                name = "Mend",
+                type = "Ability",
+            },
+            {
+                name = "Epic",
+                type = "Item",
+            },
+            {
+                name = "HealingDisc",
+                type = "Disc",
+                load_cond = function(self) return Config:GetSetting('DoHealingDisc') end,
+            },
+        },
+        ['Emergency(Aggro)']  = {
             {
                 name = "Imitate Death",
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
-                    if Core.IsTanking() then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99)
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
+                name = "MeleeMit",
+                type = "Disc",
+                cond = function(self, discName)
+                    return Core.AtCriticalHP()
                 end,
             },
             {
@@ -210,37 +240,11 @@ local _ClassConfig = {
                 type = "Ability",
                 load_cond = function(self) return Config:GetSetting('AggroFeign') end,
                 cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IsTanking()
+                    return Casting.OkayToCombatEscape()
                 end,
-            },
-            {
-                name = "MeleeMit",
-                type = "Disc",
-                cond = function(self, discName)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
-            {
-                name = "Mend",
-                type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "HealingDisc",
-                type = "Disc",
-                load_cond = function(self) return Config:GetSetting('DoHealingDisc') end,
-                cond = function(self, discName)
-                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "Epic",
-                type = "Item",
             },
         },
-        ['Burn'] = {
+        ['Burn']              = {
             {
                 name = "Spire",
                 type = "AA",
@@ -269,7 +273,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['BurnDisc'] = {
+        ['BurnDisc']          = {
             {
                 name = "Heel",
                 type = "Disc",
@@ -287,7 +291,7 @@ local _ClassConfig = {
                 type = "Disc",
             },
         },
-        ['CombatBuff'] = {
+        ['CombatBuff']        = {
             {
                 name = "FistsOfWu",
                 type = "Disc",
@@ -296,7 +300,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS'] = {
+        ['DPS']               = {
             {
                 name = "Eye Gouge",
                 type = "AA",
@@ -321,7 +325,7 @@ local _ClassConfig = {
                 type = "Ability",
             },
         },
-        ['GroupBuff'] = { -- Added to anchor clickies to
+        ['GroupBuff']         = { -- Added to anchor clickies to
 
         },
     },
@@ -365,22 +369,10 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a mob detected as a 'named' by RGMercs (see Spawns tab)..",
             Default = true,
             RequiresLoadoutChange = true,
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
         ['DoHealingDisc']   = {
             DisplayName = "Do Healing Disc",

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -422,14 +422,13 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -447,7 +446,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('ScentDebuffUse') == 2 end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         { -- On Laz, this hits slightly different resists, and in different slots, it is a choice.
@@ -457,7 +456,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('ScentDebuffUse') == 3 end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         { --Keep things from running
@@ -478,7 +477,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and
-                    Casting.BurnCheck() and not Casting.IAmFeigning() and Core.CombatActionsCheck()
+                    Casting.BurnCheck() and not mq.TLO.Me.Feigning() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -488,7 +487,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Targeting.MobNotLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Targeting.MobNotLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -498,7 +497,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Targeting.MobHasLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Targeting.MobHasLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -507,30 +506,29 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
     },
     ['Rotations']       = {
-        ['Emergency']       = {
+        ['Emergency(Aggro)'] = {
             {
                 name = "Death's Effigy",
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99) or (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100))
+                    return Casting.OkayToCombatEscape()
                 end,
             },
             {
                 name = "Harm Shield",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100))
+                    return Core.AtCriticalHP()
                 end,
             },
         },
-        ['Scent(Terris)']   = {
+        ['Scent(Terris)']    = {
             {
                 name_func = function(self)
                     local scentItems = { "Legendary Fabled Nightshade Scented Staff", "Fabled Nightshade Scented Staff", "Scent of Terris", }
@@ -556,7 +554,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Scent(Midnight)'] = {
+        ['Scent(Midnight)']  = {
             {
                 name = "ScentDebuff2",
                 type = "Spell",
@@ -565,7 +563,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare']           = {
+        ['Snare']            = {
             {
                 name = "Encroaching Darkness",
                 type = "AA",
@@ -583,7 +581,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['CombatBuff']      = {
+        ['CombatBuff']       = {
             {
                 name = "Epic",
                 type = "Item",
@@ -641,7 +639,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobHighHP)']  = {
+        ['DPS(MobHighHP)']   = {
             {
                 name = "FireDot",
                 type = "Spell",
@@ -753,7 +751,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobLowHP)']   = {
+        ['DPS(MobLowHP)']    = {
             {
                 name = "OrbNuke",
                 type = "Spell",
@@ -789,7 +787,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn']            = {
+        ['Burn']             = {
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -842,7 +840,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetHealing']      = {
+        ['PetHealing']       = {
             {
                 name = "Companion's Blessing",
                 type = "AA",
@@ -860,7 +858,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['Downtime']        = {
+        ['Downtime']         = {
             {
                 name = "SelfHPBuff",
                 type = "Spell",
@@ -905,7 +903,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target) return Casting.SelfBuffAACheck(aaName) end,
             },
         },
-        ['PetSummon']       = {
+        ['PetSummon']        = {
             {
                 name = "RedDemon",
                 type = "Item",
@@ -953,7 +951,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff']         = { -- TODO: Examine spectral guard 71
+        ['PetBuff']          = { -- TODO: Examine spectral guard 71
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -968,7 +966,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['GroupBuff']       = { -- Added to anchor clickies to
+        ['GroupBuff']        = { -- Added to anchor clickies to
 
         },
     },
@@ -1263,24 +1261,12 @@ local _ClassConfig = {
             Max = 3,
             ConfigType = "Advanced",
         },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['AggroFeign']        = {
             DisplayName = "Emergency Feign",
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a mob detected as a 'named' by RGMercs (see Spawns tab)..",
             Default = true,
         },

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -604,7 +604,7 @@ return {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -616,7 +616,7 @@ return {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -634,7 +634,7 @@ return {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -656,7 +656,7 @@ return {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Prioritized in their own rotation to help keep HP topped to the desired level, includes emergency abilities
@@ -691,7 +691,7 @@ return {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -706,7 +706,7 @@ return {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if not Config:GetSetting('DoAEDamage') or (Core.IsTanking() and mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')) then return false end
+                if not Config:GetSetting('DoAEDamage') or (Core.IsTanking() and Core.AtCriticalHP()) then return false end
                 return combat_state == "Combat" and Combat.AETargetCheck(true) and Core.CombatActionsCheck()
             end,
         },
@@ -716,13 +716,13 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']         = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "Blessing of Life",
                 type = "AA",
@@ -772,7 +772,7 @@ return {
                 end,
             },
         },
-        ['GroupBuff'] = {
+        ['GroupBuff']              = {
             {
                 name = "AegoBuff",
                 type = "Spell",
@@ -824,7 +824,7 @@ return {
                 end,
             },
         },
-        ['EmergencyDefenses'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
             --Some conditionals are commented out while I tweak percentages (or determine if they are necessary)
@@ -885,7 +885,7 @@ return {
                 type = "Spell",
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             {
                 name = "Taunt",
                 type = "Ability",
@@ -918,7 +918,7 @@ return {
                 type = "Spell",
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "BladeDisc",
                 type = "Disc",
@@ -941,7 +941,7 @@ return {
                 end,
             },
         },
-        ['AECombat'] = {
+        ['AECombat']               = {
             {
                 name = "PBAEStun",
                 type = "Spell",
@@ -957,7 +957,7 @@ return {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name = "Spire",
                 type = "AA",
@@ -997,7 +997,7 @@ return {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             {
                 name = "Protective",
                 type = "Disc",
@@ -1019,7 +1019,7 @@ return {
                 type = "AA",
             },
         },
-        ['ToTHeals'] = {
+        ['ToTHeals']               = {
             {
                 name = "SelfHeal",
                 type = "Spell",
@@ -1039,7 +1039,7 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoLightHeal') == 2 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "ForHonor",
                 type = "Spell",
@@ -1115,7 +1115,7 @@ return {
                 load_cond = function(self) return mq.TLO.Me.Ability("Slam")() end,
             },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -1256,31 +1256,6 @@ return {
             Index = 102,
             Tooltip = "The HP % where we will use defensive actions like discs, epics, etc.\nNote that fighting a named will also trigger these actions.",
             Default = 60,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before all but essential rotations are cut in favor of emergency or defensive abilities.",
-            Default = 40,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']        = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that we will use abilities like Lay on Hands or Gift of Life.\nMost other rotations are cut to give our full focus to survival.",
-            Default = 20,
             Min = 1,
             Max = 100,
             ConfigType = "Advanced",

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -305,14 +305,13 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         { --Keep things from running
@@ -548,10 +547,13 @@ return {
                 end,
             },
         },
-        ['Emergency']          = {
+        ['Emergency(Aggro)']   = {
             {
                 name = "Cover Tracks",
                 type = "AA",
+                cond = function(self, aaName)
+                    return Casting.OkayToCombatEscape()
+                end,
             },
             {
                 name = "Protection of the Spirit Wolf",
@@ -561,14 +563,15 @@ return {
                 name = "Outrider's Evasion",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Targeting.IHaveAggro(100) and (mq.TLO.Me.ActiveDisc() or "Weapon Shield Discipline") ~= "Weapon Shield Discipline"
+                    local weaponShield = Core.GetResolvedActionMapItem('WeaponShield')
+                    return not (weaponShield and mq.TLO.Me.ActiveDisc.Name() == weaponShield.RankName())
                 end,
             },
             {
                 name = "WeaponShield",
                 type = "Disc",
                 cond = function(self, discName, target)
-                    return Targeting.IHaveAggro(100) and not mq.TLO.Me.Song("Outrider's Evasion")() and Casting.NoDiscActive()
+                    return not Casting.IHaveBuff(Casting.GetAASpell("Outrider's Evasion").ID()) and Casting.NoDiscActive()
                 end,
             },
             {
@@ -922,7 +925,7 @@ return {
 
 
         --Combat
-        ['DoSwarmDot']     = {
+        ['DoSwarmDot']   = {
             DisplayName = "Swarm Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -932,7 +935,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DotNamedOnly']   = {
+        ['DotNamedOnly'] = {
             DisplayName = "Only Dot Named",
             Group = "Abilities",
             Header = "Damage",
@@ -941,7 +944,7 @@ return {
             Tooltip = "Any selected dot above will only be used on a named mob.",
             Default = true,
         },
-        ['UseEpic']        = {
+        ['UseEpic']      = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -954,21 +957,9 @@ return {
             Min = 1,
             Max = 3,
         },
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
 
         --Utility
-        ['DoHealSpell']    = {
+        ['DoHealSpell']  = {
             DisplayName = "Do Heals",
             Group = "Abilities",
             Header = "Recovery",
@@ -978,7 +969,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoJoltSpell']    = {
+        ['DoJoltSpell']  = {
             DisplayName = "Do Jolt Spell",
             Group = "Abilities",
             Header = "Utility",
@@ -988,7 +979,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoSnare']        = {
+        ['DoSnare']      = {
             DisplayName = "Use Snares",
             Group = "Abilities",
             Header = "Debuffs",
@@ -998,7 +989,7 @@ return {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['SnareCount']     = {
+        ['SnareCount']   = {
             DisplayName = "Snare Max Mob Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1009,7 +1000,7 @@ return {
             Min = 1,
             Max = 99,
         },
-        ['HealPriority']   = {
+        ['HealPriority'] = {
             DisplayName = "Healing Priority",
             Group = "Abilities",
             Header = "Recovery",

--- a/class_configs/EQ Might/rog_class_config.lua
+++ b/class_configs/EQ Might/rog_class_config.lua
@@ -152,14 +152,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -192,7 +201,7 @@ return {
         },
     },
     ['Rotations']     = {
-        ['Burn'] = {
+        ['Burn']              = {
             {
                 name = "PoisonGuide",
                 type = "Disc",
@@ -227,7 +236,7 @@ return {
                 type = "AA",
             },
         },
-        ['BurnDisc'] = {
+        ['BurnDisc']          = {
             {
                 name = "Frenzied",
                 type = "Disc",
@@ -252,7 +261,7 @@ return {
                 type = "Disc",
             },
         },
-        ['Aggro Management'] = {
+        ['Aggro Management']  = {
             {
                 name = "Escape",
                 type = "AA",
@@ -281,7 +290,7 @@ return {
                 type = "AA",
             },
         },
-        ['DPS'] = {
+        ['DPS']               = {
             {
                 name = "Epic",
                 type = "Item",
@@ -316,19 +325,18 @@ return {
                 end,
             },
         },
-        ['Emergency'] = {
+        ['Emergency(Health)'] = {
             {
                 name = "Revitalize",
                 type = "Disc",
-                cond = function(self, discSpell, target)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
             },
             {
                 name = "HealingDisc",
                 type = "Disc",
                 load_cond = function(self) return Config:GetSetting('DoHealingDisc') end,
             },
+        },
+        ['Emergency(Aggro)']  = {
             {
                 name = "Tumble",
                 type = "AA",
@@ -336,12 +344,9 @@ return {
             {
                 name = "CADisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Targeting.IHaveAggro(100)
-                end,
             },
         },
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "ThiefBuff",
                 type = "Disc",
@@ -393,7 +398,7 @@ return {
                 end,
             },
         },
-        ['GroupBuff'] = { -- Added to anchor clickies to
+        ['GroupBuff']         = { -- Added to anchor clickies to
 
         },
     },
@@ -414,10 +419,6 @@ return {
                     Strings.BoolToColorString(Config:GetSetting("DoOpener")), Strings.BoolToColorString(mq.TLO.Me.AbilityReady("Hide")()),
                     mq.TLO.Me.AbilityTimer("Hide")(), Strings.BoolToColorString(mq.TLO.Me.Invis()))
             end
-        end,
-        UnwantedAggroCheck = function(self)
-            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
-            return Targeting.IHaveAggro(100)
         end,
     },
     ['DefaultConfig'] = {
@@ -481,24 +482,12 @@ return {
             Tooltip = "Use Sneak Attack line to start combat (e.g, Daggerslash).",
             Default = true,
         },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Damage",
-            Category = "AE",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['DoHealingDisc']   = {
             DisplayName = "Do Healing Disc",
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use the EQM Custom 'Healing Will/Determination' Disc to heal yourself in emergencies.",
             Default = false,
             RequiresLoadoutChange = true,

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -477,7 +477,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -489,7 +489,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -507,7 +507,7 @@ local _ClassConfig = {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -529,7 +529,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Prioritized in their own rotation to help keep HP topped to the desired level, includes emergency abilities
@@ -565,7 +565,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSnare') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and not Globals.AutoTargetIsNamed and Targeting.GetXTHaterCount() <= Config:GetSetting('SnareCount')
             end,
         },
@@ -575,7 +575,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -585,13 +585,13 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "Shroud",
                 type = "Spell",
@@ -691,17 +691,17 @@ local _ClassConfig = {
                 desc = "Removes VoD at Critical HP",
                 type = "CustomFunc",
                 load_cond = function(self) return Casting.CanUseAA("Visage of Death") end,
-                cond = function(self) return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') and mq.TLO.Me.Buff("Visage of Death")() end,
+                cond = function(self) return Core.AtCriticalHP() and mq.TLO.Me.Buff("Visage of Death")() end,
                 custom_func = function(self)
                     Core.DoCmd("/removebuff \"Visage of Death\"")
                     return true
                 end,
             },
         },
-        ['GroupBuff'] = { -- Added to anchor clickies to
+        ['GroupBuff']              = { -- Added to anchor clickies to
 
         },
-        ['PetSummon'] = {
+        ['PetSummon']              = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -715,7 +715,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff'] = {
+        ['PetBuff']                = {
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -742,7 +742,7 @@ local _ClassConfig = {
             },
 
         },
-        ['EmergencyDefenses'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
             --Some conditionals are commented out while I tweak percentages (or determine if they are necessary)
@@ -781,7 +781,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             {
                 name = "Taunt",
                 type = "Ability",
@@ -823,7 +823,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "Artifact of Dread Gaze",
                 type = "Item",
@@ -853,7 +853,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.AETaunt,
                 load_cond = function(self) return Config:GetSetting('AETauntSpell') end,
                 cond = function(self, spell, target)
-                    return mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyStart')
+                    return not Core.AtEmergencyHP()
                 end,
             },
         },
@@ -892,7 +892,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.ForPower,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name = "Visage of Death",
                 type = "AA",
@@ -944,7 +944,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare'] = {
+        ['Snare']                  = {
             {
                 name = "Encroaching Darkness",
                 tooltip = Tooltips.EncroachingDarkness,
@@ -964,7 +964,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             {
                 name = "Protective",
                 type = "Disc",
@@ -992,7 +992,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['LifeTaps'] = {
+        ['LifeTaps']               = {
             --Full rotation to make sure we use these in priority for emergencies
             {
                 name = "Leech Touch",
@@ -1000,7 +1000,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoLeechTouch') == 2 then return false end
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
+                    return Core.AtCriticalHP()
                 end,
             },
             {
@@ -1031,7 +1031,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "ForPower",
                 type = "Spell",
@@ -1142,7 +1142,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Slam,
             },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -1531,37 +1531,12 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before all but essential rotations are cut in favor of emergency or defensive abilities.",
-            Default = 40,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']        = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that we will use abilities like Leechcurse and Leech Touch.\nMost other rotations are cut to give our full focus to survival.",
-            Default = 20,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['HoldEpicForNoDisc'] = {
             DisplayName = "Epic",
             Group = "Abilities",
             Header = "Tanking",
             Category = "Defenses",
-            Index = 105,
+            Index = 103,
             Tooltip = "Only use your epic if you have no defensive disc active.\nNote: Epic already has a check to not be used when other leech effects are active.",
             Default = true,
         },

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -199,7 +199,7 @@ local _ClassConfig = {
             return false
         end,
         BurnDiscCheck = function(self)
-            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') then return false end
+            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or Core.AtEmergencyHP() then return false end
             local burnDisc = { "Onslaught", "StrikeDisc", "Steelwrath", }
             for _, buffName in ipairs(burnDisc) do
                 local resolvedDisc = self:GetResolvedActionMapItem(buffName)
@@ -262,7 +262,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -274,7 +274,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -290,7 +290,7 @@ local _ClassConfig = {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -312,7 +312,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Defensive actions used proactively to prevent emergencies
@@ -337,7 +337,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -358,13 +358,13 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "AuraBuff",
                 type = "Disc",
@@ -418,7 +418,7 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             {
                 name = "Taunt",
                 type = "Ability",
@@ -463,7 +463,7 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "BladeDisc",
                 type = "Disc",
@@ -484,14 +484,14 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['EmergencyDefenses'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
             {
                 name = "Revitalize",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                    return Core.AtEmergencyHP()
                 end,
             },
             {
@@ -521,7 +521,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -547,7 +547,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             {
                 name = "Protective",
                 type = "Disc",
@@ -599,7 +599,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name = "Spire",
                 type = "AA",
@@ -650,13 +650,13 @@ local _ClassConfig = {
                 name = "BattlecryHeal",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') or Targeting.BigGroupHealsNeeded()
+                    return Core.AtEmergencyHP() or Targeting.BigGroupHealsNeeded()
                 end,
             },
         },
-        ['Buffs'] = {
+        ['Buffs']                  = {
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -831,31 +831,6 @@ local _ClassConfig = {
             Index = 102,
             Tooltip = "The HP % where we will use defensive actions like discs, epics, etc.\nNote that fighting a named will also trigger these actions.",
             Default = 60,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before all but essential rotations are cut in favor of emergency or defensive abilities.",
-            Default = 40,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']      = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that most other rotations are cut to give our full focus to survival.",
-            Default = 20,
             Min = 1,
             Max = 100,
             ConfigType = "Advanced",

--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -538,7 +538,7 @@ return {
                 end,
             },
         },
-        ['Snare'] = {
+        ['Snare']    = {
             {
                 name = "SnareDisc",
                 type = "Disc",
@@ -697,7 +697,7 @@ return {
                 end,
             },
         },
-        ['DPS'] = {
+        ['DPS']      = {
             {
                 name = "Epic",
                 type = "Item",

--- a/class_configs/Live/brd_class_config.lua
+++ b/class_configs/Live/brd_class_config.lua
@@ -766,10 +766,6 @@ local _ClassConfig = {
             end
             return false
         end,
-        UnwantedAggroCheck = function(self)
-            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
-            return Targeting.IHaveAggro(100)
-        end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending
             if not songSpell or not songSpell() then return false end
             return songSpell.StacksTarget() and Targeting.MobNotLowHP(Targeting.GetAutoTarget())
@@ -891,14 +887,25 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             midSong = true,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or self.Helpers.UnwantedAggroCheck(self))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            midSong = true,
+            doFullRotation = true,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -970,7 +977,7 @@ local _ClassConfig = {
         },
     },
     ['Rotations']         = {
-        ['Burn'] = {
+        ['Burn']              = {
             {
                 name = "Quick Time",
                 type = "AA",
@@ -1036,7 +1043,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['Debuff'] = {
+        ['Debuff']            = {
             {
                 name = "AESlowSong",
                 type = "Song",
@@ -1071,7 +1078,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']            = {
             {
                 name = "Epic",
                 type = "Item",
@@ -1136,7 +1143,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Casting.AARank("Intimidation") > 1 end,
             },
         },
-        ['Enduring Breath'] = {
+        ['Enduring Breath']   = {
             {
                 name = "EndBreathSong",
                 type = "Song",
@@ -1145,7 +1152,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Melody'] = {
+        ['Melody']            = {
             {
                 name = "AriaSong",
                 type = "Song",
@@ -1418,7 +1425,7 @@ local _ClassConfig = {
                 custom_func = function(self) return self.Helpers.RefreshExpiringSong(self) end,
             },
         },
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "BardDPSAura",
                 type = "Song",
@@ -1444,7 +1451,38 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
+        ['Emergency(Health)'] = {
+            {
+                name = "Hymn of the Last Stand",
+                type = "AA",
+                midSong = true,
+                load_cond = function(self) return Casting.CanUseAA('Hymn of the Last Stand') end,
+            },
+            {
+                name = "Coating",
+                type = "Item",
+                load_cond = function(self) return Config:GetSetting('DoCoating') end,
+                cond = function(self, itemName, target)
+                    return Casting.SelfBuffItemCheck(itemName)
+                end,
+            },
+        },
+        ['Emergency(Aggro)']  = {
+            {
+                name = "Fading Memories",
+                type = "AA",
+                midSong = true,
+                load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
+                cond = function(self, aaName)
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
+                name = "Shield of Notes",
+                type = "AA",
+                midSong = true,
+                load_cond = function(self) return Casting.CanUseAA('Shield of Notes') end,
+            },
             {
                 name = "Armor of Experience",
                 type = "AA",
@@ -1454,44 +1492,8 @@ local _ClassConfig = {
                     return mq.TLO.Me.PctHPs() < 35
                 end,
             },
-            {
-                name = "Fading Memories",
-                type = "AA",
-                midSong = true,
-                load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
-                cond = function(self, aaName)
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or Globals.AutoTargetIsNamed) and self.Helpers.UnwantedAggroCheck(self)
-                end,
-            },
-            {
-                name = "Hymn of the Last Stand",
-                type = "AA",
-                midSong = true,
-                load_cond = function(self) return Casting.CanUseAA('Hymn of the Last Stand') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "Shield of Notes",
-                type = "AA",
-                midSong = true,
-                load_cond = function(self) return Casting.CanUseAA('Shield of Notes') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "Coating",
-                type = "Item",
-                load_cond = function(self) return Config:GetSetting('DoCoating') end,
-                cond = function(self, itemName, target)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.SelfBuffItemCheck(itemName)
-                end,
-            },
         },
-        ['InstantRunBuff'] = {
+        ['InstantRunBuff']    = {
             {
                 name = "Selo's Sonata",
                 type = "AA",
@@ -2170,18 +2172,6 @@ local _ClassConfig = {
         },
 
         --Emergency
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['UseFading']       = {
             DisplayName = "Use Combat Escape",
             Group = "Abilities",

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -734,14 +734,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -821,7 +830,7 @@ return {
         end,
     },
     ['Rotations']         = {
-        ['Burn'] = {
+        ['Burn']              = {
             {
                 name = "Group Bestial Alignment",
                 type = "AA",
@@ -925,7 +934,7 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['Slow'] = {
+        ['Slow']              = {
             {
                 name = "Sha's Reprisal",
                 type = "AA",
@@ -944,35 +953,12 @@ return {
                 end,
             },
         },
-        ['Emergency'] = {
-            {
-                name = "Falsified Death",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('AggroFeign') then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99) and not Core.IsTanking()
-                end,
-            },
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "Warder's Gift",
                 type = "AA",
                 cond = function(self, aaName)
                     return (mq.TLO.Me.Pet.PctHPs() or 0) > 50
-                end,
-            },
-            {
-                name = "Protection of the Warder",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
                 end,
             },
             {
@@ -984,13 +970,35 @@ return {
                 end,
             },
         },
-        ['FocusedParagon'] = {
+        ['Emergency(Aggro)']  = {
+            {
+                name = "Falsified Death",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    if not Config:GetSetting('AggroFeign') then return false end
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
+                name = "Protection of the Warder",
+                type = "AA",
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
+                end,
+            },
+        },
+        ['FocusedParagon']    = {
             {
                 name = "Focused Paragon of Spirits",
                 type = "AA",
             },
         },
-        ['PetHealing'] = {
+        ['PetHealing']        = {
             {
                 name = "Mend Companion",
                 type = "AA",
@@ -1011,7 +1019,7 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['DPS'] = {
+        ['DPS']               = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -1120,7 +1128,7 @@ return {
                 end,
             },
         },
-        ['Weaves'] = {
+        ['Weaves']            = {
             {
                 name = "Round Kick",
                 type = "Ability",
@@ -1194,7 +1202,7 @@ return {
                 end,
             },
         },
-        ['GroupBuff'] = {
+        ['GroupBuff']         = {
             {
                 name = "RunSpeedBuff",
                 type = "Spell",
@@ -1259,7 +1267,7 @@ return {
                 end,
             },
         },
-        ['PetSummon'] = {
+        ['PetSummon']         = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -1274,7 +1282,7 @@ return {
                 end,
             },
         },
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -1320,7 +1328,7 @@ return {
                 end,
             },
         },
-        ['PetBuff'] = {
+        ['PetBuff']           = {
             {
                 name = "Epic",
                 type = "Item",
@@ -1683,18 +1691,6 @@ return {
             Tooltip = "Use your AE Roar (Timer 11) spell line.",
             Default = false,
             RequiresLoadoutChange = true,
-        },
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
         ['AggroFeign']     = {
             DisplayName = "Emergency Feign",

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -976,6 +976,16 @@ local _ClassConfig    = {
             end,
         },
         {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
+            end,
+        },
+        {
             name = 'Burn',
             state = 1,
             steps = 3,
@@ -1043,7 +1053,7 @@ local _ClassConfig    = {
         end,
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']         = {
             {
                 name = "Orator's Unity",
                 type = "AA",
@@ -1152,7 +1162,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetSummon'] = {
+        ['PetSummon']        = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -1166,7 +1176,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetBuff'] = {
+        ['PetBuff']          = {
             {
                 name = "PetBuffSpell",
                 type = "Spell",
@@ -1182,7 +1192,7 @@ local _ClassConfig    = {
             },
 
         },
-        ['GroupBuff'] = {
+        ['GroupBuff']        = {
             {
                 name = "ManaRegen",
                 type = "Spell",
@@ -1276,7 +1286,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Dispel'] = {
+        ['Dispel']           = {
             {
                 name = "Eradicate Magic",
                 type = "AA",
@@ -1293,7 +1303,43 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['CombatSupport'] = {
+        ['Emergency(Aggro)'] = {
+            {
+                name = "Self Stasis",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Casting.OkayToCombatEscape()
+                end,
+                post_activate = function(self, aaName, success)
+                    if not success then return end
+                    mq.delay(1000, function() return mq.TLO.Me.Buff("Self Stasis")() ~= nil end)
+                    if mq.TLO.Me.Buff("Self Stasis")() then
+                        Comms.PrintGroupMessage("We're out of combat, removing the Self Stasis buff so we can act again.")
+                        Core.DoCmd('/removebuff =Self Stasis')
+                    end
+                end,
+            },
+            {
+                name = "Arcane Whisper",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Globals.AutoTargetIsNamed
+                end,
+            },
+            {
+                name = "Doppelganger",
+                type = "AA",
+            },
+            {
+                name = "Beguiler's Banishment",
+                type = "AA",
+                load_cond = function() return Config:GetSetting("DoBeguilers") end,
+                cond = function(self, aaName)
+                    return mq.TLO.SpawnCount("npc radius 20")() > 2
+                end,
+            },
+        },
+        ['CombatSupport']    = {
             {
                 name = "Glyph Spray",
                 type = "AA",
@@ -1316,79 +1362,15 @@ local _ClassConfig    = {
                     return Casting.DetSpellCheck(spell) and Targeting.GetXTHaterCount() >= Config:GetSetting('AECount')
                 end,
             },
-
-            {
-                name = "Self Stasis",
-                type = "AA",
-                cond = function(self, aaName)
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID
-                end,
-                post_activate = function(self, aaName, success)
-                    if not success then return end
-                    mq.delay(1000, function() return mq.TLO.Me.Buff("Self Stasis")() ~= nil end)
-                    if mq.TLO.Me.Buff("Self Stasis")() then
-                        Comms.PrintGroupMessage("We're out of combat, removing the Self Stasis buff so we can act again.")
-                        Core.DoCmd('/removebuff =Self Stasis')
-                    end
-                end,
-            },
-            -- { --This can interrupt spellcasting which can just make something worse. Let us trust healers and tanks.
-            --     name = "Dimensional Instability",
-            --     type = "AA",
-            --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 30
-            --     end,
-            -- },
-            {
-                name = "Beguiler's Directed Banishment",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if target.ID() == Globals.AutoTargetID then return false end
-                    return mq.TLO.Me.PctAggro() > 99 and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-
-            },
-            {
-                name = "Beguiler's Banishment",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and mq.TLO.SpawnCount("npc radius 20")() > 2
-                end,
-
-            },
-            {
-                name = "Doppelganger",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-            },
-            -- { --This can interrupt spellcasting which can just make something worse. Let us trust healers and tanks.
-            --     name = "Dimensional Shield",
-            --     type = "AA",
-            --     cond = function(self, aaName)
-            --         return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID and mq.TLO.Me.PctHPs() <= 80            --     end,
-
-            -- },
-            {
-                name = "Arcane Whisper",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    return Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() >= 90
-                end,
-
-            },
             {
                 name = "Silent Casting",
                 type = "AA",
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() >= 60
                 end,
-
             },
         },
-        ['DPS(Default)'] = {
+        ['DPS(Default)']     = {
             {
                 name = "MindDot",
                 type = "Spell",
@@ -1430,7 +1412,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['DPS(ModernEra)'] = {
+        ['DPS(ModernEra)']   = {
             {
                 name = "DichoSpell",
                 type = "Spell",
@@ -1482,7 +1464,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']             = {
             {
                 name = "Illusions of Grandeur",
                 type = "AA",
@@ -1530,7 +1512,7 @@ local _ClassConfig    = {
                 type = "AA",
             },
         },
-        ['Tash'] = {
+        ['Tash']             = {
             {
                 name = "Bite of Tashani",
                 type = "AA",
@@ -1547,7 +1529,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['CripSlow'] = {
+        ['CripSlow']         = {
             {
                 name = "Enveloping Helix",
                 type = "AA",
@@ -1806,6 +1788,16 @@ local _ClassConfig    = {
             Default = 3,
             Max = 15,
         },
+        ['DoBeguilers']        = {
+            DisplayName = "Do Beguiler's",
+            Group = "Abilities",
+            Header = "Utility",
+            Category = "Emergency",
+            Index = 101,
+            RequiresLoadoutChange = true,
+            Tooltip = "Use Beguiler's Banishment AA when you have aggro.",
+            Default = false,
+        },
         ['DoAEStun']           = {
             DisplayName = "PBAE Stun use:",
             Group = "Abilities",
@@ -1840,18 +1832,6 @@ local _ClassConfig    = {
                 "Disabled: We will use our standard ST Mez in Gem 1.\n" ..
                 "As ST Mez: We will use the Twincast Mez as our ST Mez in Gem 1.\n" ..
                 "As Mez and to Trigger Twincast: As above and we will also use this spell in combat to trigger the twincast effect.",
-        },
-        ['EmergencyStart']     = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "The HP % emergency abilities will be used (Abilities used depend on whose health is low, the ENC or the MA).",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
         ['DoChestClick']       = {
             DisplayName = "Do Chest Click",

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -271,14 +271,23 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -287,7 +296,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and not Casting.IAmFeigning()
+                return combat_state == "Combat" and Casting.BurnCheck() and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -296,7 +305,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -305,7 +314,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -315,12 +324,12 @@ local _ClassConfig = {
             load_cond = function(self) return self:GetResolvedActionMapItem('Precision1') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "MonkAura",
                 type = "Disc",
@@ -369,45 +378,21 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
-            {
-                name = "Imitate Death",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
-                cond = function(self, aaName, target)
-                    if Core.IsTanking() then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99)
-                end,
-            },
-            {
-                name = "Feign Death",
-                type = "Ability",
-                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
-                cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IsTanking()
-                end,
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "RejectDeath",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 25
-                end,
-            },
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35
+                    return Core.AtCriticalHP()
                 end,
             },
             {
                 name = "Mend",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
-                end,
+            },
+            {
+                name = "Epic",
+                type = "Item",
             },
             {
                 name = "Coating",
@@ -417,12 +402,34 @@ local _ClassConfig = {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
+        },
+        ['Emergency(Aggro)']  = {
             {
-                name = "Epic",
-                type = "Item",
+                name = "Imitate Death",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
+                cond = function(self, aaName, target)
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
+                end,
+            },
+            {
+                name = "Feign Death",
+                type = "Ability",
+                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
+                cond = function(self, abilityName)
+                    return Casting.OkayToCombatEscape()
+                end,
             },
         },
-        ['Burn'] = {
+        ['Burn']              = {
             { -- 5m reuse
                 name = "Dicho",
                 type = "Disc",
@@ -521,7 +528,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['CombatBuff'] = {
+        ['CombatBuff']        = {
             {
                 name = "CombatEndRegen",
                 type = "Disc",
@@ -582,7 +589,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS'] = {
+        ['DPS']               = {
             {
                 name = "Synergy",
                 type = "Disc",
@@ -640,7 +647,7 @@ local _ClassConfig = {
                 type = "Ability",
             },
         },
-        ['Precision'] = {
+        ['Precision']         = {
             {
                 name = "Precision5",
                 type = "Disc",
@@ -676,7 +683,7 @@ local _ClassConfig = {
         },
     },
     ['DefaultConfig'] = {
-        ['Mode']           = {
+        ['Mode']         = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -688,7 +695,7 @@ local _ClassConfig = {
             FAQ = "What do the different Modes Do?",
             Answer = "Currently there is only DPS mode for Monks, more modes may be added in the future.",
         },
-        ['DoVetAA']        = {
+        ['DoVetAA']      = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -699,29 +706,17 @@ local _ClassConfig = {
             ConfigType = "Advanced",
             RequiresLoadoutChange = true,
         },
-        ['AggroFeign']     = {
+        ['AggroFeign']   = {
             DisplayName = "Emergency Feign",
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a mob detected as a 'named' by RGMercs (see Spawns tab)..",
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['DoChestClick']   = {
+        ['DoChestClick'] = {
             DisplayName = "Do Chest Click",
             Group = "Items",
             Header = "Clickies",
@@ -731,7 +726,7 @@ local _ClassConfig = {
             Default = mq.TLO.MacroQuest.BuildName() ~= "Emu",
             ConfigType = "Advanced",
         },
-        ['DoCoating']      = {
+        ['DoCoating']    = {
             DisplayName = "Use Coating",
             Group = "Items",
             Header = "Clickies",

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -872,14 +872,23 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -897,7 +906,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoScentDebuff') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         { --Keep things from running
@@ -908,7 +917,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and not Globals.AutoTargetIsNamed and Targeting.GetXTHaterCount() <= Config:GetSetting('SnareCount') and
-                    not Casting.IAmFeigning() and Core.CombatActionsCheck()
+                    not mq.TLO.Me.Feigning() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -918,7 +927,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and
-                    Casting.BurnCheck() and not Casting.IAmFeigning() and Core.CombatActionsCheck()
+                    Casting.BurnCheck() and not mq.TLO.Me.Feigning() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -928,7 +937,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Targeting.MobNotLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Targeting.MobNotLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -938,12 +947,12 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Targeting.MobHasLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Targeting.MobHasLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']       = {
-        ['Lich Management'] = {
+        ['Lich Management']   = {
             {
                 name = "LichSpell",
                 type = "Spell",
@@ -982,33 +991,9 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency']       = {
-            {
-                name = "Death's Effigy",
-                type = "AA",
-                cond = function(self, aaName, target)
-                    if not Config:GetSetting('AggroFeign') then return false end
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99) or (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100))
-                end,
-            },
-            {
-                name = "Death Peace",
-                type = "AA",
-                cond = function(self, aaName)
-                    if not Config:GetSetting('AggroFeign') then return false end
-                    return (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99) or (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100))
-                end,
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "Dying Grasp",
-                type = "AA",
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "Embalmer's Carapace",
                 type = "AA",
             },
             {
@@ -1017,7 +1002,29 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoLifetap') end,
             },
         },
-        ['Scent']           = {
+        ['Emergency(Aggro)']  = {
+            {
+                name = "Death's Effigy",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    if not Config:GetSetting('AggroFeign') then return false end
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
+                name = "Embalmer's Carapace",
+                type = "AA",
+            },
+            {
+                name = "Death Peace",
+                type = "AA",
+                cond = function(self, aaName)
+                    if not Config:GetSetting('AggroFeign') then return false end
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+        },
+        ['Scent']             = {
             {
                 name = "Scent of Thule",
                 type = "AA",
@@ -1033,7 +1040,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobHighHP)']  = {
+        ['DPS(MobHighHP)']    = {
             {
                 name = "DurationTap",
                 type = "Spell",
@@ -1194,7 +1201,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobLowHP)']   = {
+        ['DPS(MobLowHP)']     = {
             {
                 name = "Lifetap",
                 type = "Spell",
@@ -1233,7 +1240,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare']           = {
+        ['Snare']             = {
             {
                 name = "Encroaching Darkness",
                 type = "AA",
@@ -1251,7 +1258,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn']            = { -- TODO: Needs optimization. For now its all just kinda thrown in. --Algar
+        ['Burn']              = { -- TODO: Needs optimization. For now its all just kinda thrown in. --Algar
             {
                 name = "Scent of Thule",
                 type = "AA",
@@ -1355,7 +1362,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetHealing']      = {
+        ['PetHealing']        = {
             {
                 name = "Mend Companion",
                 type = "AA",
@@ -1376,7 +1383,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['Downtime']        = {
+        ['Downtime']          = {
             {
                 name = "Mortifier's Unity",
                 type = "AA",
@@ -1438,7 +1445,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetSummon']       = { --TODO: Double check these lists to ensure someone leveling doesn't have to change options to keep pets current at lower levels
+        ['PetSummon']         = { --TODO: Double check these lists to ensure someone leveling doesn't have to change options to keep pets current at lower levels
             {
                 name_func = function(self)
                     return string.format("%sPetSpell", self.ClassConfig.DefaultConfig.PetType.ComboOptions[Config:GetSetting('PetType')])
@@ -1457,7 +1464,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff']         = {
+        ['PetBuff']           = {
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -1732,24 +1739,12 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = true,
         },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['AggroFeign']        = {
             DisplayName = "Emergency Feign",
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a mob detected as a 'named' by RGMercs (see Spawns tab)..",
             Default = true,
         },

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -962,7 +962,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -974,7 +974,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -986,7 +986,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('AETauntAA') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -1008,7 +1008,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Prioritized in their own rotation to help keep HP topped to the desired level, includes emergency abilities
@@ -1043,7 +1043,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
@@ -1053,7 +1053,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -1063,7 +1063,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
@@ -1073,13 +1073,13 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']         = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -1212,7 +1212,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['GroupBuff'] = {
+        ['GroupBuff']              = {
             {
                 name = "Brells",
                 type = "Spell",
@@ -1256,15 +1256,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['EmergencyDefenses'] = {
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < Config:GetSetting('HPCritical')
-                end,
-            },
+        ['EmergencyDefenses']      = {
             --Note that on named we may already have a mantle/carapace running already, could make this remove other discs, but meh, Shield Flash still a thing.
             {
                 name = "Deflection",
@@ -1275,7 +1267,7 @@ local _ClassConfig = {
                     end
                 end,
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') and Casting.NoDiscActive() and
+                    return Core.AtCriticalHP() and Casting.NoDiscActive() and
                         (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000
                 end,
             },
@@ -1332,6 +1324,14 @@ local _ClassConfig = {
             {
                 name = "Forceful Rejuvenation",
                 type = "AA",
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
+                end,
             },
         },
         ['HateTools(AggroTarget)'] = {
@@ -1390,7 +1390,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('Timer6Choice') == 2 end,
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             {
                 name = "Disruption",
                 type = "AA",
@@ -1463,7 +1463,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "Heroic Leap",
                 type = "AA",
@@ -1480,7 +1480,7 @@ local _ClassConfig = {
                 type = "AA",
             },
         },
-        ['Debuff'] = {
+        ['Debuff']                 = {
             {
                 name = "Audacity",
                 type = "Spell",
@@ -1499,7 +1499,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name = "Valorous Rage",
                 type = "AA",
@@ -1578,7 +1578,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             {
                 name = "MeleeMit",
                 type = "Disc",
@@ -1611,7 +1611,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['ToTHeals'] = {
+        ['ToTHeals']               = {
             {
                 name = "Dicho",
                 type = "Spell",
@@ -1642,7 +1642,7 @@ local _ClassConfig = {
                 load_cond = function() return Config:GetSetting("DoLightHeal") end,
             },
         },
-        ['CombatWeave'] = {
+        ['CombatWeave']            = {
             { --Used if the group could benefit from the heal
                 name = "ReflexStrike",
                 type = "Disc",
@@ -1676,7 +1676,7 @@ local _ClassConfig = {
                 type = "Ability",
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "ForHonor",
                 type = "Spell",
@@ -1748,7 +1748,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Core.IsTanking() end,
             },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -2036,31 +2036,6 @@ local _ClassConfig = {
             Index = 102,
             Tooltip = "The HP % where we will use defensive actions like discs, epics, etc.\nNote that fighting a named will also trigger these actions.",
             Default = 60,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before all but essential rotations are cut in favor of emergency or defensive abilities.",
-            Default = 40,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']        = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that we will use abilities like Lay on Hands or Gift of Life.\nMost other rotations are cut to give our full focus to survival.",
-            Default = 20,
             Min = 1,
             Max = 100,
             ConfigType = "Advanced",

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -779,13 +779,10 @@ local _ClassConfig = {
                     mq.TLO.Me.PctMana() or 0, Config:GetSetting('ManaToNuke'), Strings.BoolToColorString(Casting.SpellReady(openerAbility)))
             end
         end,
-        UnwantedAggroCheck = function(self)
-            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
-            return Targeting.IHaveAggro(100)
-        end,
-        DefensesActive = function(self)
-            return not Casting.IHaveBuff("Outrider's Evasion") and (mq.TLO.Me.ActiveDisc() or "Weapon Shield Discipline") ~= "Weapon Shield Discipline" and
-                not Casting.IHaveBuff("Armor of Experience")
+        AnyDefenseUp = function(self)
+            local weaponShield = Core.GetResolvedActionMapItem('WeaponShield')
+            return Casting.IHaveBuff(Casting.GetAASpell("Outrider's Evasion").ID()) or Casting.IHaveBuff(Casting.GetAASpell("Armor of Experience").ID()) or
+                (weaponShield and mq.TLO.Me.ActiveDisc.Name() == weaponShield.RankName()) or false
         end,
     },
     ['HealRotationOrder'] = {
@@ -836,13 +833,13 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -924,7 +921,7 @@ local _ClassConfig = {
         },
     },
     ['Rotations']         = {
-        ['Downtime'] = {
+        ['Downtime']           = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -1082,7 +1079,7 @@ local _ClassConfig = {
                 cond = function(self, aaName) return not Core.IsTanking() and Casting.SelfBuffAACheck(aaName) end,
             },
         },
-        ['GroupBuff'] = {
+        ['GroupBuff']          = {
             { -- From Level 100 this delivers SingleCloakDS, PredatorBuff and StrengthBuff to the whole group.
                 name = "ShoutBuff",
                 type = "Spell",
@@ -1176,13 +1173,13 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
+        ['Emergency(Aggro)']   = {
             {
                 name = "Cover Tracks",
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoCoverTracks') and Casting.CanUseAA("Cover Tracks") end,
                 cond = function(self, aaName)
-                    return self.Helpers.UnwantedAggroCheck(self)
+                    return Casting.OkayToCombatEscape()
                 end,
             },
             {
@@ -1197,14 +1194,14 @@ local _ClassConfig = {
                 name = "Outrider's Evasion",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return not self.Helpers.DefensesActive()
+                    return not self.Helpers.AnyDefenseUp(self)
                 end,
             },
             {
                 name = "WeaponShield",
                 type = "Disc",
                 cond = function(self, discSpell, target)
-                    return not self.Helpers.DefensesActive() and Casting.NoDiscActive()
+                    return not self.Helpers.AnyDefenseUp(self) and Casting.NoDiscActive()
                 end,
             },
             {
@@ -1212,11 +1209,11 @@ local _ClassConfig = {
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
                 cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35 and not self.Helpers.DefensesActive()
+                    return Core.AtCriticalHP() and not self.Helpers.AnyDefenseUp(self)
                 end,
             },
         },
-        ['Aggro Management'] = {
+        ['Aggro Management']   = {
             {
                 name = "Silent Strikes",
                 type = "AA",
@@ -1230,7 +1227,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Debuff'] = {
+        ['Debuff']             = {
             {
                 name = "Elemental Arrow",
                 type = "AA",
@@ -1239,7 +1236,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare'] = {
+        ['Snare']              = {
             {
                 name = "Entrap",
                 type = "AA",
@@ -1257,7 +1254,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Dispel'] = {
+        ['Dispel']             = {
             {
                 name = "Entropy of Nature",
                 type = "AA",
@@ -1274,7 +1271,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']               = {
             {
                 name = "Auspice of the Hunter",
                 type = "AA",
@@ -1366,7 +1363,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['DPS'] = {
+        ['DPS']                = {
             {
                 name = "CalledShotsArrow",
                 type = "Spell",
@@ -1488,7 +1485,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Weaves'] = {
+        ['Weaves']             = {
             {
                 name = "ReflexStrike",
                 type = "Disc",
@@ -1954,17 +1951,6 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['EmergencyStart']      = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-        },
         ['JoltAggro']           = {
             DisplayName = "Aggro Shed %",
             Group = "Abilities",
@@ -1991,7 +1977,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use Cover Tracks to escape combat in an emergency.",
             Default = false,
             RequiresLoadoutChange = true,

--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -302,14 +302,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -341,7 +350,7 @@ return {
         },
     },
     ['Rotations']     = {
-        ['Burn'] = {
+        ['Burn']              = {
             {
                 name = "Frenzied",
                 type = "Disc",
@@ -431,7 +440,7 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['Aggro Management'] = {
+        ['Aggro Management']  = {
             {
                 name = "Escape",
                 type = "AA",
@@ -458,7 +467,7 @@ return {
                 end,
             },
         },
-        ['CombatBuff'] = {
+        ['CombatBuff']        = {
             {
                 name = "Epic",
                 type = "Item",
@@ -526,7 +535,7 @@ return {
                 end,
             },
         },
-        ['DPS'] = {
+        ['DPS']               = {
             {
                 name = "Backstab",
                 type = "Ability",
@@ -577,19 +586,7 @@ return {
                 end,
             },
         },
-        ['Emergency'] = {
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
-            {
-                name = "Tumble",
-                type = "AA",
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "Coating",
                 type = "Item",
@@ -598,15 +595,26 @@ return {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
+        },
+        ['Emergency(Aggro)']  = {
+            {
+                name = "Tumble",
+                type = "AA",
+            },
             {
                 name = "CADisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Targeting.IHaveAggro(100)
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
                 end,
             },
         },
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "ThiefBuff",
                 type = "Disc",
@@ -660,7 +668,7 @@ return {
                 end,
             },
         },
-        ['Hide & Sneak'] = {
+        ['Hide & Sneak']      = {
             {
                 name = "Hide & Sneak",
                 type = "CustomFunc",
@@ -729,10 +737,6 @@ return {
             end
             return true
         end,
-        UnwantedAggroCheck = function(self)
-            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
-            return Targeting.IHaveAggro(100)
-        end,
     },
     ['DefaultConfig'] = {
         ['Mode']            = {
@@ -797,18 +801,6 @@ return {
             Index = 101,
             Tooltip = "Use Sneak Attack line to start combat (e.g, Daggerslash).",
             Default = true,
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
         ['HideAggro']       = {
             DisplayName = "Hide Aggro%",

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -851,7 +851,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -863,7 +863,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -881,7 +881,7 @@ local _ClassConfig = {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -897,13 +897,13 @@ local _ClassConfig = {
             end,
         },
         { --Defensive actions triggered by low HP
-            name = 'Emergency',
+            name = 'EmergencyDefenses',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Prioritized in their own rotation to help keep HP topped to the desired level, includes emergency abilities
@@ -935,7 +935,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and self.Helpers.LeechCheck(self)
             end,
         },
@@ -946,7 +946,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSnare') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and not Globals.AutoTargetIsNamed and Targeting.GetXTHaterCount() <= Config:GetSetting('SnareCount')
             end,
         },
@@ -956,7 +956,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -966,7 +966,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
@@ -976,13 +976,13 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -1171,7 +1171,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetSummon'] = {
+        ['PetSummon']              = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -1189,7 +1189,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff'] = {
+        ['PetBuff']                = {
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -1200,7 +1200,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
             --Side Note: I reserve Bargain for manual use while driving, the omission is intentional. I haven't quite thought about how I would automate it.
@@ -1214,7 +1214,7 @@ local _ClassConfig = {
                     end
                 end,
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') and Casting.NoDiscActive() and
+                    return Core.AtCriticalHP() and Casting.NoDiscActive() and
                         (mq.TLO.Me.AltAbilityTimer("Shield Flash")() or 0) < 234000
                 end,
             },
@@ -1223,7 +1223,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.LeechCurse,
                 cond = function(self)
-                    return Casting.NoDiscActive() and mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
+                    return Casting.NoDiscActive() and Core.AtCriticalHP()
                 end,
             },
             {
@@ -1239,15 +1239,6 @@ local _ClassConfig = {
                     return mq.TLO.Me.ActiveDisc.Name() ~= "Deflection Discipline"
                 end,
             },
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                tooltip = Tooltips.ArmorofExperience,
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
-                end,
-            },
             { --Chest Click, name function stops errors in rotation window when slot is empty
                 name_func = function() return mq.TLO.Me.Inventory("Chest").Name() or "ChestClick(Missing)" end,
                 type = "Item",
@@ -1261,6 +1252,15 @@ local _ClassConfig = {
                 name = "Forceful Rejuvenation",
                 type = "AA",
                 tooltip = Tooltips.ForcefulRejuv,
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                tooltip = Tooltips.ArmorofExperience,
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
+                end,
             },
         },
         ['HateTools(AggroTarget)'] = {
@@ -1301,7 +1301,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             --used when we've lost hatred after it is initially established
             {
                 name = "Ageless Enmity",
@@ -1351,7 +1351,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return self.Helpers.ShouldMemTerror() end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('DoTerror') == 1 or mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                    if Config:GetSetting('DoTerror') == 1 or Core.AtEmergencyHP() then return false end
                     return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
@@ -1361,12 +1361,12 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return self.Helpers.ShouldMemTerror() end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('DoTerror') == 1 or mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                    if Config:GetSetting('DoTerror') == 1 or Core.AtEmergencyHP() then return false end
                     return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "Explosion of Hatred",
                 type = "AA",
@@ -1387,19 +1387,19 @@ local _ClassConfig = {
                     return setting == 3 or (setting == 2 and not Casting.CanUseAA("Explosion of Hatred"))
                 end,
                 cond = function(self, spell, target)
-                    return mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyStart')
+                    return not Core.AtEmergencyHP()
                 end,
             },
             {
                 name = "AELifeTap",
                 type = "Spell",
                 cond = function(self, spell)
-                    if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) or mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                    if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) or Core.AtEmergencyHP() then return false end
                     return Combat.AETargetCheck(true)
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name = "Visage of Death",
                 type = "AA",
@@ -1485,7 +1485,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare'] = {
+        ['Snare']                  = {
             {
                 name = "Encroaching Darkness",
                 tooltip = Tooltips.EncroachingDarkness,
@@ -1505,7 +1505,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DefensiveDiscs'] = {
+        ['DefensiveDiscs']         = {
             {
                 name = "Carapace",
                 type = "Disc",
@@ -1542,7 +1542,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['LeechEffects'] = {
+        ['LeechEffects']           = {
             {
                 name = "Epic",
                 type = "Item",
@@ -1562,7 +1562,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['LifeTaps'] = {
+        ['LifeTaps']               = {
             --Full rotation to make sure we use these in priority for emergencies
             {
                 name = "Leech Touch",
@@ -1570,7 +1570,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoLeechTouch') == 2 then return false end
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
+                    return Core.AtCriticalHP()
                 end,
             },
             --the trick with the next two is to find a sweet spot between using discs and long term CD abilities (we want these to trigger so those don't need to) and using them needlessly (which isn't much of a damage increase). Trying to get it dialed in for a good default value.
@@ -1617,7 +1617,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.ReflexStrike,
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                    return Core.AtEmergencyHP()
                 end,
             },
             {
@@ -1630,7 +1630,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['CombatWeave'] = {
+        ['CombatWeave']            = {
             {
                 name = "CombatEndRegen",
                 type = "Disc",
@@ -1693,7 +1693,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Slam,
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "ForPower",
                 type = "Spell",
@@ -1783,7 +1783,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -2270,32 +2270,7 @@ local _ClassConfig = {
             Category = "Defenses",
             Index = 102,
             Tooltip = "The HP % where we will use defensive discs and the like.\nNote that fighting a named will also trigger these actions.",
-            Default = 70,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before heavy defensive abilities like Shield Flash are triggered.\n Some non-essential rotations are skipped to help us focus on survival (See FAQ).",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']        = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that we will use disciplines like Deflection, Leechcurse, and Leech Touch.\nMost other rotations are cut to give our full focus to survival (See FAQ).",
-            Default = 30,
+            Default = 60,
             Min = 1,
             Max = 100,
             ConfigType = "Advanced",

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -322,7 +322,7 @@ local _ClassConfig = {
             return true
         end,
         BurnDiscCheck = function(self)
-            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') then return false end
+            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or Core.AtEmergencyHP() then return false end
             local burnDisc = { "Onslaught", "MightyStrike", "ChargeDisc", "OffensiveDisc", }
             for _, buffName in ipairs(burnDisc) do
                 local resolvedDisc = self:GetResolvedActionMapItem(buffName)
@@ -362,7 +362,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -374,7 +374,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout') and Targeting.HateToolsNeeded()
+                return combat_state == "Combat" and not Core.AtCriticalHP() and Targeting.HateToolsNeeded()
             end,
         },
         { --Actions that establish or maintain hatred
@@ -386,7 +386,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('DoAETaunt') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Combat.AETauntCheck(true) and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout')
+                return combat_state == "Combat" and Combat.AETauntCheck(true) and not Core.AtCriticalHP()
             end,
         },
         { --Defensive actions triggered by low HP
@@ -396,7 +396,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Dynamic weapon swapping if UseBandolier is toggled
@@ -418,7 +418,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 --need to look at rotation and decide if it should fire during emergencies. leaning towards no
-                return combat_state == "Combat" and Core.IsTanking() and (mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') or
+                return combat_state == "Combat" and Core.IsTanking() and (Core.AtEmergencyHP() or
                     Targeting.TankingXTNamed() or self.Helpers.DefensiveDiscCheck(true))
             end,
         },
@@ -428,7 +428,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout') and Core.CombatActionsCheck()
+                return combat_state == "Combat" and Casting.BurnCheck() and not Core.AtEmergencyHP() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -448,12 +448,12 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyLockout') and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not Core.AtEmergencyHP() and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -525,7 +525,7 @@ local _ClassConfig = {
                 type = "Disc",
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             {
                 name = "Attention",
                 type = "Disc",
@@ -557,7 +557,7 @@ local _ClassConfig = {
                 type = "Disc",
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "Area Taunt",
                 type = "AA",
@@ -574,22 +574,14 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['EmergencyDefenses'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 25
-                end,
-            },
             {
                 name = "Fortitude",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyLockout') and not Casting.IHaveBuff("Flash of Anger") and
+                    return Core.AtCriticalHP() and not Casting.IHaveBuff("Flash of Anger") and
                         not Casting.IHaveBuff("Blade Whirl")
                 end,
             },
@@ -623,8 +615,16 @@ local _ClassConfig = {
                     return Core.IsTanking() and self.Helpers.DiscOverwriteCheck(self)
                 end,
             },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
+                end,
+            },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -650,7 +650,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             --helper function(s) for ability stacking checks may reduce code, but this is functional.
             { --shares effect with modern chest click
                 name = "DichoShield",
@@ -720,7 +720,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Buffs'] = {
+        ['Buffs']                  = {
             {
                 name = "GroupACBuff",
                 type = "Disc",
@@ -774,7 +774,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name = "Spire of the Warlord",
                 type = "AA",
@@ -852,7 +852,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "ShieldHit",
                 type = "Disc",
@@ -956,7 +956,7 @@ local _ClassConfig = {
         },
     },
     ['DefaultConfig'] = {
-        ['Mode']             = {
+        ['Mode']            = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -968,7 +968,7 @@ local _ClassConfig = {
             FAQ = "What do the different Modes Do?",
             Answer = "Warriors have a Tank mode and a DPS Mode.",
         },
-        ['DoBattleLeap']     = {
+        ['DoBattleLeap']    = {
             DisplayName = "Do Battle Leap",
             Group = "Abilities",
             Header = "Damage",
@@ -976,7 +976,7 @@ local _ClassConfig = {
             Tooltip = "Do Battle Leap",
             Default = true,
         },
-        ['DoPress']          = {
+        ['DoPress']         = {
             DisplayName = "Do Press the Attack",
             Group = "Abilities",
             Header = "Debuffs",
@@ -984,7 +984,7 @@ local _ClassConfig = {
             Tooltip = "Use the Press to Attack stun/push AA.",
             Default = false,
         },
-        ['DoSnare']          = {
+        ['DoSnare']         = {
             DisplayName = "Use Snares",
             Group = "Abilities",
             Header = "Debuffs",
@@ -992,7 +992,7 @@ local _ClassConfig = {
             Tooltip = "Enable casting Snare abilities.",
             Default = true,
         },
-        ['DoVetAA']          = {
+        ['DoVetAA']         = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -1003,7 +1003,7 @@ local _ClassConfig = {
             ConfigType = "Advanced",
             RequiresLoadoutChange = true,
         },
-        ['DoAETaunt']        = {
+        ['DoAETaunt']       = {
             DisplayName = "Do AE Taunts",
             Group = "Abilities",
             Header = "Tanking",
@@ -1017,7 +1017,7 @@ local _ClassConfig = {
         },
 
         --Defenses
-        ['DiscCount']        = {
+        ['DiscCount']       = {
             DisplayName = "Def. Disc. Count",
             Group = "Abilities",
             Header = "Tanking",
@@ -1029,33 +1029,9 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['EmergencyStart']   = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 102,
-            Tooltip = "Your HP % before we begin to use emergency abilities.",
-            Default = 55,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyLockout'] = {
-            DisplayName = "Emergency Only",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "Your HP % before standard DPS rotations are cut in favor of emergency abilities.",
-            Default = 35,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
 
         --Equipment
-        ['DoChestClick']     = {
+        ['DoChestClick']    = {
             DisplayName = "Do Chest Click",
             Group = "Items",
             Header = "Clickies",
@@ -1064,7 +1040,7 @@ local _ClassConfig = {
             Tooltip = "Click your equipped chest.",
             Default = mq.TLO.MacroQuest.BuildName() ~= "Emu",
         },
-        ['DoCharmClick']     = {
+        ['DoCharmClick']    = {
             DisplayName = "Do Charm Click",
             Group = "Items",
             Header = "Clickies",
@@ -1073,7 +1049,7 @@ local _ClassConfig = {
             Tooltip = "Click your charm for Geomantra.",
             Default = false,
         },
-        ['DoCoating']        = {
+        ['DoCoating']       = {
             DisplayName = "Use Coating",
             Group = "Items",
             Header = "Clickies",
@@ -1082,7 +1058,7 @@ local _ClassConfig = {
             Tooltip = "Click your Blood/Spirit Drinker's Coating when defenses are triggered.",
             Default = false,
         },
-        ['UseBandolier']     = {
+        ['UseBandolier']    = {
             DisplayName = "Dynamic Weapon Swap",
             Group = "Items",
             Header = "Bandolier",
@@ -1092,7 +1068,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['EquipShield']      = {
+        ['EquipShield']     = {
             DisplayName = "Equip Shield",
             Group = "Items",
             Header = "Bandolier",
@@ -1104,7 +1080,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['EquipDW']          = {
+        ['EquipDW']         = {
             DisplayName = "Equip DW",
             Group = "Items",
             Header = "Bandolier",
@@ -1116,7 +1092,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['NamedShieldLock']  = {
+        ['NamedShieldLock'] = {
             DisplayName = "Shield on Named",
             Group = "Items",
             Header = "Bandolier",
@@ -1127,7 +1103,7 @@ local _ClassConfig = {
             FAQ = "Why does my WAR switch to a Shield on puny gray named?",
             Answer = "The Shield on Named option doesn't check levels, so feel free to disable this setting (or Bandolier swapping entirely) if you are farming fodder.",
         },
-        ['DoEpic']           = {
+        ['DoEpic']          = {
             DisplayName = "Do Epic",
             Group = "Items",
             Header = "Clickies",

--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -136,14 +136,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         { --Keep things from running
@@ -186,7 +195,7 @@ return {
         },
     },
     ['Rotations']     = {
-        ['Buffs'] = {
+        ['Buffs']              = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -216,30 +225,7 @@ return {
                 end,
             },
         },
-        ['Emergency'] = {
-            {
-                name = "BattleFocus",
-                type = "Disc",
-                cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    local battleFocus = Core.GetResolvedActionMapItem('BattleFocus')
-                    return mq.TLO.Me.PctHPs() < 35 and not (battleFocus and Casting.IHaveBuff(battleFocus.Trigger(1)))
-                end,
-            },
-            {
-                name = "Uncanny Resilience",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
-                end,
-            },
+        ['Emergency(Health)']  = {
             {
                 name = "Blood Drinker's Coating",
                 type = "Item",
@@ -249,7 +235,28 @@ return {
                 end,
             },
         },
-        ['Snare'] = {
+        ['Emergency(Aggro)']   = {
+            {
+                name = "BattleFocus",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Core.AtCriticalHP()
+                end,
+            },
+            {
+                name = "Uncanny Resilience",
+                type = "AA",
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP() and not Casting.DiscTriggerActive('BattleFocus')
+                end,
+            },
+        },
+        ['Snare']              = {
             {
                 name = "SnareStrike",
                 type = "Disc",
@@ -284,7 +291,7 @@ return {
                 type = "Disc",
             },
         },
-        ['Burn'] = {
+        ['Burn']               = {
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -326,7 +333,7 @@ return {
                 type = "Item",
             },
         },
-        ['DPS'] = {
+        ['DPS']                = {
             {
                 name = "Epic",
                 type = "Item",
@@ -401,7 +408,7 @@ return {
 
     },
     ['DefaultConfig'] = {
-        ['Mode']           = {
+        ['Mode']         = {
             DisplayName = "Mode",
             Category = "Combat",
             Tooltip = "Select the Combat Mode for this Toon",
@@ -415,7 +422,7 @@ return {
         },
 
         --Equipment
-        ['UseEpic']        = {
+        ['UseEpic']      = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -429,7 +436,7 @@ return {
             Max = 3,
             ConfigType = "Advanced",
         },
-        ['DoCoating']      = {
+        ['DoCoating']    = {
             DisplayName = "Use Coating",
             Group = "Items",
             Header = "Clickies",
@@ -440,7 +447,7 @@ return {
         },
 
         -- Combat
-        ['DoBattleLeap']   = {
+        ['DoBattleLeap'] = {
             DisplayName = "Do Battle Leap",
             Group = "Abilities",
             Header = "Damage",
@@ -449,7 +456,7 @@ return {
             Tooltip = "Use the Battle Leap AA on cooldown.",
             Default = true,
         },
-        ['DoSnare']        = {
+        ['DoSnare']      = {
             DisplayName = "Do Snare",
             Group = "Abilities",
             Header = "Debuffs",
@@ -458,7 +465,7 @@ return {
             Tooltip = "Snare opponents with low health.",
             Default = false,
         },
-        ['SnareCount']     = {
+        ['SnareCount']   = {
             DisplayName = "Snare Max Mob Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -469,7 +476,7 @@ return {
             Min = 1,
             Max = 99,
         },
-        ['DoStun']         = {
+        ['DoStun']       = {
             DisplayName = "Do Stun",
             Group = "Abilities",
             Header = "Debuffs",
@@ -480,19 +487,7 @@ return {
             FAQ = "Why am I using Stun discs on an immune mob?",
             Answer = "If enabled, these abilities fires blindly. You can turn it off in your Class options.",
         },
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['DoVetAA']        = {
+        ['DoVetAA']      = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -504,7 +499,7 @@ return {
             RequiresLoadoutChange = true,
         },
 
-        ['UseRampage']     = {
+        ['UseRampage']   = {
             DisplayName = "Rampage Use:",
             Group = "Abilities",
             Header = "Damage",

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -369,10 +369,6 @@ local _ClassConfig = {
             end
             return false
         end,
-        UnwantedAggroCheck = function(self)
-            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
-            return Targeting.IHaveAggro(100)
-        end,
         DotSongCheck = function(songSpell) --Check dot stacking, stop dotting when HP threshold is reached based on mob type, can't use utils function because we try to refresh just as the dot is ending
             if not songSpell or not songSpell() then return false end
             return songSpell.StacksTarget() and Targeting.MobNotLowHP(Targeting.GetAutoTarget())
@@ -409,14 +405,25 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             midSong = true,
             doFullRotation = true,
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or self.Helpers.UnwantedAggroCheck(self))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            midSong = true,
+            doFullRotation = true,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -488,7 +495,7 @@ local _ClassConfig = {
         },
     },
     ['Rotations']         = {
-        ['Burn'] = { --Order is heavy WIP
+        ['Burn']              = { --Order is heavy WIP
             {
                 name = "Quick Time",
                 type = "AA",
@@ -570,7 +577,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Debuff'] = {
+        ['Debuff']            = {
             {
                 name = "AESlowSong",
                 type = "Song",
@@ -605,7 +612,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']            = {
             {
                 name = "Epic",
                 type = "Item",
@@ -631,7 +638,7 @@ local _ClassConfig = {
                 midSong = true,
             },
         },
-        ['Enduring Breath'] = {
+        ['Enduring Breath']   = {
             {
                 name = "EndBreathSong",
                 type = "Song",
@@ -640,7 +647,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Melody'] = {
+        ['Melody']            = {
             {
                 name = "AriaSong",
                 type = "Song",
@@ -793,7 +800,7 @@ local _ClassConfig = {
                 custom_func = function(self) return self.Helpers.RefreshExpiringSong(self) end,
             },
         },
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "DPSAura",
                 type = "Song",
@@ -807,52 +814,47 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                midSong = true,
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
-            {
-                name = "Fading Memories",
-                type = "AA",
-                midSong = true,
-                load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
-                cond = function(self, aaName)
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or Globals.AutoTargetIsNamed) and self.Helpers.UnwantedAggroCheck(self)
-                end,
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "Hymn of the Last Stand",
                 type = "AA",
                 midSong = true,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
-            },
-            {
-                name = "Shield of Notes",
-                type = "AA",
-                midSong = true,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
-                end,
             },
             {
                 name = "Blood Drinker's Coating",
                 type = "Item",
                 cond = function(self, itemName, target)
                     if not Config:GetSetting('DoCoating') then return false end
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Casting.SelfBuffItemCheck(itemName)
+                    return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
         },
-        ['InstantRunBuff'] = {
+        ['Emergency(Aggro)']  = {
+            {
+                name = "Fading Memories",
+                type = "AA",
+                midSong = true,
+                load_cond = function(self) return Config:GetSetting('UseFading') and Casting.CanUseAA('Fading Memories') end,
+                cond = function(self, aaName)
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
+                name = "Shield of Notes",
+                type = "AA",
+                midSong = true,
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                midSong = true,
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
+                end,
+            },
+        },
+        ['InstantRunBuff']    = {
             {
                 name = "Selo's Sonata",
                 type = "AA",
@@ -1104,7 +1106,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use Fading Memories when you have aggro and you aren't the Main Assist.",
             Default = true,
             ConfigType = "Advanced",
@@ -1120,18 +1122,6 @@ local _ClassConfig = {
             Index = 102,
             Tooltip = "Click your Blood Drinker's Coating in an emergency.",
             Default = false,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
             ConfigType = "Advanced",
         },
 

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -298,14 +298,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -354,7 +363,7 @@ return {
             targetId = function(self) return Casting.GetBuffableTankingIDs() end,
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
-                local burning = combat_state == "Combat" and Casting.BurnCheck() and not Casting.IAmFeigning()
+                local burning = combat_state == "Combat" and Casting.BurnCheck() and not mq.TLO.Me.Feigning()
                 return (downtime or burning) and Core.CombatActionsCheck()
             end,
         },
@@ -394,7 +403,7 @@ return {
         end,
     },
     ['Rotations']         = {
-        ['Burn']           = {
+        ['Burn']              = {
             {
                 name = "Bestial Bloodrage",
                 type = "AA",
@@ -445,7 +454,7 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['Slow']           = {
+        ['Slow']              = {
             {
                 name = "SlowSpell",
                 type = "Spell",
@@ -454,27 +463,12 @@ return {
                 end,
             },
         },
-        ['Emergency']      = {
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "Warder's Gift",
                 type = "AA",
                 cond = function(self, aaName)
                     return (mq.TLO.Me.Pet.PctHPs() or 0) > 50
-                end,
-            },
-            {
-                name = "Protection of the Warder",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
                 end,
             },
             {
@@ -485,6 +479,12 @@ return {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
+        },
+        ['Emergency(Aggro)']  = {
+            {
+                name = "Protection of the Warder",
+                type = "AA",
+            },
             {
                 name = "ProtDisc",
                 type = "Disc",
@@ -492,8 +492,16 @@ return {
                     return Casting.NoDiscActive()
                 end,
             },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
+                end,
+            },
         },
-        ['PetHealing']     = {
+        ['PetHealing']        = {
             {
                 name = "Companion's Blessing",
                 type = "AA",
@@ -515,13 +523,13 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['FocusedParagon'] = {
+        ['FocusedParagon']    = {
             {
                 name = "Focused Paragon of Spirits",
                 type = "AA",
             },
         },
-        ['DPS']            = {
+        ['DPS']               = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -590,7 +598,7 @@ return {
                 end,
             },
         },
-        ['Weaves']         = {
+        ['Weaves']            = {
             {
                 name = "Roar of Thunder",
                 type = "AA",
@@ -624,7 +632,7 @@ return {
                 type = "AA",
             },
         },
-        ['GroupBuff']      = {
+        ['GroupBuff']         = {
             {
                 name = "RunSpeedBuff",
                 type = "Spell",
@@ -680,7 +688,7 @@ return {
                 end,
             },
         },
-        ['PetSummon']      = {
+        ['PetSummon']         = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -695,7 +703,7 @@ return {
                 end,
             },
         },
-        ['Downtime']       = {
+        ['Downtime']          = {
             {
                 name = "Gelid Rending",
                 type = "AA",
@@ -708,7 +716,7 @@ return {
                 end,
             },
         },
-        ['PetBuff']        = {
+        ['PetBuff']           = {
             {
                 name = "Epic",
                 type = "Item",
@@ -791,7 +799,7 @@ return {
                 end,
             },
         },
-        ['Growl']          = {
+        ['Growl']             = {
             {
                 name = "PetGrowl",
                 type = "Spell",
@@ -800,7 +808,7 @@ return {
                 end,
             },
         },
-        ['Vigor']          = {
+        ['Vigor']             = {
             {
                 name = "VigorBuff",
                 type = "Spell",
@@ -1063,18 +1071,6 @@ return {
             RequiresLoadoutChange = true,
         },
         --Combat
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['DoCoating']      = {
             DisplayName = "Use Coating",
             Group = "Items",

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -465,14 +465,13 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         { --AA Stuns, Runes, etc, moved from previous home in DPS
@@ -529,7 +528,7 @@ local _ClassConfig = {
         end,
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']         = {
             {
                 name = "Eldritch Rune",
                 type = "AA",
@@ -630,7 +629,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetSummon'] = {
+        ['PetSummon']        = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -644,7 +643,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff'] = {
+        ['PetBuff']          = {
             {
                 name = "SingleHasteBuff",
                 type = "Spell",
@@ -667,7 +666,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['GroupBuff'] = {
+        ['GroupBuff']        = {
             {
                 name = "HasteManaCombo",
                 type = "Spell",
@@ -793,7 +792,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['UrgentRune'] = {
+        ['UrgentRune']       = {
             {
                 name = "UrgentRune",
                 type = "Spell",
@@ -803,7 +802,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['CombatSupport'] = {
+        ['CombatSupport']    = {
             {
                 name = "Fundament: Second Spire of Enchantment",
                 type = "AA",
@@ -852,13 +851,12 @@ local _ClassConfig = {
             },
 
         },
-        ['Emergency'] = {
+        ['Emergency(Aggro)'] = {
             {
                 name = "Self Stasis",
                 type = "AA",
                 cond = function(self, aaName)
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return mq.TLO.Me.TargetOfTarget.ID() == mq.TLO.Me.ID() and mq.TLO.Target.ID() == Globals.AutoTargetID
+                    return Casting.OkayToCombatEscape()
                 end,
                 post_activate = function(self, aaName, success)
                     if not success then return end
@@ -868,42 +866,6 @@ local _ClassConfig = {
                         Core.DoCmd('/removebuff =Self Stasis')
                     end
                 end,
-            },
-            {
-                name = "Veil of Mindshadow",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Casting.SelfBuffAACheck(aaName)
-                end,
-            },
-            {
-                name = "Beguiler's Directed Banishment",
-                type = "AA",
-                load_cond = function() return Config:GetSetting("DoBeguilers") end,
-                cond = function(self, aaName, target)
-                    if target.ID() == Globals.AutoTargetID then return false end
-                    return Targeting.IHaveAggro(100) and not Globals.AutoTargetIsNamed
-                end,
-            },
-            {
-                name = "Beguiler's Banishment",
-                type = "AA",
-                load_cond = function() return Config:GetSetting("DoBeguilers") end,
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100) and mq.TLO.SpawnCount("npc radius 20")() > 2
-                end,
-            },
-
-            {
-                name = "Doppelganger",
-                type = "AA",
-                cond = function(self, aaName)
-                    return Targeting.IHaveAggro(100)
-                end,
-            },
-            {
-                name = "Color Shock",
-                type = "AA",
             },
             {
                 name = "Arcane Whisper",
@@ -919,8 +881,31 @@ local _ClassConfig = {
                     return Casting.SelfBuffAACheck(aaName)
                 end,
             },
+            {
+                name = "Veil of Mindshadow",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
+            },
+            {
+                name = "Color Shock",
+                type = "AA",
+            },
+            {
+                name = "Doppelganger",
+                type = "AA",
+            },
+            {
+                name = "Beguiler's Banishment",
+                type = "AA",
+                load_cond = function() return Config:GetSetting("DoBeguilers") end,
+                cond = function(self, aaName)
+                    return mq.TLO.SpawnCount("npc radius 20")() > 2
+                end,
+            },
         },
-        ['Dispel'] = {
+        ['Dispel']           = {
             {
                 name = "Dispel",
                 type = "Spell",
@@ -930,7 +915,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS'] = {
+        ['DPS']              = {
             { -- This triggers two nukes so we cast it whether the dot is up or not. Treat is as a nuke.
                 name = "MindDot",
                 type = "Spell",
@@ -981,7 +966,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']             = {
             {
                 name = "Illusions of Grandeur",
                 type = "AA",
@@ -1056,7 +1041,7 @@ local _ClassConfig = {
                 type = "Item",
             },
         },
-        ['Tash'] = {
+        ['Tash']             = {
             {
                 name = "Bite of Tashani",
                 type = "AA",
@@ -1073,7 +1058,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Slow'] = {
+        ['Slow']             = {
             {
                 name = "Enveloping Helix",
                 type = "AA",
@@ -1100,7 +1085,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['ArcanumWeave'] = {
+        ['ArcanumWeave']     = {
             {
                 name = "Empowered Focus of Arcanum",
                 type = "AA",
@@ -1399,18 +1384,6 @@ local _ClassConfig = {
             Max = 3,
             ConfigType = "Advanced",
         },
-        ['EmergencyStart']     = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "The HP % emergency abilities will be used (Abilities used depend on whose health is low, the ENC or the MA).",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['DoSoothing']         = {
             DisplayName = "Do Soothing Words",
             Group = "Abilities",
@@ -1426,9 +1399,9 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             RequiresLoadoutChange = true,
-            Tooltip = "Use Beguiler's (Directed) Banishment AA when you have aggro.",
+            Tooltip = "Use Beguiler's Banishment AA when you have aggro.",
             Default = false,
         },
 

--- a/class_configs/Project Lazarus/mnk_class_config.lua
+++ b/class_configs/Project Lazarus/mnk_class_config.lua
@@ -112,11 +112,6 @@ local _ClassConfig = {
         -- },
     },
     ['Helpers']       = {
-        DodgeDiscActive = function(self)
-            local dodgeDisc = Core.GetResolvedActionMapItem('Voiddance')
-            if not dodgeDisc then return false end
-            return Casting.IHaveBuff(dodgeDisc.Trigger(1))
-        end,
     },
     ['RotationOrder'] = {
         {
@@ -127,14 +122,23 @@ local _ClassConfig = {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and not Casting.IAmFeigning() and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -143,7 +147,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and Casting.BurnCheck() and not Casting.IAmFeigning()
+                return combat_state == "Combat" and Casting.BurnCheck() and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -162,7 +166,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -171,12 +175,12 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "MonkAura",
                 type = "Disc",
@@ -188,52 +192,14 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Emergency'] = {
-            {
-                name = "Imitate Death",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
-                cond = function(self, aaName, target)
-                    if Core.IsTanking() then return false end
-                    return (mq.TLO.Me.PctHPs() <= 40 and Targeting.IHaveAggro(100)) or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99)
-                end,
-            },
-            {
-                name = "Feign Death",
-                type = "Ability",
-                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
-                cond = function(self, abilityName)
-                    return Targeting.IHaveAggro(80) and not Core.IsTanking()
-                end,
-            },
-            {
-                name = "Voiddance",
-                type = "Disc",
-                cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
-            {
-                name = "MeleeMit",
-                type = "Disc",
-                cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 35 and not self.Helpers.DodgeDiscActive(self)
-                end,
-            },
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35 and not self.Helpers.DodgeDiscActive(self)
-                end,
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "Mend",
                 type = "Ability",
-                cond = function(self, abilityName)
-                    return mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart')
-                end,
+            },
+            {
+                name = "Epic",
+                type = "Item",
             },
             {
                 name = "Blood Drinker's Coating",
@@ -243,16 +209,52 @@ local _ClassConfig = {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
+        },
+        ['Emergency(Aggro)']  = {
             {
-                name = "Epic",
-                type = "Item",
+                name = "Imitate Death",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
+                cond = function(self, aaName, target)
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
+                name = "Voiddance",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Core.AtCriticalHP()
+                end,
+            },
+            {
+                name = "MeleeMit",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return not Casting.DiscTriggerActive('Voiddance')
+                end,
             },
             {
                 name = "OoW_Chest",
                 type = "Item",
             },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP() and not Casting.DiscTriggerActive('Voiddance')
+                end,
+            },
+            {
+                name = "Feign Death",
+                type = "Ability",
+                load_cond = function(self) return Config:GetSetting('AggroFeign') end,
+                cond = function(self, abilityName)
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
         },
-        ['Burn'] = {
+        ['Burn']              = {
             {
                 name = "Fundament: Third Spire of the Sensei",
                 type = "AA",
@@ -293,7 +295,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['BurnDisc'] = {
+        ['BurnDisc']          = {
             {
                 name = "Heel",
                 type = "Disc",
@@ -311,7 +313,7 @@ local _ClassConfig = {
                 type = "Disc",
             },
         },
-        ['CombatBuff'] = {
+        ['CombatBuff']        = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -335,7 +337,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS'] = {
+        ['DPS']               = {
             {
                 name = "Eye Gouge",
                 type = "AA",
@@ -412,22 +414,10 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a mob detected as a 'named' by RGMercs (see Spawns tab)..",
             Default = true,
             RequiresLoadoutChange = true,
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
         ['DoCoating']       = {
             DisplayName = "Use Coating",

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -357,19 +357,18 @@ local _ClassConfig = {
             targetId = function(self) return Casting.GetBuffableTankingIDs() end,
             cond = function(self, combat_state)
                 local downtime = combat_state == "Downtime" and Casting.OkayToBuff()
-                local burning = combat_state == "Combat" and Casting.BurnCheck() and not Casting.IAmFeigning() and Core.CombatActionsCheck()
+                local burning = combat_state == "Combat" and Casting.BurnCheck() and not mq.TLO.Me.Feigning() and Core.CombatActionsCheck()
                 return downtime or burning
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return not mq.TLO.Me.Feigning() and Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -387,7 +386,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('ScentDebuffUse') == 2 end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         { -- On Laz, this hits slightly different resists, and in different slots, it is a choice.
@@ -397,7 +396,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('ScentDebuffUse') == 3 end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Casting.OkayToDebuff() and Core.CombatActionsCheck()
             end,
         },
         { --Keep things from running
@@ -418,7 +417,7 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and
-                    Casting.BurnCheck() and not Casting.IAmFeigning() and Core.CombatActionsCheck()
+                    Casting.BurnCheck() and not mq.TLO.Me.Feigning() and Core.CombatActionsCheck()
             end,
         },
         {
@@ -428,7 +427,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Targeting.MobNotLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Targeting.MobNotLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -438,7 +437,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and Targeting.MobHasLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and Targeting.MobHasLowHP(Targeting.GetAutoTarget()) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -447,7 +446,7 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning()
             end,
         },
         {
@@ -457,19 +456,18 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoArcanumWeave') and Casting.CanUseAA("Acute Focus of Arcanum") end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and not Casting.IAmFeigning() and not mq.TLO.Me.Buff("Focus of Arcanum")() and Core.CombatActionsCheck()
+                return combat_state == "Combat" and not mq.TLO.Me.Feigning() and not mq.TLO.Me.Buff("Focus of Arcanum")() and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']       = {
-        ['Emergency']       = {
+        ['Emergency(Aggro)'] = {
             {
                 name = "Death's Effigy",
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('AggroFeign') then return false end
-                    if Config:GetSetting('CharmOn') and mq.TLO.Me.Pet.ID() > 0 then return false end
-                    return (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99) or (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100))
+                    return Casting.OkayToCombatEscape()
                 end,
             },
             {
@@ -480,11 +478,11 @@ local _ClassConfig = {
                 name = "Harm Shield",
                 type = "AA",
                 cond = function(self, aaName)
-                    return (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') and Targeting.IHaveAggro(100))
+                    return Core.AtCriticalHP()
                 end,
             },
         },
-        ['Scent(Terris)']   = {
+        ['Scent(Terris)']    = {
             {
                 name = "Scent of Terris",
                 type = "AA",
@@ -502,7 +500,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Scent(Midnight)'] = {
+        ['Scent(Midnight)']  = {
             {
                 name = "ScentDebuff2",
                 type = "Spell",
@@ -511,7 +509,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare']           = {
+        ['Snare']            = {
             {
                 name = "Encroaching Darkness",
                 type = "AA",
@@ -529,7 +527,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['CombatBuff']      = {
+        ['CombatBuff']       = {
             {
                 name = "Death Bloom",
                 type = "AA",
@@ -575,7 +573,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobHighHP)']  = {
+        ['DPS(MobHighHP)']   = {
             {
                 name = "PoisonDotDD",
                 type = "Spell",
@@ -656,7 +654,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobLowHP)']   = {
+        ['DPS(MobLowHP)']    = {
             {
                 name = "OrbNuke",
                 type = "Spell",
@@ -692,7 +690,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn']            = {
+        ['Burn']             = {
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -774,7 +772,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetHealing']      = {
+        ['PetHealing']       = {
             {
                 name = "Companion's Blessing",
                 type = "AA",
@@ -796,7 +794,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['ArcanumWeave']    = {
+        ['ArcanumWeave']     = {
             {
                 name = "Empowered Focus of Arcanum",
                 type = "AA",
@@ -819,7 +817,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Downtime']        = {
+        ['Downtime']         = {
             {
                 name = "SelfHPBuff",
                 type = "Spell",
@@ -864,7 +862,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetSummon']       = {
+        ['PetSummon']        = {
             {
                 name_func = function(self)
                     return string.format("%sPetSpell", self.ClassConfig.DefaultConfig.PetType.ComboOptions[Config:GetSetting('PetType')])
@@ -883,7 +881,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff']         = {
+        ['PetBuff']          = {
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -898,7 +896,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Pustules']        = {
+        ['Pustules']         = {
             {
                 name = "Pustules",
                 type = "Spell",
@@ -1120,24 +1118,12 @@ local _ClassConfig = {
             Min = 1,
             Max = #Globals.Constants.SpireChoices,
         },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
         ['AggroFeign']        = {
             DisplayName = "Emergency Feign",
             Group = "Abilities",
             Header = "Utility",
             Category = "Emergency",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use your Feign AA when you have aggro at low health or aggro on a mob detected as a 'named' by RGMercs (see Spawns tab)..",
             Default = true,
         },

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -551,7 +551,7 @@ return {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -563,7 +563,7 @@ return {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -580,7 +580,7 @@ return {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -602,7 +602,7 @@ return {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Prioritized in their own rotation to help keep HP topped to the desired level, includes emergency abilities
@@ -637,7 +637,7 @@ return {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -652,7 +652,7 @@ return {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if not Config:GetSetting('DoAEDamage') or (Core.IsTanking() and mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')) then return false end
+                if not Config:GetSetting('DoAEDamage') or (Core.IsTanking() and Core.AtCriticalHP()) then return false end
                 return combat_state == "Combat" and Combat.AETargetCheck(true) and Core.CombatActionsCheck()
             end,
         },
@@ -662,13 +662,13 @@ return {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']         = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "Yaulp",
                 type = "AA",
@@ -717,7 +717,7 @@ return {
                 end,
             },
         },
-        ['GroupBuff'] = {
+        ['GroupBuff']              = {
             {
                 name = "AegoBuff",
                 type = "Spell",
@@ -769,18 +769,10 @@ return {
                 end,
             },
         },
-        ['EmergencyDefenses'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
             --Some conditionals are commented out while I tweak percentages (or determine if they are necessary)
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
-                end,
-            },
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -807,6 +799,14 @@ return {
                     return Casting.NoDiscActive() and Casting.DiscOnCoolDown('BlockDisc') and Casting.DiscOnCoolDown('GuardDisc')
                 end,
             },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self)
+                    return Core.AtCriticalHP()
+                end,
+            },
         },
         ['HateTools(AggroTarget)'] = {
             {
@@ -826,7 +826,7 @@ return {
                 type = "Ability",
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             { --8min reuse, save for we still can't get a mob back after trying to taunt
                 name = "Ageless Enmity",
                 type = "AA",
@@ -861,7 +861,7 @@ return {
                 end,
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "Beacon of the Righteous",
                 type = "AA",
@@ -884,7 +884,7 @@ return {
                 end,
             },
         },
-        ['AECombat'] = {
+        ['AECombat']               = {
             {
                 name = "AEStun",
                 type = "Spell",
@@ -902,7 +902,7 @@ return {
                 load_cond = function(self) return mq.TLO.FindItem("=Forsaken Fayguard Bladecatcher")() end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name_func = function(self)
                     return string.format("Fundament: %s Spire of Holiness", Core.IsTanking() and "Third" or "First")
@@ -941,7 +941,7 @@ return {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             {
                 name = "GuardDisc",
                 type = "Disc",
@@ -963,7 +963,7 @@ return {
                 type = "AA",
             },
         },
-        ['ToTHeals'] = {
+        ['ToTHeals']               = {
             {
                 name = "Gift of Life",
                 type = "AA",
@@ -987,7 +987,7 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoLightHeal') == 2 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "StunTimer5",
                 type = "Spell",
@@ -1059,7 +1059,7 @@ return {
                 load_cond = function(self) return mq.TLO.Me.Ability("Slam")() end,
             },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -1200,31 +1200,6 @@ return {
             Index = 102,
             Tooltip = "The HP % where we will use defensive actions like discs, epics, etc.\nNote that fighting a named will also trigger these actions.",
             Default = 60,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']    = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before all but essential rotations are cut in favor of emergency or defensive abilities.",
-            Default = 40,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']        = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that we will use abilities like Lay on Hands or Gift of Life.\nMost other rotations are cut to give our full focus to survival.",
-            Default = 20,
             Min = 1,
             Max = 100,
             ConfigType = "Advanced",

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -289,14 +289,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         { --Keep things from running
@@ -527,15 +536,17 @@ return {
                 end,
             },
         },
-        ['Emergency']          = {
+        ['Emergency(Health)']  = {
             {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    return mq.TLO.Me.PctHPs() < 35 and Targeting.IHaveAggro(100)
+                name = "Blood Drinker's Coating",
+                type = "Item",
+                cond = function(self, itemName, target)
+                    if not Config:GetSetting('DoCoating') then return false end
+                    return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
+        },
+        ['Emergency(Aggro)']   = {
             {
                 name = "Protection of the Spirit Wolf",
                 type = "AA",
@@ -544,22 +555,23 @@ return {
                 name = "Outrider's Evasion",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return Targeting.IHaveAggro(100) and (mq.TLO.Me.ActiveDisc() or "Weapon Shield Discipline") ~= "Weapon Shield Discipline"
+                    local weaponShield = Core.GetResolvedActionMapItem('WeaponShield')
+                    return not (weaponShield and mq.TLO.Me.ActiveDisc.Name() == weaponShield.RankName())
                 end,
             },
             {
                 name = "WeaponShield",
                 type = "Disc",
                 cond = function(self, discName, target)
-                    return Targeting.IHaveAggro(100) and not mq.TLO.Me.Song("Outrider's Evasion")() and Casting.NoDiscActive()
+                    return not Casting.IHaveBuff(Casting.GetAASpell("Outrider's Evasion").ID()) and Casting.NoDiscActive()
                 end,
             },
             {
-                name = "Blood Drinker's Coating",
-                type = "Item",
-                cond = function(self, itemName, target)
-                    if not Config:GetSetting('DoCoating') then return false end
-                    return Casting.SelfBuffItemCheck(itemName)
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP()
                 end,
             },
         },
@@ -917,7 +929,7 @@ return {
 
 
         --Combat
-        ['DoSwarmDot']     = {
+        ['DoSwarmDot']   = {
             DisplayName = "Swarm Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -927,7 +939,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DotNamedOnly']   = {
+        ['DotNamedOnly'] = {
             DisplayName = "Only Dot Named",
             Group = "Abilities",
             Header = "Damage",
@@ -936,7 +948,7 @@ return {
             Tooltip = "Any selected dot above will only be used on a named mob.",
             Default = true,
         },
-        ['UseEpic']        = {
+        ['UseEpic']      = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -949,19 +961,7 @@ return {
             Min = 1,
             Max = 3,
         },
-        ['EmergencyStart'] = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Utility",
-            Category = "Emergency",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['DoCoating']      = {
+        ['DoCoating']    = {
             DisplayName = "Use Coating",
             Group = "Items",
             Header = "Clickies",
@@ -970,7 +970,7 @@ return {
             Tooltip = "Click your Blood Drinker's Coating in an emergency.",
             Default = false,
         },
-        ['DoVetAA']        = {
+        ['DoVetAA']      = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -983,7 +983,7 @@ return {
         },
 
         --Utility
-        ['DoHealSpell']    = {
+        ['DoHealSpell']  = {
             DisplayName = "Do Heals",
             Group = "Abilities",
             Header = "Recovery",
@@ -993,7 +993,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoJoltSpell']    = {
+        ['DoJoltSpell']  = {
             DisplayName = "Do Jolt Spell",
             Group = "Abilities",
             Header = "Utility",
@@ -1003,7 +1003,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoSnare']        = {
+        ['DoSnare']      = {
             DisplayName = "Use Snares",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1013,7 +1013,7 @@ return {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['SnareCount']     = {
+        ['SnareCount']   = {
             DisplayName = "Snare Max Mob Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1024,7 +1024,7 @@ return {
             Min = 1,
             Max = 99,
         },
-        ['HealPriority']   = {
+        ['HealPriority'] = {
             DisplayName = "Healing Priority",
             Group = "Abilities",
             Header = "Recovery",

--- a/class_configs/Project Lazarus/rog_class_config.lua
+++ b/class_configs/Project Lazarus/rog_class_config.lua
@@ -144,14 +144,23 @@ return {
             end,
         },
         {
-            name = 'Emergency',
+            name = 'Emergency(Health)',
             state = 1,
             steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return Targeting.GetXTHaterCount() > 0 and
-                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') or (Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 99))
+                return Targeting.GetXTHaterCount() > 0 and Core.AtEmergencyHP()
+            end,
+        },
+        {
+            name = 'Emergency(Aggro)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
         {
@@ -184,7 +193,7 @@ return {
         },
     },
     ['Rotations']     = {
-        ['Burn'] = {
+        ['Burn']              = {
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -217,7 +226,7 @@ return {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['BurnDisc'] = {
+        ['BurnDisc']          = {
             {
                 name = "Frenzied",
                 type = "Disc",
@@ -239,7 +248,7 @@ return {
                 type = "Disc",
             },
         },
-        ['Aggro Management'] = {
+        ['Aggro Management']  = {
             {
                 name = "Escape",
                 type = "AA",
@@ -270,7 +279,7 @@ return {
                 type = "AA",
             },
         },
-        ['DPS'] = {
+        ['DPS']               = {
             {
                 name = "Epic",
                 type = "Item",
@@ -320,27 +329,7 @@ return {
                 end,
             },
         },
-        ['Emergency'] = {
-            {
-                name = "Nimble",
-                type = "Disc",
-                cond = function(self, discSpell)
-                    return mq.TLO.Me.PctHPs() < 35
-                end,
-            },
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self, aaName)
-                    local nimble = Core.GetResolvedActionMapItem('Nimble')
-                    return mq.TLO.Me.PctHPs() < 35 and not (nimble and Casting.IHaveBuff(nimble.Trigger(1)))
-                end,
-            },
-            {
-                name = "Tumble",
-                type = "AA",
-            },
+        ['Emergency(Health)'] = {
             {
                 name = "Blood Drinker's Coating",
                 type = "Item",
@@ -349,15 +338,33 @@ return {
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
+        },
+        ['Emergency(Aggro)']  = {
+            {
+                name = "Nimble",
+                type = "Disc",
+                cond = function(self, discSpell)
+                    return Core.AtCriticalHP()
+                end,
+            },
+            {
+                name = "Tumble",
+                type = "AA",
+            },
             {
                 name = "CADisc",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Targeting.IHaveAggro(100)
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self, aaName)
+                    return Core.AtCriticalHP() and not Casting.DiscTriggerActive('Nimble')
                 end,
             },
         },
-        ['Downtime'] = {
+        ['Downtime']          = {
             {
                 name = "ThiefBuff",
                 type = "Disc",
@@ -395,7 +402,7 @@ return {
                 end,
             },
         },
-        ['Hide & Sneak'] = {
+        ['Hide & Sneak']      = {
             {
                 name = "Hide & Sneak",
                 type = "CustomFunc",
@@ -454,10 +461,6 @@ return {
                     Strings.BoolToColorString(Config:GetSetting("DoOpener")), Strings.BoolToColorString(mq.TLO.Me.AbilityReady("Hide")()),
                     mq.TLO.Me.AbilityTimer("Hide")(), Strings.BoolToColorString(mq.TLO.Me.Invis()))
             end
-        end,
-        UnwantedAggroCheck = function(self)
-            if Targeting.GetXTHaterCount() == 0 or Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
-            return Targeting.IHaveAggro(100)
         end,
     },
     ['DefaultConfig'] = {
@@ -520,18 +523,6 @@ return {
             Index = 101,
             Tooltip = "Use Sneak Attack line to start combat (e.g, Daggerslash).",
             Default = true,
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency HP%",
-            Group = "Abilities",
-            Header = "Damage",
-            Category = "AE",
-            Index = 101,
-            Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
-            Default = 50,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
         },
         ['HideAggro']       = {
             DisplayName = "Hide Aggro%",

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -407,7 +407,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -419,7 +419,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -434,7 +434,7 @@ local _ClassConfig = {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -456,7 +456,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Prioritized in their own rotation to help keep HP topped to the desired level, includes emergency abilities
@@ -492,7 +492,7 @@ local _ClassConfig = {
             load_cond = function() return Config:GetSetting('DoSnare') end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and not Globals.AutoTargetIsNamed and Targeting.GetXTHaterCount() <= Config:GetSetting('SnareCount')
             end,
         },
@@ -502,7 +502,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -512,13 +512,13 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "Touch of the Cursed",
                 type = "AA",
@@ -615,15 +615,15 @@ local _ClassConfig = {
                 name = "Emergency Visage Cancel",
                 desc = "Removes VoD at Critical HP",
                 type = "CustomFunc",
-                load_cond = function(self) Casting.CanUseAA("Visage of Death") end,
-                cond = function(self) return Config:GetSetting('HPCritical') and mq.TLO.Me.Buff("Visage of Death")() end,
+                load_cond = function(self) return Casting.CanUseAA("Visage of Death") end,
+                cond = function(self) return Core.AtCriticalHP() and mq.TLO.Me.Buff("Visage of Death")() end,
                 custom_func = function(self)
                     Core.DoCmd("/removebuff \"Visage of Death\"")
                     return true
                 end,
             },
         },
-        ['PetSummon'] = {
+        ['PetSummon']              = {
             {
                 name = "PetSpell",
                 type = "Spell",
@@ -641,7 +641,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff'] = {
+        ['PetBuff']                = {
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -660,19 +660,10 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['EmergencyDefenses'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
             --Some conditionals are commented out while I tweak percentages (or determine if they are necessary)
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                tooltip = Tooltips.ArmorofExperience,
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
-                end,
-            },
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -711,11 +702,20 @@ local _ClassConfig = {
                 name = "Emergency Visage Cancel",
                 desc = "Removes VoD at Critical HP",
                 type = "CustomFunc",
-                load_cond = function(self) Casting.CanUseAA("Visage of Death") end,
-                cond = function(self) return Config:GetSetting('HPCritical') and mq.TLO.Me.Buff("Visage of Death")() end,
+                load_cond = function(self) return Casting.CanUseAA("Visage of Death") end,
+                cond = function(self) return Core.AtCriticalHP() and mq.TLO.Me.Buff("Visage of Death")() end,
                 custom_func = function(self)
                     Core.DoCmd("/removebuff \"Visage of Death\"")
                     return true
+                end,
+            },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                tooltip = Tooltips.ArmorofExperience,
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self)
+                    return Core.AtCriticalHP()
                 end,
             },
         },
@@ -742,7 +742,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoTerror') end,
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             {
                 name = "Taunt",
                 type = "Ability",
@@ -785,7 +785,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoTerror') end,
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "Explosion of Hatred",
                 type = "AA",
@@ -802,11 +802,11 @@ local _ClassConfig = {
                 tooltip = Tooltips.AETaunt,
                 load_cond = function(self) return Config:GetSetting('AETauntSpell') end,
                 cond = function(self, spell, target)
-                    return mq.TLO.Me.PctHPs() > Config:GetSetting('EmergencyStart')
+                    return not Core.AtEmergencyHP()
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name = "Visage of Death",
                 type = "AA",
@@ -882,7 +882,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare'] = {
+        ['Snare']                  = {
             {
                 name = "Encroaching Darkness",
                 tooltip = Tooltips.EncroachingDarkness,
@@ -901,7 +901,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             {
                 name = "Mantle",
                 type = "Disc",
@@ -928,7 +928,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['LifeTaps'] = {
+        ['LifeTaps']               = {
             --Full rotation to make sure we use these in priority for emergencies
             {
                 name = "Leech Touch",
@@ -936,7 +936,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoLeechTouch') == 2 then return false end
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
+                    return Core.AtCriticalHP()
                 end,
             },
             {
@@ -967,7 +967,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "AESpearNuke",
                 type = "Spell",
@@ -1075,7 +1075,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Slam,
             },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -1469,31 +1469,6 @@ local _ClassConfig = {
             Index = 102,
             Tooltip = "The HP % where we will use defensive actions like discs, epics, etc.\nNote that fighting a named will also trigger these actions.",
             Default = 60,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before all but essential rotations are cut in favor of emergency or defensive abilities.",
-            Default = 40,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']      = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that we will use abilities like Leechcurse and Leech Touch.\nMost other rotations are cut to give our full focus to survival.",
-            Default = 20,
             Min = 1,
             Max = 100,
             ConfigType = "Advanced",

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -171,7 +171,7 @@ local _ClassConfig = {
             return false
         end,
         BurnDiscCheck = function(self)
-            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or mq.TLO.Me.PctHPs() < Config:GetSetting('EmergencyStart') then return false end
+            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or Core.AtEmergencyHP() then return false end
             local burnDisc = { "Onslaught", "StrikeDisc", "ChargeDisc", }
             for _, buffName in ipairs(burnDisc) do
                 local resolvedDisc = self:GetResolvedActionMapItem(buffName)
@@ -219,7 +219,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() and Config:GetSetting('TankAggroScan') end,
             targetId = function(self) return Targeting.CheckForAggroTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat"
             end,
         },
@@ -231,7 +231,7 @@ local _ClassConfig = {
             load_cond = function() return Core.IsTanking() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Targeting.HateToolsNeeded()
             end,
         },
@@ -247,7 +247,7 @@ local _ClassConfig = {
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical') then return false end
+                if Core.AtCriticalHP() then return false end
                 return combat_state == "Combat" and Combat.AETauntCheck(true)
             end,
         },
@@ -269,7 +269,7 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+                return combat_state == "Combat" and Core.AtEmergencyHP()
             end,
         },
         { --Defensive actions used proactively to prevent emergencies
@@ -294,7 +294,7 @@ local _ClassConfig = {
             steps = 4,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Casting.BurnCheck() and Core.CombatActionsCheck()
             end,
         },
@@ -315,13 +315,13 @@ local _ClassConfig = {
             steps = 1,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                if mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart') then return false end
+                if Core.AtEmergencyHP() then return false end
                 return combat_state == "Combat" and Core.CombatActionsCheck()
             end,
         },
     },
     ['Rotations']     = {
-        ['Downtime'] = {
+        ['Downtime']               = {
             {
                 name = "AuraBuff",
                 type = "Disc",
@@ -363,7 +363,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['HateTools(AutoTarget)'] = {
+        ['HateTools(AutoTarget)']  = {
             {
                 name = "Taunt",
                 type = "Ability",
@@ -413,7 +413,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['AEHateTools'] = {
+        ['AEHateTools']            = {
             {
                 name = "Epic",
                 type = "Item",
@@ -441,17 +441,9 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['EmergencyDefenses'] = {
+        ['EmergencyDefenses']      = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
-            {
-                name = "Armor of Experience",
-                type = "AA",
-                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
-                cond = function(self)
-                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
-                end,
-            },
             {
                 name = "Fortitude",
                 type = "Disc",
@@ -478,8 +470,16 @@ local _ClassConfig = {
                     return Core.IsTanking() and Casting.NoDiscActive()
                 end,
             },
+            {
+                name = "Armor of Experience",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoVetAA') end,
+                cond = function(self)
+                    return Core.AtCriticalHP()
+                end,
+            },
         },
-        ['Weapon Management'] = {
+        ['Weapon Management']      = {
             {
                 name = "Equip Shield",
                 type = "CustomFunc",
@@ -505,7 +505,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Defenses'] = {
+        ['Defenses']               = {
             { --shares effect with OoW Chest and Warlord's Bravery
                 name = "StandDisc",
                 type = "Disc",
@@ -550,7 +550,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn'] = {
+        ['Burn']                   = {
             {
                 name_func = function(self)
                     return string.format("Fundament: %s Spire of the Warlord", Core.IsTanking() and "Third" or "Second")
@@ -615,7 +615,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
             },
         },
-        ['Buffs'] = {
+        ['Buffs']                  = {
             {
                 name = "GroupACBuff",
                 type = "Disc",
@@ -632,7 +632,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Combat'] = {
+        ['Combat']                 = {
             {
                 name = "EndRegen",
                 type = "Disc",
@@ -807,31 +807,6 @@ local _ClassConfig = {
             Index = 102,
             Tooltip = "The HP % where we will use defensive actions like discs, epics, etc.\nNote that fighting a named will also trigger these actions.",
             Default = 60,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['EmergencyStart']  = {
-            DisplayName = "Emergency Start",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 103,
-            Tooltip = "The HP % before all but essential rotations are cut in favor of emergency or defensive abilities.",
-            Default = 40,
-            Min = 1,
-            Max = 100,
-            ConfigType = "Advanced",
-        },
-        ['HPCritical']      = {
-            DisplayName = "HP Critical",
-            Group = "Abilities",
-            Header = "Tanking",
-            Category = "Defenses",
-            Index = 104,
-            Tooltip =
-            "The HP % that most other rotations are cut to give our full focus to survival.",
-            Default = 20,
             Min = 1,
             Max = 100,
             ConfigType = "Advanced",

--- a/modules/charm.lua
+++ b/modules/charm.lua
@@ -910,7 +910,7 @@ function Module:CharmAssistNeeded()
 
     local healClear = Core.OkayToNotHeal(Config:GetSetting('HealPriority', true))
     local mezClear = Core.OkayToNotMez(Config:GetSetting('PriorityMez'))
-    local hpOk = (mq.TLO.Me.PctHPs() or 100) > (Config:GetSetting('HPCritical', true) or Config:GetSetting('EmergencyStart', true) or 0)
+    local hpOk = not Core.AtCriticalHP()
     -- only scan for a loose charm once the cheaper gates pass
     local result = healClear and mezClear and hpOk and self:FindLooseCharmToAssist() > 0
 

--- a/modules/clickies.lua
+++ b/modules/clickies.lua
@@ -2108,7 +2108,7 @@ function Module:GiveTime()
         return
     end
 
-    if Casting.IAmFeigning() then
+    if mq.TLO.Me.Feigning() then
         Logger.log_super_verbose("\ayClicky: \aw\t|->\aw \arSkipping, currently feigned!")
         return
     end

--- a/modules/lootnscoot.lua
+++ b/modules/lootnscoot.lua
@@ -2,7 +2,6 @@
 local mq              = require('mq')
 local Actors          = require("actors")
 local Base            = require("modules.base")
-local Casting         = require("utils.casting")
 local Combat          = require("utils.combat")
 local Comms           = require("utils.comms")
 local Config          = require('utils.config')
@@ -25,336 +24,336 @@ Module.CommandHandlers = {}
 Module.TempSettings    = {}
 
 Module.FAQ             = {
-	{
-		Question = "How can I loot corpses on emu servers?",
-		Answer = "RGMercs offers a Loot Module to direct and integrate LootNScoot (LNS), an emu loot management script." ..
-			"Refer to the RG forums or the LNS github for installation or usage instructions, settings here are simply to control how RGMercs interacts with it." ..
-			"Note that at one time, we offered an integrated version of LNS, but that feature has been discontinued.",
-		Settings_Used = "",
-	},
+    {
+        Question = "How can I loot corpses on emu servers?",
+        Answer = "RGMercs offers a Loot Module to direct and integrate LootNScoot (LNS), an emu loot management script." ..
+            "Refer to the RG forums or the LNS github for installation or usage instructions, settings here are simply to control how RGMercs interacts with it." ..
+            "Note that at one time, we offered an integrated version of LNS, but that feature has been discontinued.",
+        Settings_Used = "",
+    },
 }
 
 Module.DefaultConfig   = {
-	['DoLoot']                                 = {
-		DisplayName = "Load LootNScoot",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 1,
-		Tooltip = "Load the integrated LootNScoot in directed mode. Turning this off will unload the looting script.",
-		Default = false,
-		OnChange = function(oldValue, newValue)
-			if newValue == true and mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' then
-				Core.DoCmd("/lua run lootnscoot directed rgmercs")
-				suppressWarning = true
-				if not Module.Actor then Module:LootMessageHandler() end
-			elseif newValue == false and mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' then
-				Core.DoCmd("/lua stop lootnscoot")
-			end
-		end,
-	},
-	['CombatLooting']                          = {
-		DisplayName = "Combat Looting",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 2,
-		Tooltip = "Enables looting during RGMercs-defined combat.",
-		Default = false,
-	},
-	['LootRespectMedState']                    = {
-		DisplayName = "Respect Med State",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 3,
-		Tooltip = "Hold looting if you are currently meditating.",
-		Default = false,
-	},
-	['LootingTimeoutLNS']                      = {
-		DisplayName = "Looting Timeout",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 4,
-		Tooltip = "The length of time in seconds that RGMercs will allow LNS to process loot actions in a single check.",
-		Default = 5,
-		Min = 1,
-		Max = 30,
-	},
-	['MaxChaseTargetDistance']                 = {
-		DisplayName = "Max Chase Targ Dist",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 5,
-		Tooltip = "If chase is on, we won't loot (and will abort looting) any corpses when the chase target is farther than this value away from us.",
-		Default = 300,
-		Min = 1,
-		Max = 20000,
-	},
-	['OpenChests']                             = {
-		DisplayName = "Open Chests",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 6,
-		Tooltip = "Target and open nearby treasure chests. (Added for EQ/Project Might)",
-		Default = function() return Core.OnMight() end,
-	},
-	['NavToChests']                            = {
-		DisplayName = "Nav To Chests",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 7,
-		Tooltip = "Navigate to treasure chests that are out of open range. (Added for EQ/Project Might)",
-		Default = function() return Core.OnMight() end,
-	},
-	['MaxChestNavDistance']                    = {
-		DisplayName = "Max Chest Nav Dist",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 8,
-		Tooltip = "Maximum path distance RGMercs will navigate to open a treasure chest. (Added for EQ/Project Might)",
-		Default = 100,
-		Min = 10,
-		Max = 500,
-	},
-	['BreakInvisForLooting']                   = {
-		DisplayName = "Break Invis for Looting",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "LNS",
-		Index = 9,
-		Tooltip = "Enables looting if hidden or invisible.",
-		Default = false,
-	},
-	[string.format("%s_Popped", Module._name)] = {
-		DisplayName = Module._name .. " Popped",
-		Type = "Custom",
-		Default = false,
-	},
+    ['DoLoot']                                 = {
+        DisplayName = "Load LootNScoot",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 1,
+        Tooltip = "Load the integrated LootNScoot in directed mode. Turning this off will unload the looting script.",
+        Default = false,
+        OnChange = function(oldValue, newValue)
+            if newValue == true and mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' then
+                Core.DoCmd("/lua run lootnscoot directed rgmercs")
+                suppressWarning = true
+                if not Module.Actor then Module:LootMessageHandler() end
+            elseif newValue == false and mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' then
+                Core.DoCmd("/lua stop lootnscoot")
+            end
+        end,
+    },
+    ['CombatLooting']                          = {
+        DisplayName = "Combat Looting",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 2,
+        Tooltip = "Enables looting during RGMercs-defined combat.",
+        Default = false,
+    },
+    ['LootRespectMedState']                    = {
+        DisplayName = "Respect Med State",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 3,
+        Tooltip = "Hold looting if you are currently meditating.",
+        Default = false,
+    },
+    ['LootingTimeoutLNS']                      = {
+        DisplayName = "Looting Timeout",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 4,
+        Tooltip = "The length of time in seconds that RGMercs will allow LNS to process loot actions in a single check.",
+        Default = 5,
+        Min = 1,
+        Max = 30,
+    },
+    ['MaxChaseTargetDistance']                 = {
+        DisplayName = "Max Chase Targ Dist",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 5,
+        Tooltip = "If chase is on, we won't loot (and will abort looting) any corpses when the chase target is farther than this value away from us.",
+        Default = 300,
+        Min = 1,
+        Max = 20000,
+    },
+    ['OpenChests']                             = {
+        DisplayName = "Open Chests",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 6,
+        Tooltip = "Target and open nearby treasure chests. (Added for EQ/Project Might)",
+        Default = function() return Core.OnMight() end,
+    },
+    ['NavToChests']                            = {
+        DisplayName = "Nav To Chests",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 7,
+        Tooltip = "Navigate to treasure chests that are out of open range. (Added for EQ/Project Might)",
+        Default = function() return Core.OnMight() end,
+    },
+    ['MaxChestNavDistance']                    = {
+        DisplayName = "Max Chest Nav Dist",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 8,
+        Tooltip = "Maximum path distance RGMercs will navigate to open a treasure chest. (Added for EQ/Project Might)",
+        Default = 100,
+        Min = 10,
+        Max = 500,
+    },
+    ['BreakInvisForLooting']                   = {
+        DisplayName = "Break Invis for Looting",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "LNS",
+        Index = 9,
+        Tooltip = "Enables looting if hidden or invisible.",
+        Default = false,
+    },
+    [string.format("%s_Popped", Module._name)] = {
+        DisplayName = Module._name .. " Popped",
+        Type = "Custom",
+        Default = false,
+    },
 }
 
 function Module:New()
-	return Base.New(self)
+    return Base.New(self)
 end
 
 function Module:Init()
-	Base.Init(self)
-	local requireDelay = false
-	self:LootMessageHandler()
-	if not Core.OnEMU() then
-		Logger.log_debug("\ay[LOOT]: \agWe are not on EMU unloading module. Build: %s", Globals.BuildType)
-	else
-		if Config:GetSetting('DoLoot') then
-			if mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' then
-				Core.DoCmd("/lua stop lootnscoot")
-				requireDelay = true
-			end
-			Core.DoCmd("%s/lua run lootnscoot directed rgmercs", requireDelay and "/timed 15 " or "")
-		end
-		self.TempSettings.Looting = false
-		Logger.log_debug("\ay[LOOT]: \agLoot(LNS) module Loaded.")
-	end
+    Base.Init(self)
+    local requireDelay = false
+    self:LootMessageHandler()
+    if not Core.OnEMU() then
+        Logger.log_debug("\ay[LOOT]: \agWe are not on EMU unloading module. Build: %s", Globals.BuildType)
+    else
+        if Config:GetSetting('DoLoot') then
+            if mq.TLO.Lua.Script('lootnscoot').Status() == 'RUNNING' then
+                Core.DoCmd("/lua stop lootnscoot")
+                requireDelay = true
+            end
+            Core.DoCmd("%s/lua run lootnscoot directed rgmercs", requireDelay and "/timed 15 " or "")
+        end
+        self.TempSettings.Looting = false
+        Logger.log_debug("\ay[LOOT]: \agLoot(LNS) module Loaded.")
+    end
 
-	return { self = self, defaults = self.DefaultConfig, }
+    return { self = self, defaults = self.DefaultConfig, }
 end
 
 function Module:ShouldRender()
-	return Core.OnEMU()
+    return Core.OnEMU()
 end
 
 function Module:Render()
-	Base.Render(self)
-	local doLoot = Config:GetSetting('DoLoot')
-	Ui.RenderColoredText(doLoot and Globals.Constants.BasicColors.Green or Globals.Constants.BasicColors.LightRed, "Directed LNS looting is %s.", doLoot and "ENABLED" or "DISABLED")
-	ImGui.Text(
-		"Directed control of the LootNScoot script for looting on emu servers.\nSee the Loot category in the General options for integration settings.\nPlease refer to LNS documentation for all else.")
+    Base.Render(self)
+    local doLoot = Config:GetSetting('DoLoot')
+    Ui.RenderColoredText(doLoot and Globals.Constants.BasicColors.Green or Globals.Constants.BasicColors.LightRed, "Directed LNS looting is %s.", doLoot and "ENABLED" or "DISABLED")
+    ImGui.Text(
+        "Directed control of the LootNScoot script for looting on emu servers.\nSee the Loot category in the General options for integration settings.\nPlease refer to LNS documentation for all else.")
 end
 
 function Module.DoLooting()
-	if not Module.TempSettings.Looting then return end
+    if not Module.TempSettings.Looting then return end
 
-	local maxWait = Config:GetSetting('LootingTimeoutLNS') * 1000
-	while Module.TempSettings.Looting do
-		if Combat.GetCombatState() == "Combat" and not Config:GetSetting('CombatLooting') then
-			Logger.log_debug("\ay[LOOT]: Aborting Actions due to combat!")
-			if mq.TLO.Window('LootWnd').Open() then mq.TLO.Window('LootWnd').DoClose() end
-			Module.TempSettings.Looting = false
-			break
-		end
+    local maxWait = Config:GetSetting('LootingTimeoutLNS') * 1000
+    while Module.TempSettings.Looting do
+        if Combat.GetCombatState() == "Combat" and not Config:GetSetting('CombatLooting') then
+            Logger.log_debug("\ay[LOOT]: Aborting Actions due to combat!")
+            if mq.TLO.Window('LootWnd').Open() then mq.TLO.Window('LootWnd').DoClose() end
+            Module.TempSettings.Looting = false
+            break
+        end
 
-		if not Core.CombatActionsCheck() then
-			Logger.log_debug("\ay[LOOT]: Aborting Actions to respond to charm/assist/mez/heal.")
-			if mq.TLO.Window('LootWnd').Open() then mq.TLO.Window('LootWnd').DoClose() end
-			Module.TempSettings.Looting = false
-			break
-		end
+        if not Core.CombatActionsCheck() then
+            Logger.log_debug("\ay[LOOT]: Aborting Actions to respond to charm/assist/mez/heal.")
+            if mq.TLO.Window('LootWnd').Open() then mq.TLO.Window('LootWnd').DoClose() end
+            Module.TempSettings.Looting = false
+            break
+        end
 
-		if not Module:CheckChaseTargetInRange() then
-			Logger.log_debug("\ay[LOOT]: Aborting Actions due to chase target distance!")
-			Module.TempSettings.Looting = false
-			break
-		end
+        if not Module:CheckChaseTargetInRange() then
+            Logger.log_debug("\ay[LOOT]: Aborting Actions due to chase target distance!")
+            Module.TempSettings.Looting = false
+            break
+        end
 
-		mq.delay(20, function() return not Module.TempSettings.Looting end)
+        mq.delay(20, function() return not Module.TempSettings.Looting end)
 
-		maxWait = maxWait - 20
+        maxWait = maxWait - 20
 
-		if maxWait <= 0 then
-			Logger.log_debug("\ay[LOOT]: Aborting Actions due to timeout.")
-			Module.TempSettings.Looting = false
-			break
-		end
-		mq.doevents()
-		Events.DoEvents()
-	end
-	Logger.log_verbose("\ay[LOOT]: \atFinished or Aborted Looting: \agResuming")
+        if maxWait <= 0 then
+            Logger.log_debug("\ay[LOOT]: Aborting Actions due to timeout.")
+            Module.TempSettings.Looting = false
+            break
+        end
+        mq.doevents()
+        Events.DoEvents()
+    end
+    Logger.log_verbose("\ay[LOOT]: \atFinished or Aborted Looting: \agResuming")
 end
 
 function Module:LootMessageHandler()
-	self.Actor = Actors.register('loot_module', function(message)
-		local mail = message()
-		local subject = mail.Subject or ''
-		local who = mail.Who or ''
+    self.Actor = Actors.register('loot_module', function(message)
+        local mail = message()
+        local subject = mail.Subject or ''
+        local who = mail.Who or ''
 
-		if who ~= Globals.CurLoadedChar then return end
+        if who ~= Globals.CurLoadedChar then return end
 
-		if subject == ('done_looting' or 'done_processing') then
-			Module.TempSettings.Looting = false
-		elseif subject == 'processing' then
-			Module.TempSettings.Looting = true
-		end
-	end)
+        if subject == ('done_looting' or 'done_processing') then
+            Module.TempSettings.Looting = false
+        elseif subject == 'processing' then
+            Module.TempSettings.Looting = true
+        end
+    end)
 end
 
 function Module:CheckChaseTargetInRange()
-	if Config:GetSetting('ChaseOn') then
-		local chaseSpawn = mq.TLO.Spawn("pc =" .. Core.GetChaseTarget())
-		if chaseSpawn() and chaseSpawn.ID() > 0 and (chaseSpawn.Distance3D() or 0) > Config:GetSetting('MaxChaseTargetDistance') then
-			return false
-		end
-	end
-	return true
+    if Config:GetSetting('ChaseOn') then
+        local chaseSpawn = mq.TLO.Spawn("pc =" .. Core.GetChaseTarget())
+        if chaseSpawn() and chaseSpawn.ID() > 0 and (chaseSpawn.Distance3D() or 0) > Config:GetSetting('MaxChaseTargetDistance') then
+            return false
+        end
+    end
+    return true
 end
 
 function Module:OpenChest(chestId, chestName)
-	Logger.log_debug("\ay[LOOT]: \agOpening chest: \at%s", chestName)
-	mq.TLO.Spawn(chestId).DoTarget()
-	mq.delay(100, function() return mq.TLO.Target.ID() == chestId end)
-	if mq.TLO.Target.ID() == chestId then
-		Core.DoCmd("/open")
-		mq.delay(1000, function() return (mq.TLO.Spawn(chestId).Type() or "") == "Corpse" or not Core.OkayToNotHeal() end)
-	end
+    Logger.log_debug("\ay[LOOT]: \agOpening chest: \at%s", chestName)
+    mq.TLO.Spawn(chestId).DoTarget()
+    mq.delay(100, function() return mq.TLO.Target.ID() == chestId end)
+    if mq.TLO.Target.ID() == chestId then
+        Core.DoCmd("/open")
+        mq.delay(1000, function() return (mq.TLO.Spawn(chestId).Type() or "") == "Corpse" or not Core.OkayToNotHeal() end)
+    end
 end
 
 function Module:NavToChest(chestId, chestName)
-	Logger.log_debug("\ay[LOOT]: \agNavigating to chest: \at%s", chestName)
-	Movement:DoNav(true, "id %d distance=15 log=off", chestId)
-	mq.delay(1000, function() return mq.TLO.Navigation.Active() end)
+    Logger.log_debug("\ay[LOOT]: \agNavigating to chest: \at%s", chestName)
+    Movement:DoNav(true, "id %d distance=15 log=off", chestId)
+    mq.delay(1000, function() return mq.TLO.Navigation.Active() end)
 
-	local maxWait = 10000
-	while mq.TLO.Navigation.Active() and maxWait > 0 do
-		if (Combat.GetCombatState() == "Combat" and not Config:GetSetting('CombatLooting'))
-			or not Core.CombatActionsCheck() or not Core.OkayToNotHeal() then
-			Movement:DoNav(true, "stop log=off")
-			return false
-		end
-		mq.delay(100)
-		maxWait = maxWait - 100
-		mq.doevents()
-		Events.DoEvents()
-	end
+    local maxWait = 10000
+    while mq.TLO.Navigation.Active() and maxWait > 0 do
+        if (Combat.GetCombatState() == "Combat" and not Config:GetSetting('CombatLooting'))
+            or not Core.CombatActionsCheck() or not Core.OkayToNotHeal() then
+            Movement:DoNav(true, "stop log=off")
+            return false
+        end
+        mq.delay(100)
+        maxWait = maxWait - 100
+        mq.doevents()
+        Events.DoEvents()
+    end
 
-	if mq.TLO.Navigation.Active() then Movement:DoNav(true, "stop log=off") end
-	return (mq.TLO.Spawn(chestId).Distance3D() or 999) <= 20
+    if mq.TLO.Navigation.Active() then Movement:DoNav(true, "stop log=off") end
+    return (mq.TLO.Spawn(chestId).Distance3D() or 999) <= 20
 end
 
 function Module:OpenChests()
-	local navEnabled = Config:GetSetting('NavToChests')
-	local maxNav = Config:GetSetting('MaxChestNavDistance') or 100
-	local chestSearch = string.format("npc treasure radius %d", navEnabled and maxNav or 20)
+    local navEnabled = Config:GetSetting('NavToChests')
+    local maxNav = Config:GetSetting('MaxChestNavDistance') or 100
+    local chestSearch = string.format("npc treasure radius %d", navEnabled and maxNav or 20)
 
-	for i = 1, mq.TLO.SpawnCount(chestSearch)() do
-		local chest = mq.TLO.NearestSpawn(i, chestSearch)
-		local chestId = chest.ID() or 0
-		if chestId > 0 and chest.Class() == "Destructible Object"
-			and (chest.CleanName() or ""):lower():find("treasure chest", 1, true) then
-			if (chest.Distance3D() or 999) <= 20 then
-				self:OpenChest(chestId, chest.DisplayName())
-				return
-			elseif navEnabled and mq.TLO.Navigation.PathExists("id " .. chestId)()
-				and (mq.TLO.Navigation.PathLength("id " .. chestId)() or 99999) <= maxNav then
-				if self:NavToChest(chestId, chest.DisplayName()) then
-					self:OpenChest(chestId, chest.DisplayName())
-				end
-				return
-			end
-		end
-	end
+    for i = 1, mq.TLO.SpawnCount(chestSearch)() do
+        local chest = mq.TLO.NearestSpawn(i, chestSearch)
+        local chestId = chest.ID() or 0
+        if chestId > 0 and chest.Class() == "Destructible Object"
+            and (chest.CleanName() or ""):lower():find("treasure chest", 1, true) then
+            if (chest.Distance3D() or 999) <= 20 then
+                self:OpenChest(chestId, chest.DisplayName())
+                return
+            elseif navEnabled and mq.TLO.Navigation.PathExists("id " .. chestId)()
+                and (mq.TLO.Navigation.PathLength("id " .. chestId)() or 99999) <= maxNav then
+                if self:NavToChest(chestId, chest.DisplayName()) then
+                    self:OpenChest(chestId, chest.DisplayName())
+                end
+                return
+            end
+        end
+    end
 end
 
 function Module:GiveTime()
-	local combat_state = Combat.GetCachedCombatState()
+    local combat_state = Combat.GetCachedCombatState()
 
-	if not Config:GetSetting('DoLoot') then return end
+    if not Config:GetSetting('DoLoot') then return end
 
-	if Globals.PauseMain then return end
-	if mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' then
-		if not suppressWarning then
-			Logger.log_error("\ar[LOOT]: Looting is enabled, but LNS does not appear to be running!")
-			Comms.PrintGroupMessage("%s has looting enabled, but LNS does not appear to be running!", mq.TLO.Me.CleanName())
-			suppressWarning = true
-		end
-		return
-	end
+    if Globals.PauseMain then return end
+    if mq.TLO.Lua.Script('lootnscoot').Status() ~= 'RUNNING' then
+        if not suppressWarning then
+            Logger.log_error("\ar[LOOT]: Looting is enabled, but LNS does not appear to be running!")
+            Comms.PrintGroupMessage("%s has looting enabled, but LNS does not appear to be running!", mq.TLO.Me.CleanName())
+            suppressWarning = true
+        end
+        return
+    end
 
-	suppressWarning = false
+    suppressWarning = false
 
-	if not Core.OkayToNotHeal() or (not Config:GetSetting('BreakInvisForLooting') and mq.TLO.Me.Invis()) or Casting.IAmFeigning() then return end
+    if not Core.OkayToNotHeal() or (not Config:GetSetting('BreakInvisForLooting') and mq.TLO.Me.Invis()) or mq.TLO.Me.Feigning() then return end
 
-	if Combat.CombatNavActive() then return end
+    if Combat.CombatNavActive() then return end
 
-	if not self:CheckChaseTargetInRange() then
-		Logger.log_super_verbose("\ay::LOOT:: \arAborted!\ax Chase Target too far away.")
-		return
-	end
+    if not self:CheckChaseTargetInRange() then
+        Logger.log_super_verbose("\ay::LOOT:: \arAborted!\ax Chase Target too far away.")
+        return
+    end
 
-	if Config:GetSetting('LootRespectMedState') and Globals.InMedState then
-		Logger.log_super_verbose("\ay::LOOT:: \arAborted!\ax Meditating.")
-		return
-	end
+    if Config:GetSetting('LootRespectMedState') and Globals.InMedState then
+        Logger.log_super_verbose("\ay::LOOT:: \arAborted!\ax Meditating.")
+        return
+    end
 
-	local deadCount = mq.TLO.SpawnCount("npccorpse radius 100 zradius 50")()
-	local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Me.CleanName()))()
-	if myCorpseCount > 0 then deadCount = deadCount + 1 end
-	Logger.log_verbose("\ay[LOOT]: \agFound %d corpses within range.", deadCount)
-	if self.Actor == nil then self:LootMessageHandler() end
+    local deadCount = mq.TLO.SpawnCount("npccorpse radius 100 zradius 50")()
+    local myCorpseCount = mq.TLO.SpawnCount(string.format("pccorpse %s radius 100 zradius 50", mq.TLO.Me.CleanName()))()
+    if myCorpseCount > 0 then deadCount = deadCount + 1 end
+    Logger.log_verbose("\ay[LOOT]: \agFound %d corpses within range.", deadCount)
+    if self.Actor == nil then self:LootMessageHandler() end
 
-	local settled = Config:GetSetting('CombatLooting') or Combat.CombatSettled(1000)
+    local settled = Config:GetSetting('CombatLooting') or Combat.CombatSettled(1000)
 
-	if Config:GetSetting('OpenChests') and (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and settled then
-		self:OpenChests()
-	end
+    if Config:GetSetting('OpenChests') and (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and settled then
+        self:OpenChests()
+    end
 
-	-- send actors message to loot
-	if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then
-		if not settled then
-			Logger.log_super_verbose("\ay::LOOT:: \arHolding!\ax Waiting for combat to settle before looting.")
-		elseif not self.TempSettings.Looting then
-			self.Actor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', },
-				{ who = Globals.CurLoadedChar, server = serverLNSFormat, directions = 'doloot', })
-			self.TempSettings.Looting = true
-		end
-	end
+    -- send actors message to loot
+    if (combat_state ~= "Combat" or Config:GetSetting('CombatLooting')) and deadCount > 0 then
+        if not settled then
+            Logger.log_super_verbose("\ay::LOOT:: \arHolding!\ax Waiting for combat to settle before looting.")
+        elseif not self.TempSettings.Looting then
+            self.Actor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', },
+                { who = Globals.CurLoadedChar, server = serverLNSFormat, directions = 'doloot', })
+            self.TempSettings.Looting = true
+        end
+    end
 
-	if self.TempSettings.Looting then
-		Logger.log_verbose("\ay[LOOT]: \aoPausing for \atLoot Actions")
-		Module.DoLooting()
-	end
+    if self.TempSettings.Looting then
+        Logger.log_verbose("\ay[LOOT]: \aoPausing for \atLoot Actions")
+        Module.DoLooting()
+    end
 end
 
 return Module

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -4366,7 +4366,7 @@ function Module:ReturnToCampTick(ctx)
 
     if mq.TLO.Navigation.Active() then
         Logger.log_super_verbose("Pathing to camp...")
-        if (mq.TLO.Me.State() or ""):lower() == "feign" or mq.TLO.Me.Sitting() then
+        if mq.TLO.Me.Feigning() or mq.TLO.Me.Sitting() then
             Logger.log_debug("PULL:Standing up to Engage Target")
             mq.TLO.Me.Stand()
             Movement:DoNav(false, "locyxz %0.2f %0.2f %0.2f log=off %s", returnLoc.y, returnLoc.x, returnLoc.z,

--- a/modules/smartloot.lua
+++ b/modules/smartloot.lua
@@ -2,7 +2,6 @@
 local mq        = require('mq')
 local Set       = require("mq.Set")
 local Base      = require("modules.base")
-local Casting   = require("utils.casting")
 local Combat    = require("utils.combat")
 local Config    = require('utils.config')
 local Core      = require("utils.core")
@@ -19,304 +18,304 @@ Module.SettingCategories = {}
 Module.TempSettings      = {}
 
 Module.DefaultConfig     = {
-	['UseSmartLoot']                           = {
-		DisplayName = "Enable SmartLoot",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "SmartLoot",
-		Index = 1,
-		Tooltip = "Enable SmartLoot integration for automated looting.",
-		Default = false,
-		OnChange = function(self)
-			if Config:GetSetting('UseSmartLoot') and not Module.smartLootInitialized then
-				Module:InitializeSmartLoot()
-			end
-		end,
-	},
-	['SLMainLooter']                           = {
-		DisplayName = "Set RG Main",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "SmartLoot",
-		Index = 1,
-		Tooltip = "Set this toon as the main looter for smartloot.",
-		Default = false,
-	},
-	['LootingTimeoutSL']                       = {
-		DisplayName = "Looting Timeout",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "SmartLoot",
-		Index = 4,
-		Tooltip = "Maximum time in seconds to wait for SmartLoot to complete before continuing.",
-		Default = 30,
-		Min = 10,
-		Max = 60,
-	},
-	['PullsYieldForLooting']                   = {
-		DisplayName = "Hold Pulls for Looting",
-		Group = "General",
-		Header = "Loot(Emu)",
-		Category = "SmartLoot",
-		Index = 5,
-		Tooltip = "Do not pull if this character currently has a pending loot decision, or if other peers are still currently looting via SmartLoot.",
-		Default = false,
-	},
-	[string.format("%s_Popped", Module._name)] = {
-		DisplayName = Module._name .. " Popped",
-		Type = "Custom",
-		Default = false,
-	},
+    ['UseSmartLoot']                           = {
+        DisplayName = "Enable SmartLoot",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "SmartLoot",
+        Index = 1,
+        Tooltip = "Enable SmartLoot integration for automated looting.",
+        Default = false,
+        OnChange = function(self)
+            if Config:GetSetting('UseSmartLoot') and not Module.smartLootInitialized then
+                Module:InitializeSmartLoot()
+            end
+        end,
+    },
+    ['SLMainLooter']                           = {
+        DisplayName = "Set RG Main",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "SmartLoot",
+        Index = 1,
+        Tooltip = "Set this toon as the main looter for smartloot.",
+        Default = false,
+    },
+    ['LootingTimeoutSL']                       = {
+        DisplayName = "Looting Timeout",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "SmartLoot",
+        Index = 4,
+        Tooltip = "Maximum time in seconds to wait for SmartLoot to complete before continuing.",
+        Default = 30,
+        Min = 10,
+        Max = 60,
+    },
+    ['PullsYieldForLooting']                   = {
+        DisplayName = "Hold Pulls for Looting",
+        Group = "General",
+        Header = "Loot(Emu)",
+        Category = "SmartLoot",
+        Index = 5,
+        Tooltip = "Do not pull if this character currently has a pending loot decision, or if other peers are still currently looting via SmartLoot.",
+        Default = false,
+    },
+    [string.format("%s_Popped", Module._name)] = {
+        DisplayName = Module._name .. " Popped",
+        Type = "Custom",
+        Default = false,
+    },
 }
 
 Module.FAQ               = {
-	{
-		Question = "How can I get help with SmartLoot?",
-		Answer = "  SmartLoot (aka SL, Smart Loot) integration is offered by RGMercs on the basis of convenience'.\n\n" ..
-			"  All SL issues not revolving around that integration should be addressed to the author.\n\n" ..
-			"  The '/sl_help' or '/sl_getstarted' commands may assist you with setup and common issues.",
-		Settings_Used = "",
-	},
+    {
+        Question = "How can I get help with SmartLoot?",
+        Answer = "  SmartLoot (aka SL, Smart Loot) integration is offered by RGMercs on the basis of convenience'.\n\n" ..
+            "  All SL issues not revolving around that integration should be addressed to the author.\n\n" ..
+            "  The '/sl_help' or '/sl_getstarted' commands may assist you with setup and common issues.",
+        Settings_Used = "",
+    },
 }
 
 Module.CommandHandlers   = {
-	['slreset'] = {
-		handler = function(self, params)
-			Logger.log_info("\\ay[LOOT]: \\agManually resetting loot state")
-			self.TempSettings.Looting = false
-			self.TempSettings.LootStartTime = nil
-			Logger.log_info("\\ay[LOOT]: \\agLoot state reset - RGMercs should resume normal operations.")
-		end,
-		help = "Reset SmartLoot state if there is a hangup in the looting process for SL peers.",
-	},
+    ['slreset'] = {
+        handler = function(self, params)
+            Logger.log_info("\\ay[LOOT]: \\agManually resetting loot state")
+            self.TempSettings.Looting = false
+            self.TempSettings.LootStartTime = nil
+            Logger.log_info("\\ay[LOOT]: \\agLoot state reset - RGMercs should resume normal operations.")
+        end,
+        help = "Reset SmartLoot state if there is a hangup in the looting process for SL peers.",
+    },
 }
 
 Module.SettingCategories = Set.new({})
 for k, v in pairs(Module.DefaultConfig or {}) do
-	if v.Type ~= "Custom" then
-		Module.SettingCategories:add(v.Category)
-	end
+    if v.Type ~= "Custom" then
+        Module.SettingCategories:add(v.Category)
+    end
 
-	Module.FAQ[k] = { Question = v.FAQ or 'None', Answer = v.Answer or 'None', Settings_Used = k, }
+    Module.FAQ[k] = { Question = v.FAQ or 'None', Answer = v.Answer or 'None', Settings_Used = k, }
 end
 
 function Module:New()
-	return Base.New(self)
+    return Base.New(self)
 end
 
 function Module:Init()
-	Base.Init(self)
+    Base.Init(self)
 
-	if not Core.OnEMU() then
-		Logger.log_debug("\ay[LOOT]: \agWe are not on EMU, unloading module. Build: %s",
-			mq.TLO.MacroQuest.BuildName())
-	else
-		self:InitializeSmartLoot()
-		Logger.log_debug("\ay[LOOT]: \agSmartLoot integration module loaded.")
-	end
+    if not Core.OnEMU() then
+        Logger.log_debug("\ay[LOOT]: \agWe are not on EMU, unloading module. Build: %s",
+            mq.TLO.MacroQuest.BuildName())
+    else
+        self:InitializeSmartLoot()
+        Logger.log_debug("\ay[LOOT]: \agSmartLoot integration module loaded.")
+    end
 end
 
 function Module:ShouldRender()
-	return Core.OnEMU()
+    return Core.OnEMU()
 end
 
 function Module:GetSLState()
-	---@diagnostic disable-next-line: undefined-field
-	if not mq.TLO.SmartLoot then
-		return "Unknown"
-	end
+    ---@diagnostic disable-next-line: undefined-field
+    if not mq.TLO.SmartLoot then
+        return "Unknown"
+    end
 
-	---@diagnostic disable-next-line: undefined-field
-	return mq.TLO.SmartLoot.State()
+    ---@diagnostic disable-next-line: undefined-field
+    return mq.TLO.SmartLoot.State()
 end
 
 function Module:GetSLMode()
-	---@diagnostic disable-next-line: undefined-field
-	if not mq.TLO.SmartLoot then
-		return "Unknown"
-	end
+    ---@diagnostic disable-next-line: undefined-field
+    if not mq.TLO.SmartLoot then
+        return "Unknown"
+    end
 
-	---@diagnostic disable-next-line: undefined-field
-	return mq.TLO.SmartLoot.Mode()
+    ---@diagnostic disable-next-line: undefined-field
+    return mq.TLO.SmartLoot.Mode()
 end
 
 function Module:GetSLTLO()
-	---@diagnostic disable-next-line: undefined-field
-	if not mq.TLO.SmartLoot then
-		return nil
-	end
+    ---@diagnostic disable-next-line: undefined-field
+    if not mq.TLO.SmartLoot then
+        return nil
+    end
 
-	---@diagnostic disable-next-line: undefined-field
-	return mq.TLO.SmartLoot
+    ---@diagnostic disable-next-line: undefined-field
+    return mq.TLO.SmartLoot
 end
 
 function Module:SLRunning()
-	return mq.TLO.Lua.Script('smartloot').Status() == 'RUNNING'
+    return mq.TLO.Lua.Script('smartloot').Status() == 'RUNNING'
 end
 
 function Module:Render()
-	Base.Render(self)
+    Base.Render(self)
 
-	local red = { 1.0, 0.3, 0.3, 1.0, }
-	local yellow = { 1.0, 1.0, 0.3, 1.0, }
-	local green = { 0.3, 1.0, 0.3, 1.0, }
+    local red = { 1.0, 0.3, 0.3, 1.0, }
+    local yellow = { 1.0, 1.0, 0.3, 1.0, }
+    local green = { 0.3, 1.0, 0.3, 1.0, }
 
-	-- SmartLoot status display
-	local mode = "Unknown"
-	local smartLootStatus = "Not Running"
-	local peerStatus = "Unavailable"
-	local modeColor, statusColor, peerColor = red, red, red
+    -- SmartLoot status display
+    local mode = "Unknown"
+    local smartLootStatus = "Not Running"
+    local peerStatus = "Unavailable"
+    local modeColor, statusColor, peerColor = red, red, red
 
-	if self:SLRunning() then
-		if self.smartLootInitialized then
-			smartLootStatus = string.format("%s", self:GetSLState())
-			statusColor = green
-		else
-			smartLootStatus = "SmartLoot Not Initialized"
-			statusColor = yellow
-		end
-		if Globals.SLPeerLooting then
-			peerStatus = "Looting"
-			peerColor = yellow
-		else
-			peerStatus = "Idle"
-			peerColor = green
-		end
-		local currentMode = self:GetSLMode()
-		if currentMode == "rgmain" then
-			mode = "RGMain"
-			modeColor = green
-		elseif currentMode == "background" then
-			mode = "Background"
-			modeColor = green
-		end
-	end
+    if self:SLRunning() then
+        if self.smartLootInitialized then
+            smartLootStatus = string.format("%s", self:GetSLState())
+            statusColor = green
+        else
+            smartLootStatus = "SmartLoot Not Initialized"
+            statusColor = yellow
+        end
+        if Globals.SLPeerLooting then
+            peerStatus = "Looting"
+            peerColor = yellow
+        else
+            peerStatus = "Idle"
+            peerColor = green
+        end
+        local currentMode = self:GetSLMode()
+        if currentMode == "rgmain" then
+            mode = "RGMain"
+            modeColor = green
+        elseif currentMode == "background" then
+            mode = "Background"
+            modeColor = green
+        end
+    end
 
-	ImGui.Text("Mode:")
-	ImGui.SameLine()
-	ImGui.TextColored(modeColor[1], modeColor[2], modeColor[3], modeColor[4], mode)
+    ImGui.Text("Mode:")
+    ImGui.SameLine()
+    ImGui.TextColored(modeColor[1], modeColor[2], modeColor[3], modeColor[4], mode)
 
-	ImGui.Text("Status:")
-	ImGui.SameLine()
-	ImGui.TextColored(statusColor[1], statusColor[2], statusColor[3], statusColor[4], smartLootStatus)
+    ImGui.Text("Status:")
+    ImGui.SameLine()
+    ImGui.TextColored(statusColor[1], statusColor[2], statusColor[3], statusColor[4], smartLootStatus)
 
-	ImGui.Text("Peers:")
-	ImGui.SameLine()
-	ImGui.TextColored(peerColor[1], peerColor[2], peerColor[3], peerColor[4], peerStatus)
+    ImGui.Text("Peers:")
+    ImGui.SameLine()
+    ImGui.TextColored(peerColor[1], peerColor[2], peerColor[3], peerColor[4], peerStatus)
 
-	ImGui.NewLine()
-	ImGui.Text("This module integrates with SmartLoot for automated looting.")
-	ImGui.Text("Please ensure that SmartLoot is properly configured! Use '/sl_help' or '/sl_getstarted' for more details.")
+    ImGui.NewLine()
+    ImGui.Text("This module integrates with SmartLoot for automated looting.")
+    ImGui.Text("Please ensure that SmartLoot is properly configured! Use '/sl_help' or '/sl_getstarted' for more details.")
 end
 
 -- Initialize SmartLoot integration
 function Module:InitializeSmartLoot()
-	if not Config:GetSetting('UseSmartLoot') then return end
+    if not Config:GetSetting('UseSmartLoot') then return end
 
-	if not self:SLRunning() then
-		Core.DoCmd('/lua run smartloot')
-	end
+    if not self:SLRunning() then
+        Core.DoCmd('/lua run smartloot')
+    end
 
-	if self:SLRunning() then
-		Logger.log_info("\ay[LOOT]: \agSmartLoot integration enabled, please ensure you have the RGMain Looter set!")
-		if Config:GetSetting('SLMainLooter') and self:GetSLMode():lower() ~= "rgmain" then
-			mq.delay(500) -- time for command handler to load... we need something to callback preferably
-			Core.DoCmd('/sl_mode rgmain')
-			Logger.log_info("Loot: Setting this character as the main looter for SmartLoot.")
-		end
-		self.smartLootInitialized = true
-	else
-		self.smartLootInitialized = false
-	end
+    if self:SLRunning() then
+        Logger.log_info("\ay[LOOT]: \agSmartLoot integration enabled, please ensure you have the RGMain Looter set!")
+        if Config:GetSetting('SLMainLooter') and self:GetSLMode():lower() ~= "rgmain" then
+            mq.delay(500) -- time for command handler to load... we need something to callback preferably
+            Core.DoCmd('/sl_mode rgmain')
+            Logger.log_info("Loot: Setting this character as the main looter for SmartLoot.")
+        end
+        self.smartLootInitialized = true
+    else
+        self.smartLootInitialized = false
+    end
 end
 
 -- Trigger SmartLoot to process corpses
 function Module:DoLoot()
-	-- Trigger SmartLoot RGMain processing
-	if Config:GetSetting('SLMainLooter') then
-		Logger.log_debug("\ay[LOOT]: \agTriggering SmartLoot RGMain processing")
-		mq.cmd('/sl_rg_trigger')
-	end
+    -- Trigger SmartLoot RGMain processing
+    if Config:GetSetting('SLMainLooter') then
+        Logger.log_debug("\ay[LOOT]: \agTriggering SmartLoot RGMain processing")
+        mq.cmd('/sl_rg_trigger')
+    end
 
-	-- Mark that we've initiated looting
-	self.TempSettings.LootStartTime = Globals.GetTimeSeconds()
-	self.TempSettings.Looting = true
+    -- Mark that we've initiated looting
+    self.TempSettings.LootStartTime = Globals.GetTimeSeconds()
+    self.TempSettings.Looting = true
 
-	return true
+    return true
 end
 
 -- Wait for SmartLoot to complete with proper focus holding
 function Module:ProcessLooting()
-	if not self.TempSettings.Looting then
-		return
-	end
+    if not self.TempSettings.Looting then
+        return
+    end
 
-	local timeoutMs = Config:GetSetting('LootingTimeoutSL') * 1000
-	local startTime = self.TempSettings.LootStartTime or Globals.GetTimeSeconds()
+    local timeoutMs = Config:GetSetting('LootingTimeoutSL') * 1000
+    local startTime = self.TempSettings.LootStartTime or Globals.GetTimeSeconds()
 
-	-- Hold focus in loot module while SmartLoot is working
-	while self.TempSettings.Looting do
-		local elapsed = Globals.GetTimeSeconds() - startTime
+    -- Hold focus in loot module while SmartLoot is working
+    while self.TempSettings.Looting do
+        local elapsed = Globals.GetTimeSeconds() - startTime
 
-		-- Check for timeout
-		if elapsed > timeoutMs then
-			Logger.log_warn("\ay[LOOT]: \arLooting timeout reached (%d seconds) - continuing", Config:GetSetting('LootingTimeoutSL'))
-			self.TempSettings.Looting = false
-			break
-		end
+        -- Check for timeout
+        if elapsed > timeoutMs then
+            Logger.log_warn("\ay[LOOT]: \arLooting timeout reached (%d seconds) - continuing", Config:GetSetting('LootingTimeoutSL'))
+            self.TempSettings.Looting = false
+            break
+        end
 
-		-- Check for combat and abort if needed
-		if self:GetSLState() == "Combat Detected" or Targeting.GetXTHaterCount() > 0 then
-			Logger.log_debug("\ay[LOOT]: \arCombat detected - aborting looting")
-			if mq.TLO.Window("LootWnd").Open() then
-				mq.TLO.Window("LootWnd").DoClose()
-			end
-			self.TempSettings.Looting = false
-			break
-		end
+        -- Check for combat and abort if needed
+        if self:GetSLState() == "Combat Detected" or Targeting.GetXTHaterCount() > 0 then
+            Logger.log_debug("\ay[LOOT]: \arCombat detected - aborting looting")
+            if mq.TLO.Window("LootWnd").Open() then
+                mq.TLO.Window("LootWnd").DoClose()
+            end
+            self.TempSettings.Looting = false
+            break
+        end
 
-		-- Check if SL is finished
-		if self:GetSLState() == "Idle" or self:GetSLState() == "WaitingForInventorySpace" then -- we dont need to check for the TLO because it will close mercs if it isn't there
-			Logger.log_verbose("\ay[LOOT]: \agSmartLoot processing complete (%.1fs elapsed)", elapsed / 1000)
-			self.TempSettings.Looting = false
-			break
-		end
+        -- Check if SL is finished
+        if self:GetSLState() == "Idle" or self:GetSLState() == "WaitingForInventorySpace" then -- we dont need to check for the TLO because it will close mercs if it isn't there
+            Logger.log_verbose("\ay[LOOT]: \agSmartLoot processing complete (%.1fs elapsed)", elapsed / 1000)
+            self.TempSettings.Looting = false
+            break
+        end
 
-		-- Small delay to not hammer the CPU
-		mq.delay(50)
-		mq.doevents()
-		Events.DoEvents()
-	end
+        -- Small delay to not hammer the CPU
+        mq.delay(50)
+        mq.doevents()
+        Events.DoEvents()
+    end
 
-	Logger.log_verbose("\ay[LOOT]: \agFinished Processing Loot.")
+    Logger.log_verbose("\ay[LOOT]: \agFinished Processing Loot.")
 end
 
 function Module:GiveTime()
-	if not Config:GetSetting('UseSmartLoot') or not self.smartLootInitialized then return end
-	if not self:GetSLTLO() or not self:GetSLTLO().IsEnabled() then return end
-	if Globals.PauseMain then return end
+    if not Config:GetSetting('UseSmartLoot') or not self.smartLootInitialized then return end
+    if not self:GetSLTLO() or not self:GetSLTLO().IsEnabled() then return end
+    if Globals.PauseMain then return end
 
-	if not Core.OkayToNotHeal() or mq.TLO.Me.Invis() or Casting.IAmFeigning() then return end
+    if not Core.OkayToNotHeal() or mq.TLO.Me.Invis() or mq.TLO.Me.Feigning() then return end
 
-	if Combat.CombatNavActive() then return end
+    if Combat.CombatNavActive() then return end
 
-	-- Check for corpses using SmartLoot
-	if self.TempSettings.Looting or (self:GetSLTLO() and (self:GetSLTLO().HasNewCorpses() and self:GetSLTLO().SafeToLoot())) then
-		if self:DoLoot() then
-			Logger.log_verbose("\ay[LOOT]: \agInitiated SmartLoot processing")
-			-- Process looting immediately
-			self:ProcessLooting()
-		end
-	end
+    -- Check for corpses using SmartLoot
+    if self.TempSettings.Looting or (self:GetSLTLO() and (self:GetSLTLO().HasNewCorpses() and self:GetSLTLO().SafeToLoot())) then
+        if self:DoLoot() then
+            Logger.log_verbose("\ay[LOOT]: \agInitiated SmartLoot processing")
+            -- Process looting immediately
+            self:ProcessLooting()
+        end
+    end
 
-	Globals.SLPeerLooting = self:GetSLTLO().AnyPeerLooting()
+    Globals.SLPeerLooting = self:GetSLTLO().AnyPeerLooting()
 end
 
 function Module:Shutdown()
-	Logger.log_debug("\ay[LOOT]: \axSmartLoot Integration Module Unloaded.")
-	-- Clear any pending loot state
-	self.TempSettings.Looting = false
-	self.TempSettings.LootStartTime = nil
+    Logger.log_debug("\ay[LOOT]: \axSmartLoot Integration Module Unloaded.")
+    -- Clear any pending loot state
+    self.TempSettings.Looting = false
+    self.TempSettings.LootStartTime = nil
 end
 
 -- for algar reference, ignore for now

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1419,10 +1419,18 @@ function Casting.GetBuffableTankingIDs()
     return tankingIds
 end
 
+-- DEPRECATED 7/26 - sunset 10/1/26. Shim for custom configs; use mq.TLO.Me.Feigning() directly. DELETE at sunset.
 --- Checks if the character is currently feigning death.
 --- @return boolean True if the character is feigning death, false otherwise.
 function Casting.IAmFeigning()
     return mq.TLO.Me.Feigning()
+end
+
+--- Checks if we are safe to use abilities that remove us from combat/aggro.
+---@return boolean True Return true if no conditions exist that would make a combat escape undesirable
+function Casting.OkayToCombatEscape()
+    if Core.IsTanking() or mq.TLO.Group.Puller.ID() == mq.TLO.Me.ID() then return false end
+    return true
 end
 
 --- Returns true if the spell's ranked name is currently memorized in any gem slot on the spellbar (Me.Gem returns non-nil for that name).
@@ -1570,6 +1578,15 @@ end
 function Casting.DiscOnCoolDown(actionMapName)
     local disc = Core.GetResolvedActionMapItem(actionMapName)
     return not (disc and mq.TLO.Me.CombatAbilityReady(disc.RankName())())
+end
+
+--- Resolves the action map entry to a disc and returns true if its trigger buff is on us.
+---@param actionMapName string The action map entry name to resolve.
+---@return boolean True if the resolved disc's trigger effect is active on us.
+function Casting.DiscTriggerActive(actionMapName)
+    local disc = Core.GetResolvedActionMapItem(actionMapName)
+    if not disc then return false end
+    return Casting.IHaveBuff(disc.Trigger(1))
 end
 
 --- Exact-name FindItem lookup; returns true if the item exists and
@@ -2819,7 +2836,7 @@ end
 function Casting.AutoMed()
     local me = mq.TLO.Me
     if Config:GetSetting('DoMed') == 1 then return end
-    if Casting.IAmFeigning() then return end
+    if me.Feigning() then return end
 
     if me.Mount.ID() and not mq.TLO.Zone.Indoor() then
         Logger.log_verbose("Sit check returning early due to mount.")
@@ -2953,7 +2970,7 @@ end
 --- feigning, invisible, and EMU bards.
 function Casting.ClickModRod()
     local me = mq.TLO.Me
-    if not Globals.Constants.RGCasters:contains(me.Class.ShortName()) or me.PctMana() > Config:GetSetting('ModRodManaPct') or me.PctHPs() < 60 or Casting.IAmFeigning() or mq.TLO.Me.Invis() or (Core.MyClassIs("BRD") and Core.OnEMU()) then
+    if not Globals.Constants.RGCasters:contains(me.Class.ShortName()) or me.PctMana() > Config:GetSetting('ModRodManaPct') or me.PctHPs() < 60 or me.Feigning() or me.Invis() or (Core.MyClassIs("BRD") and Core.OnEMU()) then
         return
     end
 

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -111,7 +111,7 @@ function Combat.EngageTarget(autoTargetId)
 
     local target = mq.TLO.Target
 
-    if (mq.TLO.Me.Feigning() or mq.TLO.Me.State():lower() == "feign") and Config:GetSetting('AutoStandFD') then
+    if mq.TLO.Me.Feigning() and Config:GetSetting('AutoStandFD') then
         mq.TLO.Me.Stand()
     end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -1447,6 +1447,28 @@ Config.DefaultConfig                                     = {
         Default = true,
         ConfigType = "Advanced",
     },
+    ['EmergencyStart']             = {
+        DisplayName = "Emergency HP%",
+        Group = "Abilities",
+        Header = "Utility",
+        Category = "Emergency",
+        Index = 2,
+        Tooltip = "Your HP % before we begin to use emergency mitigation abilities.",
+        Default = Globals.Constants.RGTank:contains(mq.TLO.Me.Class.ShortName()) and 40 or 50,
+        Min = 1,
+        Max = 100,
+    },
+    ['HPCritical']                 = {
+        DisplayName = "Critical HP%",
+        Group = "Abilities",
+        Header = "Utility",
+        Category = "Emergency",
+        Index = 3,
+        Tooltip = "Your HP % before we resort to our deepest emergency abilities.",
+        Default = Globals.Constants.RGTank:contains(mq.TLO.Me.Class.ShortName()) and 20 or 30,
+        Min = 1,
+        Max = 100,
+    },
 
     -- Buffs/Rules
     ['DoBuffs']                    = {
@@ -3653,7 +3675,7 @@ function Config:RegisterModuleSettings(module, settings, defaultSettings, faq, f
         end
 
         if Config.TempSettings.SettingToModuleCache[setting] ~= nil then
-            Logger.log_error(
+            Logger.log_verbose(
                 "\ay[Setting] \arError: Key %s exists in multiple settings tables: \aw%s \arand \aw%s! Keeping first but this should be fixed!",
                 setting,
                 Config.TempSettings.SettingToModuleCache[setting], module)

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -372,6 +372,18 @@ function Core.IsModeActive(mode)
     return Modules:ExecModule("Class", "IsModeActive", mode)
 end
 
+--- Returns true if our HP has fallen to the Emergency HP% threshold.
+---@return boolean True if we are at or below the Emergency HP% setting.
+function Core.AtEmergencyHP()
+    return mq.TLO.Me.PctHPs() <= Config:GetSetting('EmergencyStart')
+end
+
+--- Returns true if our HP has fallen to the Critical HP% threshold.
+---@return boolean True if we are at or below the Critical HP% setting.
+function Core.AtCriticalHP()
+    return mq.TLO.Me.PctHPs() <= Config:GetSetting('HPCritical')
+end
+
 --- Returns true if the class module reports the character is in tank mode.
 ---@return boolean True if actively tanking.
 function Core.IsTanking()


### PR DESCRIPTION
* Lifted "Emergency HP" into core settings, rather than keeping it in most configs.
* Added "Critical HP" setting for all configs, not just tanks.
* Split "Emergency" rotation for non-tanks into Emergency(Health) and Emergency(Aggro).