### PR TITLE
My Backlog fixes made more backlog

### DIFF
--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -790,6 +790,7 @@ local _ClassConfig = {
             {
                 name = "Spirits of Nature",
                 type = "AA",
+                IgnoreImmuneCheck = true,
             },
             {
                 name = "Spire",

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -967,6 +967,7 @@ local _ClassConfig    = {
             {
                 name = "Soothing Words",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 load_cond = function() return Config:GetSetting("DoSoothing") end,
                 cond = function(self, aaName, target)
                     local tankId = mq.TLO.Group.MainTank.ID() or 0
@@ -1019,6 +1020,7 @@ local _ClassConfig    = {
             {
                 name = "Arcane Whisper",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and Casting.OkayToCombatEscape()
                 end,

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -753,6 +753,7 @@ local _ClassConfig = {
             {
                 name = "Arcane Whisper",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 90 and Casting.OkayToCombatEscape()
                 end,

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -10,7 +10,7 @@ local Logger      = require("utils.logger")
 local Targeting   = require("utils.targeting")
 
 return {
-    _version              = "2.1 - EQ Might",
+    _version              = "2.2 - EQ Might",
     _author               = "Derple, Algar",
     ['ModeChecks']        = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -415,7 +415,8 @@ return {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -652,7 +653,7 @@ return {
         { --Defensive actions triggered by low HP
             name = 'EmergencyDefenses',
             state = 1,
-            steps = 2, -- help ensure that we cancel visage when needed
+            steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -839,7 +840,7 @@ return {
                 name = "BlockDisc",
                 type = "Disc",
                 pre_activate = function(self)
-                    if Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -872,9 +873,6 @@ return {
             {
                 name = "ForHonor",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell)
-                end,
             },
             {
                 name = "StunTimer5",
@@ -930,6 +928,7 @@ return {
             {
                 name = "Beacon of the Righteous",
                 type = "AA",
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "PBAEStun",
@@ -1146,8 +1145,8 @@ return {
         {
             id = 'StunTimer4',
             Type = "Spell",
-            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer4')() or "" end,
-            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer4')() or "" end,
+            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer4').RankName.Name() or "" end,
+            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer4').RankName.Name() or "" end,
             AbilityRange = 150,
             cond = function(self)
                 local resolvedSpell = Core.GetResolvedActionMapItem('StunTimer4')
@@ -1158,8 +1157,8 @@ return {
         {
             id = 'StunTimer5',
             Type = "Spell",
-            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer5')() or "" end,
-            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer5')() or "" end,
+            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer5').RankName.Name() or "" end,
+            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer5').RankName.Name() or "" end,
             AbilityRange = 150,
             cond = function(self)
                 local resolvedSpell = Core.GetResolvedActionMapItem('StunTimer5')
@@ -1413,17 +1412,6 @@ return {
         },
 
         --Combat
-        -- ['DoTwinHealNuke']    = {
-        --     DisplayName = "Twin Heal Nuke",
-        --     Group = "Abilities",
-        --     Header = "Damage",
-        --     Category = "Direct",
-        --     Index = 101,
-        --     Tooltip = "Use Twin Heal Nuke Spells",
-        --     RequiresLoadoutChange = true,
-        --     Default = true,
-        --     ConfigType = "Advanced",
-        -- },
         ['DoSereneStun']      = {
             DisplayName = "Do Serene Stun",
             Group = "Abilities",
@@ -1439,7 +1427,7 @@ return {
             Group = "Abilities",
             Header = "Damage",
             Category = "Direct",
-            Index = 102,
+            Index = 101,
             Tooltip = "Use the standard Undead nuke line.",
             RequiresLoadoutChange = true,
             Default = true,
@@ -1449,7 +1437,7 @@ return {
             Group = "Abilities",
             Header = "Damage",
             Category = "Direct",
-            Index = 103,
+            Index = 102,
             Tooltip = "Use the quick undead nuke line (which includes a potential snare and ac debuff trigger).",
             RequiresLoadoutChange = true,
             Default = true,
@@ -1459,7 +1447,7 @@ return {
             Group = "Abilities",
             Header = "Damage",
             Category = "Direct",
-            Index = 104,
+            Index = 103,
             Tooltip = "Use the fire lure nuke line.",
             RequiresLoadoutChange = true,
             Default = false,
@@ -1472,6 +1460,7 @@ return {
             Index = 101,
             Tooltip = "Use the Valorous Rage AA during burns.",
             Default = false,
+            RequiresLoadoutChange = true,
         },
 
         --Buffs
@@ -1502,6 +1491,7 @@ return {
                 "You have Symbol selected and don't have another Type One Buff.\n" ..
                 "Leaving this on in other cases is not likely to cause issue, but may cause unnecessary buff checking.",
             Default = false,
+            RequiresLoadoutChange = true,
         },
         ['DoBrells']          = {
             DisplayName = "Do Brells",
@@ -1511,6 +1501,7 @@ return {
             Index = 103,
             Tooltip = "Enable Casting Brells",
             Default = true,
+            RequiresLoadoutChange = true,
         },
         ['DoWardProc']        = {
             DisplayName = "Do Ward Proc",
@@ -1520,6 +1511,7 @@ return {
             Index = 103,
             Tooltip = "Use your Ward of Tunare defensive proc buff.",
             Default = true,
+            RequiresLoadoutChange = true,
         },
         ['DoSalvation']       = {
             DisplayName = "Marr's Salvation",
@@ -1529,6 +1521,7 @@ return {
             Index = 104,
             Tooltip = "Use your group hatred reduction buff AA.",
             Default = true,
+            RequiresLoadoutChange = true,
         },
         ['ProcChoice']        = {
             DisplayName = "Proc Buff Choice:",

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -410,13 +410,13 @@ return {
     ['Helpers']           = {
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -314,6 +314,16 @@ return {
                 return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
+        {
+            name = 'Aggro Management',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro') and Casting.OkayToCombatEscape()
+            end,
+        },
         { --Keep things from running
             name = 'Snare',
             state = 1,
@@ -517,14 +527,6 @@ return {
                 end,
             },
             {
-                name = "JoltSpell",
-                type = "Spell",
-                load_cond = function(self) return Config:GetSetting('DoJoltSpell') end,
-                cond = function(self, spell, target)
-                    return Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 80 and Casting.OkayToCombatEscape()
-                end,
-            },
-            {
                 name = "Forceful Rejuvenation",
                 type = "AA",
             },
@@ -551,6 +553,7 @@ return {
             {
                 name = "Cover Tracks",
                 type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoCoverTracks') and Casting.CanUseAA("Cover Tracks") end,
                 cond = function(self, aaName)
                     return Casting.OkayToCombatEscape()
                 end,
@@ -580,6 +583,13 @@ return {
                 cond = function(self, discSpell, target)
                     return Casting.NoDiscActive()
                 end,
+            },
+        },
+        ['Aggro Management']   = {
+            {
+                name = "JoltSpell",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoJoltSpell') end,
             },
         },
         ['Combat']             = {
@@ -925,7 +935,7 @@ return {
 
 
         --Combat
-        ['DoSwarmDot']   = {
+        ['DoSwarmDot']    = {
             DisplayName = "Swarm Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -935,7 +945,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DotNamedOnly'] = {
+        ['DotNamedOnly']  = {
             DisplayName = "Only Dot Named",
             Group = "Abilities",
             Header = "Damage",
@@ -944,7 +954,7 @@ return {
             Tooltip = "Any selected dot above will only be used on a named mob.",
             Default = true,
         },
-        ['UseEpic']      = {
+        ['UseEpic']       = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -959,7 +969,7 @@ return {
         },
 
         --Utility
-        ['DoHealSpell']  = {
+        ['DoHealSpell']   = {
             DisplayName = "Do Heals",
             Group = "Abilities",
             Header = "Recovery",
@@ -969,17 +979,38 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoJoltSpell']  = {
-            DisplayName = "Do Jolt Spell",
+        ['JoltAggro']     = {
+            DisplayName = "Aggro Shed %",
             Group = "Abilities",
             Header = "Utility",
             Category = "Hate Reduction",
             Index = 101,
+            Tooltip = "Begin using hate reduction abilities above this aggro percentage.",
+            Default = 70,
+            Min = 1,
+            Max = 100,
+        },
+        ['DoJoltSpell']   = {
+            DisplayName = "Use Jolt Spell",
+            Group = "Abilities",
+            Header = "Utility",
+            Category = "Hate Reduction",
+            Index = 102,
             Tooltip = "Use your Jolt spell when your aggro is high.",
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoSnare']      = {
+        ['DoCoverTracks'] = {
+            DisplayName = "Use Cover Tracks",
+            Group = "Abilities",
+            Header = "Utility",
+            Category = "Emergency",
+            Index = 101,
+            Tooltip = "Use Cover Tracks to escape combat in an emergency.",
+            Default = true,
+            RequiresLoadoutChange = true,
+        },
+        ['DoSnare']       = {
             DisplayName = "Use Snares",
             Group = "Abilities",
             Header = "Debuffs",
@@ -989,7 +1020,7 @@ return {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['SnareCount']   = {
+        ['SnareCount']    = {
             DisplayName = "Snare Max Mob Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1000,7 +1031,7 @@ return {
             Min = 1,
             Max = 99,
         },
-        ['HealPriority'] = {
+        ['HealPriority']  = {
             DisplayName = "Healing Priority",
             Group = "Abilities",
             Header = "Recovery",

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -922,6 +922,7 @@ local _ClassConfig = {
             {
                 name = "Leech Touch",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
                     return Config:GetSetting('DoLeechTouch') ~= 1
@@ -990,6 +991,7 @@ local _ClassConfig = {
             {
                 name = "Leech Touch",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoLeechTouch') == 2 then return false end

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -77,7 +77,7 @@ local Tooltips     = {
 
 local _ClassConfig = {
     -- Added low level proc self-buffs, separated the proc lines by buff slot
-    _version          = "2.7 - EQ Might",
+    _version          = "2.8 - EQ Might",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -402,7 +402,8 @@ local _ClassConfig = {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -525,7 +526,7 @@ local _ClassConfig = {
         { --Defensive actions triggered by low HP
             name = 'EmergencyDefenses',
             state = 1,
-            steps = 2, -- help ensure that we cancel visage when needed
+            steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -686,17 +687,6 @@ local _ClassConfig = {
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
-            {
-                name = "Emergency Visage Cancel",
-                desc = "Removes VoD at Critical HP",
-                type = "CustomFunc",
-                load_cond = function(self) return Casting.CanUseAA("Visage of Death") end,
-                cond = function(self) return Core.AtCriticalHP() and mq.TLO.Me.Buff("Visage of Death")() end,
-                custom_func = function(self)
-                    Core.DoCmd("/removebuff \"Visage of Death\"")
-                    return true
-                end,
-            },
         },
         ['GroupBuff']              = { -- Added to anchor clickies to
 
@@ -756,7 +746,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.BlockDisc,
                 pre_activate = function(self)
-                    if Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -833,11 +823,13 @@ local _ClassConfig = {
                 name = "Explosion of Hatred",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfHatred,
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "Explosion of Spite",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfSpite,
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "BladeDisc",
@@ -890,6 +882,7 @@ local _ClassConfig = {
                 name = "ForPower",
                 type = "Spell",
                 tooltip = Tooltips.ForPower,
+                load_cond = function(self) return Config:GetSetting('DoForPower') end,
             },
         },
         ['Burn']                   = {
@@ -1036,7 +1029,7 @@ local _ClassConfig = {
                 name = "ForPower",
                 type = "Spell",
                 tooltip = Tooltips.ForPower,
-                load_cond = function(self) return Core.IsTanking() end,
+                load_cond = function(self) return Core.IsTanking() and Config:GetSetting('DoForPower') end,
                 cond = function(self, spell, target)
                     return Casting.DetSpellCheck(spell, target)
                 end,
@@ -1184,6 +1177,7 @@ local _ClassConfig = {
                 { name = "LifeTap", },
                 { name = "SnareDot",    cond = function(self) return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Encroaching Darkness") end, },
                 { name = "Terror",      cond = function(self) return Config:GetSetting('DoTerror') end, },
+                { name = "ForPower",    cond = function(self) return Config:GetSetting('DoForPower') end, },
                 { name = "AETaunt",     cond = function(self) return Config:GetSetting('AETauntSpell') end, },
                 { name = "BiteTap", },
                 { name = "AncientBite", },
@@ -1198,7 +1192,6 @@ local _ClassConfig = {
                 { name = "Terror2",     cond = function(self) return Config:GetSetting('DoTerror') end, },
                 { name = "LifeTap3", },
                 { name = "Terror3",     cond = function(self) return Config:GetSetting('DoTerror') end, },
-                { name = "LifeTap3", },
                 { name = "SelfDS", },
             },
         },
@@ -1348,7 +1341,7 @@ local _ClassConfig = {
             Default = true,
             FAQ = "Why is my health draining so quickly out of combat?",
             Answer =
-            "You may have Visage of Death enabled, which has a sizable self-damage component. While we will attempt to autocancel this at low health in downtime, you can disable VoD use in the Class options.",
+            "You may have Visage of Death enabled, which has a sizable self-damage component. You can disable VoD use in the Class options.",
         },
 
         --Taps
@@ -1417,8 +1410,8 @@ local _ClassConfig = {
             Header = "Damage",
             Category = "Over Time",
             Index = 102,
-            ToolTip = function() return Ui.GetDynamicTooltipForSpell("PoisonDot") end,
-            RequiresLoadoutChange = false,
+            Tooltip = function() return Ui.GetDynamicTooltipForSpell("PoisonDot") end,
+            RequiresLoadoutChange = true,
             Default = true,
         },
         ['DoDireDot']         = {
@@ -1463,7 +1456,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Index = 103,
+            Index = 104,
             Tooltip =
             "Use your Visage buff (Voice of ... line). We will continue to use the spell if slots are available (for the damage shield). The spell can be disabled directly in rotations.",
             Default = true,
@@ -1505,6 +1498,17 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
+        ['DoForPower']        = {
+            DisplayName = "Use \"For Power\"",
+            Group = "Abilities",
+            Header = "Tanking",
+            Category = "Hate Tools",
+            Index = 104,
+            Tooltip = function() return Ui.GetDynamicTooltipForSpell("ForPower") end,
+            RequiresLoadoutChange = true,
+            Default = true,
+            ConfigType = "Advanced",
+        },
 
         --Defenses
         ['DiscCount']         = {
@@ -1532,7 +1536,7 @@ local _ClassConfig = {
             ConfigType = "Advanced",
         },
         ['HoldEpicForNoDisc'] = {
-            DisplayName = "Epic",
+            DisplayName = "Epic Only Without Disc",
             Group = "Abilities",
             Header = "Tanking",
             Category = "Defenses",

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -397,13 +397,13 @@ local _ClassConfig = {
     ['Helpers']       = {
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -11,7 +11,7 @@ local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
     -- Added Mayhem line for AE taunt
-    _version          = "3.1 - EQ Might",
+    _version          = "3.2 - EQ Might",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -188,7 +188,8 @@ local _ClassConfig = {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -199,8 +200,8 @@ local _ClassConfig = {
             return false
         end,
         BurnDiscCheck = function(self)
-            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or Core.AtEmergencyHP() then return false end
-            local burnDisc = { "Onslaught", "StrikeDisc", "Steelwrath", }
+            if Core.AtEmergencyHP() then return false end
+            local burnDisc = { "Fortitude", "Onslaught", "StrikeDisc", "Steelwrath", }
             for _, buffName in ipairs(burnDisc) do
                 local resolvedDisc = self:GetResolvedActionMapItem(buffName)
                 if resolvedDisc and resolvedDisc.RankName() == mq.TLO.Me.ActiveDisc.Name() then return false end
@@ -211,7 +212,7 @@ local _ClassConfig = {
             -- Allow healing disc to be cancelled by other defensive discs
             if Casting.NoDiscActive() then return true end
             local healingDisc = Core.GetResolvedActionMapItem('HealingDisc')
-            return not healingDisc or mq.TLO.Me.ActiveDisc.Name() == healingDisc.RankName()
+            return healingDisc ~= nil and mq.TLO.Me.ActiveDisc.Name() == healingDisc.RankName()
         end,
         MeleeMitBuffCheck = function(self) -- Make sure we spread out our MeleeMit buffs because only the highest in slot 1 takes effect
             local standDisc = Core.GetResolvedActionMapItem('StandDisc')
@@ -262,7 +263,7 @@ local _ClassConfig = {
             doFullRotation = true,
             load_cond = function()
                 return Core.IsTanking() and Config:GetSetting('DoAETaunt') and
-                    (Casting.CanUseAA("Area Taunt") or Core.GetResolvedActionMapItem("BladeDisc"))
+                    (Core.GetResolvedActionMapItem("AreaTaunt") or Core.GetResolvedActionMapItem("BladeDisc"))
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -401,9 +402,6 @@ local _ClassConfig = {
             {
                 name = "AddHate",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DetSpellCheck(discSpell)
-                end,
             },
             {
                 name = "AddHate2",
@@ -715,7 +713,7 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoSnare') then return false end
-                    return Casting.DetAACheck(aaName)
+                    return Casting.DetAACheck(aaName) and not Casting.SnareImmuneTarget(target)
                 end,
             },
             {
@@ -806,7 +804,7 @@ local _ClassConfig = {
             Header = "Tanking",
             Category = "Hate Tools",
             Index = 100,
-            Tooltip = "Use AE hatred Discs and AA (see FAQ for specifics).",
+            Tooltip = "Use AE hatred Discs and AA.",
             RequiresLoadoutChange = true,
             Default = true,
         },
@@ -843,7 +841,7 @@ local _ClassConfig = {
             Header = "Clickies",
             Category = "Class Config Clickies",
             Index = 101,
-            Tooltip = "Click your Epic Weapon when AE Threat is needed. Also relies on Do AE Damage setting.",
+            Tooltip = "Click your Epic Weapon when defenses are triggered.",
             Default = false,
         },
         ['UseBandolier']    = {

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -183,13 +183,13 @@ local _ClassConfig = {
     ['Helpers']       = {
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -561,6 +561,7 @@ return {
             {
                 name = "Mind Crash",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and Targeting.IHaveAggro(100)
                 end,
@@ -568,6 +569,7 @@ return {
             {
                 name = "Arcane Whisper",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and Targeting.IHaveAggro(100)
                 end,

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -777,13 +777,13 @@ local _ClassConfig = {
         end,
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/Live/pal_class_config.lua
+++ b/class_configs/Live/pal_class_config.lua
@@ -11,7 +11,7 @@ local Targeting    = require("utils.targeting")
 local Ui           = require("utils.ui")
 
 local _ClassConfig = {
-    _version              = "2.0 - Live",
+    _version              = "2.1 - Live",
     _author               = "Algar",
     ['ModeChecks']        = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -782,7 +782,8 @@ local _ClassConfig = {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -1004,7 +1005,7 @@ local _ClassConfig = {
         { --Defensive actions triggered by low HP
             name = 'EmergencyDefenses',
             state = 1,
-            steps = 2, -- help ensure that we cancel visage when needed
+            steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -1249,7 +1250,7 @@ local _ClassConfig = {
                     return Casting.GroupBuffAACheck(aaName, target)
                 end,
                 post_activate = function(self, aaName, success)
-                    -- mq.delay(200, function() return mq.TLO.Me.Buff("Marr's Salvation")() ~= nil end)
+                    mq.delay(math.max(300, 3 * (mq.TLO.EverQuest.Ping() or 0)), function() return mq.TLO.Me.Buff("Marr's Salvation")() ~= nil end)
                     if success and Core.IsTanking() and mq.TLO.Me.Buff("Marr's Salvation")() then
                         Core.DoCmd("/removebuff \"Marr's Salvation\"")
                     end
@@ -1262,7 +1263,7 @@ local _ClassConfig = {
                 name = "Deflection",
                 type = "Disc",
                 pre_activate = function(self)
-                    if Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -1275,7 +1276,7 @@ local _ClassConfig = {
                 name = "Shield Flash",
                 type = "AA",
                 pre_activate = function(self)
-                    if Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -1342,16 +1343,10 @@ local _ClassConfig = {
             {
                 name = "Audacity",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell, target)
-                end,
             },
             {
                 name = "ForHonor",
                 type = "Spell",
-                cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell)
-                end,
             },
             {
                 name = "Disruption",
@@ -1819,8 +1814,8 @@ local _ClassConfig = {
         {
             id = 'StunTimer4',
             Type = "Spell",
-            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer4')() or "" end,
-            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer4')() or "" end,
+            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer4').RankName.Name() or "" end,
+            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer4').RankName.Name() or "" end,
             AbilityRange = 150,
             cond = function(self)
                 local resolvedSpell = Core.GetResolvedActionMapItem('StunTimer4')
@@ -1874,7 +1869,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Index = 3,
+            Index = 101,
             Tooltip = function() return Ui.GetDynamicTooltipForSpell("TempHP") end,
             Default = true,
             RequiresLoadoutChange = true,
@@ -1886,7 +1881,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Index = 5,
+            Index = 104,
             Tooltip = "Overwrite DPU with single buffs when they are better than the DPU effect.",
             Default = false,
             ConfigType = "Advanced",
@@ -1896,7 +1891,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Index = 8,
+            Index = 105,
             Tooltip = "Use Veteran AA such as Intensity of the Resolute or Armor of Experience as necessary.",
             Default = true,
             ConfigType = "Advanced",
@@ -1907,6 +1902,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
+            Index = 103,
             Tooltip = "Use Undead proc over Fury proc until Fury is rolled into Divine Protector's Unity (Level 80).",
             Default = false,
         },
@@ -1915,7 +1911,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Index = 3,
+            Index = 102,
             Tooltip = "Use your Steel Proc line.",
             Default = false,
             RequiresLoadoutChange = true,
@@ -1925,8 +1921,10 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Buffs",
             Category = "Group",
+            Index = 102,
             Tooltip = "Enable Casting Brells",
             Default = true,
+            RequiresLoadoutChange = true,
         },
         ['AegoSymbol']        = {
             DisplayName = "Aego/Symbol Choice:",
@@ -1940,12 +1938,14 @@ local _ClassConfig = {
             Default = 1,
             Min = 1,
             Max = 3,
+            RequiresLoadoutChange = true,
         },
         ['DoSalvation']       = {
             DisplayName = "Marr's Salvation",
             Group = "Abilities",
             Header = "Buffs",
             Category = "Group",
+            Index = 103,
             Tooltip = "Use your group hatred reduction buff AA (The Paladin will cancel it on themself if in Tank Mode).",
             Default = true,
             RequiresLoadoutChange = true,
@@ -1967,7 +1967,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Tanking",
             Category = "Hate Tools",
-            Index = 101,
+            Index = 102,
             Tooltip =
             "Choose which Timer 5 spell line to use (For the best experience for leveling, the standard stun will be used until others are available.\nIt is recommended to switch this line out for the Timer 3 'Healstun' once it is available.).",
             RequiresLoadoutChange = true,
@@ -1983,7 +1983,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Tanking",
             Category = "Hate Tools",
-            Index = 102,
+            Index = 103,
             Tooltip = "Choose which Timer 6 spell line to use.",
             RequiresLoadoutChange = true,
             Type = "Combo",
@@ -2008,7 +2008,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Tanking",
             Category = "Hate Tools",
-            Index = 101,
+            Index = 105,
             Tooltip = "Use AE Taunt AA.",
             RequiresLoadoutChange = true,
             Default = true,
@@ -2050,6 +2050,7 @@ local _ClassConfig = {
             Index = 101,
             Tooltip = "Click your equipped chest.",
             Default = mq.TLO.MacroQuest.BuildName() ~= "Emu",
+            RequiresLoadoutChange = true,
         },
         ['DoCharmClick']      = {
             DisplayName = "Do Charm Click",
@@ -2134,7 +2135,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Recovery",
             Category = "General Healing",
-            Index = 102,
+            Index = 104,
             Tooltip = "Use your emergency self-heal line of spells.",
             RequiresLoadoutChange = true,
             Default = true,
@@ -2144,7 +2145,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Recovery",
             Category = "General Healing",
-            Index = 102,
+            Index = 103,
             Tooltip = "Use your group heal ('Wave of ...') line of spells.",
             RequiresLoadoutChange = true,
             Default = mq.TLO.Me.Level() < 83 and true or false,
@@ -2154,7 +2155,7 @@ local _ClassConfig = {
             Group = "Abilities",
             Header = "Recovery",
             Category = "General Healing",
-            Index = 104,
+            Index = 105,
             Tooltip =
             "Memorize your 'Splash' line AE heal/cure, and use it as a group heal or cure. (If unchecked, we may mem/use it out of combat as a cure, depending on other settings.)",
             RequiresLoadoutChange = true,

--- a/class_configs/Live/rng_class_config.lua
+++ b/class_configs/Live/rng_class_config.lua
@@ -1248,9 +1248,6 @@ local _ClassConfig = {
                 name = "JoltSpell",
                 type = "Spell",
                 load_cond = function(self) return Config:GetSetting('DoJoltSpell') end,
-                cond = function(self, spell, target)
-                    return Casting.DetSpellCheck(spell, target)
-                end,
             },
         },
         ['Debuff']             = {
@@ -1996,7 +1993,7 @@ local _ClassConfig = {
             Category = "Emergency",
             Index = 101,
             Tooltip = "Use Cover Tracks to escape combat in an emergency.",
-            Default = false,
+            Default = true,
             RequiresLoadoutChange = true,
         },
     },

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -77,7 +77,7 @@ local Tooltips     = {
 }
 
 local _ClassConfig = {
-    _version          = "3.2 - Live",
+    _version          = "3.3 - Live",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -774,7 +774,8 @@ local _ClassConfig = {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -800,7 +801,7 @@ local _ClassConfig = {
         end,
         ShouldMemTerror = function()
             local setting = Config:GetSetting('DoTerror')
-            return setting == 3 or (setting == 2 and not Core.GetResolvedActionMapItem('ForPower'))
+            return setting == 3 or (setting == 2 and not (Config:GetSetting('DoForPower') and Core.GetResolvedActionMapItem('ForPower')))
         end,
     },
     ['Charm']         = {
@@ -924,8 +925,9 @@ local _ClassConfig = {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or Targeting.TankingXTNamed() or
-                    self.Helpers.DefensiveDiscCheck(true))
+                return combat_state == "Combat" and Targeting.IHaveAggro(100) and
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or Targeting.TankingXTNamed() or
+                        self.Helpers.DefensiveDiscCheck(true))
             end,
         },
         { -- Leech Effect (Epic, OoW BP, Coating) maintenance
@@ -1209,7 +1211,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.Deflection,
                 pre_activate = function(self)
-                    if not Core.ShieldEquipped() and Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -1231,7 +1233,7 @@ local _ClassConfig = {
                 type = "AA",
                 tooltip = Tooltips.ShieldFlash,
                 pre_activate = function(self)
-                    if not Core.ShieldEquipped() and Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -1296,8 +1298,7 @@ local _ClassConfig = {
                 type = "Spell",
                 tooltip = Tooltips.ForPower,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoForPower') then return false end
-                    return Casting.DetSpellCheck(spell)
+                    return Config:GetSetting('DoForPower')
                 end,
             },
         },
@@ -1371,11 +1372,13 @@ local _ClassConfig = {
                 name = "Explosion of Hatred",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfHatred,
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "Explosion of Spite",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfSpite,
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "AETaunt",
@@ -2142,7 +2145,7 @@ local _ClassConfig = {
             Header = "Damage",
             Category = "Over Time",
             Index = 102,
-            ToolTip = function() return Ui.GetDynamicTooltipForSpell("PoisonDot") end,
+            Tooltip = function() return Ui.GetDynamicTooltipForSpell("PoisonDot") end,
             RequiresLoadoutChange = true,
             Default = true,
         },

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -769,13 +769,13 @@ local _ClassConfig = {
         end,
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -301,13 +301,13 @@ local _ClassConfig = {
     ['Helpers']       = {
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/Live/war_class_config.lua
+++ b/class_configs/Live/war_class_config.lua
@@ -11,7 +11,7 @@ local Targeting   = require("utils.targeting")
 
 
 local _ClassConfig = {
-    _version          = "2.2 - Live",
+    _version          = "2.3 - Live",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -164,7 +164,7 @@ local _ClassConfig = {
             "Concordant Precision",  -- Level 108
             "Harmonious Precision",  -- Level 103
         },
-        ['AEBlades'] = {
+        ['BladeDisc'] = {
             "Cyclone Blades XIV",  -- Level 127
             "Spiraling Blades",    -- Level 124
             "Hurricane Blades",    -- Level 119
@@ -306,7 +306,8 @@ local _ClassConfig = {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -322,8 +323,8 @@ local _ClassConfig = {
             return true
         end,
         BurnDiscCheck = function(self)
-            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or Core.AtEmergencyHP() then return false end
-            local burnDisc = { "Onslaught", "MightyStrike", "ChargeDisc", "OffensiveDisc", }
+            if Core.AtEmergencyHP() then return false end
+            local burnDisc = { "Fortitude", "Onslaught", "MightyStrike", "ChargeDisc", "OffensiveDisc", }
             for _, buffName in ipairs(burnDisc) do
                 local resolvedDisc = self:GetResolvedActionMapItem(buffName)
                 if resolvedDisc and resolvedDisc.RankName() == mq.TLO.Me.ActiveDisc.Name() then return false end
@@ -360,7 +361,10 @@ local _ClassConfig = {
             steps = 1,
             timer = 1, -- Don't check this more often than once a second to avoid blowing every ability at once (aggro takes time to update)
             doFullRotation = true,
-            load_cond = function() return Core.IsTanking() and Config:GetSetting('DoAETaunt') end,
+            load_cond = function()
+                return Core.IsTanking() and Config:GetSetting('DoAETaunt') and
+                    (Casting.CanUseAA("Area Taunt") or Core.GetResolvedActionMapItem("BladeDisc"))
+            end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Combat.AETauntCheck(true) and not Core.AtCriticalHP()
@@ -418,8 +422,9 @@ local _ClassConfig = {
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 --need to look at rotation and decide if it should fire during emergencies. leaning towards no
-                return combat_state == "Combat" and Core.IsTanking() and (Core.AtEmergencyHP() or
-                    Targeting.TankingXTNamed() or self.Helpers.DefensiveDiscCheck(true))
+                return combat_state == "Combat" and Core.IsTanking() and Targeting.IHaveAggro(100) and
+                    (mq.TLO.Me.PctHPs() <= Config:GetSetting('DefenseStart') or
+                        Targeting.TankingXTNamed() or self.Helpers.DefensiveDiscCheck(true))
             end,
         },
         { --Offensive actions to temporarily boost damage dealt
@@ -498,10 +503,6 @@ local _ClassConfig = {
         },
         ['HateTools(AggroTarget)'] = {
             {
-                name = "Attention",
-                type = "Disc",
-            },
-            {
                 name = "Blast of Anger",
                 type = "AA",
             },
@@ -516,19 +517,23 @@ local _ClassConfig = {
             {
                 name = "AddHate1",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Casting.DetSpellCheck(discSpell)
-                end,
             },
             {
                 name = "AddHate2",
                 type = "Disc",
             },
-        },
-        ['HateTools(AutoTarget)']  = {
             {
                 name = "Attention",
                 type = "Disc",
+            },
+        },
+        ['HateTools(AutoTarget)']  = {
+            { --used to jumpstart hatred on named from the outset and prevent early rips from burns
+                name = "Attention",
+                type = "Disc",
+                cond = function(self, discSpell, target)
+                    return Globals.AutoTargetIsNamed
+                end,
             },
             {
                 name = "Blast of Anger",
@@ -563,6 +568,14 @@ local _ClassConfig = {
                 type = "AA",
             },
             {
+                name = "BladeDisc",
+                type = "Disc",
+                load_cond = function(self) return Config:GetSetting('BladeDiscUse') > 1 end,
+                cond = function(self, discSpell)
+                    return Config:GetSetting('DoAEDamage')
+                end,
+            },
+            {
                 name = "SelfBuffAE",
                 type = "Disc",
             },
@@ -589,7 +602,7 @@ local _ClassConfig = {
                 name = "Flash",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return not mq.TLO.Me.ActiveDisc.Name() ~= "Fortitude Discipline" and not Casting.IHaveBuff("Blade Whirl")
+                    return mq.TLO.Me.ActiveDisc.Name() ~= "Fortitude Discipline" and not Casting.IHaveBuff("Blade Whirl")
                 end,
             },
             {
@@ -700,8 +713,8 @@ local _ClassConfig = {
                 cond = function(self, aaName)
                     local absorbDisc = Core.GetResolvedActionMapItem('AbsorbDisc')
                     local standDisc = Core.GetResolvedActionMapItem('StandDisc')
-                    return (not standDisc or mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName()) and mq.TLO.Me.Song(absorbDisc)() and not Casting.IHaveBuff("Guardian's Boon") and
-                        not Casting.IHaveBuff("Guardian's Bravery")
+                    return (not standDisc or mq.TLO.Me.ActiveDisc.Name() ~= standDisc.RankName()) and (not absorbDisc or mq.TLO.Me.Song(absorbDisc)()) and
+                        not Casting.IHaveBuff("Guardian's Boon") and not Casting.IHaveBuff("Guardian's Bravery")
                 end,
             },
             {
@@ -877,7 +890,8 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Config:GetSetting('DoBattleLeap') then return false end
-                    return not mq.TLO.Me.HeadWet() --Stops Leap from launching us above the water's surface
+                    return Casting.SelfBuffAACheck(aaName) and not Casting.IHaveBuff("Group Bestial Alignment")
+                        and not mq.TLO.Me.HeadWet() --Stops Leap from launching us above the water's surface
                 end,
             },
             {
@@ -885,6 +899,14 @@ local _ClassConfig = {
                 type = "AA",
                 cond = function(self, aaName, target)
                     return Core.IsTanking()
+                end,
+            },
+            {
+                name = "BladeDisc",
+                type = "Disc",
+                load_cond = function(self) return Config:GetSetting('BladeDiscUse') == 3 and Core.GetResolvedActionMapItem('BladeDisc') end,
+                cond = function(self, discSpell)
+                    return Config:GetSetting('DoAEDamage') and mq.TLO.Me.PctEndurance() >= Config:GetSetting("ManaToNuke") -- save endurance for emergency discs
                 end,
             },
             {
@@ -1012,8 +1034,20 @@ local _ClassConfig = {
             Tooltip = "Use AE hatred Discs and AA.",
             Default = true,
             RequiresLoadoutChange = true,
-            FAQ = "Why am I using AE damage when there are mezzed mobs around?",
-            Answer = "It is not currently possible to properly determine Mez status without direct Targeting. If you are mezzing, consider turning this option off.",
+        },
+        ['BladeDiscUse']    = {
+            DisplayName = "Blade Disc Use:",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "AE",
+            Index = 101,
+            Tooltip = "When to use your AE Blade Disc Line (DPS mode will not attempt to regain hate).",
+            RequiresLoadoutChange = true,
+            Type = "Combo",
+            ComboOptions = { 'Disabled', 'Only To Regain Hate', 'Whenever Possible', },
+            Default = 2,
+            Min = 1,
+            Max = 3,
         },
 
         --Defenses
@@ -1027,6 +1061,18 @@ local _ClassConfig = {
             Default = 4,
             Min = 1,
             Max = 10,
+            ConfigType = "Advanced",
+        },
+        ['DefenseStart']    = {
+            DisplayName = "Defense HP",
+            Group = "Abilities",
+            Header = "Tanking",
+            Category = "Defenses",
+            Index = 102,
+            Tooltip = "The HP % where we will use defensive actions like discs, epics, etc.\nNote that fighting a named will also trigger these actions.",
+            Default = 60,
+            Min = 1,
+            Max = 100,
             ConfigType = "Advanced",
         },
 

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -577,6 +577,7 @@ return {
             {
                 name = "SwarmPet",
                 type = "Spell",
+                IgnoreImmuneCheck = true,
             },
             {
                 name = "Icelance1",

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -776,6 +776,7 @@ local _ClassConfig = {
             {
                 name = "Spirits of Nature",
                 type = "AA",
+                IgnoreImmuneCheck = true,
             },
             { -- Spire, the SpireChoice setting will determine which ability is displayed/used.
                 name_func = function(self)

--- a/class_configs/Project Lazarus/enc_class_config.lua
+++ b/class_configs/Project Lazarus/enc_class_config.lua
@@ -837,6 +837,7 @@ local _ClassConfig = {
             {
                 name = "Soothing Words",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 load_cond = function() return Config:GetSetting("DoSoothing") end,
                 cond = function(self, aaName, target)
                     local tankId = mq.TLO.Group.MainTank.ID() or 0
@@ -864,6 +865,7 @@ local _ClassConfig = {
             {
                 name = "Arcane Whisper",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and Casting.OkayToCombatEscape()
                 end,

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -756,6 +756,7 @@ local _ClassConfig = {
             {
                 name = "Gathering Dusk",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and Targeting.GetAutoTargetPctHPs() <= Config:GetSetting('BurnHPThreshold') and mq.TLO.Me.PctAggro() <= 25
                 end,

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -350,13 +350,13 @@ return {
     ['Helpers']           = {
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/Project Lazarus/pal_class_config.lua
+++ b/class_configs/Project Lazarus/pal_class_config.lua
@@ -10,7 +10,7 @@ local Logger      = require("utils.logger")
 local Targeting   = require("utils.targeting")
 
 return {
-    _version              = "2.1 - Project Lazarus",
+    _version              = "2.2 - Project Lazarus",
     _author               = "Derple, Algar",
     ['ModeChecks']        = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -355,7 +355,8 @@ return {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -598,7 +599,7 @@ return {
         { --Defensive actions triggered by low HP
             name = 'EmergencyDefenses',
             state = 1,
-            steps = 2, -- help ensure that we cancel visage when needed
+            steps = 1,
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -612,7 +613,7 @@ return {
             doFullRotation = true,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
-                return combat_state == "Combat" and (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('LightHealPoint')
+                return combat_state == "Combat" and Targeting.LightHealsNeeded(mq.TLO.Me.TargetOfTarget)
             end,
         },
         { --Defensive actions used proactively to prevent emergencies
@@ -648,7 +649,7 @@ return {
             load_cond = function()
                 local aeSpell = Config:GetSetting('AEStunUse') == 3 and Core.GetResolvedActionMapItem('AEStun')
                 local pbaeSpell = Config:GetSetting('PBAEStunUse') == 3 and Core.GetResolvedActionMapItem('PBAEStun')
-                return Core.IsTanking() or aeSpell or pbaeSpell
+                return aeSpell or pbaeSpell or mq.TLO.FindItem("=Forsaken Fayguard Bladecatcher")() ~= nil
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -784,7 +785,7 @@ return {
                 name = "BlockDisc",
                 type = "Disc",
                 pre_activate = function(self)
-                    if Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -796,7 +797,8 @@ return {
                 name = "SancDisc",
                 type = "Disc",
                 cond = function(self, discSpell)
-                    return Casting.NoDiscActive() and Casting.DiscOnCoolDown('BlockDisc') and Casting.DiscOnCoolDown('GuardDisc')
+                    return Casting.NoDiscActive() and not mq.TLO.Me.Song("Rampart")() and
+                        Casting.DiscOnCoolDown('BlockDisc') and Casting.DiscOnCoolDown('GuardDisc')
                 end,
             },
             {
@@ -865,6 +867,7 @@ return {
             {
                 name = "Beacon of the Righteous",
                 type = "AA",
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "PBAEStun",
@@ -910,7 +913,7 @@ return {
                 type = "AA",
             },
             {
-                name = "Inquisitor's Judgement",
+                name = "Inquisitor's Judgment",
                 type = "AA",
             },
             {
@@ -968,7 +971,7 @@ return {
                 name = "Gift of Life",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 0) < Config:GetSetting('HPCritical')
+                    return (mq.TLO.Me.TargetOfTarget.PctHPs() or 999) < Config:GetSetting('HPCritical')
                 end,
             },
             {
@@ -1090,8 +1093,8 @@ return {
         {
             id = 'StunTimer4',
             Type = "Spell",
-            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer4')() or "" end,
-            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer4')() or "" end,
+            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer4').RankName.Name() or "" end,
+            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer4').RankName.Name() or "" end,
             AbilityRange = 150,
             cond = function(self)
                 local resolvedSpell = Core.GetResolvedActionMapItem('StunTimer4')
@@ -1102,8 +1105,8 @@ return {
         {
             id = 'StunTimer5',
             Type = "Spell",
-            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer5')() or "" end,
-            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer5')() or "" end,
+            DisplayName = function() return Core.GetResolvedActionMapItem('StunTimer5').RankName.Name() or "" end,
+            AbilityName = function() return Core.GetResolvedActionMapItem('StunTimer5').RankName.Name() or "" end,
             AbilityRange = 150,
             cond = function(self)
                 local resolvedSpell = Core.GetResolvedActionMapItem('StunTimer5')
@@ -1228,6 +1231,7 @@ return {
             Index = 102,
             Tooltip = "Click your Blood/Spirit Drinker's Coating when defenses are triggered.",
             Default = false,
+            RequiresLoadoutChange = true,
         },
         ['UseBandolier']      = {
             DisplayName = "Dynamic Weapon Swap",

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -308,6 +308,16 @@ return {
                 return Targeting.IHaveAggro(100) and (Core.AtEmergencyHP() or Globals.AutoTargetIsNamed)
             end,
         },
+        {
+            name = 'Aggro Management',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and mq.TLO.Me.PctAggro() > Config:GetSetting('JoltAggro') and Casting.OkayToCombatEscape()
+            end,
+        },
         { --Keep things from running
             name = 'Snare',
             state = 1,
@@ -352,6 +362,11 @@ return {
         HaveSelfWard = function(self)
             local ward = Core.GetResolvedActionMapItem('SelfBuff')
             return ward and Casting.IHaveBuff(ward) or false
+        end,
+        AnyDefenseUp = function(self)
+            local weaponShield = Core.GetResolvedActionMapItem('WeaponShield')
+            return Casting.IHaveBuff(Casting.GetAASpell("Outrider's Evasion").ID()) or Casting.IHaveBuff(Casting.GetAASpell("Armor of Experience").ID()) or
+                (weaponShield and mq.TLO.Me.ActiveDisc.Name() == weaponShield.RankName()) or false
         end,
         rangedNav = function(reason)
             if Config:GetSetting('DoMelee') then return false end
@@ -506,14 +521,6 @@ return {
                 end,
             },
             {
-                name = "JoltSpell",
-                type = "Spell",
-                load_cond = function(self) return Config:GetSetting('DoJoltSpell') end,
-                cond = function(self, spell, target)
-                    return Globals.AutoTargetIsNamed and mq.TLO.Me.PctAggro() > 80 and Casting.OkayToCombatEscape()
-                end,
-            },
-            {
                 name = "Forceful Rejuvenation",
                 type = "AA",
             },
@@ -548,6 +555,14 @@ return {
         },
         ['Emergency(Aggro)']   = {
             {
+                name = "Cover Tracks",
+                type = "AA",
+                load_cond = function(self) return Config:GetSetting('DoCoverTracks') and Casting.CanUseAA("Cover Tracks") end,
+                cond = function(self, aaName)
+                    return Casting.OkayToCombatEscape()
+                end,
+            },
+            {
                 name = "Protection of the Spirit Wolf",
                 type = "AA",
             },
@@ -555,15 +570,14 @@ return {
                 name = "Outrider's Evasion",
                 type = "AA",
                 cond = function(self, aaName, target)
-                    local weaponShield = Core.GetResolvedActionMapItem('WeaponShield')
-                    return not (weaponShield and mq.TLO.Me.ActiveDisc.Name() == weaponShield.RankName())
+                    return not self.Helpers.AnyDefenseUp(self)
                 end,
             },
             {
                 name = "WeaponShield",
                 type = "Disc",
                 cond = function(self, discName, target)
-                    return not Casting.IHaveBuff(Casting.GetAASpell("Outrider's Evasion").ID()) and Casting.NoDiscActive()
+                    return not self.Helpers.AnyDefenseUp(self) and Casting.NoDiscActive()
                 end,
             },
             {
@@ -571,8 +585,15 @@ return {
                 type = "AA",
                 load_cond = function(self) return Config:GetSetting('DoVetAA') end,
                 cond = function(self, aaName)
-                    return Core.AtCriticalHP()
+                    return Core.AtCriticalHP() and not self.Helpers.AnyDefenseUp(self)
                 end,
+            },
+        },
+        ['Aggro Management']   = {
+            {
+                name = "JoltSpell",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoJoltSpell') end,
             },
         },
         ['Combat']             = {
@@ -930,7 +951,7 @@ return {
 
 
         --Combat
-        ['DoSwarmDot']   = {
+        ['DoSwarmDot']    = {
             DisplayName = "Swarm Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -940,7 +961,7 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DotNamedOnly'] = {
+        ['DotNamedOnly']  = {
             DisplayName = "Only Dot Named",
             Group = "Abilities",
             Header = "Damage",
@@ -949,7 +970,7 @@ return {
             Tooltip = "Any selected dot above will only be used on a named mob.",
             Default = true,
         },
-        ['UseEpic']      = {
+        ['UseEpic']       = {
             DisplayName = "Epic Use:",
             Group = "Items",
             Header = "Clickies",
@@ -962,7 +983,7 @@ return {
             Min = 1,
             Max = 3,
         },
-        ['DoCoating']    = {
+        ['DoCoating']     = {
             DisplayName = "Use Coating",
             Group = "Items",
             Header = "Clickies",
@@ -971,7 +992,7 @@ return {
             Tooltip = "Click your Blood Drinker's Coating in an emergency.",
             Default = false,
         },
-        ['DoVetAA']      = {
+        ['DoVetAA']       = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
@@ -984,7 +1005,7 @@ return {
         },
 
         --Utility
-        ['DoHealSpell']  = {
+        ['DoHealSpell']   = {
             DisplayName = "Do Heals",
             Group = "Abilities",
             Header = "Recovery",
@@ -994,17 +1015,38 @@ return {
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoJoltSpell']  = {
-            DisplayName = "Do Jolt Spell",
+        ['JoltAggro']     = {
+            DisplayName = "Aggro Shed %",
             Group = "Abilities",
             Header = "Utility",
             Category = "Hate Reduction",
             Index = 101,
+            Tooltip = "Begin using hate reduction abilities above this aggro percentage.",
+            Default = 70,
+            Min = 1,
+            Max = 100,
+        },
+        ['DoJoltSpell']   = {
+            DisplayName = "Use Jolt Spell",
+            Group = "Abilities",
+            Header = "Utility",
+            Category = "Hate Reduction",
+            Index = 102,
             Tooltip = "Use your Jolt spell when your aggro is high.",
             Default = true,
             RequiresLoadoutChange = true,
         },
-        ['DoSnare']      = {
+        ['DoCoverTracks'] = {
+            DisplayName = "Use Cover Tracks",
+            Group = "Abilities",
+            Header = "Utility",
+            Category = "Emergency",
+            Index = 101,
+            Tooltip = "Use Cover Tracks to escape combat in an emergency.",
+            Default = true,
+            RequiresLoadoutChange = true,
+        },
+        ['DoSnare']       = {
             DisplayName = "Use Snares",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1014,7 +1056,7 @@ return {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['SnareCount']   = {
+        ['SnareCount']    = {
             DisplayName = "Snare Max Mob Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1025,7 +1067,7 @@ return {
             Min = 1,
             Max = 99,
         },
-        ['HealPriority'] = {
+        ['HealPriority']  = {
             DisplayName = "Healing Priority",
             Group = "Abilities",
             Header = "Recovery",

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -840,6 +840,7 @@ local _ClassConfig = {
             {
                 name = "Leech Touch",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 tooltip = Tooltips.ThoughtLeech,
                 cond = function(self, aaName, target)
                     return Config:GetSetting('DoLeechTouch') ~= 1
@@ -932,6 +933,7 @@ local _ClassConfig = {
             {
                 name = "Leech Touch",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 tooltip = Tooltips.LeechTouch,
                 cond = function(self, aaName, target)
                     if Config:GetSetting('DoLeechTouch') == 2 then return false end
@@ -1045,6 +1047,7 @@ local _ClassConfig = {
             {
                 name = "Unbridled Strike of Fear",
                 type = "AA",
+                IgnoreImmuneCheck = true,
             },
             {
                 name = "PowerTapAC",

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -78,7 +78,7 @@ local Tooltips     = {
 }
 
 local _ClassConfig = {
-    _version          = "2.7 - Project Lazarus",
+    _version          = "2.8 - Project Lazarus",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -347,7 +347,8 @@ local _ClassConfig = {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -669,7 +670,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.BlockDisc,
                 pre_activate = function(self)
-                    if Config:GetSetting('UseBandolier') then
+                    if Config:GetSetting('UseBandolier') and not Core.ShieldEquipped() then
                         Core.SafeCallFunc("Equip Shield", ItemManager.BandolierSwap, "Shield")
                     end
                 end,
@@ -690,7 +691,7 @@ local _ClassConfig = {
                 type = "Disc",
                 tooltip = Tooltips.UnholyAura,
                 cond = function(self, discSpell, target)
-                    return Casting.NoDiscActive()
+                    return Casting.NoDiscActive() and not mq.TLO.Me.Song("Rampart")()
                 end,
             },
             {
@@ -785,11 +786,13 @@ local _ClassConfig = {
                 name = "Explosion of Hatred",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfHatred,
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "Explosion of Spite",
                 type = "AA",
                 tooltip = Tooltips.ExplosionOfSpite,
+                load_cond = function(self) return Config:GetSetting('AETauntAA') end,
             },
             {
                 name = "AETaunt",
@@ -911,6 +914,7 @@ local _ClassConfig = {
                 type = "Item",
                 tooltip = Tooltips.Epic,
                 cond = function(self, itemName, target)
+                    if Config:GetSetting('HoldEpicForNoDisc') and not (Casting.NoDiscActive() and not mq.TLO.Me.Song("Rampart")()) then return false end
                     return self.Helpers.LeechCheck(self) or Targeting.TankingXTNamed()
                 end,
             },
@@ -986,7 +990,9 @@ local _ClassConfig = {
                 name = "AEPoisonDot",
                 type = "Spell",
                 tooltip = Tooltips.PoisonDot,
-                load_cond = function(self) return Config:GetSetting('DoPoisonDot') and Core.GetResolvedActionMapItem('AEPoisonDot') end,
+                load_cond = function(self)
+                    return Config:GetSetting('DoPoisonDot') and Config:GetSetting('DoAEPoisonDot') and Core.GetResolvedActionMapItem('AEPoisonDot')
+                end,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAEDamage') then return false end
                     if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
@@ -997,7 +1003,10 @@ local _ClassConfig = {
                 name = "PoisonDot",
                 type = "Spell",
                 tooltip = Tooltips.PoisonDot,
-                load_cond = function(self) return Config:GetSetting('DoPoisonDot') and not Core.GetResolvedActionMapItem('AEPoisonDot') end,
+                load_cond = function(self)
+                    return Config:GetSetting('DoPoisonDot') and
+                        not (Config:GetSetting('DoAEPoisonDot') and Core.GetResolvedActionMapItem('AEPoisonDot'))
+                end,
                 cond = function(self, spell, target)
                     if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.HaveManaToDot() and Casting.DotSpellCheck(spell)
@@ -1114,12 +1123,17 @@ local _ClassConfig = {
                     end, -- This will set the spell name to "AESpearNuke" if the setting is enabled and we have a valid spell in our book.
                 },
                 { name = "LifeTap", },
-                { name = "SnareDot",    cond = function(self) return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Encroaching Darkness") end, },
-                { name = "Terror",      cond = function(self) return Config:GetSetting('DoTerror') end, },
-                { name = "AETaunt",     cond = function(self) return Config:GetSetting('AETauntSpell') end, },
+                { name = "SnareDot", cond = function(self) return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Encroaching Darkness") end, },
+                { name = "Terror",   cond = function(self) return Config:GetSetting('DoTerror') end, },
+                { name = "AETaunt",  cond = function(self) return Config:GetSetting('AETauntSpell') end, },
                 { name = "BiteTap", },
-                { name = "BondTap",     cond = function(self) return Config:GetSetting('DoBondTap') end, },
-                { name = "PoisonDot",   cond = function(self) return Config:GetSetting('DoPoisonDot') end, },
+                { name = "BondTap",  cond = function(self) return Config:GetSetting('DoBondTap') end, },
+                {
+                    name_func = function(self)
+                        return (Config:GetSetting('DoAEPoisonDot') and Core.GetResolvedActionMapItem('AEPoisonDot')) and "AEPoisonDot" or "PoisonDot"
+                    end,
+                    cond = function(self) return Config:GetSetting('DoPoisonDot') end,
+                },
                 { name = "DireDot",     cond = function(self) return Config:GetSetting('DoDireDot') end, },
                 { name = "PowerTapAC",  cond = function(self) return Config:GetSetting('DoACTap') end, },
                 { name = "PowerTapAtk", cond = function(self) return Config:GetSetting('DoAtkTap') end, },
@@ -1195,7 +1209,7 @@ local _ClassConfig = {
     },
     ['DefaultConfig'] = {
         --Mode
-        ['Mode']            = {
+        ['Mode']              = {
             DisplayName = "Mode",
             Category = "Mode",
             Tooltip = "Select the active Combat Mode for this PC.",
@@ -1209,7 +1223,7 @@ local _ClassConfig = {
         },
 
         --Buffs and Debuffs
-        ['DoSnare']         = {
+        ['DoSnare']           = {
             DisplayName = "Use Snares",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1219,7 +1233,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['SnareCount']      = {
+        ['SnareCount']        = {
             DisplayName = "Snare Max Mob Count",
             Group = "Abilities",
             Header = "Debuffs",
@@ -1230,7 +1244,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 99,
         },
-        ['ProcChoice']      = {
+        ['ProcChoice']        = {
             DisplayName = "Buff Slot 1 Proc:",
             Group = "Abilities",
             Header = "Buffs",
@@ -1244,7 +1258,7 @@ local _ClassConfig = {
             Max = 3,
             RequiresLoadoutChange = true,
         },
-        ['DoCallBuff']      = {
+        ['DoCallBuff']        = {
             DisplayName = "Use Call of Darkness",
             Group = "Abilities",
             Header = "Buffs",
@@ -1254,7 +1268,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['DoVisage']        = {
+        ['DoVisage']          = {
             DisplayName = "Use Visage of Death",
             Group = "Abilities",
             Header = "Buffs",
@@ -1266,12 +1280,12 @@ local _ClassConfig = {
             Answer =
             "You may have Visage of Death enabled, which has a sizable self-damage component. While we will attempt to autocancel this at low health in downtime, you can disable VoD use in the Class options.",
         },
-        ['DoVetAA']         = {
+        ['DoVetAA']           = {
             DisplayName = "Use Vet AA",
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Index = 103,
+            Index = 105,
             Tooltip = "Use Veteran AA such as Intensity of the Resolute or Armor of Experience as necessary.",
             Default = true,
             ConfigType = "Advanced",
@@ -1279,7 +1293,7 @@ local _ClassConfig = {
         },
 
         --Taps
-        ['StartLifeTap']    = {
+        ['StartLifeTap']      = {
             DisplayName = "HP % for LifeTaps",
             Group = "Abilities",
             Header = "Damage",
@@ -1290,7 +1304,7 @@ local _ClassConfig = {
             Min = 1,
             Max = 100,
         },
-        ['DoACTap']         = {
+        ['DoACTap']           = {
             DisplayName = "Use AC Tap",
             Group = "Abilities",
             Header = "Damage",
@@ -1301,7 +1315,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['DoAtkTap']        = {
+        ['DoAtkTap']          = {
             DisplayName = "Use Attack Tap",
             Group = "Abilities",
             Header = "Damage",
@@ -1312,7 +1326,7 @@ local _ClassConfig = {
             Default = true,
             ConfigType = "Advanced",
         },
-        ['DoLeechTouch']    = {
+        ['DoLeechTouch']      = {
             DisplayName = "Leech Touch Use:",
             Group = "Abilities",
             Header = "Damage",
@@ -1328,7 +1342,7 @@ local _ClassConfig = {
         },
 
         --DoT Spells
-        ['DoBondTap']       = {
+        ['DoBondTap']         = {
             DisplayName = "Use Bond Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1338,17 +1352,17 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DoPoisonDot']     = {
+        ['DoPoisonDot']       = {
             DisplayName = "Use Poison Dot",
             Group = "Abilities",
             Header = "Damage",
             Category = "Over Time",
             Index = 102,
-            ToolTip = function() return Ui.GetDynamicTooltipForSpell("PoisonDot") end,
-            RequiresLoadoutChange = false,
+            Tooltip = function() return Ui.GetDynamicTooltipForSpell("PoisonDot") end,
+            RequiresLoadoutChange = true,
             Default = true,
         },
-        ['DoDireDot']       = {
+        ['DoDireDot']         = {
             DisplayName = "Use Dire Dot",
             Group = "Abilities",
             Header = "Damage",
@@ -1358,7 +1372,7 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
-        ['DotNamedOnly']    = {
+        ['DotNamedOnly']      = {
             DisplayName = "Only Dot Named",
             Group = "Abilities",
             Header = "Damage",
@@ -1369,7 +1383,7 @@ local _ClassConfig = {
         },
 
         -- AE Damage
-        ['DoAESpearNuke']   = {
+        ['DoAESpearNuke']     = {
             DisplayName = "Use AE Spear",
             Group = "Abilities",
             Header = "Damage",
@@ -1383,7 +1397,7 @@ local _ClassConfig = {
             Answer =
             "The three best Spears on Laz have been converted to AE spells. Enable Use AE Spear for these spells to be memorized.\nAE Damage must also be enabled for them to be used.",
         },
-        ['DoAELifeTap']     = {
+        ['DoAELifeTap']       = {
             DisplayName = "Use AE Hate/LifeTap",
             Group = "Abilities",
             Header = "Damage",
@@ -1393,21 +1407,35 @@ local _ClassConfig = {
             RequiresLoadoutChange = true,
             Default = false,
         },
+        ['DoAEPoisonDot']     = {
+            DisplayName = "Use AE Poison Dot",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "AE",
+            Index = 103,
+            Tooltip = function() return Ui.GetDynamicTooltipForSpell("AEPoisonDot") end,
+            Default = false,
+            RequiresLoadoutChange = true,
+            ConfigType = "Advanced",
+            FAQ = "Why am I still using a lower-level poison dot?",
+            Answer =
+            "The best Poison Dots on Laz have been converted to AE spells. Enable Use AE Poison Dot for these spells to be memorized.\nAE Damage must also be enabled for them to be used.",
+        },
 
         --Hate Tools
-        ['DoHateBuff']      = {
+        ['DoHateBuff']        = {
             DisplayName = "Use Hate Buff",
             Group = "Abilities",
             Header = "Buffs",
             Category = "Self",
-            Index = 103,
+            Index = 104,
             Tooltip =
             "Use your Visage buff (Voice of ... line). We will continue to use the spell if slots are available (for the damage shield). The spell can be disabled directly in rotations.",
             Default = true,
             ConfigType = "Advanced",
             RequiresLoadoutChange = true,
         },
-        ['DoTerror']        = {
+        ['DoTerror']          = {
             DisplayName = "Use Terror Taunts",
             Group = "Abilities",
             Header = "Tanking",
@@ -1418,7 +1446,7 @@ local _ClassConfig = {
             ConfigType = "Advanced",
             RequiresLoadoutChange = true,
         },
-        ['AETauntAA']       = {
+        ['AETauntAA']         = {
             DisplayName = "Use AE Taunt AA",
             Group = "Abilities",
             Header = "Tanking",
@@ -1431,7 +1459,7 @@ local _ClassConfig = {
             FAQ = "Why do we treat the Explosions the same? One is targeted, one is PBAE",
             Answer = "There are currently no scripted conditions where Hatred would be used at long range, thus, for ease of use, we can treat them similarly.",
         },
-        ['AETauntSpell']    = {
+        ['AETauntSpell']      = {
             DisplayName = "Use AE Taunt Spell",
             Group = "Abilities",
             Header = "Tanking",
@@ -1444,7 +1472,7 @@ local _ClassConfig = {
         },
 
         --Defenses
-        ['DiscCount']       = {
+        ['DiscCount']         = {
             DisplayName = "Def. Disc. Count",
             Group = "Abilities",
             Header = "Tanking",
@@ -1456,7 +1484,7 @@ local _ClassConfig = {
             Max = 10,
             ConfigType = "Advanced",
         },
-        ['DefenseStart']    = {
+        ['DefenseStart']      = {
             DisplayName = "Defense HP",
             Group = "Abilities",
             Header = "Tanking",
@@ -1468,9 +1496,18 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
+        ['HoldEpicForNoDisc'] = {
+            DisplayName = "Epic Only Without Disc",
+            Group = "Abilities",
+            Header = "Tanking",
+            Category = "Defenses",
+            Index = 103,
+            Tooltip = "Only use your epic if you have no defensive disc active.\nNote: Epic already has a check to not be used when other leech effects are active.",
+            Default = true,
+        },
 
         --Equipment
-        ['DoCoating']       = {
+        ['DoCoating']         = {
             DisplayName = "Use Coating",
             Group = "Items",
             Header = "Clickies",
@@ -1479,7 +1516,7 @@ local _ClassConfig = {
             Tooltip = "Click your Blood Drinker's Coating when defenses are triggered.",
             Default = false,
         },
-        ['UseBandolier']    = {
+        ['UseBandolier']      = {
             DisplayName = "Dynamic Weapon Swap",
             Group = "Items",
             Header = "Bandolier",
@@ -1489,7 +1526,7 @@ local _ClassConfig = {
             Default = false,
             RequiresLoadoutChange = true,
         },
-        ['EquipShield']     = {
+        ['EquipShield']       = {
             DisplayName = "Equip Shield",
             Group = "Items",
             Header = "Bandolier",
@@ -1501,7 +1538,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['Equip2Hand']      = {
+        ['Equip2Hand']        = {
             DisplayName = "Equip 2Hand",
             Group = "Items",
             Header = "Bandolier",
@@ -1513,7 +1550,7 @@ local _ClassConfig = {
             Max = 100,
             ConfigType = "Advanced",
         },
-        ['NamedShieldLock'] = {
+        ['NamedShieldLock']   = {
             DisplayName = "Shield on Named",
             Group = "Items",
             Header = "Bandolier",

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -342,13 +342,13 @@ local _ClassConfig = {
     ['Helpers']       = {
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -155,13 +155,13 @@ local _ClassConfig = {
     ['Helpers']       = {
         --function to determine if we have enough mobs in range to use a defensive disc
         DefensiveDiscCheck = function(printDebug)
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            if xtCount < Config:GetSetting('DiscCount') then return false end
+            local occupiedCount = mq.TLO.Me.XTarget() or 0
+            if occupiedCount < Config:GetSetting('DiscCount') then return false end
             local haters = Set.new({})
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
-                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
+                if Targeting.IsXTHater(xtarg) and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -403,6 +403,7 @@ local _ClassConfig = {
             {
                 name = "Projection of Fury",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed
                 end,

--- a/class_configs/Project Lazarus/war_class_config.lua
+++ b/class_configs/Project Lazarus/war_class_config.lua
@@ -10,7 +10,7 @@ local Logger       = require("utils.logger")
 local Targeting    = require("utils.targeting")
 
 local _ClassConfig = {
-    _version          = "3.1 - Project Lazarus",
+    _version          = "3.2 - Project Lazarus",
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
@@ -88,7 +88,7 @@ local _ClassConfig = {
             "Field Conqueror",                -- Level 71 Laz Custom
             "Field Armorer",                  -- Level 65
         },
-        ['AEBlades'] = {
+        ['BladeDisc'] = {
             "Maelstrom Blade", -- Level 71 Laz Custom
             "Vortex Blade",    -- Level 69
             "Cyclone Blade",   -- Level 65
@@ -160,7 +160,8 @@ local _ClassConfig = {
             local haters = Set.new({})
             for i = 1, xtCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
-                if xtarg and xtarg.ID() > 0 and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) and (xtarg.Distance() or 999) <= 30 then
+                if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and
+                    (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater") and (xtarg.Distance() or 999) <= 30 then
                     if printDebug then
                         Logger.log_verbose("DefensiveDiscCheck(): XT(%d) Counting %s(%d) as a hater in range.", i, xtarg.CleanName() or "None", xtarg.ID())
                     end
@@ -171,8 +172,8 @@ local _ClassConfig = {
             return false
         end,
         BurnDiscCheck = function(self)
-            if mq.TLO.Me.ActiveDisc.Name() == "Fortitude Discipline" or Core.AtEmergencyHP() then return false end
-            local burnDisc = { "Onslaught", "StrikeDisc", "ChargeDisc", }
+            if Core.AtEmergencyHP() then return false end
+            local burnDisc = { "Fortitude", "Onslaught", "StrikeDisc", }
             for _, buffName in ipairs(burnDisc) do
                 local resolvedDisc = self:GetResolvedActionMapItem(buffName)
                 if resolvedDisc and resolvedDisc.RankName() == mq.TLO.Me.ActiveDisc.Name() then return false end
@@ -219,7 +220,7 @@ local _ClassConfig = {
             doFullRotation = true,
             load_cond = function()
                 return Core.IsTanking() and Config:GetSetting('DoAETaunt') and
-                    (Casting.CanUseAA("Area Taunt") or Core.GetResolvedActionMapItem("Epic") or Core.GetResolvedActionMapItem("AEBlades"))
+                    (Core.GetResolvedActionMapItem("AreaTaunt") or Core.GetResolvedActionMapItem("Epic") or Core.GetResolvedActionMapItem("BladeDisc"))
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -339,10 +340,6 @@ local _ClassConfig = {
                 type = "Ability",
             },
             {
-                name = "Attention",
-                type = "Disc",
-            },
-            {
                 name = "Blast of Anger",
                 type = "AA",
             },
@@ -350,17 +347,15 @@ local _ClassConfig = {
                 name = "Scowl",
                 type = "Disc",
                 load_cond = function(self) return Config:GetSetting('UseScowl') and Core.GetResolvedActionMapItem('Scowl') end,
-                cond = function(self, discSpell)
-                    return Casting.DetSpellCheck(discSpell)
-                end,
             },
             {
                 name = "AddHate",
                 type = "Disc",
                 load_cond = function(self) return not (Config:GetSetting('UseScowl') and Core.GetResolvedActionMapItem('Scowl')) end,
-                cond = function(self, discSpell)
-                    return Casting.DetSpellCheck(discSpell)
-                end,
+            },
+            {
+                name = "Attention",
+                type = "Disc",
             },
         },
         ['HateTools(AutoTarget)']  = {
@@ -423,8 +418,9 @@ local _ClassConfig = {
                 end,
             },
             {
-                name = "AEBlades",
+                name = "BladeDisc",
                 type = "Disc",
+                load_cond = function(self) return Config:GetSetting('BladeDiscUse') > 1 end,
                 cond = function(self, discSpell)
                     return Config:GetSetting('DoAEDamage')
                 end,
@@ -671,6 +667,14 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "BladeDisc",
+                type = "Disc",
+                load_cond = function(self) return Config:GetSetting('BladeDiscUse') == 3 and Core.GetResolvedActionMapItem('BladeDisc') end,
+                cond = function(self, discSpell)
+                    return Config:GetSetting('DoAEDamage') and mq.TLO.Me.PctEndurance() >= Config:GetSetting("ManaToNuke") -- save endurance for emergency discs
+                end,
+            },
+            {
                 name = "Knee Strike",
                 type = "AA",
             },
@@ -771,9 +775,23 @@ local _ClassConfig = {
             Header = "Tanking",
             Category = "Hate Tools",
             Index = 101,
-            Tooltip = "Use AE hatred Discs and AA (see FAQ for specifics).",
+            Tooltip = "Use AE hatred Discs and AA.",
             RequiresLoadoutChange = true,
             Default = true,
+        },
+        ['BladeDiscUse']    = {
+            DisplayName = "Blade Disc Use:",
+            Group = "Abilities",
+            Header = "Damage",
+            Category = "AE",
+            Index = 101,
+            Tooltip = "When to use your AE Blade Disc Line (DPS mode will not attempt to regain hate).",
+            RequiresLoadoutChange = true,
+            Type = "Combo",
+            ComboOptions = { 'Disabled', 'Only To Regain Hate', 'Whenever Possible', },
+            Default = 2,
+            Min = 1,
+            Max = 3,
         },
         ['UseScowl']        = {
             DisplayName = "Use Scowl",

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -531,6 +531,7 @@ return {
             {
                 name = "Mind Crash",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and Targeting.IHaveAggro(100)
                 end,
@@ -538,6 +539,7 @@ return {
             {
                 name = "Arcane Whisper",
                 type = "AA",
+                IgnoreImmuneCheck = true,
                 cond = function(self, aaName, target)
                     return Globals.AutoTargetIsNamed and Targeting.IHaveAggro(100)
                 end,

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -556,7 +556,7 @@ Module.DefaultConfig                = {
         Answer = "Chain to Camp mode is intended for a non-tank, non-assist puller to pull a stream of mobs back to a camp, one at a time.\n\n" ..
             "The puller will keep leaving camp to pull, even during combat, until the number of haters on xtarget matches or exceeds the Chain Count.",
         Min = 1,
-        Max = Globals.XTargetSlots,
+        Max = mq.TLO.Me.XTargetSlots() or 20,
     },
     ['PullIgnoreTime']                         = {
         DisplayName = "Ignore Timer",

--- a/tests/unit_tests.lua
+++ b/tests/unit_tests.lua
@@ -15,9 +15,12 @@ local function mockSpawn(id, name, pctHp, isNamed, distance)
         _isNamed   = isNamed,
         _dist      = distance or 50,
         _isTempPet = false,
+        _type      = "NPC",
     }
     setmetatable(t, { __call = function() return true end, })
     t.ID         = function() return t._id end
+    t.Type       = function() return t._type end
+    t.Master     = { Type = function() return nil end, }
     t.CleanName  = function() return t._name end
     t.Name       = function() return t._name end
     t.PctHPs     = function() return t._pctHp end

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -237,14 +237,8 @@ function Combat.ValidMAXTarget(target)
         return false
     end
 
-    if target.ID() > 0 and target.Dead() then
-        Logger.log_verbose("ValidateMATarget: Spawn ID %d is dead", spawnId)
-        return false
-    end
-
-    if target.ID() > 0 and not (target.Aggressive() or target.TargetType():lower() == "auto hater" or spawnId == Globals.ForceTargetID) then
-        Logger.log_verbose("ValidateMATarget: Spawn ID %d is not aggressive or auto hater or forced (Aggressive: %s, TargetType: %s)", spawnId,
-            Strings.BoolToColorString(target.Aggressive()), target.TargetType())
+    if not Targeting.IsXTHater(target) then
+        Logger.log_verbose("ValidateMATarget: Spawn ID %d is not a live hater", spawnId)
         return false
     end
 
@@ -357,7 +351,7 @@ end
 ---@param myLevel         number                               Cached value of Me.Level().
 ---@return number|nil                                          Spawn id to target immediately, or nil to continue scanning.
 function Combat.ProcessXTarget(xtSpawn, radius, namedPref, hpPref, immediate, primaryTarget, fallbackTarget, aggroScan, myLevel)
-    if not xtSpawn or not xtSpawn() then return nil end
+    if not xtSpawn or (xtSpawn.ID() or 0) == 0 then return nil end
     if not Combat.ValidMAXTarget(xtSpawn) then
         Logger.log_verbose("MATargetScan XTarget %s [%d] is not a valid target, skipping.", xtSpawn.CleanName() or "Error", xtSpawn.ID() or 0)
         return nil
@@ -426,9 +420,9 @@ function Combat.MATargetScan(radius, zradius)
     local fallbackTarget = { hp = initHp, id = 0, name = "None", }
     local aggroScan      = Config:GetSetting("MAAggroScan")
     local myLevel        = mq.TLO.Me.Level() or 0
-    local xtCount        = mq.TLO.Me.XTarget()
+    local slotCount      = mq.TLO.Me.XTargetSlots() or 0
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local result = Combat.ProcessXTarget(mq.TLO.Me.XTarget(i), radius, namedPref, hpPref, immediate, primaryTarget, fallbackTarget, aggroScan, myLevel)
         if result then return result end
     end
@@ -464,14 +458,14 @@ function Combat.TankAggroScan()
         return
     end
 
-    local xtCount = mq.TLO.Me.XTarget() or 0
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
     local assistRange = Config:GetSetting('AssistRange')
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtarg = mq.TLO.Me.XTarget(i)
-        if xtarg() then
-            local xtId = xtarg.ID() or 0
-            if xtId > 0 and xtId ~= Globals.AutoTargetID and not Globals.NoHateTargetIDs:contains(xtId) and ((xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater")) then
+        if Targeting.IsXTHater(xtarg) then
+            local xtId = xtarg.ID()
+            if xtId ~= Globals.AutoTargetID and not Globals.NoHateTargetIDs:contains(xtId) then
                 if xtarg.PctAggro() < 100 and (xtarg.Distance() or 999) <= assistRange and Globals.Constants.RGNotMezzedAnims:contains(xtarg.Animation()) then
                     if Combat.OkToEngagePreValidateId(xtId) then
                         Logger.log_verbose("TankAggroScan: Found Aggro Target: %s (id %d).", xtarg.DisplayName(), xtId)
@@ -1208,13 +1202,13 @@ end
 ---@param minMana number The minimum mana threshold to consider.
 ---@return number The spawn id with the worst hurt mana above the specified threshold.
 function Combat.FindWorstHurtManaXT(minMana)
-    local xtSize = mq.TLO.Me.XTargetSlots()
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
     local worstId = 0
     local worstPct = minMana
 
-    Logger.log_verbose("\ayChecking for worst HurtMana XTargs. XT Slot Count: %d", xtSize)
+    Logger.log_verbose("\ayChecking for worst HurtMana XTargs. XT Slot Count: %d", slotCount)
 
-    for i = 1, xtSize do
+    for i = 1, slotCount do
         local healTarget = mq.TLO.Me.XTarget(i)
 
         if healTarget and healTarget() and Targeting.TargetIsType("pc", healTarget) and (healTarget.Distance3D() or 0) < 300 then
@@ -1241,13 +1235,13 @@ end
 ---@param minHPs number The minimum HP threshold to consider.
 ---@return number The spawn id with the worst health condition that meets the criteria.
 function Combat.FindWorstHurtXT(minHPs)
-    local xtSize = mq.TLO.Me.XTargetSlots()
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
     local worstId = 0
     local worstPct = minHPs
 
-    Logger.log_verbose("\ayChecking for worst Hurt XTargs. XT Slot Count: %d", xtSize)
+    Logger.log_verbose("\ayChecking for worst Hurt XTargs. XT Slot Count: %d", slotCount)
 
-    for i = 1, xtSize do
+    for i = 1, slotCount do
         local healTarget = mq.TLO.Me.XTarget(i)
 
         if healTarget and healTarget() and Targeting.TargetIsType("pc", healTarget) and (healTarget.Distance3D() or 0) < 300 then
@@ -1369,25 +1363,28 @@ end
 ---@return boolean
 function Combat.AETauntCheck(printDebug)
     if Globals.NoHateTargetIDs:contains(Globals.AutoTargetID) then return false end
-    local xtCount = mq.TLO.Me.XTarget() or 0
-    if xtCount < Config:GetSetting('AETauntCnt') then return false end
+    local occupiedCount = mq.TLO.Me.XTarget() or 0
+    if occupiedCount < Config:GetSetting('AETauntCnt') then return false end
 
     local mobs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
     if mobs < Config:GetSetting('AETauntCnt') then return false end
 
     local tauntme = Set.new({})
-    for i = 1, xtCount do
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
+    for i = 1, slotCount do
         local xtarg = mq.TLO.Me.XTarget(i)
-        if xtarg and xtarg.ID() > 0 and (xtarg.Aggressive() or xtarg.TargetType():lower() == "auto hater" or xtarg.ID() == Globals.ForceTargetID) and xtarg.PctAggro() < 100 and (xtarg.Distance() or 999) <= 50 and Globals.Constants.RGNotMezzedAnims:contains(xtarg.Animation()) then
+        if Targeting.IsXTHater(xtarg) and xtarg.PctAggro() < 100 and (xtarg.Distance() or 999) <= 50 and Globals.Constants.RGNotMezzedAnims:contains(xtarg.Animation()) then
             if printDebug then
                 Logger.log_verbose("AETauntCheck(): XT(%d) Counting %s(%d) as a hater eligible to AE Taunt.", i, xtarg.CleanName() or "None",
                     xtarg.ID())
             end
             tauntme:add(xtarg.ID())
+            if not Config:GetSetting('SafeAETaunt') then return true end --no need to find more than one if we don't care about safe taunt
         end
-        if not Config:GetSetting('SafeAETaunt') and #tauntme:toList() > 0 then return true end --no need to find more than one if we don't care about safe taunt
     end
-    return #tauntme:toList() > 0 and not (Config:GetSetting('SafeAETaunt') and #tauntme:toList() < mobs)
+
+    local tauntCount = #tauntme:toList()
+    return tauntCount > 0 and not (Config:GetSetting('SafeAETaunt') and tauntCount < mobs)
 end
 
 --- Returns true if AE damage conditions are met (enough haters in range, optionally all mobs are haters).

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -48,7 +48,6 @@ Globals.CurZoneId                     = mq.TLO.Zone.ID()
 Globals.CurInstanceId                 = mq.TLO.Me.Instance()
 Globals.CurLoadedChar                 = mq.TLO.Me.DisplayName()
 Globals.CurLoadedClass                = mq.TLO.Me.Class.ShortName()
-Globals.XTargetSlots                  = mq.TLO.Me.XTargetSlots() or 20
 Globals.CurServer                     = mq.TLO.EverQuest.Server()
 Globals.CurServerNormalized           = mq.TLO.EverQuest.Server():gsub(" ", "")
 Globals.CastResult                    = 0

--- a/utils/movement.lua
+++ b/utils/movement.lua
@@ -330,18 +330,20 @@ end
 function Movement:DetectMobBehind()
     local me = mq.TLO.Me
     local myHeading = me.Heading.DegreesCCW() or 0
-    local xtCount = me.XTarget() or 0
+    local slotCount = me.XTargetSlots() or 0
     local nearest = nil
     local nearestDistSq = math.huge
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtSpawn = me.XTarget(i)
         local xtId = (xtSpawn and xtSpawn.ID()) or 0
+        local xtType = xtId > 0 and (xtSpawn.Type() or ""):lower() or ""
         if xtId > 0 and not xtSpawn.Dead() and not xtSpawn.Fleeing()
             and (math.ceil(xtSpawn.PctHPs() or 0)) > 0
             and (xtSpawn.Aggressive() or (xtSpawn.TargetType() or ""):lower() == "auto hater" or xtId == Globals.ForceTargetID)
             and Globals.Constants.RGNotMezzedAnims:contains(xtSpawn.Animation())
-            and (xtSpawn.PctAggro() or 0) >= 100 then
+            and (xtSpawn.PctAggro() or 0) >= 100
+            and xtType ~= "pc" and xtType ~= "mercenary" then
             local theirHeadingTo = xtSpawn.HeadingTo.DegreesCCW() or 0
             local diff = math.abs(myHeading - theirHeadingTo) % 360
             if diff > 180 then diff = 360 - diff end

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -287,9 +287,9 @@ function Targeting.GetAutoTargetAggroPct()
         return mq.TLO.Target.PctAggro() or 0
     end
 
-    local xtCount = mq.TLO.Me.XTarget()
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtSpawn = mq.TLO.Me.XTarget(i)
 
         if xtSpawn() and (xtSpawn.ID() or 0) == Globals.AutoTargetID then
@@ -341,6 +341,22 @@ function Targeting.FacingTarget()
     return math.abs((mq.TLO.Target.HeadingTo.DegreesCCW() or mq.TLO.Me.Heading.DegreesCCW()) - mq.TLO.Me.Heading.DegreesCCW()) <= 20
 end
 
+--- Returns true if the XTarget entry is a live mob that hates us.
+---@param xtarg xtarget The XTarget entry to test.
+---@return boolean True if the entry is a hater, false for empties, corpses, PCs, mercenaries and player pets.
+function Targeting.IsXTHater(xtarg)
+    local xtargID = xtarg and xtarg.ID() or 0
+    if xtargID == 0 or xtarg.Dead() then return false end
+
+    local spawnType = (xtarg.Type() or "Corpse"):lower()
+    if spawnType == "corpse" then return false end
+    if (xtarg.TargetType() or ""):lower() == "auto hater" then return true end
+    if not (xtarg.Aggressive() or xtargID == Globals.ForceTargetID) then return false end
+    if spawnType == "npc" then return true end
+
+    return not (spawnType == "pc" or spawnType == "mercenary" or xtarg.Master.Type() == "PC")
+end
+
 --- Returns the highest aggro percentage the player has across the current
 --- target and all aggressive or force-targeted XTarget entries.
 ---@return number Highest aggro percentage 0–100.
@@ -350,13 +366,14 @@ function Targeting.GetHighestAggroPct()
 
     local highestPct = target.PctAggro() or 0
 
-    local xtCount    = me.XTarget()
+    local slotCount  = me.XTargetSlots() or 0
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtSpawn = me.XTarget(i)
 
-        if xtSpawn() and (xtSpawn.ID() or 0) > 0 and (xtSpawn.Aggressive() or xtSpawn.TargetType():lower() == "auto hater" or xtSpawn.ID() == Globals.ForceTargetID) then
-            if xtSpawn.PctAggro() > highestPct then highestPct = xtSpawn.PctAggro() end
+        if Targeting.IsXTHater(xtSpawn) then
+            local aggroPct = xtSpawn.PctAggro() or 0
+            if aggroPct > highestPct then highestPct = aggroPct end
         end
     end
 
@@ -376,16 +393,12 @@ function Targeting.IHaveAggro(pct)
         return true
     end
 
-    local xtCount = me.XTarget()
+    local slotCount = me.XTargetSlots() or 0
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtSpawn = me.XTarget(i)
-        local xtSpawnID = xtSpawn and xtSpawn.ID() or 0
 
-        if xtSpawnID > 0 and not xtSpawn.Dead() and (xtSpawn.Type() or "Corpse") ~= "Corpse" and
-            (xtSpawn.Aggressive() or (xtSpawn.TargetType() or ""):lower() == "auto hater" or xtSpawnID == Globals.ForceTargetID) then
-            if (xtSpawn.PctAggro() or 0) >= pct then return true end
-        end
+        if Targeting.IsXTHater(xtSpawn) and (xtSpawn.PctAggro() or 0) >= pct then return true end
     end
 
     return false
@@ -399,12 +412,11 @@ function Targeting.TankingXTNamed()
     end
     Targeting.TankingNamedCheckTime = Globals.GetTimeSeconds()
     Targeting.TankingNamedFound = false
-    local xtCount = mq.TLO.Me.XTarget() or 0
-    for i = 1, xtCount do
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
+    for i = 1, slotCount do
         local xt = mq.TLO.Me.XTarget(i)
         -- check for exactly 100% to help ensure the mob is targeting us, over 100% can indicate another is still targeted
-        if xt and xt.ID() > 0 and not xt.Dead()
-            and (xt.Aggressive() or (xt.TargetType() or ""):lower() == "auto hater")
+        if Targeting.IsXTHater(xt)
             and (xt.PctAggro() or 0) == 100
             and Targeting.IsNamed(xt) then
             Targeting.TankingNamedFound = true
@@ -418,12 +430,12 @@ end
 ---@param printDebug boolean? If true, logs each hater found.
 ---@return table Set of hater spawn IDs.
 function Targeting.GetXTHaterIDsSet(printDebug)
-    local xtCount = mq.TLO.Me.XTarget() or 0
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
     local uniqHaters = Set.new({})
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtarg = mq.TLO.Me.XTarget(i)
-        if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater" or xtarg.ID() == Globals.ForceTargetID) then
+        if Targeting.IsXTHater(xtarg) then
             if printDebug then
                 Logger.log_verbose("GetXTHaters(): XT(%d) Counting %s(%d) as a hater.", i, xtarg.CleanName() or "None", xtarg.ID())
             end
@@ -453,14 +465,14 @@ end
 ---@return boolean True if at least count unique haters are on XTarget.
 function Targeting.HasXTHaters(count)
     count = count or 1
-    local xtCount = mq.TLO.Me.XTarget() or 0
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
     local seenHaters = {}
     local uniqHaters = 0
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtarg = mq.TLO.Me.XTarget(i)
-        local xtargID = xtarg and xtarg.ID() or 0
-        if xtargID > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater" or xtargID == Globals.ForceTargetID) then
+        if Targeting.IsXTHater(xtarg) then
+            local xtargID = xtarg.ID()
             if not seenHaters[xtargID] then
                 seenHaters[xtargID] = true
                 uniqHaters = uniqHaters + 1
@@ -483,13 +495,11 @@ end
 ---@param range number Distance in units to check against.
 ---@return boolean True if a hater is within range.
 function Targeting.XTHaterInRange(range)
-    local xtCount = mq.TLO.Me.XTarget() or 0
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtarg = mq.TLO.Me.XTarget(i)
-        if xtarg and xtarg.ID() > 0 and not xtarg.Dead() and (xtarg.Type() or "Corpse") ~= "Corpse" and (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater" or xtarg.ID() == Globals.ForceTargetID) then
-            if (xtarg.Distance3D() or 999) <= range then return true end
-        end
+        if Targeting.IsXTHater(xtarg) and (xtarg.Distance3D() or 999) <= range then return true end
     end
 
     return false
@@ -519,9 +529,10 @@ end
 ---@param autoHater boolean? If true, require the slot to be an auto hater.
 ---@return boolean True if the spawn is found in XTarget (and meets autoHater if set).
 function Targeting.IsSpawnXTHater(spawnId, autoHater)
-    local xtCount = mq.TLO.Me.XTarget() or 0
+    if (spawnId or 0) <= 0 then return false end
+    local slotCount = mq.TLO.Me.XTargetSlots() or 0
 
-    for i = 1, xtCount do
+    for i = 1, slotCount do
         local xtarg = mq.TLO.Me.XTarget(i)
         if xtarg and xtarg.ID() == spawnId then
             if autoHater == true then

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -1710,12 +1710,11 @@ function Ui.RenderForceTargetList(showPopout)
         function(sort_specs)
             Ui.TempSettings.SortedXT = {}
             Ui.TempSettings.SortedXTIDToSlot = {}
-            local xtCount = mq.TLO.Me.XTarget() or 0
-            for i = 1, xtCount do
+            local slotCount = mq.TLO.Me.XTargetSlots() or 0
+            for i = 1, slotCount do
                 local xtarg = mq.TLO.Me.XTarget(i)
                 local xtargID = xtarg and xtarg.ID() or 0
-                if xtargID > 0 and (xtarg.Aggressive() or (xtarg.TargetType() or ""):lower() == "auto hater" or xtargID == Globals.ForceTargetID) and
-                    Ui.TempSettings.SortedXTIDToSlot[xtargID] == nil and not xtarg.Dead() then
+                if Targeting.IsXTHater(xtarg) and Ui.TempSettings.SortedXTIDToSlot[xtargID] == nil then
                     table.insert(Ui.TempSettings.SortedXT, xtarg)
                     Ui.TempSettings.SortedXTIDToSlot[xtargID] = { Name = xtarg.CleanName() or "None", Slot = i, ID = xtargID, }
                 end


### PR DESCRIPTION
* RNG(All) - Aggro Management Adjustments
* * Aligned rotations and entries between configs.
* WAR/PAL/SHD(All) - Aligned defensive rotations, entries and options
* * WAR(Live) - Defensive actions now begin at the "Defense HP" setting (default: 60).
* * Corrected or improved various rotation entries and options.
* XTarget Hater Detection Fixes
* Unresistable abilities are no longer skipped for elemental immunity