### PR TITLE
Safe Targeting Adjustments

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -396,6 +396,7 @@ local function Main()
             Globals.LooseCharms = {}
             Globals.LastCachedBuffUpdate = {}
             Globals.AutoTargetID = 0
+            Globals.ValidAutoTargetIDs = Set.new({})
             Globals.AutoTargetIsNamed = false
             Globals.AggroTargetID = 0
             Globals.CombatNavTargetId = 0
@@ -446,11 +447,11 @@ local function Main()
         if Globals.CurrentState ~= "Downtime" then
             Logger.log_debug("Switching to Downtime state.")
 
-            -- clear the cache during state transition.
-            Targeting.ClearSafeTargetCache()
+            Targeting.PruneValidAutoTargets()
             Targeting.ForceBurnTargetID = 0
             Globals.LastPulledID        = 0
             Combat.PullStuckTime        = 0
+            Combat.StrangerWarnedIDs    = {}
             Globals.AutoTargetID        = 0
             Globals.CombatNavTargetId   = 0
             Globals.IgnoredTargetIDs    = Set.new({})

--- a/modules/pull.lua
+++ b/modules/pull.lua
@@ -42,6 +42,7 @@ Module.TempSettings.TargetSpawnID         = 0
 Module.TempSettings.PullTargets           = {}
 Module.TempSettings.PullMetaData          = {}
 Module.TempSettings.PullIgnoreTargets     = {}
+Module.TempSettings.StrangerSkip          = {}
 Module.TempSettings.PullListUpdated       = false
 Module.TempSettings.PullAllowSet          = {}
 Module.TempSettings.PullDenySet           = {}
@@ -157,7 +158,7 @@ Module.Constants.PullFilterReasons              = {
     ['CON_OUT_OF_RANGE']    = 15,
     ['LEVEL_DIFF_TOO_HIGH'] = 16,
     ['NO_PATH']             = 17,
-    ['FIGHTING_STRANGER']   = 18,
+    ['STRANGER_NEAR']       = 18,
 }
 
 Module.Constants.PullFilterReasonDisplayStrings = {
@@ -178,7 +179,7 @@ Module.Constants.PullFilterReasonDisplayStrings = {
     ['CON_OUT_OF_RANGE']    = { Display = Icons.FA_EXCLAMATION, Text = "Con Out of Range", Color = 'Yellow', },
     ['LEVEL_DIFF_TOO_HIGH'] = { Display = Icons.FA_CHEVRON_UP, Text = "Level Difference Too High", Color = 'Red', },
     ['NO_PATH']             = { Display = Icons.MD_CLEAR, Text = "No Path / Unreachable", Color = 'Red', },
-    ['FIGHTING_STRANGER']   = { Display = Icons.FA_FIRE, Text = "Fighting a Stranger", Color = 'Red', },
+    ['STRANGER_NEAR']       = { Display = Icons.FA_USER_SECRET, Text = "Stranger Nearby", Color = 'Red', },
 }
 
 Module.Constants.PullFilterReasonsIDToName      = {}
@@ -312,7 +313,7 @@ Module.Constants.AbortLogMessages   = {
     listUpdated = "\ar ALERT: Aborting pull due to change in pull allow or deny list. \ax",
     disabled = "\ar ALERT: Pulling Disabled at user request. \ax",
     spawnGone = "PULL:\ar ALERT: Aborting mob died or despawned \ax",
-    stranger = "PULL:\ar ALERT: Aborting mob is fighting a stranger and safe targeting is enabled! \ax",
+    stranger = "PULL:\ar ALERT: Aborting mob has a stranger near it and Attempt Safe Pulling is enabled! \ax",
     unreachable = "PULL:\ar ALERT: Aborting Fight To target has been unreachable for too long \ax",
     tooFar = "PULL:\ar ALERT: Aborting mob moved out of spawn distance \ax",
     noPath = "PULL:\ar ALERT: Aborting mob no longer reachable on mesh \ax",
@@ -580,6 +581,21 @@ Module.DefaultConfig                = {
         Index = 5,
         Tooltip = "Allow pulling mobs that are in water.",
         Default = false,
+    },
+    ['AttemptSafePulling']                     = {
+        DisplayName = "Attempt Safe Pulling",
+        Group = "Movement",
+        Header = "Pulling",
+        Category = "Pull Rules",
+        Index = 10,
+        Tooltip = "Attempt to avoid pulling mobs that are near strangers. This is a best-effort attempt (see FAQ).",
+        Default = false,
+        ConfigType = "Advanced",
+        FAQ = "What does Attempt Safe Pulling do?",
+        Answer = "Attempt Safe Pulling attempts to scan for the presence of strangers near mobs that are assessed for pulling. " ..
+            "This is a best-effort guess; unfortunately, PC location data is not reliable at distance, and who is targeting what is not exposed directly to the client in most cases.\n\n" ..
+            "A stranger is anyone who is not a Mercs peer, not in your group or raid, not in your guild, not a DanNet peer, and not on your assist or heal list.\n\n" ..
+            "Because of unreliable data, this may cause false positives; use with caution.",
     },
     ['PullBackwards']                          = {
         DisplayName = "Pull Facing Backwards",
@@ -1421,13 +1437,13 @@ function Module.DecideAbort(attempt, abortCtx)
     if abortCtx.spawnGone then return 'spawnGone' end
 
     if attempt.source == 'objective' then
-        if abortCtx.safeTargeting and abortCtx.fightingStranger then return 'stranger' end
+        if abortCtx.attemptSafePulling and abortCtx.strangerNear then return 'stranger' end
         if abortCtx.graceExpired then return 'unreachable' end
         if not abortCtx.navigating and abortCtx.timedOut then return 'objectiveTimeout' end
     elseif attempt.source == 'scan' then
         if abortCtx.distance > abortCtx.maxPathRange then return 'tooFar' end
         if not abortCtx.pathExists then return 'noPath' end
-        if abortCtx.safeTargeting and abortCtx.fightingStranger then return 'stranger' end
+        if abortCtx.attemptSafePulling and abortCtx.strangerNear then return 'stranger' end
         if not abortCtx.navigating and abortCtx.timedOut then return 'timeout' end
     elseif attempt.source == 'manual' then
         if not abortCtx.navigating and abortCtx.timedOut then return 'manualTimeout' end
@@ -2602,6 +2618,7 @@ end
 
 function Module:ClearIgnoreList()
     self.TempSettings.PullIgnoreTargets = {}
+    self.TempSettings.StrangerSkip = {}
 end
 
 function Module:ValidateIgnoreList()
@@ -3744,11 +3761,20 @@ function Module:GetPullableSpawns()
             return false
         end
 
-        if Config:GetSetting('SafeTargeting') and Targeting.IsSpawnFightingStranger(spawn, 500) then
-            Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \ar mob is fighting a stranger and safe targeting is enabled!",
-                spawnName, spawn.ID())
-            recordReason(spawn, reasons.FIGHTING_STRANGER)
-            return false
+        if Config:GetSetting('AttemptSafePulling') then
+            local skipUntil = self.TempSettings.StrangerSkip[spawn.ID()]
+            if skipUntil and Globals.GetTimeMS() < skipUntil then
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \ar recently aborted for a nearby stranger, still skipping!", spawnName, spawn.ID())
+                recordReason(spawn, reasons.STRANGER_NEAR)
+                return false
+            end
+            self.TempSettings.StrangerSkip[spawn.ID()] = nil
+
+            if Targeting.IsSpawnNearStranger(spawn) then
+                Logger.log_verbose("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \ar a stranger is near it!", spawnName, spawn.ID())
+                recordReason(spawn, reasons.STRANGER_NEAR)
+                return false
+            end
         end
 
         Logger.log_debug("\atPULL::FindPullTarget \awSpawn \am%s\aw (\at%d\aw) \agPotential Pull Added to List", spawn.CleanName(), spawn.ID())
@@ -3819,8 +3845,8 @@ function Module:CheckAttemptAbort(attempt, bNavigating)
     }
 
     if attempt.source == 'objective' then
-        abortCtx.safeTargeting = Config:GetSetting('SafeTargeting')
-        abortCtx.fightingStranger = Targeting.IsSpawnFightingStranger(spawn, 500)
+        abortCtx.attemptSafePulling = Config:GetSetting('AttemptSafePulling')
+        abortCtx.strangerNear = abortCtx.attemptSafePulling and attempt.engageStartedAt == nil and Targeting.IsSpawnNearStranger(spawn)
         local _, graceExpired = self:CheckReachable("id " .. attempt.targetId)
         abortCtx.graceExpired = graceExpired
         abortCtx.timedOut = attempt.engageStartedAt ~= nil and (Globals.GetTimeSeconds() - attempt.engageStartedAt) >= Config:GetSetting('PullIgnoreTime')
@@ -3828,8 +3854,8 @@ function Module:CheckAttemptAbort(attempt, bNavigating)
         abortCtx.distance = spawn.Distance() or 0
         abortCtx.maxPathRange = Config:GetSetting("MaxPathRange")
         abortCtx.pathExists = mq.TLO.Navigation.PathExists("id " .. attempt.targetId)()
-        abortCtx.safeTargeting = Config:GetSetting('SafeTargeting')
-        abortCtx.fightingStranger = Targeting.IsSpawnFightingStranger(spawn, 500)
+        abortCtx.attemptSafePulling = Config:GetSetting('AttemptSafePulling')
+        abortCtx.strangerNear = abortCtx.attemptSafePulling and attempt.engageStartedAt == nil and Targeting.IsSpawnNearStranger(spawn)
         abortCtx.timedOut = attempt.engageStartedAt ~= nil and (Globals.GetTimeSeconds() - attempt.engageStartedAt) >= Config:GetSetting('PullIgnoreTime')
     elseif attempt.source == 'manual' then
         abortCtx.timedOut = attempt.engageStartedAt ~= nil and (Globals.GetTimeSeconds() - attempt.engageStartedAt) >= Config:GetSetting('PullIgnoreTime')
@@ -3843,6 +3869,8 @@ function Module:CheckAttemptAbort(attempt, bNavigating)
         self.TempSettings.PullListUpdated = false
     elseif reason == 'timeout' then
         table.insert(self.TempSettings.PullIgnoreTargets, mq.TLO.Spawn(attempt.targetId))
+    elseif reason == 'stranger' then
+        self.TempSettings.StrangerSkip[attempt.targetId] = Globals.GetTimeMS() + 60000
     elseif reason == 'objectiveTimeout' then
         self:AnnounceStop("Fight To target could not be engaged - pulls disabled.", false)
     end
@@ -3917,9 +3945,7 @@ function Module:RunEntryGates(ctx)
             self.TempSettings.HuntAnchor = nil
             Core.DoCmd("/mapfilter pullradius off")
         end
-        if #self.TempSettings.PullIgnoreTargets > 0 then
-            self:ClearIgnoreList()
-        end
+        if next(self.TempSettings.StrangerSkip) or #self.TempSettings.PullIgnoreTargets > 0 then self:ClearIgnoreList() end
     end
 
     Logger.log_verbose("PULL:GiveTime() - DoPull: %s", Strings.BoolToColorString(Config:GetSetting('DoPull')))
@@ -4148,6 +4174,14 @@ function Module:PreAttemptTick(ctx)
                 return
             end
 
+            if Config:GetSetting('AttemptSafePulling') then
+                local skipUntil = self.TempSettings.StrangerSkip[objective.id]
+                if (skipUntil and Globals.GetTimeMS() < skipUntil) or Targeting.IsSpawnNearStranger(objectiveSpawn) then
+                    self:SetPullState(PullStates.PULL_WAITING_SHOULDPULL, "A stranger is near the target - retrying")
+                    return
+                end
+            end
+
             pullID = objective.id
             source = 'objective'
         else
@@ -4346,13 +4380,6 @@ function Module:NavToTargetTick(ctx)
     if mq.TLO.Target.Master.Type() == 'PC' then
         Logger.log_debug("\atPULL::PullTarget \awPullTarget :: Spawn \am%s\aw (\at%d\aw) is Charmed Pet -- Skipping", mq.TLO.Target.CleanName(), mq.TLO.Target.ID())
         abortPull = true
-    end
-
-    if Config:GetSetting('SafeTargeting') then
-        -- Hard coding 500 units as our radius as it's probably twice our effective spell range.
-        if Targeting.IsSpawnFightingStranger(mq.TLO.Spawn(attempt.targetId), 500) then
-            abortPull = true
-        end
     end
 
     local target = mq.TLO.Target

--- a/tests/unit_tests.lua
+++ b/tests/unit_tests.lua
@@ -26,6 +26,9 @@ local function mockSpawn(id, name, pctHp, isNamed, distance)
     t.PctHPs     = function() return t._pctHp end
     t.Distance   = function() return t._dist end
     t.Distance3D = function() return t._dist end
+    t.X          = function() return -99999 end
+    t.Y          = function() return -99999 end
+    t.Z          = function() return -99999 end
     t.PctAggro   = function() return 100 end
     t.Moving     = function() return false end
     t.Animation  = function() return 0 end
@@ -546,8 +549,8 @@ function UnitTests.RunAll()
                 pauseMain = false,
                 spawnGone = false,
                 navigating = false,
-                safeTargeting = false,
-                fightingStranger = false,
+                attemptSafePulling = false,
+                strangerNear = false,
                 graceExpired = false,
                 distance = 100,
                 maxPathRange = 1000,
@@ -576,20 +579,20 @@ function UnitTests.RunAll()
 
         assertEq("DecideAbort scan: too far", DecideAbort(scanAttempt, baseCtx({ distance = 1001, })), 'tooFar')
         assertEq("DecideAbort scan: no path", DecideAbort(scanAttempt, baseCtx({ pathExists = false, })), 'noPath')
-        assertEq("DecideAbort scan: stranger", DecideAbort(scanAttempt, baseCtx({ safeTargeting = true, fightingStranger = true, })), 'stranger')
-        assertEq("DecideAbort scan: stranger needs safe targeting", DecideAbort(scanAttempt, baseCtx({ fightingStranger = true, })), nil)
+        assertEq("DecideAbort scan: stranger", DecideAbort(scanAttempt, baseCtx({ attemptSafePulling = true, strangerNear = true, })), 'stranger')
+        assertEq("DecideAbort scan: stranger needs the setting on", DecideAbort(scanAttempt, baseCtx({ strangerNear = true, })), nil)
         assertEq("DecideAbort scan: timeout", DecideAbort(scanAttempt, baseCtx({ timedOut = true, })), 'timeout')
         assertEq("DecideAbort scan: timeout inactive while navigating", DecideAbort(scanAttempt, baseCtx({ timedOut = true, navigating = true, })), nil)
 
-        assertEq("DecideAbort objective: stranger", DecideAbort(objectiveAttempt, baseCtx({ safeTargeting = true, fightingStranger = true, })), 'stranger')
+        assertEq("DecideAbort objective: stranger", DecideAbort(objectiveAttempt, baseCtx({ attemptSafePulling = true, strangerNear = true, })), 'stranger')
         assertEq("DecideAbort objective: unreachable grace", DecideAbort(objectiveAttempt, baseCtx({ graceExpired = true, })), 'unreachable')
         assertEq("DecideAbort objective: no distance abort", DecideAbort(objectiveAttempt, baseCtx({ distance = 1001, })), nil)
         assertEq("DecideAbort objective: timeout", DecideAbort(objectiveAttempt, baseCtx({ timedOut = true, })), 'objectiveTimeout')
 
         assertEq("DecideAbort manual: exempt from scan arm",
-            DecideAbort(manualAttempt, baseCtx({ distance = 1001, pathExists = false, safeTargeting = true, fightingStranger = true, })), nil)
+            DecideAbort(manualAttempt, baseCtx({ distance = 1001, pathExists = false, attemptSafePulling = true, strangerNear = true, })), nil)
         assertEq("DecideAbort manual: exempt from objective arm",
-            DecideAbort(manualAttempt, baseCtx({ safeTargeting = true, fightingStranger = true, graceExpired = true, })), nil)
+            DecideAbort(manualAttempt, baseCtx({ attemptSafePulling = true, strangerNear = true, graceExpired = true, })), nil)
 
         assertEq("DecideUserAbort: clean ctx", DecideUserAbort(baseCtx(), 'scan'), nil)
         assertEq("DecideUserAbort: paused", DecideUserAbort(baseCtx({ pausePulls = true, }), 'scan'), 'paused')

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -1,21 +1,22 @@
-local mq             = require('mq')
-local Set            = require('mq.set')
-local Comms          = require("utils.comms")
-local Config         = require('utils.config')
-local Core           = require("utils.core")
-local DanNet         = require('lib.dannet.helpers')
-local Events         = require("utils.events")
-local Globals        = require('utils.globals')
-local Logger         = require("utils.logger")
-local Math           = require("utils.math")
-local Modules        = require("utils.modules")
-local Movement       = require("utils.movement")
-local Strings        = require("utils.strings")
-local Targeting      = require("utils.targeting")
+local mq                = require('mq')
+local Set               = require('mq.set')
+local Comms             = require("utils.comms")
+local Config            = require('utils.config')
+local Core              = require("utils.core")
+local DanNet            = require('lib.dannet.helpers')
+local Events            = require("utils.events")
+local Globals           = require('utils.globals')
+local Logger            = require("utils.logger")
+local Math              = require("utils.math")
+local Modules           = require("utils.modules")
+local Movement          = require("utils.movement")
+local Strings           = require("utils.strings")
+local Targeting         = require("utils.targeting")
 
-local Combat         = { _version = '1.0', _name = "Combat", _author = 'Derple', }
-Combat.__index       = Combat
-Combat.PullStuckTime = 0
+local Combat            = { _version = '1.0', _name = "Combat", _author = 'Derple', }
+Combat.__index          = Combat
+Combat.PullStuckTime    = 0
+Combat.StrangerWarnedIDs = {}
 
 --- Returns the current live combat state based on XTarget hater count.
 ---@return string "Combat" if there are active haters, "Downtime" otherwise.
@@ -303,14 +304,27 @@ function Combat.IsPreferredType(spawnIsNamed, namedPref)
         or (namedPref.prefTrash and not spawnIsNamed)
 end
 
-local function processFallbackSpawn(spawn, checkNamed, radius, namedPref, hpPref, primaryTarget, fallbackTarget)
+local function skipForStranger(spawn)
+    local spawnId = spawn and spawn.ID() or 0
+    if Globals.ValidAutoTargetIDs:contains(spawnId) or spawnId == Globals.LastPulledID then return false end
+    if not Targeting.IsSpawnNearStranger(spawn) then return false end
+
+    if not Combat.StrangerWarnedIDs[spawnId] then
+        Combat.StrangerWarnedIDs[spawnId] = true
+        Logger.log_warn("\ayLeaving \at%s\ay alone - a stranger is nearby and Attempt Safe Targeting is enabled.", spawn.CleanName() or "Unknown")
+    end
+
+    return true
+end
+
+local function processFallbackSpawn(spawn, checkNamed, namedPref, hpPref, primaryTarget, fallbackTarget)
     if not spawn or not spawn() then return end
     if Targeting.IsTempPet(spawn) then return end
     if Targeting.IsDeniedTarget(spawn) then return end
     local fallbackId = spawn.ID() or 0
     if fallbackId ~= Globals.ForceTargetID and fallbackId ~= Globals.ForceCombatID and Globals.CharmedPetIDs:contains(fallbackId) then return end
     if (spawn.CleanName() or ""):find("Guard") then return end
-    if Config:GetSetting('SafeTargeting') and Targeting.IsSpawnFightingStranger(spawn, radius) then return end
+    if Config:GetSetting('AttemptSafeTargeting') and skipForStranger(spawn) then return end
     local spawnIsNamed = checkNamed and Targeting.IsNamed(spawn) or false
 
     if Combat.IsPreferredType(spawnIsNamed, namedPref) then
@@ -327,16 +341,15 @@ end
 --- Scans nearby spawns matching search and updates the primaryTarget bucket as a fallback when XTargets yield nothing.
 ---@param search        string                               Spawn search string passed to NearestSpawn.
 ---@param checkNamed    boolean                              If true, named status is evaluated for namedPref filtering.
----@param radius        number                               Max distance to consider a spawn valid.
 ---@param namedPref     {prefNamed:boolean,prefTrash:boolean} Named targeting preference flags.
 ---@param hpPref        {prefLow:boolean,prefHigh:boolean}   HP targeting preference flags.
 ---@param primaryTarget {hp:number,id:number,found:boolean}  Primary target bucket, mutated in place.
 ---@param fallbackTarget {hp:number,id:number,name:string}  Non-preferred-type bucket, mutated in place.
-function Combat.FallbackScan(search, checkNamed, radius, namedPref, hpPref, primaryTarget, fallbackTarget)
+function Combat.FallbackScan(search, checkNamed, namedPref, hpPref, primaryTarget, fallbackTarget)
     local count = mq.TLO.SpawnCount(search)()
     Logger.log_verbose("MATargetScan FallbackScan: %s ===> %d", search, count)
     for i = 1, count do
-        processFallbackSpawn(mq.TLO.NearestSpawn(i, search), checkNamed, radius, namedPref, hpPref, primaryTarget, fallbackTarget)
+        processFallbackSpawn(mq.TLO.NearestSpawn(i, search), checkNamed, namedPref, hpPref, primaryTarget, fallbackTarget)
     end
 end
 
@@ -361,12 +374,12 @@ function Combat.ProcessXTarget(xtSpawn, radius, namedPref, hpPref, immediate, pr
     local xtName  = xtSpawn.CleanName() or "Error"
     local spawnId = xtSpawn.ID() or 0
 
-    if Config:GetSetting('SafeTargeting') and Targeting.IsSpawnFightingStranger(xtSpawn, radius) then
-        Logger.log_verbose("MATargetScan XTarget %s [%d] Distance: %d - is fighting someone else - ignoring it.", xtName, spawnId, xtSpawn.Distance())
-        return nil
-    end
     if (xtSpawn.Distance() or 999) > radius then
         Logger.log_verbose("MATargetScan \ar%s distance[%d] is out of radius: %d", xtName, xtSpawn.Distance() or 0, radius)
+        return nil
+    end
+    if Config:GetSetting('AttemptSafeTargeting') and skipForStranger(xtSpawn) then
+        Logger.log_verbose("MATargetScan XTarget %s [%d] Distance: %d - another player is next to it - ignoring it.", xtName, spawnId, xtSpawn.Distance())
         return nil
     end
 
@@ -435,9 +448,9 @@ function Combat.MATargetScan(radius, zradius)
         elseif Config:GetSetting('AreaScanFallback') then
             -- We didn't find anything to kill yet so spawn search
             Logger.log_verbose("MATargetScan Falling back on Spawn Searching")
-            Combat.FallbackScan(aggroSearch, true, radius, namedPref, hpPref, primaryTarget, fallbackTarget)
+            Combat.FallbackScan(aggroSearch, true, namedPref, hpPref, primaryTarget, fallbackTarget)
             if not primaryTarget.found and fallbackTarget.id == 0 then
-                Combat.FallbackScan(aggroSearchPet, false, radius, namedPref, hpPref, primaryTarget, fallbackTarget)
+                Combat.FallbackScan(aggroSearchPet, false, namedPref, hpPref, primaryTarget, fallbackTarget)
             end
             if not primaryTarget.found and fallbackTarget.id > 0 then
                 Logger.log_verbose("MATargetScan \agArea scan found only non-preferred type, falling back to: %d", fallbackTarget.id)
@@ -719,10 +732,16 @@ function Combat.FindBestAutoTarget(validateFn)
     end
 
     if Globals.AutoTargetID > 0 then
-        -- Only the MA consumes the pull; a non-MA puller still needs LastPulledID to avoid dropping its inbound target.
-        if Core.IAmMA() and Globals.AutoTargetID == Globals.LastPulledID then
-            Globals.LastPulledID = 0
-            Combat.PullStuckTime = 0
+        if validateFn then
+            if Globals.AutoTargetID ~= Globals.ForceTargetID and Globals.AutoTargetID ~= Globals.ForceCombatID then
+                Globals.ValidAutoTargetIDs:add(Globals.AutoTargetID)
+            end
+
+            -- Only the MA consumes the pull; a non-MA puller still needs LastPulledID to avoid dropping its inbound target.
+            if Core.IAmMA() and Globals.AutoTargetID == Globals.LastPulledID then
+                Globals.LastPulledID = 0
+                Combat.PullStuckTime = 0
+            end
         end
 
         if assistTargetIsNamed ~= nil then
@@ -803,8 +822,9 @@ function Combat.OkToEngagePreValidateId(targetId)
         return false
     end
 
-    if Config:GetSetting('SafeTargeting') and Targeting.IsSpawnFightingStranger(target, 100) then
-        Logger.log_verbose("\ayOkToEngagePrevalidate check for %s(ID: %d) - Fighting Stranger --> Not Engaging", targetName, targetId)
+    if Config:GetSetting('AttemptSafeTargeting') and targetId ~= Globals.ForceTargetID and targetId ~= Globals.ForceCombatID
+        and skipForStranger(target) then
+        Logger.log_verbose("\ayOkToEngagePrevalidate check for %s(ID: %d) - Another Player Is Next To It --> Not Engaging", targetName, targetId)
         return false
     end
 
@@ -884,8 +904,9 @@ function Combat.OkToEngage(autoTargetId)
         return false
     end
 
-    if Config:GetSetting('SafeTargeting') and Targeting.IsSpawnFightingStranger(target, 100) then
-        Logger.log_verbose("\ayOkToEngage check for %s(ID: %d) - Fighting Stranger --> Not Engaging", targetName, targetId)
+    if Config:GetSetting('AttemptSafeTargeting') and targetId ~= Globals.ForceTargetID and targetId ~= Globals.ForceCombatID
+        and skipForStranger(target) then
+        Logger.log_verbose("\ayOkToEngage check for %s(ID: %d) - Another Player Is Next To It --> Not Engaging", targetName, targetId)
         return false
     end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -667,15 +667,22 @@ Config.DefaultConfig                                     = {
         Default = false,
         ConfigType = "Advanced",
     },
-    ['SafeTargeting']              = {
-        DisplayName = "Use Safe Targeting",
+    ['AttemptSafeTargeting']       = {
+        DisplayName = "Attempt Safe Targeting",
         Group = "Combat",
         Header = "Targeting",
         Category = "Targeting Behavior",
         Index = 3,
-        Tooltip = "Do not target mobs that are fighting others (except if those others pass safety checks, such as if they are DanNet peers.).",
-        Default = true,
+        Tooltip = "Attempt to avoid targeting or engaging mobs that are near strangers. This is a best-effort attempt with serious possible side effects (see FAQ).",
+        Default = false,
         ConfigType = "Advanced",
+        FAQ = "What does Attempt Safe Targeting do?",
+        Answer = "Attempt Safe Targeting attempts to scan for the presence of strangers near mobs that are assessed for engagement. " ..
+            "This is a best-effort guess; unfortunately, who is targeting what is not exposed directly to the client in most cases.\n\n" ..
+            "A stranger is anyone who is not a Mercs peer, not in your group or raid, not in your guild, not a DanNet peer, and not on your assist or heal list.\n\n" ..
+            "This setting may be dangerous. While your current autotarget is protected, this could stop engagement of targets if a PC closes on YOUR position, " ..
+            "and mobs that are on XTarget, yet not engageable because of a nearby stranger, can interfere with various functions, such as downtime buffing, or even pulling modes.\n\n" ..
+            "We recommend this setting stay disabled. Players not using this feature may wish to familiarize themselves with the /rgl backoff command.",
     },
     ['TargetNonAggressives']       = {
         DisplayName = "Target Non-Aggressives",

--- a/utils/globals.lua
+++ b/utils/globals.lua
@@ -14,6 +14,7 @@ Globals.Config                        = nil
 Globals.MainAssist                    = ""
 Globals.ScriptDir                     = ""
 Globals.AutoTargetID                  = 0
+Globals.ValidAutoTargetIDs            = Set.new({})
 Globals.AggroTargetID                 = 0
 Globals.MATargetID                    = 0
 Globals.ForceTargetID                 = 0

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -13,10 +13,13 @@ local Targeting                 = { _version = '1.0', _name = "Targeting", _auth
 Targeting.__index               = Targeting
 Targeting.ForceNamed            = false
 Targeting.ForceBurnTargetID     = 0
-Targeting.SafeTargetCache       = {}
 Targeting.XTClearTime           = 0
 Targeting.TankingNamedCheckTime = 0
 Targeting.TankingNamedFound     = false
+Targeting.NearbyPCLocs          = {}
+Targeting.NearbyPCLocsTime      = 0
+Targeting.NearbyPCLocsRadius    = 0
+Targeting.NearbyPCSafeNames     = {}
 
 Targeting.XTargetTypeKeywords   = {
     ["Target's Target"]      = "targetstarget",
@@ -642,44 +645,65 @@ function Targeting.ClearStuckXTargets()
     end
 end
 
---- Returns true if any PC/pet/merc within radius is assisting spawn but is
---- not in our group, raid, guild, or DanNet — meaning attacking them would
---- grief another player.
----@param spawn MQSpawn The spawn to check for cross-player fighting.
----@param radius number Search radius in EQ units.
----@return boolean True if an unfamiliar player is fighting spawn.
-function Targeting.IsSpawnFightingStranger(spawn, radius)
-    local searchTypes = { "PC", "PCPET", "MERCENARY", }
+--- Rebuilds NearbyPCLocs with the position and owner name of every PC, PC pet and mercenary but our
+--- own within radius of us, reusing the last sweep while it is fresh and still wide enough. Capped
+--- at 599 because the server stops broadcasting a player's position to us at 600.
+---@param radius number Distance from the player the caller needs covered.
+function Targeting.RefreshNearbyPCLocs(radius)
+    radius = math.min(math.ceil(radius / 100) * 100, 599)
+    if Globals.GetTimeMS() - Targeting.NearbyPCLocsTime < 100 and Targeting.NearbyPCLocsRadius >= radius then return end
 
-    for _, t in ipairs(searchTypes) do
-        local count = mq.TLO.SpawnCount(string.format("%s radius %d zradius %d", t, radius, radius))()
+    local myName = mq.TLO.Me.DisplayName() or ""
 
-        for i = 1, count do
-            local cur_spawn = mq.TLO.NearestSpawn(i, string.format("%s radius %d zradius %d", t, radius, radius))
+    Targeting.NearbyPCLocs = {}
+    Targeting.NearbyPCSafeNames = {}
+    Targeting.NearbyPCLocsTime = Globals.GetTimeMS()
+    Targeting.NearbyPCLocsRadius = radius
 
-            if cur_spawn() and not Targeting.SafeTargetCache[cur_spawn.ID()] then
-                if (cur_spawn.AssistName() or ""):len() > 0 then
-                    Logger.log_verbose("My Interest: %s =? Their Interest: %s", spawn.CleanName(),
-                        cur_spawn.AssistName())
-                    if cur_spawn.AssistName() == spawn.Name() then
-                        Logger.log_verbose("[%s] Fighting same mob as: %s Theirs: %s Ours: %s", t,
-                            cur_spawn.CleanName(), cur_spawn.AssistName(), spawn.Name())
-                        local checkName = cur_spawn and cur_spawn() or cur_spawn.CleanName() or "None"
+    for _, searchType in ipairs({ "pc", "pcpet", "mercenary", }) do
+        local search = string.format("%s radius %d", searchType, radius)
+        local i = 1
 
-                        if Targeting.TargetIsType("mercenary", cur_spawn) and cur_spawn.Owner() then checkName = cur_spawn.Owner.CleanName() end
-                        if Targeting.TargetIsType("pet", cur_spawn) then checkName = cur_spawn.Master.CleanName() end
+        while true do
+            local nearby = mq.TLO.NearestSpawn(i, search)
+            if not nearby() then break end
 
-                        if not Targeting.IsSafeName("pc", checkName) then
-                            Logger.log_verbose(
-                                "\ar WARNING: \ax Almost attacked other PCs [%s] mob. Not attacking \aw%s\ax",
-                                checkName, cur_spawn.AssistName())
-                            return true
-                        end
-                    end
-                end
+            local checkName = nearby.DisplayName() or ""
+            if Targeting.TargetIsType("mercenary", nearby) and nearby.Owner() then checkName = nearby.Owner.DisplayName() or "" end
+            if Targeting.TargetIsType("pet", nearby) then checkName = nearby.Master.DisplayName() or "" end
 
-                -- this is pretty expensive to calculate so lets cache it.
-                Targeting.SafeTargetCache[cur_spawn.ID()] = true
+            if checkName ~= myName then
+                table.insert(Targeting.NearbyPCLocs, { name = checkName, x = nearby.X() or 0, y = nearby.Y() or 0, z = nearby.Z() or 0, })
+            end
+
+            i = i + 1
+        end
+    end
+end
+
+--- Returns true if an unfamiliar PC, PC pet or mercenary is standing within 50 units of
+--- spawn. Proximity only: it cannot tell whether they are actually fighting it.
+---@param spawn MQSpawn The spawn to check for nearby unfamiliar players.
+---@return boolean True if an unfamiliar player is close enough to have a claim on spawn.
+function Targeting.IsSpawnNearStranger(spawn)
+    if not (spawn and spawn()) then return false end
+
+    local spawnX, spawnY, spawnZ = spawn.X(), spawn.Y(), spawn.Z()
+    if not (spawnX and spawnY and spawnZ) then return false end
+
+    local spawnDistance = spawn.Distance3D() or 0
+    if spawnDistance > 599 then return false end
+
+    Targeting.RefreshNearbyPCLocs(spawnDistance + 50)
+
+    for _, loc in ipairs(Targeting.NearbyPCLocs) do
+        if ((loc.x - spawnX) ^ 2) + ((loc.y - spawnY) ^ 2) + ((loc.z - spawnZ) ^ 2) <= 2500 then
+            if Targeting.NearbyPCSafeNames[loc.name] == nil then
+                Targeting.NearbyPCSafeNames[loc.name] = Targeting.IsSafeName("pc", loc.name)
+            end
+            if not Targeting.NearbyPCSafeNames[loc.name] then
+                Logger.log_verbose("\arNOTICE:\ax \aw%s\ax is next to \aw%s\ax - leaving it alone.", loc.name, spawn.CleanName() or "None")
+                return true
             end
         end
     end
@@ -687,13 +711,18 @@ function Targeting.IsSpawnFightingStranger(spawn, radius)
     return false
 end
 
---- Returns true if name is a "safe" player: DanNet peer, group, raid, guild,
---- or on the AssistList config. Prevents accidentally engaging friendly players.
+--- Returns true if name is a "safe" player: Mercs peer, DanNet peer, group, raid,
+--- guild, or on the AssistList or HealList. Prevents accidentally engaging friendly players.
 ---@param spawnType string Spawn type for guild check query, e.g. "pc".
 ---@param name string Character name to verify.
 ---@return boolean True if the name belongs to a friendly player.
 function Targeting.IsSafeName(spawnType, name)
     Logger.log_verbose("IsSafeName(%s)", name)
+    if Comms.IsValidPeer(Comms.GetPeerName(name)) then
+        Logger.log_verbose("IsSafeName(%s): Peer Safe", name)
+        return true
+    end
+
     if mq.TLO.DanNet(name)() then
         Logger.log_verbose("IsSafeName(%s): Dannet Safe", name)
         return true
@@ -731,12 +760,6 @@ function Targeting.IsSafeName(spawnType, name)
 
     Logger.log_verbose("IsSafeName(%s): false", name)
     return false
-end
-
---- Resets SafeTargetCache so IsSpawnFightingStranger re-evaluates each spawn
---- from scratch on the next call.
-function Targeting.ClearSafeTargetCache()
-    Targeting.SafeTargetCache = {}
 end
 
 --- Returns true if target is a member of the player's current group.
@@ -942,6 +965,15 @@ function Targeting.HateToolsNeeded()
     if Globals.AutoTargetID == 0 or mq.TLO.Target.ID() ~= Globals.AutoTargetID then return false end
     if Globals.NoHateTargetIDs:contains(Globals.AutoTargetID) then return false end
     return mq.TLO.Me.PctAggro() < 100 or (mq.TLO.Target.SecondaryPctAggro() or 0) > 60 or Globals.AutoTargetIsNamed
+end
+
+--- Removes validated auto target IDs whose spawns are dead or gone, so the server can reuse them.
+function Targeting.PruneValidAutoTargets()
+    for _, id in ipairs(Globals.ValidAutoTargetIDs:toList()) do
+        if not Core.ValidCombatTarget(id) then
+            Globals.ValidAutoTargetIDs:remove(id)
+        end
+    end
 end
 
 --- Removes no hate target IDs whose spawns are confirmed dead.


### PR DESCRIPTION
* Removed "Use Safe Targeting" and rewrote the underlying functions.
* New Setting: "Attempt Safe Pulling" - avoid pulling mobs that have strangers near them (default: off).
* New Setting: "Attempt Safe Targeting" - avoid targeting or engaging mobs that have strangers near them (default: off).
* Please refer to the in-game FAQs for details and warnings.