### PR TITLE
ci: skip build + RedGuides publish on #nobuild

### DIFF
--- a/.github/workflows/package-main.yaml
+++ b/.github/workflows/package-main.yaml
@@ -18,7 +18,14 @@ concurrency:
 
 jobs:
   release:
-    if: github.repository == 'DerpleDude/rgmercs'
+    # Skip the whole release (and, by extension, the RedGuides publish that
+    # chains off this run's success) when the pushed HEAD commit message
+    # contains '#nobuild'. A skipped job makes this run conclude 'skipped', so
+    # the downstream "Publish to RedGuides" workflow_run guard (== 'success')
+    # never fires.
+    if: >-
+      github.repository == 'DerpleDude/rgmercs' &&
+      !contains(github.event.head_commit.message, '#nobuild')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Adds a `#nobuild` escape hatch to the release pipeline. When the pushed HEAD commit message contains `#nobuild`, the `release` job in `package-main.yaml` is skipped.

Because the run then concludes `skipped` (not `success`), the chained **Publish to RedGuides** workflow — which is guarded on `github.event.workflow_run.conclusion == 'success'` — also does not run. So a single one-line guard suppresses both halves: no version bump, no GitHub release, no RedGuides upload.

## The change

```yaml
if: >-
  github.repository == 'DerpleDude/rgmercs' &&
  !contains(github.event.head_commit.message, '#nobuild')
```

## Notes

- Only the **HEAD** commit of the push is checked (`github.event.head_commit.message`). A `#nobuild` buried in a non-tip commit of a multi-commit push won't be detected.
- `contains` is case-sensitive — `#NoBuild` would not match.
- **Merge method matters for suppressing *this* PR's build:** the commit that lands on `main` must carry `#nobuild`. This PR's title and branch commit both include it, so a squash-merge (message from title) or a merge/rebase (preserving the commit) will all keep the marker on the landing commit.

#nobuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)