### PR TITLE
Mount/Familiar/Illusion Benefits

### DIFF
--- a/modules/move.lua
+++ b/modules/move.lua
@@ -902,6 +902,121 @@ function Module:DoCombatCampCheck()
     Combat.CombatCampCheck(self.TempSettings)
 end
 
+--- Returns the clicky to use for a benefit, falling back to the keyring's assigned stat item when no item is set.
+---@param settingName string The item setting to read.
+---@param keyring keyring The keyring to fall back to.
+---@return string
+function Module:GetBenefitItemName(settingName, keyring)
+    local itemName = Config:GetSetting(settingName) or ""
+    if itemName:len() > 0 then return itemName end
+
+    -- clients without keyrings have no TLO to ask
+    return keyring and keyring.Stat() or ""
+end
+
+--- Returns the mount clicky to use, falling back to the Stat Mount only when we are mounting for the benefit.
+---@return string
+function Module:GetMountItemName()
+    local mountItemName = Config:GetSetting('MountItem') or ""
+    if mountItemName:len() > 0 or Config:GetSetting('DoMount') ~= 3 then return mountItemName end
+
+    return mq.TLO.Mount and mq.TLO.Mount.Stat() or ""
+end
+
+--- Returns the lasting benefit buff granted by the given mount, familiar or illusion item, and the mount/familiar/illusion itself.
+---@param itemName string The clicky to read.
+---@return MQSpell? benefitSpell The buff we are clicking the item for, nil if the item grants none.
+---@return MQSpell? primarySpell The mount, familiar or illusion to get rid of afterward, nil if it can't be resolved.
+function Module:GetBenefitSpells(itemName)
+    if (itemName or ""):len() == 0 then return nil end
+
+    local benefitItem = mq.TLO.FindItem("=" .. itemName)
+    if not benefitItem() then return nil end
+
+    local clickySpell = benefitItem.Clicky.Spell
+    if (clickySpell.ID() or 0) == 0 then return nil end
+
+    -- Live keeps the benefit in its own slot; RoF2 has only the one and pairs the two spells with a trigger
+    if (benefitItem.Blessing.Spell.ID() or 0) ~= clickySpell.ID() then
+        return benefitItem.Blessing.Spell, clickySpell
+    end
+
+    for i = 1, (clickySpell.NumEffects() or 0) do
+        if clickySpell.Attrib(i)() == 374 then
+            return clickySpell, clickySpell.Trigger(i)
+        end
+    end
+
+    return clickySpell, nil
+end
+
+--- Determines if the character should mount.
+---@return boolean True if the character should mount, false otherwise.
+function Module:ShouldMount()
+    if Config:GetSetting('DoMount') == 1 then return false end
+
+    local mountItemName = self:GetMountItemName()
+    local passBasicChecks = mountItemName:len() > 0 and mq.TLO.Me.CanMount()
+
+    local passCheckMountOne = (not Config:GetSetting('DoMelee') and (Config:GetSetting('DoMount') == 2 and (mq.TLO.Me.Mount.ID() or 0) == 0))
+    local passCheckMountTwo = false
+
+    if Config:GetSetting('DoMount') == 3 then
+        local blessingSpell = self:GetBenefitSpells(mountItemName)
+        passCheckMountTwo = blessingSpell ~= nil and (mq.TLO.Me.Buff("=" .. blessingSpell.Name()).ID() or 0) == 0
+    end
+
+    return passBasicChecks and (passCheckMountOne or passCheckMountTwo)
+end
+
+--- Determines whether the character should dismount.
+---@return boolean True if the character should dismount, false otherwise.
+function Module:ShouldDismount()
+    -- if mount item is empty and we are on a mount then the user probably wants mount on.
+    return self:GetMountItemName():len() > 0 and Config:GetSetting('DoMount') ~= 2 and ((mq.TLO.Me.Mount.ID() or 0) > 0)
+end
+
+--- Clicks a familiar or illusion item for its lasting buff, then gets rid of the familiar or illusion that came with it.
+---@param itemName string The clicky to use.
+---@param bIsFamiliar boolean? True for a familiar, which arrives as a pet on EMU and as a buff on Live.
+function Module:DoBenefitClicky(itemName, bIsFamiliar)
+    local benefitSpell, primarySpell = self:GetBenefitSpells(itemName)
+    if not benefitSpell or Casting.IHaveBuff(benefitSpell.ID()) then return end
+    if not Casting.CheckOkayToBuff() then return end
+
+    local previousPetId = mq.TLO.Me.Pet.ID() or 0
+
+    if not Casting.UseItem(itemName, mq.TLO.Me.ID()) then return end
+
+    if bIsFamiliar then
+        -- the pet arrives from the server after the cast completes
+        mq.delay(1000, function() return (mq.TLO.Me.Pet.ID() or 0) ~= previousPetId end)
+
+        if (mq.TLO.Me.Pet.ID() or 0) ~= previousPetId then
+            self:RunCmd("/pet get lost")
+            return
+        end
+    end
+
+    if not primarySpell then return end
+
+    if Casting.IHaveBuff(primarySpell.ID()) then
+        self:RunCmd("/removebuff =%s", primarySpell.Name())
+        return
+    end
+
+    -- some illusions are a wrapper that fires one of several forms depending on your class
+    for i = 1, (primarySpell.NumEffects() or 0) do
+        if primarySpell.Attrib(i)() == 374 then
+            local triggeredSpell = primarySpell.Trigger(i)
+            if triggeredSpell and Casting.IHaveBuff(triggeredSpell.ID()) then
+                self:RunCmd("/removebuff =%s", triggeredSpell.Name())
+                return
+            end
+        end
+    end
+end
+
 function Module:GiveTime()
     if mq.TLO.Me.Hovering() and Config:GetSetting('ChaseOn') then
         if Config:GetSetting('BreakOnDeath') then
@@ -934,14 +1049,22 @@ function Module:GiveTime()
             Casting.UseItem(Config:GetSetting('ShrinkPetItem'), mq.TLO.Me.Pet.ID())
         end
 
-        if Config.ShouldMount() then
+        if self:ShouldMount() and Casting.CheckOkayToBuff() then
             Logger.log_debug("\ayMounting...")
-            Casting.UseItem(Config:GetSetting('MountItem'), mq.TLO.Me.ID())
+            Casting.UseItem(self:GetMountItemName(), mq.TLO.Me.ID())
         end
 
-        if Config.ShouldDismount() then
+        if self:ShouldDismount() then
             Logger.log_debug("\ayDismounting...")
             self:RunCmd("/dismount")
+        end
+
+        if Config:GetSetting('DoFamiliarBenefit') then
+            self:DoBenefitClicky(self:GetBenefitItemName('FamiliarItem', mq.TLO.Familiar), true)
+        end
+
+        if Config:GetSetting('DoIllusionBenefit') then
+            self:DoBenefitClicky(self:GetBenefitItemName('IllusionItem', mq.TLO.Illusion))
         end
     end
 

--- a/utils/config.lua
+++ b/utils/config.lua
@@ -546,9 +546,9 @@ Config.DefaultConfig                                     = {
         Header = "Clickies",
         Category = "General Clickies",
         Index = 3,
-        Tooltip = "Choose how/when to use mounts. A character with melee combat enabled will only use a mount if set to use as a buff.",
+        Tooltip = "Choose how/when to use mounts. A character with melee combat enabled will only use a mount if set to use for the benefit.",
         Type = "Combo",
-        ComboOptions = { 'Never', 'For use as mount', 'For buff only', },
+        ComboOptions = { 'Never', 'For use as mount', 'For benefit only', },
         Default = 2,
         Min = 1,
         Max = 3,
@@ -560,7 +560,49 @@ Config.DefaultConfig                                     = {
         Header = "Clickies",
         Category = "General Clickies",
         Index = 4,
-        Tooltip = "Mount Clicky item to use.",
+        Tooltip = "Mount Clicky item to use, or leave empty to use your Stat Mount for the benefit.",
+        Type = "ClickyItem",
+        Default = "",
+        ConfigType = "Normal",
+    },
+    ['DoFamiliarBenefit']          = {
+        DisplayName = "Do Familiar Benefit",
+        Group = "Items",
+        Header = "Clickies",
+        Category = "General Clickies",
+        Index = 5,
+        Tooltip = "Click a familiar item for its lasting benefit, then remove the familiar itself.",
+        Default = false,
+        ConfigType = "Normal",
+    },
+    ['FamiliarItem']               = {
+        DisplayName = "Familiar Item",
+        Group = "Items",
+        Header = "Clickies",
+        Category = "General Clickies",
+        Index = 6,
+        Tooltip = "Familiar Clicky item to use. Leave empty to use your Stat Familiar.",
+        Type = "ClickyItem",
+        Default = "",
+        ConfigType = "Normal",
+    },
+    ['DoIllusionBenefit']          = {
+        DisplayName = "Do Illusion Benefit",
+        Group = "Items",
+        Header = "Clickies",
+        Category = "General Clickies",
+        Index = 7,
+        Tooltip = "Click an illusion item for its lasting benefit, then remove the illusion itself.",
+        Default = false,
+        ConfigType = "Normal",
+    },
+    ['IllusionItem']               = {
+        DisplayName = "Illusion Item",
+        Group = "Items",
+        Header = "Clickies",
+        Category = "General Clickies",
+        Index = 8,
+        Tooltip = "Illusion Clicky item to use. Leave empty to use your Stat Illusion.",
         Type = "ClickyItem",
         Default = "",
         ConfigType = "Normal",
@@ -570,7 +612,7 @@ Config.DefaultConfig                                     = {
         Group = "Items",
         Header = "Clickies",
         Category = "General Clickies",
-        Index = 5,
+        Index = 9,
         Tooltip = "Use Shrink items.",
         Default = false,
         ConfigType = "Normal",
@@ -580,7 +622,7 @@ Config.DefaultConfig                                     = {
         Group = "Items",
         Header = "Clickies",
         Category = "General Clickies",
-        Index = 6,
+        Index = 10,
         Tooltip = "Item to use to Shrink yourself.",
         Type = "ClickyItem",
         Default = "",
@@ -4405,35 +4447,6 @@ end
 ---@return number
 function Config:GetMainOpacity()
     return tonumber((self:GetSetting('BgOpacity') or 100) / 100) or 1.0
-end
-
---- Determines if the character should mount.
---- @return boolean True if the character should mount, false otherwise.
-function Config.ShouldMount()
-    if Config:GetSetting('DoMount') == 1 then return false end
-
-    local passBasicChecks = Config:GetSetting('MountItem'):len() > 0 and mq.TLO.Me.CanMount()
-
-    local passCheckMountOne = (not Config:GetSetting('DoMelee') and (Config:GetSetting('DoMount') == 2 and (mq.TLO.Me.Mount.ID() or 0) == 0))
-    local passCheckMountTwo = ((Config:GetSetting('DoMount') == 3 and (mq.TLO.Me.Buff("Mount Blessing").ID() or 0) == 0))
-    local passMountItemGivesBlessing = false
-
-    if passCheckMountTwo then
-        local mountItem = mq.TLO.FindItem(Config:GetSetting('MountItem'))
-        if mountItem and mountItem() then
-            passMountItemGivesBlessing = mountItem.Blessing() ~= nil
-        end
-    end
-
-    return passBasicChecks and (passCheckMountOne or (passCheckMountTwo and passMountItemGivesBlessing))
-end
-
---- Determines whether the character should dismount.
---- This function checks certain conditions to decide if the character should dismount.
---- @return boolean True if the character should dismount, false otherwise.
-function Config.ShouldDismount()
-    -- if mount item is empty and we are on a mount then the user probably wants mount on.
-    return (Config:GetSetting('MountItem') or ""):len() > 0 and Config:GetSetting('DoMount') ~= 2 and ((mq.TLO.Me.Mount.ID() or 0) > 0)
 end
 
 --- Determines if the priority follow condition is met.

--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -3018,11 +3018,15 @@ function Ui.RenderOption(type, setting, id, requiresLoadoutChange, ...)
         ImGui.PushID(id .. "__btn")
         local width = ImGui.GetContentRegionAvailVec().x - 30
         if Ui.MarqueeButton(nameLen > 0 and itemName or "[Drop Here]", 15, width) then
-            if mq.TLO.Cursor() then
+            -- keyring items ride the cursor attachment instead of the cursor itself
+            local cursorAttachment = mq.TLO.CursorAttachment
+            local droppedItemName = mq.TLO.Cursor.Name() or (cursorAttachment() and cursorAttachment.Item.Name())
+
+            if droppedItemName then
                 if type == "ClickyItemWithConditions" then
-                    setting.itemName = mq.TLO.Cursor.Name()
+                    setting.itemName = droppedItemName
                 else
-                    setting = mq.TLO.Cursor.Name()
+                    setting = droppedItemName
                 end
 
                 pressed = true


### PR DESCRIPTION
* Added support for setting familiar/illusion benefits. Improved mount benefit detection.
* Added item entry blocks for the above benefits.
* * If the feature is enabled (mounts: set for benefit only) and the block is left blank, we will use your currently selected "Stat" mount/familiar/illusion from your keyring.
* * If you wish to override this behavior, or have no keyring, simply place another item on the cursor and click into the block. This supports linking directly from the keyring.