### PR TITLE
Peer Scoping Fixes

### DIFF
--- a/modules/class.lua
+++ b/modules/class.lua
@@ -2490,21 +2490,19 @@ function Module:DoEvents()
 end
 
 -- true when the stagger option is set and a peer is landing a group det dispel on our group
-function Module:GroupAACureStaggered(actorPeers)
+function Module:GroupAACureStaggered()
     if not Config:GetSetting('StaggerGroupAACures') then return false end
-    for _, heartbeat in pairs(actorPeers) do
-        local data = heartbeat.Data
-        if data and (Globals.GetTimeSeconds() - (heartbeat.LastHeartbeat or 0)) <= 3 then
-            if data.CastingGroupDispel and mq.TLO.Group.Member(data.Target)() then
-                Logger.log_debug("[Cures] %s is landing a group det dispel on my groupmate %s, bypassing cure checks.", data.Name, data.Target)
-                return true
-            end
-            -- DEPRECATED 7/26 - sunset 9/1/26. Peers predating the ['Cure'] table don't broadcast the flag; fall back to the named group-cure AAs.
-            local casting = data.Casting or ""
-            if (casting == "Radiant Cure" or casting == "Group Purify Soul") and mq.TLO.Group.Member(data.Target)() then
-                Logger.log_debug("[Cures] %s is casting %s on my groupmate %s, bypassing cure checks.", data.Name, casting, data.Target)
-                return true
-            end
+    for _, peer in ipairs(Comms.GetZonePeers(false)) do
+        local data = peer.data
+        if data.CastingGroupDispel and mq.TLO.Group.Member(data.Target)() then
+            Logger.log_debug("[Cures] %s is landing a group det dispel on my groupmate %s, bypassing cure checks.", data.Name, data.Target)
+            return true
+        end
+        -- DEPRECATED 7/26 - sunset 9/1/26. Peers predating the ['Cure'] table don't broadcast the flag; fall back to the named group-cure AAs.
+        local casting = data.Casting or ""
+        if (casting == "Radiant Cure" or casting == "Group Purify Soul") and mq.TLO.Group.Member(data.Target)() then
+            Logger.log_debug("[Cures] %s is casting %s on my groupmate %s, bypassing cure checks.", data.Name, casting, data.Target)
+            return true
         end
     end
     return false
@@ -2513,8 +2511,7 @@ end
 -- new-model cure pass: cure myself from my own classified effects, then a group or heal-list peer that needs it (one cure per pass, self > group > heal list)
 function Module:RunCureWalk()
     Core.GetBuffTable()
-    local actorPeers = Comms.GetAllPeerHeartbeats(false)
-    self.TempSettings.GroupDispelCovered = self:GroupAACureStaggered(actorPeers)
+    self.TempSettings.GroupDispelCovered = self:GroupAACureStaggered()
 
     local scope = Config:GetSetting('ActorCureScope')                     -- 1 = Self, 2 = Group, 3 = Heal List
     local scanPeers = self.TempSettings.CuresPeerCapable and scope > 1
@@ -2530,20 +2527,19 @@ function Module:RunCureWalk()
     -- partition curable peers by priority: my group first, then heal-list peers outside my group (scope 3 only)
     local healList = scope >= 3 and Set.new(Config:GetSetting('HealList') or {}) or nil
     local groupPeers, healPeers = {}, {}
-    for _, heartbeat in pairs(actorPeers) do
-        local data = heartbeat.Data
-        if data and (#(data.CureEffects or {}) > 0 or data.Mezzed) then -- skip the spawn search for peers with nothing to cure
+    for _, peer in ipairs(Comms.GetZonePeers(false)) do
+        local data = peer.data
+        if #(data.CureEffects or {}) > 0 or data.Mezzed then -- skip the spawn search for peers with nothing to cure
             if mq.TLO.Group.Member(data.Name)() then
-                table.insert(groupPeers, heartbeat)
+                table.insert(groupPeers, data)
             elseif healList and healList:contains(data.Name) then
-                table.insert(healPeers, heartbeat)
+                table.insert(healPeers, data)
             end
         end
     end
 
     for _, peerList in ipairs({ groupPeers, healPeers, }) do
-        for _, heartbeat in ipairs(peerList) do
-            local data = heartbeat.Data
+        for _, data in ipairs(peerList) do
             local cureTarget = mq.TLO.Spawn(string.format("pc =%s", data.Name))
             if (cureTarget.ID() or 0) > 0 and cureTarget.ID() ~= mq.TLO.Me.ID() and (cureTarget.Distance() or 999) < 150 then
                 if self:RunCure(cureTarget, data.CureEffects, data.Mezzed, denySet, allowSet) then return end
@@ -2566,7 +2562,7 @@ function Module:RunCureRotation(combat_state)
     -- Legacy per-type detection + CureNow path for custom configs predating the ['Cure'] table.
     local actorPeers = Comms.GetAllPeerHeartbeats(false)
 
-    if self:GroupAACureStaggered(actorPeers) then return end
+    if self:GroupAACureStaggered() then return end
 
     Logger.log_verbose("\ao[Cures] Checking for curables...")
 

--- a/utils/binds.lua
+++ b/utils/binds.lua
@@ -585,7 +585,6 @@ Binds.Handlers    = {
         about = "All groupmembers running RGMercs will click on every possible 'Yes' Dialogue they have up.",
         handler = function()
             Comms.SendAllPeersDoCmd(false, true, "/notify LargeDialogWindow LDW_YesButton leftmouseup")
-            Comms.SendAllPeersDoCmd(false, true, "/notify LargeDialogWindow LDW_YesButton leftmouseup")
             Comms.SendAllPeersDoCmd(false, true, "/notify LargeDialogWindow LDW_OkButton leftmouseup")
             Comms.SendAllPeersDoCmd(false, true, "/notify ConfirmationDialogBox CD_Yes_Button leftmouseup")
             Comms.SendAllPeersDoCmd(false, true, "/notify ConfirmationDialogBox CD_OK_Button leftmouseup")
@@ -602,13 +601,12 @@ Binds.Handlers    = {
         handler = function(radius)
             if not radius then radius = 15 end
 
-            local peers = Comms.GetPeers(false)
+            local peers = Comms.GetZonePeers(false)
             local peerCount = #peers
             if peerCount < 1 then return end
             local angle_step = (2 * math.pi) / peerCount
 
-            for i, peerFullName in ipairs(peers) do
-                local peerName = Comms.GetNameFromPeer(peerFullName)
+            for i, peer in ipairs(peers) do
                 local radians = (i - 1) * angle_step
                 local xMove = math.cos(radians) * (radius)
                 local yMove = math.sin(radians) * (radius)
@@ -616,8 +614,8 @@ Binds.Handlers    = {
                 local xOff = mq.TLO.Me.X() + math.floor(xMove)
                 local yOff = mq.TLO.Me.Y() + math.floor(yMove)
 
-                Core.DoCmd("/dex %s /nav locyxz %2.3f %2.3f %2.3f", peerName, yOff, xOff, mq.TLO.Me.Z())
-                Core.DoCmd("/dex %s /timed 50 /face %s", peerName, mq.TLO.Me.DisplayName())
+                Core.DoCmd("/dex %s /nav locyxz %2.3f %2.3f %2.3f", peer.name, yOff, xOff, mq.TLO.Me.Z())
+                Core.DoCmd("/dex %s /timed 50 /face %s", peer.name, mq.TLO.Me.DisplayName())
             end
         end,
     },

--- a/utils/casting.lua
+++ b/utils/casting.lua
@@ -1324,14 +1324,14 @@ function Casting.GetBuffableRaidIDs()
         local peerName = Comms.GetNameFromPeer(peer)
         local raidMember = mq.TLO.Raid.Member(peerName or "")
         if raidMember() and raidMember.Spawn() then
-            if checkCorpses and Casting.HasNearbyCorpse(peer) then
-                Logger.log_debug("Raidmember corpse detected (%s), aborting group buff rotation.", peer)
+            if checkCorpses and Casting.HasNearbyCorpse(peerName) then
+                Logger.log_debug("Raidmember corpse detected (%s), aborting group buff rotation.", peerName)
                 return {}
             end
             raidIds:add(raidMember.ID())
 
             if Config:GetSetting("DoActorPetBuffs") then
-                local groupMember = mq.TLO.Group.Member(peer)
+                local groupMember = mq.TLO.Group.Member(peerName or "")
                 if groupMember() and groupMember.Pet.ID() > 0 and not groupMember.OtherZone() then
                     if not (groupMember.Pet.CleanName() or "familiar"):lower():find("familiar") then
                         raidIds:add(groupMember.Pet.ID())

--- a/utils/comms.lua
+++ b/utils/comms.lua
@@ -136,9 +136,8 @@ function Comms.SendPeerDoCmd(peer, cmd, ...)
         cmd = cmd, })
 end
 
---- Broadcasts a /cmd to all known peers. Optionally restricted to
---- peers in the current zone, and optionally including self.
---- @param inZoneOnly boolean Only send to peers in the current zone.
+--- Broadcasts a /cmd to same-server peers, optionally narrowed to our zone and instance and optionally run locally.
+--- @param inZoneOnly boolean Only send to peers in the current zone and instance.
 --- @param includeSelf boolean Execute the command locally as well.
 --- @param cmd string The command format string.
 --- @param ... any Format arguments for the command string.
@@ -149,9 +148,19 @@ function Comms.SendAllPeersDoCmd(inZoneOnly, includeSelf, cmd, ...)
         mq.cmd(cmd)
     end
 
-    for peer, data in pairs(Comms.PeersHeartbeats) do
-        if data.Data.Zone == mq.TLO.Zone.Name() or not inZoneOnly then
-            Comms.SendMessage(peer, "Core", "DoCmd", {
+    if inZoneOnly then
+        for _, peer in ipairs(Comms.GetZonePeers(false)) do
+            Comms.SendMessage(peer.key, "Core", "DoCmd", {
+                cmd = cmd, })
+        end
+        return
+    end
+
+    local myName = Comms.GetPeerName()
+    local myServer = mq.TLO.EverQuest.Server() or ""
+    for peerKey, heartbeat in pairs(Comms.PeersHeartbeats) do
+        if peerKey ~= myName and heartbeat.Data.Server == myServer then
+            Comms.SendMessage(peerKey, "Core", "DoCmd", {
                 cmd = cmd, })
         end
     end


### PR DESCRIPTION
* Internal peer commands and peer data no longer reach characters on another server or instance.
* Peer pets are now buffed in raid scope.
* /rgl yes no longer clicks each dialog twice.