### PR TITLE
XTarget / Rotation Order Adjustments, WIZ(Laz) Update

### DIFF
--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -89,6 +89,9 @@ return {
             "Wildmagic Salvo", -- Level 71 Laz Custom
             "Wildmagic Burst", -- Level 68
         },
+        ['AncientIceNuke'] = {
+            "Ancient: Spear of Gelaqua", -- Level 70
+        },
         ['FireNuke'] = {
             "Spark of Fire",   -- Level 66
             "Draught of Ro",   -- Level 62
@@ -109,7 +112,6 @@ return {
             "Sunstrike",                     -- Level 60
         },
         ['IceNuke'] = {
-            -- "Ancient: Spear of Gelaqua", -- Level 70, Commented for now, because of the recast... considering, need to playtest.
             "Spark of Ice",                -- Level 69
             "Black Ice",                   -- Level 65
             "Draught of E`ci",             -- Level 64
@@ -438,7 +440,7 @@ return {
             name = 'Force of Will',
             state = 1,
             steps = 1,
-            load_cond = function() return Casting.CanUseAA("Force of Will") end,
+            load_cond = function() return Casting.CanUseAA("Force of Will") or mq.TLO.FindItem("=Scepter of Incantations")() end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Targeting.AggroCheckOkay()
@@ -609,6 +611,10 @@ return {
         },
         ['Force of Will'] = {
             {
+                name = "Scepter of Incantations",
+                type = "Item",
+            },
+            {
                 name = "Force of Will",
                 type = "AA",
             },
@@ -619,14 +625,6 @@ return {
                 type = "Spell",
                 cond = function(self, spell, target)
                     return not Casting.IHaveBuff("Weave of Power")
-                end,
-            },
-            {
-                name = "AEStunNuke",
-                type = "Spell",
-                load_cond = function(self) return Config:GetSetting('DoAEStunNuke') end,
-                cond = function(self, spell, target)
-                    return Combat.AETargetCheck(true)
                 end,
             },
             {
@@ -643,8 +641,16 @@ return {
                 type = "Spell",
             },
             {
-                name = "Scepter of Incantations",
-                type = "Item",
+                name = "AEStunNuke",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoAEStunNuke') end,
+                cond = function(self, spell, target)
+                    return Combat.AETargetCheck(true)
+                end,
+            },
+            {
+                name = "AncientIceNuke",
+                type = "Spell",
             },
             {
                 name = "FireEtherealNuke",
@@ -864,19 +870,20 @@ return {
                         return not self.Helpers.HasWeaveRotation() and Config:GetSetting('DoRain') and Config:GetSetting('ElementChoice') == 2
                     end,
                 },
-                { name = "ChaosNuke",    cond = function(self) return self.Helpers.HasWeaveRotation() end, },
-                { name = "HarvestSpell", cond = function(self) return self.Helpers.UseHarvestSpell() end, },
-                { name = "SnareSpell",   cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
-                { name = "StunSpell",    cond = function() return Config:GetSetting('DoStun') end, },
-                { name = "JoltSpell",    cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
-                { name = "SwarmPet",     cond = function() return Config:GetSetting('DoSwarmPet') end, },
-                { name = "AEStunNuke",   cond = function() return Config:GetSetting('DoAEStunNuke') end, },
-                { name = "PBTimer4",     cond = function() return Core.IsModeActive('PBAE') end, },
-                { name = "FireJyll",     cond = function() return Core.IsModeActive('PBAE') end, },
-                { name = "IceJyll",      cond = function() return Core.IsModeActive('PBAE') end, },
-                { name = "MagicJyll",    cond = function() return Core.IsModeActive('PBAE') end, },
+                { name = "ChaosNuke",      cond = function(self) return self.Helpers.HasWeaveRotation() end, },
+                { name = "AncientIceNuke", cond = function(self) return self.Helpers.HasWeaveRotation() end, },
+                { name = "HarvestSpell",   cond = function(self) return self.Helpers.UseHarvestSpell() end, },
+                { name = "SnareSpell",     cond = function() return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Atol's Shackles") end, },
+                { name = "StunSpell",      cond = function() return Config:GetSetting('DoStun') end, },
+                { name = "JoltSpell",      cond = function() return not Casting.CanUseAA("Concussive Intuition") end, },
+                { name = "SwarmPet",       cond = function() return Config:GetSetting('DoSwarmPet') end, },
+                { name = "AEStunNuke",     cond = function() return Config:GetSetting('DoAEStunNuke') end, },
+                { name = "PBTimer4",       cond = function() return Core.IsModeActive('PBAE') end, },
+                { name = "FireJyll",       cond = function() return Core.IsModeActive('PBAE') end, },
+                { name = "IceJyll",        cond = function() return Core.IsModeActive('PBAE') end, },
+                { name = "MagicJyll",      cond = function() return Core.IsModeActive('PBAE') end, },
                 { name = "SelfRune1", },
-                { name = "EvacSpell",    cond = function() return not Casting.CanUseAA("Exodus") end, },
+                { name = "EvacSpell",      cond = function() return not Casting.CanUseAA("Exodus") end, },
                 { name = "SelfHPBuff", },
             },
         },

--- a/init.lua
+++ b/init.lua
@@ -486,6 +486,7 @@ local function Main()
     if mq.TLO.Me.Hovering() then Events.HandleDeath() end
 
     Combat.SetMainAssist()
+    Targeting.RefreshWatchedXTs()
     Ui.GetAssistWarningString()
 
     if not Globals.BackOffFlag then
@@ -651,5 +652,6 @@ end
 
 Core.CheckPlugins(unloadedPlugins, true)
 
+Targeting.ClearWatchedXTs()
 Modules:ExecAll("Shutdown")
 Config:Shutdown()

--- a/utils/combat.lua
+++ b/utils/combat.lua
@@ -87,9 +87,6 @@ function Combat.SetMainAssist()
                         Logger.log_info("SetMainAssist: Setting new assist to %s [%d]", assistName, listAssistSpawn.ID())
                         Globals.MainAssist = assistName or ""
                     end
-                    if assistName ~= mq.TLO.Me.CleanName() then
-                        Targeting.AddXTByName(2, assistName)
-                    end
                     return
                 end
             end
@@ -1257,39 +1254,6 @@ function Combat.AnyHurtGroupPet(minHPs)
     return false
 end
 
---- Finds the entity with the worst hurt mana exceeding a minimum threshold.
----@param minMana number The minimum mana threshold to consider.
----@return number The spawn id with the worst hurt mana above the specified threshold.
-function Combat.FindWorstHurtManaXT(minMana)
-    local slotCount = mq.TLO.Me.XTargetSlots() or 0
-    local worstId = 0
-    local worstPct = minMana
-
-    Logger.log_verbose("\ayChecking for worst HurtMana XTargs. XT Slot Count: %d", slotCount)
-
-    for i = 1, slotCount do
-        local healTarget = mq.TLO.Me.XTarget(i)
-
-        if healTarget and healTarget() and Targeting.TargetIsType("pc", healTarget) and (healTarget.Distance3D() or 0) < 300 then
-            if Globals.Constants.RGCasters:contains(healTarget.Class.ShortName()) then -- berzerkers have special handing
-                if healTarget.PctMana() < worstPct then
-                    Logger.log_verbose("\aySo far %s is the worst off.", healTarget.DisplayName())
-                    worstPct = healTarget.PctMana() or worstPct
-                    worstId = healTarget.PctMana() and healTarget.ID() or worstId
-                end
-            end
-        end
-    end
-
-    if worstId > 0 then
-        Logger.log_verbose("\agWorst HurtMana xtarget id is %d", worstId)
-    else
-        Logger.log_verbose("\agNo one is HurtMana!")
-    end
-
-    return worstId
-end
-
 --- Finds the entity with the worst health condition that meets the minimum HP requirement.
 ---@param minHPs number The minimum HP threshold to consider.
 ---@return number The spawn id with the worst health condition that meets the criteria.
@@ -1333,7 +1297,7 @@ function Combat.FindWorstHurtHealList(minHPs)
     Logger.log_verbose("\ayChecking for worst Hurt from Heal List.")
     for _, name in ipairs(Config:GetSetting('HealList') or {}) do
         local hpPct, id = nil, nil
-        local data = Comms.GetPeerHeartbeat(Comms.GetPeerName(name, Globals.CurServer)).Data
+        local data = Comms.GetPeerHeartbeatByName(name).Data
 
         if data and data.HPs and data.ZoneId == Globals.CurZoneId and data.InstanceId == Globals.CurInstanceId then
             -- RGMercs peer in our zone/instance: evaluate from the heartbeat (no spawn lookup, squared distance, no sqrt)
@@ -1373,22 +1337,20 @@ end
 function Combat.FindWorstHurtManaHealList(minMana)
     local worstId = 0
     local worstPct = minMana
-    local manaPct = 101
 
     Logger.log_verbose("\ayChecking for worst Hurt Mana from Heal List.")
     for _, name in ipairs(Config:GetSetting('HealList') or {}) do
-        local healTarget = mq.TLO.Spawn(string.format("PC =%s", name))
-        if healTarget and healTarget() and (healTarget.Distance3D() or 0) < 300 and not healTarget.Dead() then
-            local heartbeat = Comms.GetPeerHeartbeatByName(name)
+        local heartbeat = Comms.GetPeerHeartbeatByName(name)
 
-            if heartbeat and heartbeat.Data and heartbeat.Data.Mana then
-                manaPct = tonumber(heartbeat.Data.Mana) or 101
-            end
-
-            if manaPct < worstPct then
-                Logger.log_verbose("\aySo far %s is the worst off mana.", healTarget.DisplayName() or "Error")
-                worstId = healTarget.ID()
-                worstPct = manaPct
+        if heartbeat and heartbeat.Data and heartbeat.Data.Mana then
+            local healTarget = mq.TLO.Spawn(string.format("PC =%s", name))
+            if healTarget and healTarget() and (healTarget.Distance3D() or 0) < 300 and not healTarget.Dead() then
+                local manaPct = tonumber(heartbeat.Data.Mana) or 101
+                if manaPct < worstPct then
+                    Logger.log_verbose("\aySo far %s is the worst off mana.", healTarget.DisplayName() or "Error")
+                    worstId = healTarget.ID()
+                    worstPct = manaPct
+                end
             end
         end
     end
@@ -1407,12 +1369,8 @@ end
 ---@return number Spawn id of the worst-off target, or 0 if none qualify.
 function Combat.FindWorstHurtMana(minMana)
     local worstId = Combat.FindWorstHurtManaGroupMember(minMana)
-    if worstId == 0 then
-        if Config:GetSetting('UseHealList') then
-            worstId = Combat.FindWorstHurtManaHealList(minMana)
-        else
-            worstId = Combat.FindWorstHurtManaXT(minMana)
-        end
+    if worstId == 0 and Config:GetSetting('UseHealList') then
+        worstId = Combat.FindWorstHurtManaHealList(minMana)
     end
     return worstId or 0
 end
@@ -1422,28 +1380,41 @@ end
 ---@return boolean
 function Combat.AETauntCheck(printDebug)
     if Globals.NoHateTargetIDs:contains(Globals.AutoTargetID) then return false end
-    local occupiedCount = mq.TLO.Me.XTarget() or 0
-    if occupiedCount < Config:GetSetting('AETauntCnt') then return false end
 
-    local mobs = mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
-    if mobs < Config:GetSetting('AETauntCnt') then return false end
+    local minHaters = Config:GetSetting('AETauntCnt')
+    -- no sense walking the list if we dont have enough xtargs to begin with
+    if (mq.TLO.Me.XTarget() or 0) < minHaters then return false end
 
-    local tauntme = Set.new({})
-    local slotCount = mq.TLO.Me.XTargetSlots() or 0
+    local safeTaunt = Config:GetSetting('SafeAETaunt')
+    local logHaters = printDebug and Logger.get_log_level() >= 5
+    local seenHaters = Set.new({})
+    local haterCount = 0
+    local tauntCount = 0
+    local me = mq.TLO.Me
+    local slotCount = me.XTargetSlots() or 0
+
     for i = 1, slotCount do
-        local xtarg = mq.TLO.Me.XTarget(i)
-        if Targeting.IsXTHater(xtarg) and xtarg.PctAggro() < 100 and (xtarg.Distance() or 999) <= 50 and Globals.Constants.RGNotMezzedAnims:contains(xtarg.Animation()) then
-            if printDebug then
-                Logger.log_verbose("AETauntCheck(): XT(%d) Counting %s(%d) as a hater eligible to AE Taunt.", i, xtarg.CleanName() or "None",
-                    xtarg.ID())
+        local xtarg = me.XTarget(i)
+        if Targeting.IsXTHater(xtarg) then
+            local xtargID = xtarg.ID()
+            if not seenHaters:contains(xtargID) and not Globals.NoHateTargetIDs:contains(xtargID) and (xtarg.Distance3D() or 999) <= 50 then
+                seenHaters:add(xtargID)
+                haterCount = haterCount + 1
+                if xtarg.PctAggro() < 100 and Globals.Constants.RGNotMezzedAnims:contains(xtarg.Animation()) then
+                    tauntCount = tauntCount + 1
+                    if logHaters then
+                        Logger.log_verbose("AETauntCheck(): XT(%d) Counting %s(%d) as a hater eligible to AE Taunt.", i, xtarg.CleanName() or "None", xtargID)
+                    end
+                end
+                if not safeTaunt and tauntCount > 0 and haterCount >= minHaters then return true end
             end
-            tauntme:add(xtarg.ID())
-            if not Config:GetSetting('SafeAETaunt') then return true end --no need to find more than one if we don't care about safe taunt
         end
     end
 
-    local tauntCount = #tauntme:toList()
-    return tauntCount > 0 and not (Config:GetSetting('SafeAETaunt') and tauntCount < mobs)
+    if haterCount < minHaters or tauntCount == 0 then return false end
+
+    -- SafeAETaunt only: every nearby NPC must already be a hater
+    return haterCount >= mq.TLO.SpawnCount("NPC radius 50 zradius 50")()
 end
 
 --- Returns true if AE damage conditions are met (enough haters in range, optionally all mobs are haters).

--- a/utils/rotation.lua
+++ b/utils/rotation.lua
@@ -434,7 +434,7 @@ end
 
 --- Reorders entryList in place to match a saved order of entry names, keying by name+occurrence so duplicate names stay distinct.
 ---@param entryList table Array of rotation entry descriptors, reordered in place.
----@param savedOrder table? Array of entry names defining the desired order; entries absent from it keep their built order at the end. Nil/empty is a no-op.
+---@param savedOrder table? Array of entry names defining the desired order; entries absent from it follow the nearest entry above them that is present. Nil/empty is a no-op.
 function Rotation.ApplyEntryOrder(entryList, savedOrder)
     if not savedOrder or #savedOrder == 0 then return end
     local pos = {}
@@ -443,14 +443,25 @@ function Rotation.ApplyEntryOrder(entryList, savedOrder)
         savedSeen[entryName] = (savedSeen[entryName] or 0) + 1
         pos[entryName .. "\0" .. savedSeen[entryName]] = i
     end
-    local base = #savedOrder
     local liveSeen = {}
     local keyed = {}
+    local anchor = 0
+    local anchorOffset = 0
     for i, entry in ipairs(entryList) do
         liveSeen[entry.name] = (liveSeen[entry.name] or 0) + 1
-        keyed[i] = { entry = entry, key = pos[entry.name .. "\0" .. liveSeen[entry.name]] or (base + i), }
+        local savedPos = pos[entry.name .. "\0" .. liveSeen[entry.name]]
+        if savedPos then
+            anchor = savedPos
+            anchorOffset = 0
+        else
+            anchorOffset = anchorOffset + 1
+        end
+        keyed[i] = { entry = entry, key = savedPos or anchor, offset = savedPos and 0 or anchorOffset, }
     end
-    table.sort(keyed, function(a, b) return a.key < b.key end)
+    table.sort(keyed, function(a, b)
+        if a.key ~= b.key then return a.key < b.key end
+        return a.offset < b.offset
+    end)
     for i, k in ipairs(keyed) do entryList[i] = k.entry end
 end
 

--- a/utils/targeting.lua
+++ b/utils/targeting.lua
@@ -22,6 +22,7 @@ Targeting.NearbyPCLocs          = {}
 Targeting.NearbyPCLocsTime      = 0
 Targeting.NearbyPCLocsRadius    = 0
 Targeting.NearbyPCSafeNames     = {}
+Targeting.WatchedXTs            = {}
 
 Targeting.XTargetTypeKeywords   = {
     ["Target's Target"]      = "targetstarget",
@@ -490,15 +491,15 @@ end
 function Targeting.HasXTHaters(count)
     count = count or 1
     local slotCount = mq.TLO.Me.XTargetSlots() or 0
-    local seenHaters = {}
+    local seenHaters = Set.new({})
     local uniqHaters = 0
 
     for i = 1, slotCount do
         local xtarg = mq.TLO.Me.XTarget(i)
         if Targeting.IsXTHater(xtarg) then
             local xtargID = xtarg.ID()
-            if not seenHaters[xtargID] then
-                seenHaters[xtargID] = true
+            if not seenHaters:contains(xtargID) then
+                seenHaters:add(xtargID)
                 uniqHaters = uniqHaters + 1
                 if uniqHaters >= count then return true end
             end
@@ -576,12 +577,15 @@ end
 --- Sets XTarget slot to the spawn named name if the slot doesn't already hold it.
 ---@param slot number XTarget slot index (1–20).
 ---@param name string Exact spawn name to target.
+---@return boolean True if the slot was set.
 function Targeting.AddXTByName(slot, name)
-    if not name then return end
+    if not name then return false end
     local spawnToAdd = mq.TLO.Spawn("=" .. name)
     if spawnToAdd and spawnToAdd() and mq.TLO.Me.XTarget(slot).ID() ~= spawnToAdd.ID() then
         Core.DoCmd("/xtarget set %d \"%s\"", slot, name)
+        return true
     end
+    return false
 end
 
 --- Sets XTarget slot to the spawn with the given ID if not already set.
@@ -605,6 +609,73 @@ function Targeting.ResetXTSlot(slot)
     Core.DoCmd("/xtarget set %d ET", slot)
     mq.delay(500, function() return (mq.TLO.Me.XTarget(slot).TargetType() or "") == "Empty Target" end)
     Core.DoCmd("/xtarget set %d autohater", slot)
+end
+
+--- Watches heal list members with no heartbeat from an XTarget slot so the server sends us their health.
+function Targeting.RefreshWatchedXTs()
+    local needSlot = {}
+
+    if Config:GetSetting('UseHealList') then
+        for _, name in ipairs(Config:GetSetting('HealList') or {}) do
+            local data = Comms.GetPeerHeartbeatByName(name).Data
+            if not (data and data.HPs) then
+                local watchTarget = mq.TLO.Spawn(string.format("PC =%s", name))
+                if watchTarget() and watchTarget.ID() ~= mq.TLO.Me.ID() then
+                    needSlot[name] = true
+                end
+            end
+        end
+    end
+
+    for slot, name in pairs(Targeting.WatchedXTs) do
+        local xtarg = mq.TLO.Me.XTarget(slot)
+        if (xtarg.TargetType() or "") ~= "Specific PC" or (xtarg.Name() or ""):lower() ~= name:lower() then
+            Targeting.WatchedXTs[slot] = nil
+        elseif needSlot[name] then
+            needSlot[name] = nil
+        else
+            Logger.log_debug("RefreshWatchedXTs: stopped watching %s, freed XTarget slot %d.", name, slot)
+            Targeting.ResetXTSlot(slot)
+            Targeting.WatchedXTs[slot] = nil
+        end
+    end
+
+    for name in pairs(needSlot) do
+        local claimSlot, freeSlot = nil, nil
+
+        for slot = mq.TLO.Me.XTargetSlots() or 0, 2, -1 do
+            local xtarg = mq.TLO.Me.XTarget(slot)
+            if not Targeting.WatchedXTs[slot] then
+                if (xtarg.TargetType() or "") == "Specific PC" and (xtarg.Name() or ""):lower() == name:lower() then
+                    claimSlot = slot
+                    break
+                elseif not freeSlot and slot > 1 and (xtarg.TargetType() or "") == "Auto Hater" then
+                    freeSlot = slot
+                end
+            end
+        end
+
+        if not claimSlot then claimSlot = freeSlot end
+
+        if claimSlot then
+            Logger.log_debug("RefreshWatchedXTs: watching %s in XTarget slot %d.", name, claimSlot)
+            if Targeting.AddXTByName(claimSlot, name) then
+                mq.delay(500, function() return (mq.TLO.Me.XTarget(claimSlot).Name() or ""):lower() == name:lower() end)
+            end
+            Targeting.WatchedXTs[claimSlot] = name
+        end
+    end
+end
+
+--- Hands back every XTarget slot we are watching someone from.
+function Targeting.ClearWatchedXTs()
+    for slot, name in pairs(Targeting.WatchedXTs) do
+        if (mq.TLO.Me.XTarget(slot).Name() or ""):lower() == name:lower() then
+            Logger.log_debug("ClearWatchedXTs: stopped watching %s, freed XTarget slot %d.", name, slot)
+            Targeting.ResetXTSlot(slot)
+        end
+        Targeting.WatchedXTs[slot] = nil
+    end
 end
 
 --- EMU only: when any Auto Hater XTarget slot is holding a corpse during downtime, fires #clearxtargets and restores user-configured slot types.


### PR DESCRIPTION
WIZ(Laz) - High-level DPS rotation priority adjustments

Xtarget Management Update
* Non-peer Heal List members are now properly watched in the xtarget list.
* A non-peer MA is no longer watched in the xtarget list.
* We no longer attempt to check mana levels of a watched xtarget.

Rotation Entry Adjustments
* Adding new entries to a rotation or adjacent list (dispel, rez, etc) via config update or other means will now place the item closer to the default order rather than automatically moving it to the end.