### PR TITLE
Load Condition Sweep

### DIFF
--- a/class_configs/EQ Might/ber_class_config.lua
+++ b/class_configs/EQ Might/ber_class_config.lua
@@ -444,6 +444,7 @@ return {
             Category = "Snare",
             Index = 101,
             Tooltip = "Snare opponents with low health.",
+            RequiresLoadoutChange = true,
             Default = false,
         },
         ['SnareCount']    = {

--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -691,7 +691,7 @@ local _ClassConfig = {
             {
                 name = "AreaAriaSong",
                 type = "Song",
-                load_cond = function(self) return Config:GetSetting('AriaChoice') == 2 and self.Helpers.AriaClickyChoice() == "None" end,
+                load_cond = function(self) return Config:GetSetting('UseAria') > 1 and Config:GetSetting('AriaChoice') == 2 and self.Helpers.AriaClickyChoice() == "None" end,
                 cond = function(self, songSpell)
                     return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
@@ -699,7 +699,7 @@ local _ClassConfig = {
             {
                 name = "GroupAriaSong",
                 type = "Song",
-                load_cond = function(self) return Config:GetSetting('AriaChoice') == 3 and self.Helpers.AriaClickyChoice() == "None" end,
+                load_cond = function(self) return Config:GetSetting('UseAria') > 1 and Config:GetSetting('AriaChoice') == 3 and self.Helpers.AriaClickyChoice() == "None" end,
                 cond = function(self, songSpell)
                     return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.RefreshBuffSong(self, songSpell)
                 end,
@@ -708,7 +708,7 @@ local _ClassConfig = {
                 name = "Ancient Artifact of Power",
                 type = "Item",
                 midSong = true,
-                load_cond = function(self) return self.Helpers.AriaClickyChoice() == "AncientArtifact" end,
+                load_cond = function(self) return Config:GetSetting('UseAria') > 1 and self.Helpers.AriaClickyChoice() == "AncientArtifact" end,
                 cond = function(self, itemName)
                     return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.AriaClickyRefresh(self, itemName)
                 end,
@@ -717,7 +717,7 @@ local _ClassConfig = {
                 name = "Echo of Trusik Lute",
                 type = "Item",
                 midSong = true,
-                load_cond = function(self) return self.Helpers.AriaClickyChoice() == "EchoLute" end,
+                load_cond = function(self) return Config:GetSetting('UseAria') > 1 and self.Helpers.AriaClickyChoice() == "EchoLute" end,
                 cond = function(self, itemName)
                     return self.Helpers.CheckSongStateUse(self, "UseAria") and self.Helpers.AriaClickyRefresh(self, itemName)
                 end,
@@ -1145,6 +1145,7 @@ local _ClassConfig = {
             Tooltip = "Use Fading Memories when you have aggro and you aren't the Main Assist.",
             Default = true,
             ConfigType = "Advanced",
+            RequiresLoadoutChange = true,
             FAQ = "Why is my Bard regularly using Fading Memories",
             Answer = "When Use Combat Escape is enabled, Fading Memories will be used when the Bard has any unwanted aggro.\n" ..
                 "This helps the common issue of bards gaining aggro from singing before a tank has the chance to secure it.",

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -591,8 +591,8 @@ return {
             {
                 name = "Paragon of Spirit",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoParagon') end,
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoParagon') then return false end
                     return Casting.GroupLowManaCount(Config:GetSetting('ParaPct')) > 0
                 end,
                 pre_activate = function(self)
@@ -604,16 +604,18 @@ return {
             {
                 name = "BloodDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "EndemicDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
@@ -1008,6 +1010,7 @@ return {
             Index = 102,
             Tooltip = "Use your Pet Snare Proc Buff (does not stack with Pet Damage or Slow Proc Buff).",
             Default = false,
+            RequiresLoadoutChange = true,
             FAQ = "Why am I continually using proc buffs on my pet?",
             Answer = "Pet proc buffs do not stack, you should only select one.\n" ..
                 "If neither Snare nor Slow proc are selected, the Damage proc will be used.",
@@ -1099,6 +1102,7 @@ return {
             Index = 102,
             Tooltip = "Buff Group/Pet with Infusion of Spirit",
             Default = false,
+            RequiresLoadoutChange = true,
         },
         ['DoHaste']        = {
             DisplayName = "Use Haste",

--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -441,8 +441,9 @@ local _ClassConfig = {
             {
                 name = "GroupElixir",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoGroupElixir') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoGroupElixir') or (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') then return false end
+                    if (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -561,8 +562,9 @@ local _ClassConfig = {
             {
                 name = "CompleteHeal",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoCompleteHeal') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting("DoCompleteHeal") or not Targeting.TargetIsTanking(target) then return false end
+                    if not Targeting.TargetIsTanking(target) then return false end
                     return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct')
                 end,
             },
@@ -869,8 +871,8 @@ local _ClassConfig = {
             {
                 name = "SelfHPBuff",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('AegoSymbol') ~= 3 end,
                 cond = function(self, spell)
-                    if Config:GetSetting('AegoSymbol') == 3 then return false end
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
@@ -910,18 +912,23 @@ local _ClassConfig = {
                     return "Symbol Buff Clicky"
                 end,
                 type = "Item",
-                load_cond = function() return mq.TLO.Me.Level() >= 68 and (mq.TLO.FindItem("=Mythical Armband of Elushar")() or mq.TLO.FindItem("=Legendary Armband of Mithaniel")()) end,
+                load_cond = function()
+                    return Config:GetSetting('AegoSymbol') >= 2 and Config:GetSetting('AegoSymbol') <= 3 and
+                        mq.TLO.Me.Level() >= 68 and (mq.TLO.FindItem("=Mythical Armband of Elushar")() or mq.TLO.FindItem("=Legendary Armband of Mithaniel")())
+                end,
                 cond = function(self, itemName, target)
-                    if Config:GetSetting('AegoSymbol') == 1 or Config:GetSetting('AegoSymbol') == 4 then return false end
                     return Casting.GroupBuffItemCheck(itemName, target)
                 end,
             },
             {
                 name = "GroupSymbolBuff",
                 type = "Spell",
-                load_cond = function() return mq.TLO.Me.Level() < 68 or not mq.TLO.FindItem("=Legendary Armband of Mithaniel")() end,
+                load_cond = function()
+                    return Config:GetSetting('AegoSymbol') >= 2 and Config:GetSetting('AegoSymbol') <= 3 and
+                        (mq.TLO.Me.Level() < 68 or not mq.TLO.FindItem("=Legendary Armband of Mithaniel")())
+                end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('AegoSymbol') == 1 or Config:GetSetting('AegoSymbol') == 4 or ((spell.TargetType() or ""):lower() == "single" and not Targeting.TargetIsTanking(target)) then return false end
+                    if (spell.TargetType() or ""):lower() == "single" and not Targeting.TargetIsTanking(target) then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -1047,6 +1054,7 @@ local _ClassConfig = {
                 "You have Aegolism selected and are below level 40 (We are still using a HP Type One buff).\n" ..
                 "You have Symbol selected and don't have someone else providing a Type One buff.\n" ..
                 "Leaving this on in other cases is not likely to cause issue, but may cause unnecessary buff checking.",
+            RequiresLoadoutChange = true,
             Default = false,
         },
         ['VieBuffMode']       = {
@@ -1319,6 +1327,7 @@ local _ClassConfig = {
             Category = "Self",
             Index = 101,
             Tooltip = "Use your Yaulp (AA or spell line) to help maintain your mana and buff your melee ability.",
+            RequiresLoadoutChange = true,
             Default = true,
             FAQ = "Why am I using Yaulp? Clerics are not supposed to melee!",
             Answer = "The Yaulp spells we use also contain a mana regen component. You can disable this behavior on the Utility tab in the Class Options.",

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -499,7 +499,7 @@ local _ClassConfig = {
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             load_cond = function(self) return Core.OnEMU() end,
             cond = function(self, combat_state)
-                if not Config:GetSetting('DoPet') or mq.TLO.Me.Pet.ID() ~= 0 then return false end
+                if mq.TLO.Me.Pet.ID() ~= 0 then return false end
                 return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToPetBuff() and Casting.AmIBuffable()
             end,
         },

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -604,8 +604,9 @@ return {
             {
                 name = "SwarmDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSwarmDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoSwarmDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -447,7 +447,6 @@ local _ClassConfig = {
         {
             name = 'PetSummon',
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
-            load_cond = function(self) return Config:GetSetting('DoPet') end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() == 0 and Casting.OkayToPetBuff() and Casting.AmIBuffable()
             end,

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -837,8 +837,9 @@ local _ClassConfig = {
                 name = "Cannibalization",
                 type = "AA",
                 allowDead = true,
+                load_cond = function() return Config:GetSetting('DoAACanni') end,
                 cond = function(self, aaName)
-                    if not (Config:GetSetting('DoAACanni') and Config:GetSetting('DoCombatCanni')) then return false end
+                    if not Config:GetSetting('DoCombatCanni') then return false end
                     return mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
@@ -846,8 +847,9 @@ local _ClassConfig = {
                 name = "CanniSpell",
                 type = "Spell",
                 allowDead = true,
+                load_cond = function() return Config:GetSetting('DoSpellCanni') end,
                 cond = function(self, spell)
-                    if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
+                    if not Config:GetSetting('DoCombatCanni') then return false end
                     return mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -912,8 +914,8 @@ local _ClassConfig = {
             {
                 name = "AEMaloSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoAEMalo') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoAEMalo') then return false end
                     return Targeting.HasXTHaters(Config:GetSetting('AEMaloCount')) and Casting.DetSpellCheck(spell)
                 end,
             },
@@ -948,7 +950,6 @@ local _ClassConfig = {
                 type = "Spell",
                 load_cond = function(self) return Config:GetSetting('DoAESlow') and not Casting.CanUseAA("Tigir's Insect Swarm") end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoAESlow') or Casting.CanUseAA("Tigir's Insect Swarm") then return false end
                     return Targeting.HasXTHaters(Config:GetSetting('AESlowCount')) and Casting.DetSpellCheck(spell) and not Casting.SlowImmuneTarget(target)
                 end,
             },
@@ -1001,40 +1002,43 @@ local _ClassConfig = {
             {
                 name = "CurseDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoCurseDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoCurseDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "SaryrnDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSaryrnDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoSaryrnDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "UltorDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoUltorDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoUltorDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "ColdNuke",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoColdNuke') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoColdNuke') then return false end
                     return (Targeting.MobHasLowHP() or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed)) and Casting.OkayToNuke(true)
                 end,
             },
             {
                 name = "PoisonNuke",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoPoisonNuke') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoPoisonNuke') then return false end
                     return (Targeting.MobHasLowHP() or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed)) and Casting.OkayToNuke(true)
                 end,
             },
@@ -1081,15 +1085,17 @@ local _ClassConfig = {
             {
                 name = "Cannibalization",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoAACanni') end,
                 cond = function(self, aaName)
-                    return Config:GetSetting('DoAACanni') and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
             {
                 name = "CanniSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSpellCanni') end,
                 cond = function(self, spell)
-                    return Config:GetSetting('DoSpellCanni') and Casting.CastReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
+                    return Casting.CastReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },

--- a/class_configs/Live/ber_class_config.lua
+++ b/class_configs/Live/ber_class_config.lua
@@ -547,7 +547,7 @@ return {
                 end,
             },
         },
-        ['Burn'] = { --This really needs to be refactored with helper functions sometime. Other prioriities atm. Algar 3/2/25
+        ['Burn']     = { --This really needs to be refactored with helper functions sometime. Other prioriities atm. Algar 3/2/25
             {
                 name = "PrimaryBurnDisc",
                 type = "Disc",
@@ -780,9 +780,7 @@ return {
             {
                 name = "Phantom",
                 type = "Disc",
-                cond = function(self, discSpell)
-                    return Config:GetSetting('DoPet')
-                end,
+                load_cond = function() return Config:GetSetting('DoPet') end,
             },
             {
                 name = "SappingStrike",
@@ -807,9 +805,9 @@ return {
             {
                 name = "Alliance",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoAlliance') end,
                 cond = function(self, spell)
-                    return Config:GetSetting('DoAlliance') and Casting.CanAlliance() and
-                        not Casting.TargetHasBuff(spell)
+                    return Casting.CanAlliance() and not Casting.TargetHasBuff(spell)
                 end,
             },
             {

--- a/class_configs/Live/bst_class_config.lua
+++ b/class_configs/Live/bst_class_config.lua
@@ -964,8 +964,8 @@ return {
             {
                 name = "Coating",
                 type = "Item",
+                load_cond = function() return Config:GetSetting('DoCoating') end,
                 cond = function(self, itemName, target)
-                    if not Config:GetSetting('DoCoating') then return false end
                     return Casting.SelfBuffItemCheck(itemName)
                 end,
             },
@@ -974,8 +974,8 @@ return {
             {
                 name = "Falsified Death",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('AggroFeign') end,
                 cond = function(self, aaName, target)
-                    if not Config:GetSetting('AggroFeign') then return false end
                     return Casting.OkayToCombatEscape()
                 end,
             },

--- a/class_configs/Live/clr_class_config.lua
+++ b/class_configs/Live/clr_class_config.lua
@@ -401,7 +401,7 @@ local _ClassConfig = {
             "Hand of Tenacity",              -- Level 75
             "Hand of Conviction",            -- Level 70
             "Hand of Virtue",                -- Level 65
-            "Ancient: Gift of Aegolism",     -- Level 60 
+            "Ancient: Gift of Aegolism",     -- Level 60
             "Blessing of Aegolism",          -- Level 60
             "Aegolism",                      -- Level 60 (Single Target)
             "Blessing of Temperance",        -- Level 45
@@ -1606,6 +1606,7 @@ local _ClassConfig = {
             "Choose whether to use the Aegolism or Symbol Line of HP Buffs.\nPlease note using both is supported for party members who block buffs, but these buffs do not stack once we transition from using a HP Type-One buff in place of Aegolism.",
             Type = "Combo",
             ComboOptions = { 'Aegolism', 'Both (See Tooltip!)', 'Symbol', 'None', },
+            RequiresLoadoutChange = true,
             Default = 1,
             Min = 1,
             Max = 4,
@@ -1621,6 +1622,7 @@ local _ClassConfig = {
                 "You have Aegolism selected and are below level 60 (We are still using a HP Type One buff).\n" ..
                 "You have Symbol selected and you are below level 95 (We don't have Unified Symbols yet).\n" ..
                 "Leaving this on in other cases is not likely to cause issue, but may cause unnecessary buff checking.",
+            RequiresLoadoutChange = true,
             Default = false,
         },
         ['DoVieBuff']         = {

--- a/class_configs/Live/dru_class_config.lua
+++ b/class_configs/Live/dru_class_config.lua
@@ -1654,6 +1654,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 106,
             Tooltip = "Cast Movement Spells/AA.",
+            RequiresLoadoutChange = true,
             Default = false,
             FAQ = "Why am I spamming movement buffs?",
             Answer = "Some move spells freely overwrite those of other classes, so if multiple movebuffs are being used, a buff loop may occur.\n" ..

--- a/class_configs/Live/enc_class_config.lua
+++ b/class_configs/Live/enc_class_config.lua
@@ -1215,37 +1215,38 @@ local _ClassConfig    = {
             {
                 name = "GroupSpellShield",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoGroupSpellShield') end,
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoGroupSpellShield') then return false end
                     return Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },
             {
                 name = "GroupDotShield",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoGroupDotShield') end,
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoGroupDotShield') then return false end
                     return Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },
             {
                 name = "GroupAuspiceBuff",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoGroupAuspice') end,
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoGroupAuspice') then return false end
                     return Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },
             {
                 name = "NdtBuff",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoNDTBuff') end,
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
                     --Single target versions of the spell will only be used on Melee, group versions will be cast if they are missing from any groupmember
-                    if not Config:GetSetting('DoNDTBuff') or ((spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target)) then return false end
+                    if (spell.TargetType() or ""):lower() ~= "group v2" and not Targeting.TargetIsAMelee(target) then return false end
 
                     return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
@@ -1253,18 +1254,20 @@ local _ClassConfig    = {
             {
                 name = "SpellProcBuff",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoProcBuff') end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoProcBuff') or not Targeting.TargetIsACaster(target) then return false end
+                    if not Targeting.TargetIsACaster(target) then return false end
                     return Casting.CastReady(spell) and Casting.GroupBuffCheck(spell, target)
                 end,
             },
             {
                 name = "GroupRune",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('RuneChoice') == 2 end,
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('RuneChoice') ~= 2 or ((spell.Level() or 0) > 73 and Targeting.TargetIsTanking(target)) then return false end
+                    if (spell.Level() or 0) > 73 and Targeting.TargetIsTanking(target) then return false end
                     return Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },
@@ -1280,9 +1283,9 @@ local _ClassConfig    = {
             {
                 name = "SingleRune",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('RuneChoice') == 1 end,
                 active_cond = function(self, spell) return mq.TLO.Me.FindBuff("id " .. tostring(spell.ID()))() ~= nil end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('RuneChoice') ~= 1 then return false end
                     return Casting.GroupBuffCheck(spell, target) and Casting.ReagentCheck(spell)
                 end,
             },
@@ -1341,8 +1344,9 @@ local _ClassConfig    = {
             {
                 name = "PBAEStunSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoAEStun') > 1 end,
                 cond = function(self, spell, target)
-                    if (Config:GetSetting('DoAEStun') == 2 and Core.GetMainAssistPctHPs() > Config:GetSetting('EmergencyStart')) or Config:GetSetting('DoAEStun') == 1 then return false end
+                    if Config:GetSetting('DoAEStun') == 2 and Core.GetMainAssistPctHPs() > Config:GetSetting('EmergencyStart') then return false end
                     return Casting.DetSpellCheck(spell) and Targeting.HasXTHaters(Config:GetSetting('AECount'))
                 end,
             },
@@ -1358,40 +1362,41 @@ local _ClassConfig    = {
             {
                 name = "MindDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoMindDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoMindDot') then return false end
                     return Casting.DotSpellCheck(spell) and (Globals.AutoTargetIsNamed or not Casting.IHaveBuff(spell and spell.Trigger()))
                 end,
             },
             {
                 name = "StrangleDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoStrangleDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoStrangleDot') then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "MagicNuke",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoNuke') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoNuke') then return false end
                     return Casting.OkayToNuke()
                 end,
             },
             {
                 name = "ManaDrainNuke",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoManaDrain') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoManaDrain') then return false end
                     return (target.CurrentMana() or 0) > 10 and Casting.OkayToNuke()
                 end,
             },
             {
                 name = "TwinCastMez",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('TwincastMez') == 3 end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('TwincastMez') ~= 3 or Modules:ExecModule("Mez", "IsMezImmune", target.ID()) then return false end
+                    if Modules:ExecModule("Mez", "IsMezImmune", target.ID()) then return false end
                     return not Casting.IHaveBuff(spell) and not mq.TLO.Me.Buff("Twincast")()
                 end,
             },
@@ -1442,8 +1447,9 @@ local _ClassConfig    = {
             {
                 name = "TwinCastMez",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('TwincastMez') == 3 end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('TwincastMez') ~= 3 or Modules:ExecModule("Mez", "IsMezImmune", target.ID()) then return false end
+                    if Modules:ExecModule("Mez", "IsMezImmune", target.ID()) then return false end
                     return not Casting.IHaveBuff(spell) and not mq.TLO.Me.Buff("Improved Twincast")()
                 end,
             },
@@ -1525,8 +1531,8 @@ local _ClassConfig    = {
             {
                 name = "Slowing Helix",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoSlow') end,
                 cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoSlow') then return false end
                     local aaSpell = Casting.GetAASpell(aaName)
                     return Casting.DetAACheck(aaName) and (aaSpell.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and not Casting.SlowImmuneTarget(target)
                 end,
@@ -1534,24 +1540,24 @@ local _ClassConfig    = {
             {
                 name = "CripSlowSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSlow') and Casting.CanUseAA("Slowing Helix") end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoSlow') or not Casting.CanUseAA("Slowing Helix") then return false end
                     return Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "SlowSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSlow') and not Casting.CanUseAA("Slowing Helix") and not Core.GetResolvedActionMapItem('CripSlowSpell') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoSlow') or Casting.CanUseAA("Slowing Helix") or Core.GetResolvedActionMapItem('CripSlowSpell') then return false end
                     return Casting.DetSpellCheck(spell) and (spell.RankName.SlowPct() or 0) > (Targeting.GetTargetSlowedPct()) and not Casting.SlowImmuneTarget(target)
                 end,
             },
             {
                 name = "CrippleSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoCripple') and not Casting.CanUseAA("Slowing Helix") and not Core.GetResolvedActionMapItem('CripSlowSpell') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoCripple') or Casting.CanUseAA("Slowing Helix") or Core.GetResolvedActionMapItem('CripSlowSpell') then return false end
                     return Casting.DetSpellCheck(spell)
                 end,
             },

--- a/class_configs/Live/mag_class_config.lua
+++ b/class_configs/Live/mag_class_config.lua
@@ -1321,9 +1321,9 @@ local _ClassConfig = {
             {
                 name = "AllianceBuff",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoAlliance') end,
                 cond = function(self, spell, target)
-                    return Globals.AutoTargetIsNamed and not Casting.TargetHasBuff(spell) and
-                        Config:GetSetting('DoAlliance') and Casting.CanAlliance()
+                    return Globals.AutoTargetIsNamed and not Casting.TargetHasBuff(spell) and Casting.CanAlliance()
                 end,
             },
             {
@@ -1544,8 +1544,8 @@ local _ClassConfig = {
             {
                 name = "Wind of Malaise",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoAEMalo') end,
                 cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoAEMalo') then return false end
                     return Casting.DetAACheck(aaName)
                 end,
             },
@@ -1704,8 +1704,9 @@ local _ClassConfig = {
             {
                 name = "Summon Modulation Shard",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('SummonModRods') end,
                 cond = function(self, aaName, target)
-                    if not Config:GetSetting('SummonModRods') or not Casting.CanUseAA(aaName) or not Targeting.TargetIsACaster(target) then return false end
+                    if not Casting.CanUseAA(aaName) or not Targeting.TargetIsACaster(target) then return false end
                     local modRodItem = mq.TLO.Spell(aaName).RankName.Base(1)()
                     return modRodItem and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItem), 1000) == "0" and
                         (mq.TLO.Cursor.ID() or 0) == 0
@@ -1719,9 +1720,10 @@ local _ClassConfig = {
             {
                 name = "ManaRodSummon",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('SummonModRods') and not Casting.CanUseAA("Summon Modulation Shard") end,
                 cond = function(self, spell, target)
                     if not spell() then return false end
-                    if Casting.CanUseAA("Summon Modulation Shard") or not Config:GetSetting('SummonModRods') or not Targeting.TargetIsACaster(target) then return false end
+                    if not Targeting.TargetIsACaster(target) then return false end
                     local myId = Casting.GetUseableSpellId(spell) -- Adjust for possible unsubbed accounts
                     local modRodItemId = mq.TLO.Spell(myId).Base(1)() or 0
                     return (mq.TLO.Spell(myId).Base(1)() or 0) > 0 and DanNet.query(target.CleanName(), string.format("FindItemCount[%d]", modRodItemId), 1000) == "0" and

--- a/class_configs/Live/mnk_class_config.lua
+++ b/class_configs/Live/mnk_class_config.lua
@@ -569,8 +569,8 @@ local _ClassConfig = {
             {
                 name = "Alliance",
                 type = "Disc",
+                load_cond = function() return Config:GetSetting('DoAlliance') end,
                 cond = function(self, discSpell)
-                    if not Config:GetSetting('DoAlliance') then return false end
                     return not Casting.TargetHasBuff(discSpell.Trigger(1))
                 end,
             },

--- a/class_configs/Live/nec_class_config.lua
+++ b/class_configs/Live/nec_class_config.lua
@@ -956,9 +956,10 @@ local _ClassConfig = {
             {
                 name = "LichSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoLich') end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    return Config:GetSetting('DoLich') and Casting.SelfBuffCheck(spell, nil, true) and
+                    return Casting.SelfBuffCheck(spell, nil, true) and
                         (not Config:GetSetting('DoUnity') or not Casting.AAReady("Mortifier's Unity")) and
                         mq.TLO.Me.PctHPs() > Config:GetSetting('StopLichHP') and mq.TLO.Me.PctMana() <= Config:GetSetting('StartLichMana')
                 end,
@@ -967,10 +968,9 @@ local _ClassConfig = {
                 name = "LichControl",
                 type = "CustomFunc",
                 cond = function(self, _)
-                    local lichSpell = Core.GetResolvedActionMapItem('LichSpell')
-
-                    return not (Config:GetSetting('DoUnity') and Casting.CanUseAA("Mortifier's Unity")) and lichSpell and lichSpell() and Casting.IHaveBuff(lichSpell) and
-                        (mq.TLO.Me.PctHPs() <= Config:GetSetting('StopLichHP') or mq.TLO.Me.PctMana() >= Config:GetSetting('StopLichMana'))
+                    if not self.Helpers.LichBuffName(self) then return false end
+                    if not Config:GetSetting('DoLich') then return true end
+                    return mq.TLO.Me.PctHPs() <= Config:GetSetting('StopLichHP') or mq.TLO.Me.PctMana() >= Config:GetSetting('StopLichMana')
                 end,
                 custom_func = function(self)
                     Core.SafeCallFunc("Stop Necro Lich", self.Helpers.CancelLich, self)
@@ -1387,8 +1387,10 @@ local _ClassConfig = {
             {
                 name = "Mortifier's Unity",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoUnity') end,
                 cond = function(self, aaName)
-                    return Config:GetSetting('DoUnity') and mq.TLO.Me.PctHPs() > Config:GetSetting('StopLichHP') and Casting.SelfBuffAACheck(aaName)
+                    if mq.TLO.Me.PctHPs() <= Config:GetSetting('StopLichHP') then return false end
+                    return self.Helpers.UnityNeeded(self, aaName)
                 end,
             },
             {
@@ -1500,10 +1502,36 @@ local _ClassConfig = {
             return false
         end,
 
-        CancelLich = function(self)
+        UnityNeeded = function(self, aaName)
+            if not Casting.CanUseAA(aaName) then return false end
+            local wantLich = Config:GetSetting('DoLich') and mq.TLO.Me.PctMana() <= Config:GetSetting('StartLichMana')
+            local unitySpell = mq.TLO.Me.AltAbility(aaName).Spell
+            for i = 1, unitySpell.NumEffects() do
+                local trigger = unitySpell.Trigger(i)
+                if not (trigger and trigger() and trigger.ID() > 0) then break end
+                local triggerName = trigger.Name() or ""
+                if mq.TLO.Me.BlockedBuff(triggerName)() ~= triggerName and not mq.TLO.Me.FindBuff("id " .. trigger.ID())() and trigger.Stacks() then
+                    if wantLich or not (trigger.HasSPA(15)() and trigger.HasSPA(0)()) then return true end
+                end
+            end
+            return false
+        end,
+
+        LichBuffName = function(self)
             -- detspa means detremental spell affect
             -- spa is positive spell affect
-            local lichName = mq.TLO.Me.FindBuff("detspa hp and spa mana")()
+            local lichName = mq.TLO.Me.FindBuff("detspa hp and spa mana and spa ultravision")()
+            if lichName then return lichName end
+
+            local lichSpell = Core.GetResolvedActionMapItem('LichSpell')
+            if lichSpell and lichSpell() and Casting.IHaveBuff(lichSpell) then return lichSpell.RankName.Name() end
+
+            return nil
+        end,
+
+        CancelLich = function(self)
+            local lichName = self.Helpers.LichBuffName(self)
+            if not lichName then return end
             Core.DoCmd("/removebuff %s", lichName)
         end,
 

--- a/class_configs/Live/rog_class_config.lua
+++ b/class_configs/Live/rog_class_config.lua
@@ -515,8 +515,8 @@ return {
             {
                 name = "Alliance",
                 type = "Disc",
+                load_cond = function() return Config:GetSetting('DoAlliance') end,
                 cond = function(self, discSpell)
-                    if not Config:GetSetting('DoAlliance') then return false end
                     return not Casting.TargetHasBuff(discSpell.Trigger(1))
                 end,
             },

--- a/class_configs/Live/shd_class_config.lua
+++ b/class_configs/Live/shd_class_config.lua
@@ -854,7 +854,7 @@ local _ClassConfig = {
                 local setting = Config:GetSetting('AETauntSpell')
                 local tauntSpell = (setting == 3 or (setting == 2 and not Casting.CanUseAA("Explosion of Hatred"))) and Core.GetResolvedActionMapItem('AETaunt')
                 local hateAA = Config:GetSetting('AETauntAA') and (Casting.CanUseAA("Explosion of Spite") or Casting.CanUseAA("Explosion of Hatred"))
-                return tauntSpell or hateAA or (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage'))
+                return tauntSpell or hateAA or Config:GetSetting('DoAELifeTap')
             end,
             targetId = function(self) return Targeting.CheckForAutoTargetID() end,
             cond = function(self, combat_state)
@@ -1006,10 +1006,12 @@ local _ClassConfig = {
                 name = "Dark Lord's Unity (Azia)",
                 type = "AA",
                 tooltip = Tooltips.DLUA,
+                load_cond = function()
+                    return Config:GetSetting('ProcChoice') == 1 or
+                        (Config:GetSetting('ProcChoice') == 2 and not Casting.CanUseAA("Dark Lord's Unity (Beza)"))
+                end,
                 active_cond = function(self, aaName) return Casting.IHaveBuff(mq.TLO.Me.AltAbility(aaName).Spell.Trigger(2).ID() or 0) end,
                 cond = function(self, aaName, target)
-                    if Config:GetSetting('ProcChoice') == 3 then return false end
-                    if Config:GetSetting('ProcChoice') == 2 and Casting.CanUseAA("Dark Lord's Unity (Beza)") then return false end
                     return Casting.SelfBuffAACheck(aaName)
                 end,
             },
@@ -1017,9 +1019,9 @@ local _ClassConfig = {
                 name = "Dark Lord's Unity (Beza)",
                 type = "AA",
                 tooltip = Tooltips.DLUB,
+                load_cond = function() return Config:GetSetting('ProcChoice') == 2 end,
                 active_cond = function(self, aaName) return Casting.IHaveBuff(mq.TLO.Me.AltAbility(aaName).Spell.Trigger(2).ID() or 0) end,
                 cond = function(self, aaName, target)
-                    if Config:GetSetting('ProcChoice') ~= 2 then return false end
                     return Casting.SelfBuffAACheck(aaName)
                 end,
             },
@@ -1118,9 +1120,10 @@ local _ClassConfig = {
                 name = "TempHP",
                 type = "Spell",
                 tooltip = Tooltips.TempHP,
+                load_cond = function() return Config:GetSetting('DoTempHP') end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    if not Config:GetSetting('DoTempHP') or not Casting.CastReady(spell) then return false end
+                    if not Casting.CastReady(spell) then return false end
                     return spell.RankName.Stacks() and (mq.TLO.Me.Buff(spell).Duration.TotalSeconds() or 0) < 45
                 end,
             },
@@ -1138,9 +1141,9 @@ local _ClassConfig = {
                 name = "Voice of Thule",
                 type = "AA",
                 tooltip = Tooltips.HateBuff,
+                load_cond = function() return Config:GetSetting('DoHateBuff') end,
                 active_cond = function(self, aaName) return Casting.IHaveBuff(mq.TLO.Me.AltAbility(aaName).Spell.ID()) end,
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoHateBuff') then return false end
                     return Casting.SelfBuffAACheck(aaName)
                 end,
             },
@@ -1148,9 +1151,10 @@ local _ClassConfig = {
                 name = "HateBuff",
                 type = "Spell",
                 tooltip = Tooltips.HateBuff,
+                load_cond = function() return Config:GetSetting('DoHateBuff') and not Casting.CanUseAA('Voice of Thule') end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    if not Config:GetSetting('DoHateBuff') or Casting.CanUseAA('Voice of Thule') or not Casting.CastReady(spell) then return false end
+                    if not Casting.CastReady(spell) then return false end
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
@@ -1297,9 +1301,7 @@ local _ClassConfig = {
                 name = "ForPower",
                 type = "Spell",
                 tooltip = Tooltips.ForPower,
-                cond = function(self, spell, target)
-                    return Config:GetSetting('DoForPower')
-                end,
+                load_cond = function() return Config:GetSetting('DoForPower') end,
             },
         },
         ['HateTools(AutoTarget)']  = {
@@ -1352,7 +1354,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return self.Helpers.ShouldMemTerror() end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('DoTerror') == 1 or Core.AtEmergencyHP() then return false end
+                    if Core.AtEmergencyHP() then return false end
                     return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
@@ -1362,7 +1364,7 @@ local _ClassConfig = {
                 tooltip = Tooltips.Terror,
                 load_cond = function(self) return self.Helpers.ShouldMemTerror() end,
                 cond = function(self, spell, target)
-                    if Config:GetSetting('DoTerror') == 1 or Core.AtEmergencyHP() then return false end
+                    if Core.AtEmergencyHP() then return false end
                     return (mq.TLO.Target.SecondaryPctAggro() or 0) > 60
                 end,
             },
@@ -1396,8 +1398,9 @@ local _ClassConfig = {
             {
                 name = "AELifeTap",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoAELifeTap') end,
                 cond = function(self, spell)
-                    if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) or Core.AtEmergencyHP() then return false end
+                    if not Config:GetSetting('DoAEDamage') or Core.AtEmergencyHP() then return false end
                     return Combat.AETargetCheck(true)
                 end,
             },
@@ -1581,8 +1584,8 @@ local _ClassConfig = {
                 name = "Dicho",
                 type = "Spell",
                 tooltip = Tooltips.Dicho,
+                load_cond = function() return Config:GetSetting('DoDicho') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDicho') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
                     return (myHP <= Config:GetSetting('EmergencyStart') or (Casting.HaveManaToNuke() and myHP <= Config:GetSetting('StartDicho')))
                 end,
@@ -1591,8 +1594,8 @@ local _ClassConfig = {
                 name = "DireTap",
                 type = "Spell",
                 tooltip = Tooltips.DireTap,
+                load_cond = function() return Config:GetSetting('DoDireTap') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDireTap') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
                     return (myHP <= Config:GetSetting('EmergencyStart') or (Casting.HaveManaToNuke() and myHP <= Config:GetSetting('StartDireTap')))
                 end,
@@ -1609,8 +1612,9 @@ local _ClassConfig = {
             {
                 name = "AELifeTap",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoAELifeTap') end,
                 cond = function(self, spell, target)
-                    if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) then return false end
+                    if not Config:GetSetting('DoAEDamage') then return false end
                     local myHP = mq.TLO.Me.PctHPs()
                     return (myHP <= Config:GetSetting('EmergencyStart') or (Casting.HaveManaToNuke() and myHP <= Config:GetSetting('StartLifeTap'))) and Combat.AETargetCheck(true)
                 end,
@@ -1701,8 +1705,8 @@ local _ClassConfig = {
                 name = "ForPower",
                 type = "Spell",
                 tooltip = Tooltips.ForPower,
+                load_cond = function() return Config:GetSetting('DoForPower') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoForPower') then return false end
                     return Casting.DetSpellCheck(spell)
                 end,
             },

--- a/class_configs/Live/shm_class_config.lua
+++ b/class_configs/Live/shm_class_config.lua
@@ -1301,7 +1301,6 @@ local _ClassConfig = {
                 type = "Spell",
                 load_cond = function(self) return Config:GetSetting('DoDiseaseDot') end,
                 cond = function(self, spell, target)
-                    if Core.IsModeActive("Heal") and not Config:GetSetting('DoHealDPS') then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
@@ -1388,8 +1387,9 @@ local _ClassConfig = {
             {
                 name = "GroupRenewalHoT",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoHealOverTime') and Casting.CanUseAA("Luminary's Synergy") end,
                 cond = function(self, spell)
-                    if not Casting.CanUseAA("Luminary's Synergy") or not Config:GetSetting('DoHealOverTime') or not Casting.CastReady(spell) then return false end
+                    if not Casting.CastReady(spell) then return false end
                     return spell.RankName.Stacks() and (mq.TLO.Me.Song(spell).Duration.TotalSeconds() or 0) < 30
                 end,
             },
@@ -1779,7 +1779,6 @@ local _ClassConfig = {
             Category = "Common Rules",
             Index = 101,
             Tooltip = "This is a top-level setting that governs any DPS spells in heal mode, and can be used as a quick-toggle to enable/disable abilities without reloading spells.",
-            RequiresLoadoutChange = true,
             Default = true,
             FAQ = "I feel that my Shaman is too concerned with DPS, dots and nukes, what can be done?",
             Answer = "Disabling Use HealDPS will stop the use of these spells. You can control which individual spells you mem with their respective settings.",
@@ -1881,6 +1880,7 @@ local _ClassConfig = {
             Category = "Class Config Clickies",
             Index = 102,
             Tooltip = "Click your equipped chest.",
+            RequiresLoadoutChange = true,
             Default = mq.TLO.MacroQuest.BuildName() ~= "Emu",
             FAQ = "What the heck is a chest click?",
             Answer = "Most classes have useful abilities on their equipped chest after level 75 or so. The SHM's is generally a healing tool (emergency group heal).",
@@ -1893,6 +1893,7 @@ local _ClassConfig = {
             Category = "Other Recovery",
             Index = 104,
             Tooltip = "Use Canni AA",
+            RequiresLoadoutChange = true,
             Default = true,
             ConfigType = "Advanced",
         },
@@ -2045,6 +2046,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 106,
             Tooltip = "Do Haste Spells/AAs",
+            RequiresLoadoutChange = true,
             Default = true,
             ConfigType = "Advanced",
             FAQ = "Why aren't I casting Talisman of Celerity or other haste buffs?",
@@ -2153,6 +2155,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 107,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },
@@ -2163,6 +2166,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 108,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },
@@ -2173,6 +2177,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 109,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },
@@ -2183,6 +2188,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 110,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },

--- a/class_configs/Live/wiz_class_config.lua
+++ b/class_configs/Live/wiz_class_config.lua
@@ -1126,6 +1126,7 @@ return {
             {
                 name = "FireRain",
                 type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoRain') end,
                 cond = function(self, spell, target)
                     return self.Helpers.RainCheck(target)
                 end,
@@ -1152,6 +1153,7 @@ return {
             {
                 name = "IceRain",
                 type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoRain') end,
                 cond = function(self, spell, target)
                     return self.Helpers.RainCheck(target)
                 end,

--- a/class_configs/Project Lazarus/ber_class_config.lua
+++ b/class_configs/Project Lazarus/ber_class_config.lua
@@ -466,6 +466,7 @@ return {
             Category = "Snare",
             Index = 101,
             Tooltip = "Snare opponents with low health.",
+            RequiresLoadoutChange = true,
             Default = false,
         },
         ['SnareCount']   = {

--- a/class_configs/Project Lazarus/brd_class_config.lua
+++ b/class_configs/Project Lazarus/brd_class_config.lua
@@ -1013,6 +1013,7 @@ local _ClassConfig = {
                 "Third Spire: Large Group HP Buff.",
             Type = "Combo",
             ComboOptions = Globals.Constants.SpireChoices,
+            RequiresLoadoutChange = true,
             Default = 3,
             Min = 1,
             Max = #Globals.Constants.SpireChoices,
@@ -1106,6 +1107,7 @@ local _ClassConfig = {
             Tooltip = "Use Fading Memories when you have aggro and you aren't the Main Assist.",
             Default = true,
             ConfigType = "Advanced",
+            RequiresLoadoutChange = true,
             FAQ = "Why is my Bard regularly using Fading Memories",
             Answer = "When Use Combat Escape is enabled, Fading Memories will be used when the Bard has any unwanted aggro.\n" ..
                 "This helps the common issue of bards gaining aggro from singing before a tank has the chance to secure it.",

--- a/class_configs/Project Lazarus/bst_class_config.lua
+++ b/class_configs/Project Lazarus/bst_class_config.lua
@@ -531,8 +531,8 @@ return {
             {
                 name = "Paragon of Spirit",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoParagon') end,
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoParagon') then return false end
                     return Casting.GroupLowManaCount(Config:GetSetting('ParaPct')) > 0
                 end,
             },
@@ -547,16 +547,18 @@ return {
             {
                 name = "BloodDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "EndemicDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
@@ -618,8 +620,8 @@ return {
             {
                 name = "RunSpeedBuff",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoRunSpeed') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoRunSpeed') then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -723,8 +725,9 @@ return {
             {
                 name = "RunSpeedBuff",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoRunSpeed') end,
                 cond = function(self, spell)
-                    return Config:GetSetting('DoRunSpeed') and Casting.PetBuffCheck(spell)
+                    return Casting.PetBuffCheck(spell)
                 end,
             },
             {
@@ -945,6 +948,7 @@ return {
             Index = 102,
             Tooltip = "Use your Pet Snare Proc Buff (does not stack with Pet Damage or Slow Proc Buff).",
             Default = false,
+            RequiresLoadoutChange = true,
             FAQ = "Why am I continually using proc buffs on my pet?",
             Answer = "Pet proc buffs do not stack, you should only select one.\n" ..
                 "If neither Snare nor Slow proc are selected, the Damage proc will be used.",

--- a/class_configs/Project Lazarus/clr_class_config.lua
+++ b/class_configs/Project Lazarus/clr_class_config.lua
@@ -388,8 +388,9 @@ local _ClassConfig = {
             {
                 name = "GroupElixir",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoGroupElixir') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoGroupElixir') or (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') then return false end
+                    if (target.PctHPs() or 999) <= Config:GetSetting('BigHealPoint') then return false end
                     return Casting.GroupBuffCheck(spell, target)
                 end,
             },
@@ -478,8 +479,9 @@ local _ClassConfig = {
             {
                 name = "CompleteHeal",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoCompleteHeal') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting("DoCompleteHeal") or not Targeting.TargetIsTanking(target) then return false end
+                    if not Targeting.TargetIsTanking(target) then return false end
                     return (target.PctHPs() or 999) <= Config:GetSetting('CompleteHealPct')
                 end,
             },
@@ -929,6 +931,7 @@ local _ClassConfig = {
             "Choose whether to use the Aegolism or Symbol Line of HP Buffs.\nPlease note using both is supported for party members who block buffs, but these buffs do not stack once we transition from using a HP Type-One buff in place of Aegolism.",
             Type = "Combo",
             ComboOptions = { 'Aegolism', 'Both (See Tooltip!)', 'Symbol', 'None', },
+            RequiresLoadoutChange = true,
             Default = 1,
             Min = 1,
             Max = 4,
@@ -944,6 +947,7 @@ local _ClassConfig = {
                 "You have Aegolism selected and are below level 40 (We are still using a HP Type One buff).\n" ..
                 "You have Symbol selected and don't have someone else providing a Type One buff.\n" ..
                 "Leaving this on in other cases is not likely to cause issue, but may cause unnecessary buff checking.",
+            RequiresLoadoutChange = true,
             Default = false,
         },
         ['DoVieBuff']         = {
@@ -992,6 +996,7 @@ local _ClassConfig = {
                 "Third Spire: Group Mitigation Buff.",
             Type = "Combo",
             ComboOptions = Globals.Constants.SpireChoices,
+            RequiresLoadoutChange = true,
             Default = 3,
             Min = 1,
             Max = #Globals.Constants.SpireChoices,

--- a/class_configs/Project Lazarus/dru_class_config.lua
+++ b/class_configs/Project Lazarus/dru_class_config.lua
@@ -483,7 +483,7 @@ local _ClassConfig = {
             targetId = function(self) return { mq.TLO.Me.ID(), } end,
             load_cond = function(self) return Core.OnEMU() end,
             cond = function(self, combat_state)
-                if not Config:GetSetting('DoPet') or mq.TLO.Me.Pet.ID() ~= 0 then return false end
+                if mq.TLO.Me.Pet.ID() ~= 0 then return false end
                 return combat_state == "Downtime" and Core.CombatActionsCheck() and Casting.OkayToPetBuff() and Casting.AmIBuffable()
             end,
         },
@@ -1174,6 +1174,7 @@ local _ClassConfig = {
                 "Third Spire: Large Group HP Buff.",
             Type = "Combo",
             ComboOptions = Globals.Constants.SpireChoices,
+            RequiresLoadoutChange = true,
             Default = 3,
             Min = 1,
             Max = #Globals.Constants.SpireChoices,

--- a/class_configs/Project Lazarus/nec_class_config.lua
+++ b/class_configs/Project Lazarus/nec_class_config.lua
@@ -1119,6 +1119,7 @@ local _ClassConfig = {
                 "Third Spire: DoT Crit Damage Buff.",
             Type = "Combo",
             ComboOptions = Globals.Constants.SpireChoices,
+            RequiresLoadoutChange = true,
             Default = 3,
             Min = 1,
             Max = #Globals.Constants.SpireChoices,

--- a/class_configs/Project Lazarus/rng_class_config.lua
+++ b/class_configs/Project Lazarus/rng_class_config.lua
@@ -608,8 +608,9 @@ return {
             {
                 name = "SwarmDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSwarmDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoSwarmDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },

--- a/class_configs/Project Lazarus/shd_class_config.lua
+++ b/class_configs/Project Lazarus/shd_class_config.lua
@@ -591,9 +591,9 @@ local _ClassConfig = {
                 name = "Voice of Thule",
                 type = "AA",
                 tooltip = Tooltips.HateBuff,
+                load_cond = function() return Config:GetSetting('DoHateBuff') end,
                 active_cond = function(self, aaName) return Casting.IHaveBuff(mq.TLO.Me.AltAbility(aaName).Spell.ID()) end,
                 cond = function(self, aaName)
-                    if not Config:GetSetting('DoHateBuff') then return false end
                     return Casting.SelfBuffAACheck(aaName)
                 end,
             },
@@ -601,9 +601,10 @@ local _ClassConfig = {
                 name = "HateBuff",
                 type = "Spell",
                 tooltip = Tooltips.HateBuff,
+                load_cond = function() return Config:GetSetting('DoHateBuff') end,
                 active_cond = function(self, spell) return Casting.IHaveBuff(spell) end,
                 cond = function(self, spell)
-                    if not Config:GetSetting('DoHateBuff') or not Casting.CastReady(spell) then return false end
+                    if not Casting.CastReady(spell) then return false end
                     return Casting.SelfBuffCheck(spell)
                 end,
             },
@@ -953,8 +954,9 @@ local _ClassConfig = {
                 name = "AELifeTap", --conditions on this may require further tuning, right now it does not respect the start tap settings
                 type = "Spell",
                 tooltip = Tooltips.AELifeTap,
+                load_cond = function() return Config:GetSetting('DoAELifeTap') end,
                 cond = function(self, spell)
-                    if not (Config:GetSetting('DoAELifeTap') and Config:GetSetting('DoAEDamage')) or not spell or not spell() then return false end
+                    if not Config:GetSetting('DoAEDamage') or not spell or not spell() then return false end
                     return Casting.SelfBuffCheck(spell) and Combat.AETargetCheck(true)
                 end,
             },

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -804,24 +804,24 @@ local _ClassConfig = {
             {
                 name = "AEMaloSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoAEMalo') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoAEMalo') then return false end
                     return Targeting.HasXTHaters(Config:GetSetting('AEMaloCount')) and Casting.DetSpellCheck(spell)
                 end,
             },
             {
                 name = "Malosinete",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoSTMalo') end,
                 cond = function(self, aaName, target)
-                    if not Config:GetSetting('DoSTMalo') then return false end
                     return Casting.DetAACheck(aaName)
                 end,
             },
             {
                 name = "MaloSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSTMalo') and not Casting.CanUseAA("Malosinete") end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoSTMalo') or Casting.CanUseAA("Malosinete") then return false end
                     return Casting.DetSpellCheck(spell)
                 end,
             },
@@ -840,7 +840,6 @@ local _ClassConfig = {
                 type = "Spell",
                 load_cond = function(self) return Config:GetSetting('DoAESlow') and not Casting.CanUseAA("Tigir's Insect Swarm") end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoAESlow') or Casting.CanUseAA("Tigir's Insect Swarm") then return false end
                     return Targeting.HasXTHaters(Config:GetSetting('AESlowCount')) and Casting.DetSpellCheck(spell) and not Casting.SlowImmuneTarget(target)
                 end,
             },
@@ -884,33 +883,37 @@ local _ClassConfig = {
             {
                 name = "CurseDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoCurseDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoCurseDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "PoisonRainDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoPoisonRainDot') end,
                 cond = function(self, spell, target)
                     if not Config:GetSetting('DoAEDamage') then return false end
-                    if not Config:GetSetting('DoPoisonRainDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "SaryrnDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSaryrnDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoSaryrnDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
             {
                 name = "UltorDot",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoUltorDot') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoUltorDot') or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed) then return false end
+                    if Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed then return false end
                     return Casting.DotSpellCheck(spell) and Casting.HaveManaToDot()
                 end,
             },
@@ -918,8 +921,9 @@ local _ClassConfig = {
                 name = "Cannibalization",
                 type = "AA",
                 allowDead = true,
+                load_cond = function() return Config:GetSetting('DoAACanni') end,
                 cond = function(self, aaName)
-                    if not (Config:GetSetting('DoAACanni') and Config:GetSetting('DoCombatCanni')) then return false end
+                    if not Config:GetSetting('DoCombatCanni') then return false end
                     return mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
@@ -927,8 +931,9 @@ local _ClassConfig = {
                 name = "CanniSpell",
                 type = "Spell",
                 allowDead = true,
+                load_cond = function() return Config:GetSetting('DoSpellCanni') end,
                 cond = function(self, spell)
-                    if not (Config:GetSetting('DoSpellCanni') and Config:GetSetting('DoCombatCanni')) then return false end
+                    if not Config:GetSetting('DoCombatCanni') then return false end
                     return mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -943,16 +948,16 @@ local _ClassConfig = {
             {
                 name = "ColdNuke",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoColdNuke') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoColdNuke') then return false end
                     return (Targeting.MobHasLowHP() or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed)) and Casting.OkayToNuke(true)
                 end,
             },
             {
                 name = "PoisonNuke",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoPoisonNuke') end,
                 cond = function(self, spell, target)
-                    if not Config:GetSetting('DoPoisonNuke') then return false end
                     return (Targeting.MobHasLowHP() or (Config:GetSetting('DotNamedOnly') and not Globals.AutoTargetIsNamed)) and Casting.OkayToNuke(true)
                 end,
             },
@@ -979,15 +984,17 @@ local _ClassConfig = {
             {
                 name = "Cannibalization",
                 type = "AA",
+                load_cond = function() return Config:GetSetting('DoAACanni') end,
                 cond = function(self, aaName)
-                    return Config:GetSetting('DoAACanni') and mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
+                    return mq.TLO.Me.PctMana() < Config:GetSetting('AACanniManaPct') and mq.TLO.Me.PctHPs() >= Config:GetSetting('AACanniMinHP')
                 end,
             },
             {
                 name = "CanniSpell",
                 type = "Spell",
+                load_cond = function() return Config:GetSetting('DoSpellCanni') end,
                 cond = function(self, spell)
-                    return Config:GetSetting('DoSpellCanni') and Casting.CastReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
+                    return Casting.CastReady(spell) and mq.TLO.Me.PctMana() < Config:GetSetting('SpellCanniManaPct') and
                         mq.TLO.Me.PctHPs() >= Config:GetSetting('SpellCanniMinHP')
                 end,
             },
@@ -1744,6 +1751,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 105,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },
@@ -1754,6 +1762,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 106,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },
@@ -1764,6 +1773,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 107,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },
@@ -1774,6 +1784,7 @@ local _ClassConfig = {
             Category = "Group",
             Index = 108,
             Tooltip = "Use Low Level (<= 70) HP Buffs",
+            RequiresLoadoutChange = true,
             Default = false,
             ConfigType = "Advanced",
         },

--- a/class_configs/Project Lazarus/wiz_class_config.lua
+++ b/class_configs/Project Lazarus/wiz_class_config.lua
@@ -665,6 +665,7 @@ return {
             {
                 name = "FireRain",
                 type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoRain') end,
                 cond = function(self, spell, target)
                     return self.Helpers.RainCheck(target)
                 end,
@@ -689,6 +690,7 @@ return {
             {
                 name = "IceRain",
                 type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoRain') end,
                 cond = function(self, spell, target)
                     return self.Helpers.RainCheck(target)
                 end,


### PR DESCRIPTION
* Adjusted rotation entries that used setting checks in conditions to use load conditions if appropriate.
* Fixed some settings used as load conditions not triggering a loadout rescan when changed.
* NEC(Live) - Improved interaction between Mortifier's Unity and Lich Control.