### PR TITLE
EQ Might Patch Aug 13

### DIFF
--- a/class_configs/EQ Might/ber_class_config.lua
+++ b/class_configs/EQ Might/ber_class_config.lua
@@ -10,6 +10,7 @@ return {
     _author           = "Algar, Derple",
     ['ModeChecks']    = {
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Rez']           = {
         ['Combat']   = {
@@ -17,6 +18,11 @@ return {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']          = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Modes']         = {
@@ -241,6 +247,10 @@ return {
             {
                 name = "Revitalize",
                 type = "Disc",
+            },
+            {
+                name = "Eternal Recovery",
+                type = "AA",
             },
             {
                 name = "HealingDisc",

--- a/class_configs/EQ Might/brd_class_config.lua
+++ b/class_configs/EQ Might/brd_class_config.lua
@@ -49,7 +49,7 @@ local _ClassConfig = {
         CanMez       = function() return true end,
         CanCharm     = function() return true end,
         IsMezzing    = function() return Config:GetSetting('MezOn') end,
-        IsCuring     = function() return Config:GetSetting('UseCure') end,
+        IsCuring     = function() return Config:GetSetting('DoCures') or Config:GetSetting('UseCure') end,
         IsDispelling = function() return Config:GetSetting('DoDispel') end,
         IsRezing     = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
     },
@@ -65,11 +65,14 @@ local _ClassConfig = {
         },
     },
     ['Cure']              = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
+        },
         ['Poison'] = {
-            { type = "Song", name = "CureSong", },
+            { type = "Song", name = "CureSong", cond = function() return Config:GetSetting('UseCure') end, },
         },
         ['Disease'] = {
-            { type = "Song", name = "CureSong", },
+            { type = "Song", name = "CureSong", cond = function() return Config:GetSetting('UseCure') end, },
         },
     },
     ['Themes']            = {
@@ -872,6 +875,11 @@ local _ClassConfig = {
             {
                 name = "Revitalize",
                 type = "Disc",
+                midSong = true,
+            },
+            {
+                name = "Eternal Recovery",
+                type = "AA",
                 midSong = true,
             },
             {

--- a/class_configs/EQ Might/bst_class_config.lua
+++ b/class_configs/EQ Might/bst_class_config.lua
@@ -23,6 +23,7 @@ return {
     },
     ['Cure']              = {
         ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
             { type = "AA", name = "Nature's Salve", selfOnly = true, },
         },
     },
@@ -511,6 +512,10 @@ return {
             },
         },
         ['Emergency(Health)'] = {
+            {
+                name = "Eternal Recovery",
+                type = "AA",
+            },
             {
                 name = "Warder's Gift",
                 type = "AA",

--- a/class_configs/EQ Might/clr_class_config.lua
+++ b/class_configs/EQ Might/clr_class_config.lua
@@ -479,6 +479,13 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Eternal Recovery",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.TargetIsMyself(target)
+                end,
+            },
+            {
                 name = "Sanctuary",
                 type = "AA",
                 cond = function(self, aaName, target)

--- a/class_configs/EQ Might/dru_class_config.lua
+++ b/class_configs/EQ Might/dru_class_config.lua
@@ -384,6 +384,9 @@ local _ClassConfig = {
             "Chillgrave", -- Level 69 EQM Custom
             "Frostgrave", -- Level 63 EQ Custom
         },
+        ['SnareHot'] = {
+            "Earthwave Rejuvenation", -- Level 69, PrM Custom
+        },
     },
     ['AASets']            = {
         ['Spire'] = {
@@ -421,11 +424,27 @@ local _ClassConfig = {
     ['HealRotations']     = {
         ['BigHealPoint'] = {
             {
+                name = "SnareHot",
+                type = "Spell",
+                load_cond = function(self) return Config:GetSetting('DoSnareHot') end,
+                cond = function(self, spell, target)
+                    if Combat.GetCachedCombatState() ~= "Combat" then return false end
+                    return Casting.GroupBuffCheck(spell, target)
+                end,
+            },
+            {
                 name = "Balance of the Grove",
                 type = "AA",
                 cond = function(self, aaName, target)
                     if not Targeting.GroupedWithTarget(target) then return false end
                     return Targeting.TargetIsTanking(target)
+                end,
+            },
+            {
+                name = "Eternal Recovery",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.TargetIsMyself(target)
                 end,
             },
             {
@@ -563,6 +582,16 @@ local _ClassConfig = {
             cond = function(self, combat_state)
                 return combat_state == "Combat" and Core.CombatActionsCheck() and not Globals.AutoTargetIsNamed and
                     Targeting.HasXTHatersMax(Config:GetSetting('SnareCount'))
+            end,
+        },
+        {
+            name = 'SnareHotBuff',
+            state = 1,
+            steps = 1,
+            load_cond = function(self) return Config:GetSetting('DoSnareHot') and Core.GetResolvedActionMapItem('SnareHot') end,
+            targetId = function(self) return Casting.GetBuffableTankingIDs() end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and (not Config:GetSetting('SnareHotNamedOnly') or Targeting.HasXTNamed()) and Core.CombatActionsCheck()
             end,
         },
         {
@@ -867,6 +896,15 @@ local _ClassConfig = {
                 end,
             },
         },
+        ['SnareHotBuff']     = {
+            {
+                name = "SnareHot",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
+                end,
+            },
+        },
         ['GroupBuff']        = {
             {
                 name = "Flight of Eagles",
@@ -1053,6 +1091,7 @@ local _ClassConfig = {
             spells = {
                 { name = "HealSpell", },
                 { name = "GroupHeal", },
+                { name = "SnareHot",       cond = function(self) return Config:GetSetting('DoSnareHot') end, },
                 { name = "SnareSpell",     cond = function(self) return Config:GetSetting('DoSnare') and not Casting.CanUseAA("Entrap") end, },
                 { name = "ReptileBuff", },
                 { name = "ATKDebuff",      cond = function(self) return Config:GetSetting('DoATKDebuff') end, },
@@ -1363,6 +1402,25 @@ local _ClassConfig = {
         },
 
         -- Utility
+        ['DoSnareHot']        = {
+            DisplayName = "Use Snare HoT",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "General Healing",
+            Index = 101,
+            Tooltip = "Use snaring HoTs like Earthwave Rejuvenation as an emergency heal and as a combat buff on your tanks.",
+            RequiresLoadoutChange = true,
+            Default = false,
+        },
+        ['SnareHotNamedOnly'] = {
+            DisplayName = "Snare HoT Named Only",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "General Healing",
+            Index = 102,
+            Tooltip = "Only use the snaring HoT as a tank buff when a named is on your XTarget.",
+            Default = true,
+        },
         ['KeepPoisonMemmed']  = {
             DisplayName = "Mem Cure Poison",
             Group = "Abilities",

--- a/class_configs/EQ Might/enc_class_config.lua
+++ b/class_configs/EQ Might/enc_class_config.lua
@@ -25,6 +25,7 @@ local _ClassConfig    = {
         IsMezzing    = function() return Config:GetSetting('MezOn') end,
         IsDispelling = function() return Config:GetSetting('DoDispel') end,
         IsRezing     = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring     = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Dispel']        = {
         { name = "Dispel", type = "Spell", },
@@ -35,6 +36,11 @@ local _ClassConfig    = {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']          = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Modes']         = {
@@ -538,6 +544,16 @@ local _ClassConfig    = {
             end,
         },
         {
+            name = 'Emergency(Health)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            cond = function(self, combat_state)
+                return Targeting.HasXTHaters() and Core.AtEmergencyHP()
+            end,
+        },
+        {
             name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
@@ -650,7 +666,7 @@ local _ClassConfig    = {
         end,
     },
     ['Rotations']     = {
-        ['Downtime']         = {
+        ['Downtime']          = {
             {
                 name = "Eldritch Rune",
                 type = "AA",
@@ -733,7 +749,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetSummon']        = {
+        ['PetSummon']         = {
             {
                 name = "Asterion",
                 type = "Item",
@@ -759,7 +775,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetBuff']          = {
+        ['PetBuff']           = {
             {
                 name = "HasteBuff",
                 type = "Spell",
@@ -784,7 +800,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['GroupBuff']        = {
+        ['GroupBuff']         = {
             {
                 name = "Legendary Timeless Belt of the Wise",
                 type = "Item",
@@ -934,7 +950,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['CombatSupport']    = {
+        ['CombatSupport']     = {
             {
                 name = "Spire",
                 type = "AA",
@@ -987,7 +1003,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['PetHealing']       = {
+        ['PetHealing']        = {
             {
                 name = "Companion's Blessing",
                 type = "AA",
@@ -1001,7 +1017,13 @@ local _ClassConfig    = {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['Emergency(Aggro)'] = {
+        ['Emergency(Health)'] = {
+            {
+                name = "Eternal Recovery",
+                type = "AA",
+            },
+        },
+        ['Emergency(Aggro)']  = {
             {
                 name = "Self Stasis",
                 type = "AA",
@@ -1056,7 +1078,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['DPS']              = {
+        ['DPS']               = {
             {
                 name = "Epic",
                 type = "Item",
@@ -1119,7 +1141,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Burn']             = {
+        ['Burn']              = {
             {
                 name = "Illusions of Grandeur",
                 type = "AA",
@@ -1167,7 +1189,7 @@ local _ClassConfig    = {
                 type = "Item",
             },
         },
-        ['Tash']             = {
+        ['Tash']              = {
             {
                 name = "Bite of Tashani",
                 type = "AA",
@@ -1193,7 +1215,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Cripple']          = {
+        ['Cripple']           = {
             {
                 name = "CrippleSpell",
                 type = "Spell",
@@ -1202,7 +1224,7 @@ local _ClassConfig    = {
                 end,
             },
         },
-        ['Slow']             = {
+        ['Slow']              = {
             {
                 name = "Enveloping Helix",
                 type = "AA",

--- a/class_configs/EQ Might/mag_class_config.lua
+++ b/class_configs/EQ Might/mag_class_config.lua
@@ -15,6 +15,7 @@ local _ClassConfig = {
     _author           = "Derple, Morisato, Algar",
     ['ModeChecks']    = {
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Rez']           = {
         ['Combat']   = {
@@ -22,6 +23,11 @@ local _ClassConfig = {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']          = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Modes']         = {
@@ -398,6 +404,16 @@ local _ClassConfig = {
             targetId = function(self) return mq.TLO.Me.Pet.ID() > 0 and { mq.TLO.Me.Pet.ID(), } or {} end,
             cond = function(self, combat_state)
                 return combat_state == "Downtime" and mq.TLO.Me.Pet.ID() > 0 and Casting.OkayToPetBuff()
+            end,
+        },
+        {
+            name = 'Emergency(Health)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            cond = function(self, combat_state)
+                return Targeting.HasXTHaters() and Core.AtEmergencyHP()
             end,
         },
         {
@@ -845,6 +861,12 @@ local _ClassConfig = {
                 cond = function(self, spell)
                     return Casting.DetSpellCheck(spell)
                 end,
+            },
+        },
+        ['Emergency(Health)'] = {
+            {
+                name = "Eternal Recovery",
+                type = "AA",
             },
         },
         ['GroupBuff'] = {

--- a/class_configs/EQ Might/mnk_class_config.lua
+++ b/class_configs/EQ Might/mnk_class_config.lua
@@ -23,7 +23,8 @@ local _ClassConfig = {
     },
     ['Cure']          = {
         ['DetDispel'] = {
-            { type = "AA", name = "Purify Body", selfOnly = true, },
+            { type = "AA", name = "Radiant Cure", },
+            { type = "AA", name = "Purify Body",  selfOnly = true, },
         },
     },
     ['Modes']         = {
@@ -215,6 +216,10 @@ local _ClassConfig = {
             {
                 name = "Epic",
                 type = "Item",
+            },
+            {
+                name = "Eternal Recovery",
+                type = "AA",
             },
             {
                 name = "HealingDisc",

--- a/class_configs/EQ Might/nec_class_config.lua
+++ b/class_configs/EQ Might/nec_class_config.lua
@@ -18,6 +18,7 @@ local _ClassConfig = {
     ['ModeChecks']      = {
         CanCharm = function() return true end,
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Rez']             = {
         ['Combat']   = {
@@ -25,6 +26,11 @@ local _ClassConfig = {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']            = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Themes']          = {
@@ -426,6 +432,16 @@ local _ClassConfig = {
             end,
         },
         {
+            name = 'Emergency(Health)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            cond = function(self, combat_state)
+                return Targeting.HasXTHaters() and Core.AtEmergencyHP()
+            end,
+        },
+        {
             name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
@@ -515,7 +531,13 @@ local _ClassConfig = {
         },
     },
     ['Rotations']       = {
-        ['Emergency(Aggro)'] = {
+        ['Emergency(Health)'] = {
+            {
+                name = "Eternal Recovery",
+                type = "AA",
+            },
+        },
+        ['Emergency(Aggro)']  = {
             {
                 name = "Death's Effigy",
                 type = "AA",
@@ -532,7 +554,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Scent(Terris)']    = {
+        ['Scent(Terris)']     = {
             {
                 name_func = function(self)
                     local scentItems = { "Legendary Fabled Nightshade Scented Staff", "Fabled Nightshade Scented Staff", "Scent of Terris", }
@@ -558,7 +580,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Scent(Midnight)']  = {
+        ['Scent(Midnight)']   = {
             {
                 name = "ScentDebuff2",
                 type = "Spell",
@@ -567,7 +589,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Snare']            = {
+        ['Snare']             = {
             {
                 name = "Encroaching Darkness",
                 type = "AA",
@@ -585,7 +607,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['CombatBuff']       = {
+        ['CombatBuff']        = {
             {
                 name = "Epic",
                 type = "Item",
@@ -643,7 +665,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobHighHP)']   = {
+        ['DPS(MobHighHP)']    = {
             {
                 name = "FireDot",
                 type = "Spell",
@@ -755,7 +777,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['DPS(MobLowHP)']    = {
+        ['DPS(MobLowHP)']     = {
             {
                 name = "OrbNuke",
                 type = "Spell",
@@ -791,7 +813,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['Burn']             = {
+        ['Burn']              = {
             {
                 name = "OoW_Chest",
                 type = "Item",
@@ -844,7 +866,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetHealing']       = {
+        ['PetHealing']        = {
             {
                 name = "Companion's Blessing",
                 type = "AA",
@@ -862,7 +884,7 @@ local _ClassConfig = {
                 load_cond = function(self) return Config:GetSetting('DoPetHealSpell') end,
             },
         },
-        ['Downtime']         = {
+        ['Downtime']          = {
             {
                 name = "SelfHPBuff",
                 type = "Spell",
@@ -907,7 +929,7 @@ local _ClassConfig = {
                 cond = function(self, aaName, target) return Casting.SelfBuffAACheck(aaName) end,
             },
         },
-        ['PetSummon']        = {
+        ['PetSummon']         = {
             {
                 name = "RedDemon",
                 type = "Item",
@@ -955,7 +977,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['PetBuff']          = { -- TODO: Examine spectral guard 71
+        ['PetBuff']           = { -- TODO: Examine spectral guard 71
             {
                 name = "PetHaste",
                 type = "Spell",
@@ -970,7 +992,7 @@ local _ClassConfig = {
                 end,
             },
         },
-        ['GroupBuff']        = { -- Added to anchor clickies to
+        ['GroupBuff']         = { -- Added to anchor clickies to
 
         },
     },

--- a/class_configs/EQ Might/pal_class_config.lua
+++ b/class_configs/EQ Might/pal_class_config.lua
@@ -510,6 +510,13 @@ return {
                 end,
             },
             {
+                name = "Eternal Recovery",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.TargetIsMyself(target)
+                end,
+            },
+            {
                 name = "Marr's Gift",
                 type = "AA",
                 cond = function(self, aaName, target)
@@ -902,6 +909,14 @@ return {
             { -- better aggro than force of disruption at current available ranks (stun is worth 1200 for any mob >18khp)
                 name = "Divine Stun",
                 type = "AA",
+            },
+            {
+                name = "Projection of Piety",
+                type = "AA",
+                IgnoreImmuneCheck = true,
+                cond = function(self, aaName, target)
+                    return Globals.AutoTargetIsNamed and (mq.TLO.Target.SecondaryPctAggro() or 0) > 80
+                end,
             },
             {
                 name = "ForHonor",

--- a/class_configs/EQ Might/rng_class_config.lua
+++ b/class_configs/EQ Might/rng_class_config.lua
@@ -14,6 +14,7 @@ return {
     ['ModeChecks']        = {
         IsHealing = function() return Config:GetSetting('DoHealSpell') end,
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Rez']               = {
         ['Combat']   = {
@@ -21,6 +22,11 @@ return {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']              = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Modes']             = {
@@ -305,6 +311,16 @@ return {
             end,
         },
         {
+            name = 'Emergency(Health)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return Targeting.CheckForAutoTargetID() end,
+            cond = function(self, combat_state)
+                return Targeting.HasXTHaters() and not mq.TLO.Me.Feigning() and Core.AtEmergencyHP()
+            end,
+        },
+        {
             name = 'Emergency(Aggro)',
             state = 1,
             steps = 1,
@@ -547,6 +563,12 @@ return {
                 cond = function(self, spell, target)
                     return Casting.DetSpellCheck(spell) and Targeting.MobHasLowHP(target) and not Casting.SnareImmuneTarget(target)
                 end,
+            },
+        },
+        ['Emergency(Health)']  = {
+            {
+                name = "Eternal Recovery",
+                type = "AA",
             },
         },
         ['Emergency(Aggro)']   = {

--- a/class_configs/EQ Might/rog_class_config.lua
+++ b/class_configs/EQ Might/rog_class_config.lua
@@ -23,6 +23,9 @@ return {
         },
     },
     ['Cure']          = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
+        },
         ['Poison'] = {
             { type = "AA", name = "Purge Poison", selfOnly = true, },
         },
@@ -329,6 +332,10 @@ return {
             {
                 name = "Revitalize",
                 type = "Disc",
+            },
+            {
+                name = "Eternal Recovery",
+                type = "AA",
             },
             {
                 name = "HealingDisc",

--- a/class_configs/EQ Might/shd_class_config.lua
+++ b/class_configs/EQ Might/shd_class_config.lua
@@ -82,6 +82,7 @@ local _ClassConfig = {
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Rez']           = {
         ['Combat']   = {
@@ -89,6 +90,11 @@ local _ClassConfig = {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']          = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Modes']         = {
@@ -735,6 +741,10 @@ local _ClassConfig = {
             --Note that in Tank Mode, defensive discs are preemptively cycled on named in the (non-emergency) Defenses rotation
             --Abilities should be placed in order of lowest to highest triggered HP thresholds
             --Some conditionals are commented out while I tweak percentages (or determine if they are necessary)
+            {
+                name = "Eternal Recovery",
+                type = "AA",
+            },
             {
                 name = "OoW_Chest",
                 type = "Item",

--- a/class_configs/EQ Might/shm_class_config.lua
+++ b/class_configs/EQ Might/shm_class_config.lua
@@ -301,8 +301,9 @@ local _ClassConfig = {
             "Ghost of Renewal",           -- Level 70
         },
         ['SnareHot'] = {
-            "Torpor",   -- Level 60
-            "Stoicism", -- Level 44
+            "Earthwave Rejuvenation", -- Level 69, PrM Custom
+            "Torpor",                 -- Level 60
+            "Stoicism",               -- Level 44
         },
         ['SingleHot'] = {
             "Halcyon Breeze",         -- Level 71
@@ -541,6 +542,13 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Eternal Recovery",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return self.CombatState == "Combat" and Targeting.TargetIsMyself(target)
+                end,
+            },
+            {
                 name = "Ancestral Guard",
                 type = "AA",
                 cond = function(self, aaName, target)
@@ -709,6 +717,16 @@ local _ClassConfig = {
             end,
         },
         {
+            name = 'SnareHotBuff',
+            state = 1,
+            steps = 1,
+            load_cond = function(self) return Config:GetSetting('DoSnareHot') and Core.GetResolvedActionMapItem('SnareHot') end,
+            targetId = function(self) return Casting.GetBuffableTankingIDs() end,
+            cond = function(self, combat_state)
+                return combat_state == "Combat" and (not Config:GetSetting('SnareHotNamedOnly') or Targeting.HasXTNamed()) and Core.CombatActionsCheck()
+            end,
+        },
+        {
             name = 'ProcBuff',
             state = 1,
             steps = 1,
@@ -863,6 +881,15 @@ local _ClassConfig = {
                         mq.delay(50) -- slight delay to prevent chat bug with command issue
                         self:SetPetHold()
                     end
+                end,
+            },
+        },
+        ['SnareHotBuff']   = {
+            {
+                name = "SnareHot",
+                type = "Spell",
+                cond = function(self, spell, target)
+                    return Casting.GroupBuffCheck(spell, target)
                 end,
             },
         },
@@ -1466,10 +1493,18 @@ local _ClassConfig = {
             Header = "Recovery",
             Category = "General Healing",
             Index = 102,
-            Tooltip = "Use snaring HoTs like torpor when HP is very low.",
+            Tooltip = "Use snaring HoTs like torpor as an emergency heal and as a combat buff on your tanks.",
             RequiresLoadoutChange = true,
             Default = false,
-            ConfigType = "Advanced",
+        },
+        ['SnareHotNamedOnly'] = {
+            DisplayName = "Snare HoT Named Only",
+            Group = "Abilities",
+            Header = "Recovery",
+            Category = "General Healing",
+            Index = 103,
+            Tooltip = "Only use the snaring HoT as a tank buff when a named is on your XTarget.",
+            Default = true,
         },
         ['KeepPoisonMemmed']  = {
             DisplayName = "Mem Cure Poison",

--- a/class_configs/EQ Might/war_class_config.lua
+++ b/class_configs/EQ Might/war_class_config.lua
@@ -16,6 +16,7 @@ local _ClassConfig = {
     ['ModeChecks']    = {
         IsTanking = function() return Core.IsModeActive("Tank") end,
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Rez']           = {
         ['Combat']   = {
@@ -23,6 +24,11 @@ local _ClassConfig = {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']          = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Modes']         = {
@@ -496,6 +502,10 @@ local _ClassConfig = {
                 end,
             },
             {
+                name = "Eternal Recovery",
+                type = "AA",
+            },
+            {
                 name = "Fortitude",
                 type = "Disc",
                 cond = function(self, discSpell)
@@ -656,6 +666,20 @@ local _ClassConfig = {
             },
         },
         ['Buffs']                  = {
+            {
+                name = "Blade Guardian",
+                type = "AA",
+                cond = function(self, aaName)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
+            },
+            {
+                name = "Brace For Impact",
+                type = "AA",
+                cond = function(self, aaName, target)
+                    return Casting.SelfBuffAACheck(aaName)
+                end,
+            },
         },
         ['Combat']                 = {
             {

--- a/class_configs/EQ Might/wiz_class_config.lua
+++ b/class_configs/EQ Might/wiz_class_config.lua
@@ -16,6 +16,7 @@ return {
     _author           = "Derple, Algar",
     ['ModeChecks']    = {
         IsRezing = function() return Core.GetResolvedActionMapItem('RezStaff') ~= nil and (Config:GetSetting('DoBattleRez') or not Targeting.HasXTHaters()) end,
+        IsCuring = function() return Config:GetSetting('DoCures') and Casting.CanUseAA("Radiant Cure") end,
     },
     ['Rez']           = {
         ['Combat']   = {
@@ -23,6 +24,11 @@ return {
         },
         ['Downtime'] = {
             { type = "Item", name = "RezStaff", },
+        },
+    },
+    ['Cure']          = {
+        ['DetDispel'] = {
+            { type = "AA", name = "Radiant Cure", },
         },
     },
     ['Modes']         = {
@@ -374,6 +380,16 @@ return {
             end,
         },
         {
+            name = 'Emergency(Health)',
+            state = 1,
+            steps = 1,
+            doFullRotation = true,
+            targetId = function(self) return { mq.TLO.Me.ID(), } end,
+            cond = function(self, combat_state)
+                return Targeting.HasXTHaters() and Core.AtEmergencyHP()
+            end,
+        },
+        {
             name = 'Aggro Management',
             state = 1,
             steps = 1,
@@ -555,6 +571,12 @@ return {
             --         return Config:GetSetting('DoAEDamage')
             --     end,
             -- },
+        },
+        ['Emergency(Health)'] = {
+            {
+                name = "Eternal Recovery",
+                type = "AA",
+            },
         },
         ['Aggro Management'] =
         {

--- a/class_configs/Project Lazarus/shm_class_config.lua
+++ b/class_configs/Project Lazarus/shm_class_config.lua
@@ -1423,7 +1423,6 @@ local _ClassConfig = {
             Tooltip = "Use snaring HoTs like torpor as an emergency heal and as a combat buff on your tanks.",
             RequiresLoadoutChange = true,
             Default = true,
-            ConfigType = "Advanced",
         },
         ['SnareHotNamedOnly'] = {
             DisplayName = "Snare HoT Named Only",
@@ -1433,7 +1432,6 @@ local _ClassConfig = {
             Index = 103,
             Tooltip = "Only use the snaring HoT as a tank buff when a named is on your XTarget.",
             Default = true,
-            ConfigType = "Advanced",
         },
         ['KeepPoisonMemmed']  = {
             DisplayName = "Mem Cure Poison",


### PR DESCRIPTION
* All - Added Radiant Cure support (if missing).
* All - Added Eternal Recovery as an emergency self-heal.
* DRU/SHM - Expanded/Added SnareHot options.
* * Used as a big heal on all, and upkept as a buff on tanks (optional: on named only, default: on).
* WAR - Added new AA Brace For Impact and Blade Guardian.