### PR TITLE
User Modules: allow a user module to replace a built-in

### DIFF
--- a/docs/user_modules.md
+++ b/docs/user_modules.md
@@ -27,6 +27,26 @@ local Module = { _version = '1.0', _name = "MyModule", _author = 'YourName', }
 
 `_about` is optional. Supply a sentence describing what your module does and the UserModules tab draws an info icon beside its name carrying that text, which is how anyone else on your machine finds out what it is for.
 
+`_replaces` is optional and changes what `_name` means: see Replacing a built-in module below.
+
+## Replacing a built-in module
+
+A user module can take a built-in module's place entirely. Declare the built-in's exact `_name` plus `_replaces = true`:
+
+```lua
+local Module = { _version = '1.0', _name = "Pull", _author = 'YourName', _replaces = true, }
+Module.__index = Module
+setmetatable(Module, { __index = require("modules.pull"), })
+```
+
+Enabling the module unloads the built-in and loads yours in its place — same slot in the execution order, same settings namespace, and every internal dispatch to that module name now reaches yours. Disabling it (or a load failure) restores the built-in on the spot. Because the settings namespace is shared, the user's saved settings carry across the swap in both directions.
+
+Inherit from the built-in you are replacing, as above, rather than from `modules.base` — you keep its full UI and behavior and override only the methods you want to change. The rest of RGMercs calls into these modules expecting their full method surface, so a from-scratch replacement has to supply all of it.
+
+Two caveats. Built-in modules keep state on their class table, which `require` shares between the built-in and your subclass — so a replacement and its built-in must never run at the same time, which is why this is a swap rather than a side-by-side load. And a replacement inherits no version guarantee: an RGMercs update can change the built-in's internals out from under your overrides, so re-test after updating.
+
+Without `_replaces`, declaring a built-in's name is still refused as a collision. The loot modules (LootNScoot, SmartLoot) and the UserModules module itself cannot be replaced.
+
 ## Refresh vs. reload
 
 **Refresh** re-reads the folder and rebuilds the list: new files, deleted files, changed `_name`s, new collisions. It does not touch anything that is already running.

--- a/modules/usermodules.lua
+++ b/modules/usermodules.lua
@@ -263,6 +263,11 @@ function Module:Render()
                 Ui.RenderColoredText(Globals.Constants.Colors.ConditionMidColor, Icons.MD_INFO_OUTLINE)
                 Ui.Tooltip(manifestEntry.about)
             end
+            if manifestEntry and manifestEntry.replaces and Modules.BuiltInModulePaths[row.name] then
+                ImGui.SameLine()
+                Ui.RenderColoredText(Globals.Constants.Colors.ConditionMidColor, Icons.MD_SWAP_HORIZ)
+                Ui.Tooltip(string.format("Replaces the built-in %s module while enabled.", row.name))
+            end
             ImGui.TableNextColumn()
             Ui.RenderText(manifestEntry and manifestEntry.fileName or "-")
             ImGui.TableNextColumn()

--- a/utils/core.lua
+++ b/utils/core.lua
@@ -95,6 +95,7 @@ function Core.ScanUserModules()
                     entry.version = rawget(module, '_version')
                     entry.author = rawget(module, '_author')
                     entry.about = rawget(module, '_about')
+                    entry.replaces = rawget(module, '_replaces') == true
                 end
             end
         end
@@ -129,7 +130,9 @@ function Core.ScanUserModules()
     for _, entry in ipairs(Globals.UserModuleManifest) do
         if entry.name then
             local claimedBy = claimedNames[entry.name:lower()]
-            if claimedBy and claimedBy ~= entry.fileName then
+            if claimedBy == "an RGMercs module" and entry.replaces and Modules.BuiltInModulePaths[entry.name] then
+                claimedNames[entry.name:lower()] = entry.fileName
+            elseif claimedBy and claimedBy ~= entry.fileName then
                 entry.collisionWith = claimedBy
             else
                 claimedNames[entry.name:lower()] = entry.fileName

--- a/utils/modules.lua
+++ b/utils/modules.lua
@@ -28,6 +28,24 @@ Modules.ModuleList            = {}
 --- Name → file path for the user modules currently loaded from mq.configDir.
 Modules.LoadedUserModules     = {}
 
+--- Name → require path for the built-in modules a user module may replace.
+Modules.BuiltInModulePaths    = {
+    Class        = "modules.class",
+    Movement     = "modules.move",
+    Clickies     = "modules.clickies",
+    Pull         = "modules.pull",
+    Drag         = "modules.drag",
+    Charm        = "modules.charm",
+    Mez          = "modules.mez",
+    Travel       = "modules.travel",
+    Spawns       = "modules.spawns",
+    Map          = "modules.map",
+    Perf         = "modules.performance",
+    Contributors = "modules.contributors",
+    FAQ          = "modules.faq",
+    Debug        = "modules.debug",
+}
+
 --- Name → message from the most recent failed load attempt.
 Modules.UserModuleLoadErrors  = {}
 
@@ -101,16 +119,19 @@ end
 --- execution order, then calls its Init function.
 ---@param moduleName string Name key to store the module under.
 ---@param filePath string Require-style path to the module file.
-function Modules:loadModule(moduleName, filePath)
+---@param orderIndex number? Position in the execution order; appends when nil.
+function Modules:loadModule(moduleName, filePath, orderIndex)
     self:unloadModule(moduleName)
     self.ModuleList[moduleName] = require(filePath):New()
-    table.insert(self.ModuleOrder, moduleName)
+    table.insert(self.ModuleOrder, math.min(orderIndex or (#self.ModuleOrder + 1), #self.ModuleOrder + 1), moduleName)
     Logger.log_info("Load %s", moduleName) -- temp debug text
     Modules:ExecModule(moduleName, "Init")
 end
 
---- Loads a user module from an absolute file path, appends it to the execution
---- order and initializes it, rolling back if the file errors.
+--- Loads a user module from an absolute file path, adds it to the execution
+--- order and initializes it, rolling back if the file errors. A module that
+--- declares _replaces under a built-in's name takes that module's place,
+--- inheriting its slot in the execution order.
 ---@param moduleName string Declared _name of the module.
 ---@param filePath string Absolute path to the user module file.
 ---@return boolean success True when the module loaded and initialized.
@@ -126,8 +147,29 @@ function Modules:loadUserModule(moduleName, filePath)
         return false
     end
 
+    local replacing = false
+    local orderIndex = nil
+
     local success, initError = pcall(function()
-        local instance = chunk():New()
+        local class = chunk()
+        if type(class) ~= "table" then
+            error("File did not return a module table.", 0)
+        end
+
+        if rawget(class, '_replaces') and self.BuiltInModulePaths[moduleName] then
+            replacing = true
+            for i, v in ipairs(self.ModuleOrder) do
+                if v == moduleName then
+                    orderIndex = i
+                    break
+                end
+            end
+            self:unloadModule(moduleName)
+            Config:ClearModuleSettings(moduleName)
+            Logger.log_info("\ayReplacing the built-in \at%s\ay module with \at%s\ay.", moduleName, filePath)
+        end
+
+        local instance = class:New()
         if type(instance) ~= "table" then
             error("New() did not return a module instance.", 0)
         end
@@ -141,13 +183,27 @@ function Modules:loadUserModule(moduleName, filePath)
         self.LoadedUserModules[moduleName] = filePath
         self:ExecModule(moduleName, "Init")
 
-        table.insert(self.ModuleOrder, moduleName)
+        table.insert(self.ModuleOrder, math.min(orderIndex or (#self.ModuleOrder + 1), #self.ModuleOrder + 1), moduleName)
         Config:UpdateCommandHandlers()
     end)
 
     if not success then
         Logger.log_error("\arUser module \at%s\ar failed to initialize: %s", moduleName, initError)
         self:unloadUserModule(moduleName)
+        if replacing then
+            if not self.ModuleList[moduleName] then
+                self:loadModule(moduleName, self.BuiltInModulePaths[moduleName], orderIndex)
+                Config:UpdateCommandHandlers()
+            elseif orderIndex then
+                for i, v in ipairs(self.ModuleOrder) do
+                    if v == moduleName then
+                        table.remove(self.ModuleOrder, i)
+                        break
+                    end
+                end
+                table.insert(self.ModuleOrder, math.min(orderIndex, #self.ModuleOrder + 1), moduleName)
+            end
+        end
         self.UserModuleLoadErrors[moduleName] = initError
         return false
     end
@@ -158,12 +214,23 @@ function Modules:loadUserModule(moduleName, filePath)
 end
 
 --- Shuts down a loaded user module and drops its in-memory settings
---- registration; persisted values are left in the database.
+--- registration; persisted values are left in the database. A module that
+--- replaced a built-in has that built-in restored in its place.
 ---@param moduleName string Declared _name of the module.
 function Modules:unloadUserModule(moduleName)
     if not self.LoadedUserModules[moduleName] then return end
 
     local Config = require("utils.config")
+
+    local orderIndex = nil
+    if self.BuiltInModulePaths[moduleName] then
+        for i, v in ipairs(self.ModuleOrder) do
+            if v == moduleName then
+                orderIndex = i
+                break
+            end
+        end
+    end
 
     self:unloadModule(moduleName)
     self.LoadedUserModules[moduleName] = nil
@@ -171,6 +238,11 @@ function Modules:unloadUserModule(moduleName)
     self.UserModuleFrameTimes[moduleName] = nil
 
     Config:ClearModuleSettings(moduleName)
+
+    if self.BuiltInModulePaths[moduleName] then
+        self:loadModule(moduleName, self.BuiltInModulePaths[moduleName], orderIndex)
+    end
+
     Config:UpdateCommandHandlers()
 end
 


### PR DESCRIPTION
## Summary

Follow-up to #1363. A user module that declares `_replaces = true` under a built-in's exact `_name` now takes that module's place when enabled:

- The built-in is unloaded and its settings registration cleared (database values untouched — the same sequence the loot-module swap uses), and the user module loads into the built-in's slot in the execution order.
- The replacement owns the settings namespace and receives every internal dispatch to that module name (`ExecModule`, command handlers, map/HUD integrations), so subclassing the built-in keeps its full UI and behavior while overriding individual methods.
- Disabling the module — or any failure while loading it — restores the built-in in place, same slot, same settings.

A complete Pull replacement is now ~20 lines:

```lua
local Pull     = require("modules.pull")

local Module   = { _version = '1.0', _name = "Pull", _author = 'You', _replaces = true, }
Module.__index = Module
setmetatable(Module, { __index = Pull, })

function Module:New()
    return Pull.New(self)
end

return Module
```

## Details

- `Modules.BuiltInModulePaths` maps replaceable built-ins to their require paths, used both to gate the feature and to restore on disable/rollback. The loot modules (they have their own swap) and UserModules itself are excluded.
- The scan stamps `entry.replaces`; the collision check admits a valid replacement while still refusing accidental name collisions, and a second file claiming the same built-in still collides (first alphabetically wins, as before).
- The UserModules tab marks replacement rows with a swap icon and tooltip.
- `docs/user_modules.md` gains a "Replacing a built-in module" section, including the shared-class-state caveat (built-in and replacement share the class table via `require`, which is why this is a swap rather than a side-by-side load).

## Testing

Not yet run in-game. Worth exercising before merge:

- Enable → disable → re-enable a replacement, confirming the tab identity and settings survive both directions.
- A replacement whose `Init` throws, confirming the built-in is restored in its original slot.
- Disabling a replacement mid-pull: pull's class-level `TempSettings` persists across the swap by design, so the restored built-in resumes with the replacement's state — needs a look to confirm that's benign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)